### PR TITLE
Add AI chat panel with OpenAI and Anthropic integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,8 @@ HOST=127.0.0.1
 # CORS
 CORS_ORIGIN=http://localhost:3000
 
-# OpenAI API key (required for AI chat feature, server-side only)
+# OpenAI API key (required for OpenAI chat models, server-side only)
 # OPENAI_API_KEY=sk-...
+
+# Anthropic API key (required for Claude chat models, server-side only)
+# ANTHROPIC_API_KEY=sk-ant-...

--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ HOST=127.0.0.1
 
 # CORS
 CORS_ORIGIN=http://localhost:3000
+
+# OpenAI API key (required for AI chat feature, server-side only)
+# OPENAI_API_KEY=sk-...

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ yarn.lock
 
 # Environment
 **/.env
+**/.env.local
 
 # CDK local/cached context (account-specific, auto-generated)
 cdk.context.local.json

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "expense-budget-tracker-web",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.63",
+        "@anthropic-ai/sdk": "^0.78.0",
         "@openai/agents": "^0.5.2",
         "@openai/agents-openai": "^0.5.2",
         "d3": "^7.9.0",
@@ -28,27 +28,33 @@
         "typescript": "5.9.3"
       }
     },
-    "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.63",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.63.tgz",
-      "integrity": "sha512-ZNiaQb/v6xkbrGt3dtq5J0DGY+AaOhoehUyposa3msvlAlkTHWNGR+NhbCcTE0ML1U91xhPqMAAwZIUqrlkKyQ==",
-      "license": "SEE LICENSE IN README.md",
-      "engines": {
-        "node": ">=18.0.0"
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
       },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.34.2",
-        "@img/sharp-darwin-x64": "^0.34.2",
-        "@img/sharp-linux-arm": "^0.34.2",
-        "@img/sharp-linux-arm64": "^0.34.2",
-        "@img/sharp-linux-x64": "^0.34.2",
-        "@img/sharp-linuxmusl-arm64": "^0.34.2",
-        "@img/sharp-linuxmusl-x64": "^0.34.2",
-        "@img/sharp-win32-arm64": "^0.34.2",
-        "@img/sharp-win32-x64": "^0.34.2"
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       },
       "peerDependencies": {
-        "zod": "^4.0.0"
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -2277,6 +2283,19 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -3118,6 +3137,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,11 +8,15 @@
       "name": "expense-budget-tracker-web",
       "version": "0.1.0",
       "dependencies": {
+        "@openai/agents": "^0.5.2",
+        "@openai/agents-openai": "^0.5.2",
         "d3": "^7.9.0",
         "next": "16.1.6",
+        "openai": "^6.25.0",
         "pg": "^8.18.0",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "zod": "^4.0.0"
       },
       "devDependencies": {
         "@types/d3": "^7.4.3",
@@ -31,6 +35,19 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@img/colour": {
@@ -499,6 +516,47 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.1.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
@@ -631,6 +689,72 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@openai/agents": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.5.2.tgz",
+      "integrity": "sha512-TMIz2W9NSXDFHXmVuZiwYB5JTBMSwCgqwB5B5Np5ZuJjOIKxinGGcMhTntm3gtdmDgJR5ghbb+IEEC2BSzbEFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.5.2",
+        "@openai/agents-openai": "0.5.2",
+        "@openai/agents-realtime": "0.5.2",
+        "debug": "^4.4.0",
+        "openai": "^6.20.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-core": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.5.2.tgz",
+      "integrity": "sha512-9B6Ndo8/jyD32ZRfFc9j7JGdGRyh89gSMV281LHewoJ8Py4zopQBjiYDn3kBmREvHoO/kaPXgf8yHPtwT3OoDw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "openai": "^6.20.0"
+      },
+      "optionalDependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openai/agents-openai": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.5.2.tgz",
+      "integrity": "sha512-o5RG2WzBVSYqrMpBhYfR8YVxfui8nv4zZghl63cXL9wqoRisYe15zXl8dFFRKcYHRwpUBsOqa0DzOGh5sAjQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.5.2",
+        "debug": "^4.4.0",
+        "openai": "^6.20.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-realtime": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.5.2.tgz",
+      "integrity": "sha512-eN0JfffIGQGG9YqEc8jz7xDXh/ulDmjMq3Iaa81cPET9w2VS5mUScRkhHXu1Ts7MJpacYyiuWuA/PEAkRAJyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.5.2",
+        "@types/ws": "^8.18.1",
+        "debug": "^4.4.0",
+        "ws": "^8.18.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -937,7 +1061,6 @@
       "version": "24.10.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -986,6 +1109,64 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -996,6 +1177,89 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1031,6 +1295,83 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/csstype": {
@@ -1441,6 +1782,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -1448,6 +1806,16 @@
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/detect-libc": {
@@ -1458,6 +1826,359 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
+      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
@@ -1472,6 +2193,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -1480,6 +2208,130 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1497,6 +2349,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/next": {
@@ -1550,6 +2412,104 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.25.0.tgz",
+      "integrity": "sha512-mEh6VZ2ds2AGGokWARo18aPISI1OhlgdEIC1ewhkZr8pSIT31dec0ecr9Nhxx0JlybyOgoAT1sWeKtwPZzJyww==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pg": {
@@ -1645,6 +2605,16 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -1712,6 +2682,79 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
@@ -1729,11 +2772,38 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
       "license": "Unlicense"
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/rw": {
       "version": "1.3.3",
@@ -1765,6 +2835,60 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -1811,6 +2935,105 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1827,6 +3050,16 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/styled-jsx": {
@@ -1852,11 +3085,36 @@
         }
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -1876,8 +3134,71 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -1886,6 +3207,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "optional": true,
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "expense-budget-tracker-web",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.63",
         "@openai/agents": "^0.5.2",
         "@openai/agents-openai": "^0.5.2",
         "d3": "^7.9.0",
@@ -25,6 +26,29 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "typescript": "5.9.3"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.63",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.63.tgz",
+      "integrity": "sha512-ZNiaQb/v6xkbrGt3dtq5J0DGY+AaOhoehUyposa3msvlAlkTHWNGR+NhbCcTE0ML1U91xhPqMAAwZIUqrlkKyQ==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.34.2",
+        "@img/sharp-darwin-x64": "^0.34.2",
+        "@img/sharp-linux-arm": "^0.34.2",
+        "@img/sharp-linux-arm64": "^0.34.2",
+        "@img/sharp-linux-x64": "^0.34.2",
+        "@img/sharp-linuxmusl-arm64": "^0.34.2",
+        "@img/sharp-linuxmusl-x64": "^0.34.2",
+        "@img/sharp-win32-arm64": "^0.34.2",
+        "@img/sharp-win32-x64": "^0.34.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "pg": "^8.18.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.63",
     "@openai/agents": "^0.5.2",
     "@openai/agents-openai": "^0.5.2",
     "openai": "^6.25.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,11 @@
     "next": "16.1.6",
     "pg": "^8.18.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "@openai/agents": "^0.5.2",
+    "@openai/agents-openai": "^0.5.2",
+    "openai": "^6.25.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/d3": "^7.4.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,7 @@
     "pg": "^8.18.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.63",
+    "@anthropic-ai/sdk": "^0.78.0",
     "@openai/agents": "^0.5.2",
     "@openai/agents-openai": "^0.5.2",
     "openai": "^6.25.0",

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -1,0 +1,71 @@
+import { streamAgentResponse } from "@/server/chat/openai/agent";
+import type { ChatMessage } from "@/server/chat/types";
+import { CHAT_MODELS } from "@/lib/chatModels";
+import { extractUserId, extractWorkspaceId } from "@/server/userId";
+
+type ChatRequestBody = Readonly<{
+  messages: ReadonlyArray<ChatMessage>;
+  model: string;
+}>;
+
+export const POST = async (request: Request): Promise<Response> => {
+  const body: ChatRequestBody = await request.json();
+
+  const validModel = CHAT_MODELS.find((m) => m.id === body.model);
+  if (validModel === undefined) {
+    return new Response(`Unknown model: ${body.model}`, { status: 400 });
+  }
+
+  if (!Array.isArray(body.messages) || body.messages.length === 0) {
+    return new Response("messages array is empty", { status: 400 });
+  }
+
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (openaiKey === undefined || openaiKey === "") {
+    console.error("chat POST: OPENAI_API_KEY environment variable is not set");
+    return new Response("OPENAI_API_KEY environment variable is not set", { status: 500 });
+  }
+
+  let userId: string;
+  let workspaceId: string;
+  try {
+    userId = extractUserId(request);
+    workspaceId = extractWorkspaceId(request);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("chat POST: auth header extraction failed: %s", message);
+    return new Response(message, { status: 401 });
+  }
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const event of streamAgentResponse({
+          model: body.model,
+          messages: body.messages,
+          userId,
+          workspaceId,
+        })) {
+          const line = `data: ${JSON.stringify(event)}\n\n`;
+          controller.enqueue(encoder.encode(line));
+          if (event.type === "done") break;
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error("chat POST: stream error: %s", message);
+        const errorLine = `data: ${JSON.stringify({ type: "error", message })}\n\n`;
+        controller.enqueue(encoder.encode(errorLine));
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+};

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -1,0 +1,9 @@
+import { ChatPanel } from "@/ui/chat/ChatPanel";
+
+export default function ChatPage() {
+  return (
+    <main className="container" style={{ display: "flex", justifyContent: "center" }}>
+      <ChatPanel mode="fullscreen" />
+    </main>
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1600,6 +1600,13 @@ tbody tr:last-child .budget-cm-actual {
   color: var(--muted);
 }
 
+.chat-model-label {
+  font-family: inherit;
+  font-size: 12px;
+  padding: 2px 6px;
+  color: var(--muted);
+}
+
 .chat-attach-btn {
   font-family: inherit;
   font-size: 12px;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1666,6 +1666,15 @@ tbody tr:last-child .budget-cm-actual {
 
 @media (max-width: 768px) {
   .chat-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100% !important;
+    height: 100%;
+    z-index: 100;
+  }
+
+  .chat-resize-handle {
     display: none;
   }
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1405,6 +1405,22 @@ tbody tr:last-child .budget-cm-actual {
   flex-direction: column;
   background: var(--bg);
   z-index: 60;
+  position: relative;
+}
+
+.chat-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  bottom: 0;
+  width: 6px;
+  cursor: col-resize;
+  z-index: 61;
+}
+.chat-resize-handle:hover,
+.chat-resize-handle.dragging {
+  background: var(--panel-border);
+  opacity: 0.4;
 }
 
 .chat-sidebar-fullscreen {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -11,6 +11,10 @@
   box-sizing: border-box;
 }
 
+*:focus {
+  outline: none;
+}
+
 html,
 body {
   margin: 0;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -15,12 +15,16 @@ html,
 body {
   margin: 0;
   padding: 0;
+  height: 100%;
 }
 
 body {
   background: var(--bg);
   color: var(--text);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 a {
@@ -77,6 +81,13 @@ a:hover {
   border-color: var(--text);
 }
 
+.header-sticky {
+  flex-shrink: 0;
+  z-index: 50;
+  background: var(--bg);
+  border-bottom: 1px solid var(--panel-border);
+}
+
 .topbar {
   display: flex;
   justify-content: space-between;
@@ -96,13 +107,11 @@ a:hover {
 
 .container {
   width: 100%;
-  padding: 24px 16px 56px;
+  padding: 0;
 }
 
 .panel {
   background: var(--panel);
-  border: 1px solid var(--panel-border);
-  border-radius: 0;
   padding: 16px;
 }
 
@@ -125,10 +134,6 @@ a:hover {
   padding: 0 16px 12px;
   align-items: center;
   flex-wrap: wrap;
-  position: sticky;
-  top: 0;
-  background: var(--bg);
-  z-index: 50;
 }
 
 .badge {
@@ -1381,12 +1386,15 @@ tbody tr:last-child .budget-cm-actual {
 
 .chat-layout-shell {
   display: flex;
+  flex: 1;
   min-height: 0;
+  overflow: hidden;
 }
 
 .chat-main-content {
   flex: 1;
   min-width: 0;
+  overflow-y: auto;
 }
 
 .chat-sidebar {
@@ -1395,9 +1403,6 @@ tbody tr:last-child .budget-cm-actual {
   border-right: 1px solid var(--panel-border);
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 80px);
-  position: sticky;
-  top: 80px;
   background: var(--bg);
   z-index: 60;
 }
@@ -1408,7 +1413,6 @@ tbody tr:last-child .budget-cm-actual {
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 80px);
   background: var(--bg);
 }
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1377,3 +1377,276 @@ tbody tr:last-child .budget-cm-actual {
   border-color: var(--text);
 }
 
+/* Chat panel */
+
+.chat-layout-shell {
+  display: flex;
+  min-height: 0;
+}
+
+.chat-main-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.chat-sidebar {
+  width: 360px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--panel-border);
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 80px);
+  position: sticky;
+  top: 80px;
+  background: var(--bg);
+  z-index: 60;
+}
+
+.chat-sidebar-fullscreen {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 80px);
+  background: var(--bg);
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--panel-border);
+  flex-shrink: 0;
+}
+
+.chat-header-title {
+  font-size: 12px;
+  font-weight: 650;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.chat-close-btn {
+  background: none;
+  border: 1px solid var(--panel-border);
+  padding: 2px 8px;
+  font-family: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  color: var(--muted);
+  line-height: 1;
+}
+
+.chat-close-btn:hover {
+  color: var(--text);
+  border-color: var(--text);
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chat-empty {
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+  padding: 24px 0;
+}
+
+.chat-msg {
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-width: 85%;
+  padding: 8px 12px;
+}
+
+.chat-msg-user {
+  align-self: flex-end;
+  background: var(--accent);
+  color: var(--bg);
+}
+
+.chat-msg-assistant {
+  align-self: flex-start;
+  border: 1px solid var(--panel-border);
+}
+
+.chat-msg-error {
+  color: #c0392b;
+  border-color: #c0392b;
+}
+
+.chat-streaming-indicator {
+  display: block;
+  color: var(--text);
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.chat-dots {
+  display: inline-block;
+  min-width: 2em;
+  min-height: 1lh;
+}
+
+.chat-dots::after {
+  content: "\200B";
+  animation: dotsReveal 1.2s steps(1) infinite;
+}
+
+@keyframes dotsReveal {
+  0% { content: "\200B"; }
+  25% { content: "."; }
+  50% { content: ".."; }
+  75% { content: "..."; }
+}
+
+.chat-input-area {
+  border-top: 1px solid var(--panel-border);
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 6px;
+  align-items: flex-end;
+}
+
+.chat-textarea {
+  flex: 1;
+  resize: none;
+  font-family: inherit;
+  font-size: 13px;
+  padding: 6px 8px;
+  border: 1px solid var(--panel-border);
+  background: var(--bg);
+  color: var(--text);
+  min-height: 36px;
+  max-height: 120px;
+  outline: none;
+}
+
+.chat-textarea:focus {
+  border-color: var(--text);
+}
+
+.chat-send-btn {
+  font-family: inherit;
+  font-size: 12px;
+  padding: 6px 12px;
+  border: 1px solid var(--panel-border);
+  background: var(--bg);
+  color: var(--muted);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.chat-send-btn:hover {
+  color: var(--text);
+  border-color: var(--text);
+}
+
+.chat-send-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.chat-controls {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.chat-model-select {
+  font-family: inherit;
+  font-size: 12px;
+  padding: 2px 6px;
+  border: 1px solid var(--panel-border);
+  background: var(--bg);
+  color: var(--muted);
+}
+
+.chat-attach-btn {
+  font-family: inherit;
+  font-size: 12px;
+  padding: 2px 8px;
+  border: 1px solid var(--panel-border);
+  background: var(--bg);
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.chat-attach-btn:hover {
+  color: var(--text);
+  border-color: var(--text);
+}
+
+.chat-attachment-preview {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.chat-attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border: 1px solid var(--panel-border);
+}
+
+.chat-attachment-remove {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--muted);
+  font-family: inherit;
+}
+
+.chat-attachment-remove:hover {
+  color: #c0392b;
+}
+
+.chat-toggle-floating {
+  position: fixed;
+  bottom: 16px;
+  left: 16px;
+  z-index: 60;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 6px 12px;
+  border: 1px solid var(--panel-border);
+  background: var(--bg);
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.chat-toggle-floating:hover {
+  color: var(--text);
+  border-color: var(--text);
+}
+
+@media (max-width: 768px) {
+  .chat-sidebar {
+    display: none;
+  }
+}
+

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -51,32 +51,34 @@ export default async function RootLayout(props: Readonly<{ children: React.React
     <html lang="en">
       <body>
         <FilteredModeProvider isDemoMode={demo}>
-          {demo && (
-            <div className="demo-banner">
-              Demo mode — data is static, writes are discarded
-            </div>
-          )}
-          <FilteredBanner />
-          <header className="topbar">
-            <a href="/" className="topbar-brand">Expense Budget Tracker</a>
-            <div className="topbar-actions">
-              <ModeToggle isDemoMode={demo} />
-              <AccountMenu
-                authEnabled={authEnabled}
-                workspaces={workspaces}
-                currentWorkspaceId={currentWorkspaceId}
-              />
-            </div>
-          </header>
-          <nav className="nav">
-            <a href="/budget">Budget</a>
-            <a href="/transactions">Transactions</a>
-            <a href="/balances">Balances</a>
-            <a href="/dashboards">Dashboard</a>
-            <a href="/settings">Settings</a>
-            <a href="/chat">Chat</a>
-            <CurrencySelector initialCurrency={reportingCurrency} />
-          </nav>
+          <div className="header-sticky">
+            {demo && (
+              <div className="demo-banner">
+                Demo mode — data is static, writes are discarded
+              </div>
+            )}
+            <FilteredBanner />
+            <header className="topbar">
+              <a href="/" className="topbar-brand">Expense Budget Tracker</a>
+              <div className="topbar-actions">
+                <ModeToggle isDemoMode={demo} />
+                <AccountMenu
+                  authEnabled={authEnabled}
+                  workspaces={workspaces}
+                  currentWorkspaceId={currentWorkspaceId}
+                />
+              </div>
+            </header>
+            <nav className="nav">
+              <a href="/budget">Budget</a>
+              <a href="/transactions">Transactions</a>
+              <a href="/balances">Balances</a>
+              <a href="/dashboards">Dashboard</a>
+              <a href="/settings">Settings</a>
+              <a href="/chat">Chat</a>
+              <CurrencySelector initialCurrency={reportingCurrency} />
+            </nav>
+          </div>
           <ChatLayoutProvider>
             <ChatLayoutShell>
               {children}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 
+import { readChatCookies } from "@/lib/chatCookies";
 import { isDemoMode } from "@/lib/demoMode";
 import { listWorkspaces, type WorkspaceSummary } from "@/server/listWorkspaces";
 import { getReportCurrency } from "@/server/reportCurrency";
@@ -22,6 +23,7 @@ export const metadata: Metadata = {
 export default async function RootLayout(props: Readonly<{ children: React.ReactNode }>) {
   const { children } = props;
   const demo = await isDemoMode();
+  const { chatOpen, chatWidth } = await readChatCookies();
 
   const authEnabled = process.env.AUTH_MODE === "proxy";
   let reportingCurrency = "USD";
@@ -79,7 +81,7 @@ export default async function RootLayout(props: Readonly<{ children: React.React
               <CurrencySelector initialCurrency={reportingCurrency} />
             </nav>
           </div>
-          <ChatLayoutProvider>
+          <ChatLayoutProvider initialChatOpen={chatOpen} initialChatWidth={chatWidth}>
             <ChatLayoutShell>
               {children}
             </ChatLayoutShell>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,8 @@ import { isDemoMode } from "@/lib/demoMode";
 import { listWorkspaces, type WorkspaceSummary } from "@/server/listWorkspaces";
 import { getReportCurrency } from "@/server/reportCurrency";
 import { AccountMenu } from "@/ui/AccountMenu";
+import { ChatLayoutProvider } from "@/ui/chat/ChatLayoutProvider";
+import { ChatLayoutShell } from "@/ui/chat/ChatLayoutShell";
 import { CurrencySelector } from "@/ui/CurrencySelector";
 import { FilteredBanner } from "@/ui/FilteredBanner";
 import { FilteredModeProvider } from "@/ui/FilteredModeProvider";
@@ -72,9 +74,14 @@ export default async function RootLayout(props: Readonly<{ children: React.React
             <a href="/balances">Balances</a>
             <a href="/dashboards">Dashboard</a>
             <a href="/settings">Settings</a>
+            <a href="/chat">Chat</a>
             <CurrencySelector initialCurrency={reportingCurrency} />
           </nav>
-          {children}
+          <ChatLayoutProvider>
+            <ChatLayoutShell>
+              {children}
+            </ChatLayoutShell>
+          </ChatLayoutProvider>
         </FilteredModeProvider>
       </body>
     </html>

--- a/apps/web/src/lib/chatCookies.ts
+++ b/apps/web/src/lib/chatCookies.ts
@@ -1,0 +1,27 @@
+import { cookies } from "next/headers";
+
+const CHAT_OPEN_COOKIE = "chat-open";
+const CHAT_WIDTH_COOKIE = "chat-width";
+const MIN_WIDTH = 280;
+const MAX_WIDTH = 600;
+const DEFAULT_WIDTH = 360;
+
+type ChatCookies = Readonly<{
+  chatOpen: boolean;
+  chatWidth: number;
+}>;
+
+const clampWidth = (value: number): number =>
+  Math.max(MIN_WIDTH, Math.min(value, MAX_WIDTH));
+
+/** Read chat layout cookies. For Server Components. */
+export const readChatCookies = async (): Promise<ChatCookies> => {
+  const cookieStore = await cookies();
+  const chatOpen = cookieStore.get(CHAT_OPEN_COOKIE)?.value === "true";
+
+  const rawWidth = cookieStore.get(CHAT_WIDTH_COOKIE)?.value;
+  const parsed = rawWidth !== undefined ? Number(rawWidth) : NaN;
+  const chatWidth = Number.isFinite(parsed) ? clampWidth(parsed) : DEFAULT_WIDTH;
+
+  return { chatOpen, chatWidth };
+};

--- a/apps/web/src/lib/chatModels.ts
+++ b/apps/web/src/lib/chatModels.ts
@@ -1,0 +1,14 @@
+export type ChatModelDef = Readonly<{
+  id: string;
+  label: string;
+  vendor: "openai";
+}>;
+
+export const CHAT_MODELS: ReadonlyArray<ChatModelDef> = [
+  { id: "gpt-4.1", label: "GPT-4.1", vendor: "openai" },
+  { id: "gpt-4.1-mini", label: "GPT-4.1 Mini", vendor: "openai" },
+  { id: "gpt-4.1-nano", label: "GPT-4.1 Nano", vendor: "openai" },
+  { id: "gpt-5.2", label: "GPT-5.2", vendor: "openai" },
+];
+
+export const DEFAULT_MODEL_ID = "gpt-4.1-mini";

--- a/apps/web/src/lib/chatModels.ts
+++ b/apps/web/src/lib/chatModels.ts
@@ -16,4 +16,4 @@ export const CHAT_MODELS: ReadonlyArray<ChatModelDef> = [
   { id: "gpt-4.1-nano", label: "GPT-4.1 Nano", vendor: "openai" },
 ];
 
-export const DEFAULT_MODEL_ID = "gpt-5.2";
+export const DEFAULT_MODEL_ID = "claude-opus-4-6";

--- a/apps/web/src/lib/chatModels.ts
+++ b/apps/web/src/lib/chatModels.ts
@@ -1,7 +1,9 @@
+export type ChatModelVendor = "openai" | "anthropic";
+
 export type ChatModelDef = Readonly<{
   id: string;
   label: string;
-  vendor: "openai";
+  vendor: ChatModelVendor;
 }>;
 
 export const CHAT_MODELS: ReadonlyArray<ChatModelDef> = [
@@ -9,6 +11,9 @@ export const CHAT_MODELS: ReadonlyArray<ChatModelDef> = [
   { id: "gpt-4.1-mini", label: "GPT-4.1 Mini", vendor: "openai" },
   { id: "gpt-4.1-nano", label: "GPT-4.1 Nano", vendor: "openai" },
   { id: "gpt-5.2", label: "GPT-5.2", vendor: "openai" },
+  { id: "claude-opus-4-6", label: "Claude Opus 4.6", vendor: "anthropic" },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", vendor: "anthropic" },
+  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", vendor: "anthropic" },
 ];
 
 export const DEFAULT_MODEL_ID = "gpt-5.2";

--- a/apps/web/src/lib/chatModels.ts
+++ b/apps/web/src/lib/chatModels.ts
@@ -11,4 +11,4 @@ export const CHAT_MODELS: ReadonlyArray<ChatModelDef> = [
   { id: "gpt-5.2", label: "GPT-5.2", vendor: "openai" },
 ];
 
-export const DEFAULT_MODEL_ID = "gpt-4.1-mini";
+export const DEFAULT_MODEL_ID = "gpt-5.2";

--- a/apps/web/src/lib/chatModels.ts
+++ b/apps/web/src/lib/chatModels.ts
@@ -7,13 +7,13 @@ export type ChatModelDef = Readonly<{
 }>;
 
 export const CHAT_MODELS: ReadonlyArray<ChatModelDef> = [
-  { id: "gpt-4.1", label: "GPT-4.1", vendor: "openai" },
-  { id: "gpt-4.1-mini", label: "GPT-4.1 Mini", vendor: "openai" },
-  { id: "gpt-4.1-nano", label: "GPT-4.1 Nano", vendor: "openai" },
-  { id: "gpt-5.2", label: "GPT-5.2", vendor: "openai" },
   { id: "claude-opus-4-6", label: "Claude Opus 4.6", vendor: "anthropic" },
   { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", vendor: "anthropic" },
   { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", vendor: "anthropic" },
+  { id: "gpt-5.2", label: "GPT-5.2", vendor: "openai" },
+  { id: "gpt-4.1", label: "GPT-4.1", vendor: "openai" },
+  { id: "gpt-4.1-mini", label: "GPT-4.1 Mini", vendor: "openai" },
+  { id: "gpt-4.1-nano", label: "GPT-4.1 Nano", vendor: "openai" },
 ];
 
 export const DEFAULT_MODEL_ID = "gpt-5.2";

--- a/apps/web/src/server/chat/anthropic/agent.ts
+++ b/apps/web/src/server/chat/anthropic/agent.ts
@@ -1,0 +1,119 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import type { ChatMessage, ChatStreamEvent } from "@/server/chat/types";
+import {
+  SYSTEM_INSTRUCTIONS,
+  extractText,
+  summarizeContent,
+} from "@/server/chat/shared";
+import {
+  createDbMcpServer,
+  QUALIFIED_TOOL_NAME,
+  MCP_SERVER_NAME,
+  MCP_TOOL_NAME,
+} from "./tools";
+
+export type StreamAgentParams = Readonly<{
+  messages: ReadonlyArray<ChatMessage>;
+  model: string;
+  userId: string;
+  workspaceId: string;
+}>;
+
+const MCP_TOOL_PREFIX = `mcp__${MCP_SERVER_NAME}__`;
+
+const stripMcpPrefix = (name: string): string =>
+  name.startsWith(MCP_TOOL_PREFIX)
+    ? name.slice(MCP_TOOL_PREFIX.length)
+    : name;
+
+const buildPromptText = (messages: ReadonlyArray<ChatMessage>): string => {
+  const parts: Array<string> = [];
+  for (const msg of messages) {
+    const prefix = msg.role === "user" ? "User" : "Assistant";
+    const text =
+      msg.role === "assistant"
+        ? extractText(msg.content)
+        : summarizeContent(msg.content);
+    parts.push(`${prefix}: ${text}`);
+  }
+  return parts.join("\n\n");
+};
+
+export async function* streamAgentResponse(
+  params: StreamAgentParams,
+): AsyncGenerator<ChatStreamEvent> {
+  const mcpServer = createDbMcpServer(params.userId, params.workspaceId);
+
+  const promptText = buildPromptText(params.messages);
+
+  const abortController = new AbortController();
+
+  const stream = query({
+    prompt: promptText,
+    options: {
+      model: params.model,
+      systemPrompt: SYSTEM_INSTRUCTIONS,
+      mcpServers: { [MCP_SERVER_NAME]: mcpServer },
+      allowedTools: [QUALIFIED_TOOL_NAME],
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+      persistSession: false,
+      maxTurns: 10,
+      includePartialMessages: true,
+      abortController,
+    },
+  });
+
+  try {
+    for await (const message of stream) {
+      if (message.type === "stream_event") {
+        const event = message.event;
+
+        if (
+          event.type === "content_block_delta" &&
+          event.delta.type === "text_delta"
+        ) {
+          yield { type: "delta", text: event.delta.text };
+        }
+
+        if (
+          event.type === "content_block_start" &&
+          event.content_block.type === "tool_use"
+        ) {
+          yield {
+            type: "tool_call",
+            name: stripMcpPrefix(event.content_block.name),
+            status: "started",
+          };
+        }
+      }
+
+      if (message.type === "assistant") {
+        for (const block of message.message.content) {
+          if (block.type === "tool_use") {
+            yield {
+              type: "tool_call",
+              name: stripMcpPrefix(block.name),
+              status: "completed",
+            };
+          }
+        }
+      }
+
+      if (message.type === "result") {
+        if (message.subtype === "success") {
+          yield { type: "done" };
+        } else {
+          const errorText = message.errors?.join("; ") ?? "Unknown error";
+          yield { type: "error", message: errorText };
+        }
+        return;
+      }
+    }
+
+    yield { type: "done" };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    yield { type: "error", message: errorMessage };
+  }
+}

--- a/apps/web/src/server/chat/anthropic/tools.ts
+++ b/apps/web/src/server/chat/anthropic/tools.ts
@@ -3,6 +3,11 @@ import { TOOL_DESCRIPTION, execQuery } from "@/server/chat/shared";
 
 export const TOOL_NAME = "query_database";
 
+export const CODE_EXECUTION_TOOL: Anthropic.Beta.Messages.BetaCodeExecutionTool20250825 = {
+  type: "code_execution_20250825",
+  name: "code_execution",
+};
+
 export const DB_TOOL: Anthropic.Tool = {
   name: TOOL_NAME,
   description: TOOL_DESCRIPTION,

--- a/apps/web/src/server/chat/anthropic/tools.ts
+++ b/apps/web/src/server/chat/anthropic/tools.ts
@@ -1,0 +1,39 @@
+import { tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { TOOL_DESCRIPTION, execQuery } from "@/server/chat/shared";
+
+type McpServer = ReturnType<typeof createSdkMcpServer>;
+
+export const MCP_SERVER_NAME = "expense-tracker-db";
+export const MCP_TOOL_NAME = "query_database";
+export const QUALIFIED_TOOL_NAME = `mcp__${MCP_SERVER_NAME}__${MCP_TOOL_NAME}`;
+
+export const createDbMcpServer = (
+  userId: string,
+  workspaceId: string,
+): McpServer =>
+  createSdkMcpServer({
+    name: MCP_SERVER_NAME,
+    version: "1.0.0",
+    tools: [
+      tool(
+        MCP_TOOL_NAME,
+        TOOL_DESCRIPTION,
+        {
+          sql: z.string().describe("SQL statement to execute (SELECT, INSERT, UPDATE, DELETE)"),
+        },
+        async (args: { sql: string }) => {
+          try {
+            const result = await execQuery(args.sql, userId, workspaceId);
+            return { content: [{ type: "text" as const, text: result.json }] };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return {
+              isError: true,
+              content: [{ type: "text" as const, text: message }],
+            };
+          }
+        },
+      ),
+    ],
+  });

--- a/apps/web/src/server/chat/openai/agent.ts
+++ b/apps/web/src/server/chat/openai/agent.ts
@@ -1,0 +1,164 @@
+import { Agent, run } from "@openai/agents";
+import { codeInterpreterTool } from "@openai/agents-openai";
+import type {
+  ChatMessage,
+  ChatStreamEvent,
+  ContentPart,
+} from "@/server/chat/types";
+import { pgQueryTool, type AgentContext } from "./tools";
+
+// Agents SDK protocol format — NOT the Responses API wire format.
+// The SDK reads `image` (not `image_url`) and `file` (not `file_data`).
+type UserContentPart =
+  | { type: "input_text"; text: string }
+  | { type: "input_image"; image: string }
+  | { type: "input_file"; file: string; filename: string };
+
+type AssistantContentPart = { type: "output_text"; text: string };
+
+type InputMessage =
+  | { role: "user"; content: string | ReadonlyArray<UserContentPart> }
+  | { role: "assistant"; content: ReadonlyArray<AssistantContentPart> };
+
+const SYSTEM_INSTRUCTIONS = `You are a financial assistant for an expense tracker app.
+You have access to the user's expense database via the query_database tool and a code interpreter for analysis.
+When the user asks about their finances, write SQL queries to fetch the data.
+Present results clearly with formatting. Use the code interpreter for calculations, charts, or file analysis.
+Be concise and direct. If a query returns no data, say so clearly.`;
+
+const mapUserPart = (part: ContentPart): UserContentPart => {
+  switch (part.type) {
+    case "text":
+      return { type: "input_text", text: part.text };
+    case "image":
+      return {
+        type: "input_image",
+        image: `data:${part.mediaType};base64,${part.base64Data}`,
+      };
+    case "file":
+      return {
+        type: "input_file",
+        file: `data:${part.mediaType};base64,${part.base64Data}`,
+        filename: part.fileName,
+      };
+  }
+};
+
+const extractText = (content: ReadonlyArray<ContentPart>): string =>
+  content
+    .filter((p) => p.type === "text")
+    .map((p) => (p.type === "text" ? p.text : ""))
+    .join("");
+
+const summarizeContent = (content: ReadonlyArray<ContentPart>): string => {
+  const parts: Array<string> = [];
+  for (const p of content) {
+    if (p.type === "text") {
+      parts.push(p.text);
+    } else if (p.type === "image") {
+      parts.push("[attached image]");
+    } else if (p.type === "file") {
+      parts.push(`[attached file: ${p.fileName}]`);
+    }
+  }
+  return parts.join("\n");
+};
+
+const buildInput = (
+  messages: ReadonlyArray<ChatMessage>,
+): ReadonlyArray<InputMessage> => {
+  // Only include actual file data for the latest user message;
+  // older attachments are summarized as text since the model already saw them.
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  const result: Array<InputMessage> = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    if (msg.role === "assistant") {
+      result.push({
+        role: "assistant",
+        content: [{ type: "output_text", text: extractText(msg.content) }],
+      });
+      continue;
+    }
+
+    // User message
+    const hasAttachments = msg.content.some((p) => p.type !== "text");
+
+    if (!hasAttachments) {
+      if (msg.content.length === 1 && msg.content[0].type === "text") {
+        result.push({ role: "user", content: msg.content[0].text });
+      } else {
+        result.push({ role: "user", content: extractText(msg.content) });
+      }
+      continue;
+    }
+
+    if (i === lastUserIdx) {
+      result.push({ role: "user", content: msg.content.map(mapUserPart) });
+    } else {
+      result.push({ role: "user", content: summarizeContent(msg.content) });
+    }
+  }
+  return result;
+};
+
+export type StreamAgentParams = Readonly<{
+  messages: ReadonlyArray<ChatMessage>;
+  model: string;
+  userId: string;
+  workspaceId: string;
+}>;
+
+export async function* streamAgentResponse(
+  params: StreamAgentParams,
+): AsyncGenerator<ChatStreamEvent> {
+  const agent = new Agent<AgentContext>({
+    name: "Expense Assistant",
+    instructions: SYSTEM_INSTRUCTIONS,
+    model: params.model,
+    tools: [pgQueryTool, codeInterpreterTool()],
+  });
+
+  const context: AgentContext = {
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+  };
+
+  const input = buildInput(params.messages);
+
+  const result = await run(agent, input as Parameters<typeof run>[1], {
+    stream: true,
+    context,
+    maxTurns: 10,
+  });
+
+  let activeToolName: string | null = null;
+
+  for await (const event of result) {
+    if (event.type === "raw_model_stream_event") {
+      if (event.data.type === "output_text_delta") {
+        yield { type: "delta", text: event.data.delta };
+      }
+    } else if (event.type === "run_item_stream_event") {
+      if (event.name === "tool_called" && event.item.type === "tool_call_item") {
+        activeToolName = event.item.rawItem.type === "function_call"
+          ? event.item.rawItem.name
+          : event.item.rawItem.type;
+        yield { type: "tool_call", name: activeToolName, status: "started" };
+      } else if (event.name === "tool_output" && event.item.type === "tool_call_output_item") {
+        yield { type: "tool_call", name: activeToolName ?? "tool", status: "completed" };
+        activeToolName = null;
+      }
+    }
+  }
+
+  yield { type: "done" };
+}

--- a/apps/web/src/server/chat/openai/agent.ts
+++ b/apps/web/src/server/chat/openai/agent.ts
@@ -1,5 +1,5 @@
 import { Agent, run } from "@openai/agents";
-import { codeInterpreterTool } from "@openai/agents-openai";
+import { codeInterpreterTool, webSearchTool } from "@openai/agents-openai";
 import type {
   ChatMessage,
   ChatStreamEvent,
@@ -27,7 +27,8 @@ type InputMessage =
 
 const OPENAI_SYSTEM_INSTRUCTIONS =
   SYSTEM_INSTRUCTIONS +
-  "\nYou also have a code interpreter for calculations, charts, or file analysis. Use it when appropriate.";
+  "\nYou also have a code interpreter for calculations, charts, or file analysis. Use it when appropriate." +
+  "\nYou also have web search. Use it to look up current exchange rates, financial news, tax rules, or any other real-time information.";
 
 const mapUserPart = (part: ContentPart): UserContentPart => {
   switch (part.type) {
@@ -107,7 +108,7 @@ export async function* streamAgentResponse(
     name: "Expense Assistant",
     instructions: OPENAI_SYSTEM_INSTRUCTIONS,
     model: params.model,
-    tools: [pgQueryTool, codeInterpreterTool()],
+    tools: [pgQueryTool, codeInterpreterTool(), webSearchTool({ searchContextSize: "medium" })],
   });
 
   const context: AgentContext = {

--- a/apps/web/src/server/chat/openai/agent.ts
+++ b/apps/web/src/server/chat/openai/agent.ts
@@ -22,6 +22,9 @@ type InputMessage =
 
 const SYSTEM_INSTRUCTIONS = `You are a financial assistant for an expense tracker app.
 You have access to the user's expense database via the query_database tool and a code interpreter for analysis.
+You can read data (SELECT) and write data (INSERT, UPDATE, DELETE) — for example, adding transactions, updating budgets, or deleting entries.
+Before any write operation (INSERT, UPDATE, DELETE), you MUST first describe the exact changes you plan to make and wait for the user's explicit confirmation. Only execute the write after the user approves. Read queries (SELECT) do not require confirmation.
+When inserting rows, always include the workspace_id column.
 When the user asks about their finances, write SQL queries to fetch the data.
 Present results clearly with formatting. Use the code interpreter for calculations, charts, or file analysis.
 Be concise and direct. If a query returns no data, say so clearly.`;

--- a/apps/web/src/server/chat/openai/tools.ts
+++ b/apps/web/src/server/chat/openai/tools.ts
@@ -10,24 +10,28 @@ export type AgentContext = Readonly<{
 const MAX_ROWS = 100;
 const STATEMENT_TIMEOUT_MS = 10_000;
 
-const isSelectOnly = (sql: string): boolean => {
+const ALLOWED_FIRST_KEYWORDS = new Set([
+  "SELECT", "WITH", "INSERT", "UPDATE", "DELETE",
+]);
+
+const isDml = (sql: string): boolean => {
   const first = sql.trimStart().split(/\s/)[0]?.toUpperCase();
-  return first === "SELECT" || first === "WITH";
+  return first !== undefined && ALLOWED_FIRST_KEYWORDS.has(first);
 };
 
 export const pgQueryTool = tool({
   name: "query_database",
-  description: `Execute a read-only SQL query against the expense tracker database.
-Tables: ledger_entries (ts, account_id, amount, currency, kind, category, counterparty, note),
-        budget_lines (budget_month, direction, category, planned_value, currency),
+  description: `Execute a SQL statement (SELECT, INSERT, UPDATE, DELETE) against the expense tracker database.
+Tables: ledger_entries (ts, account_id, amount, currency, kind, category, counterparty, note, workspace_id),
+        budget_lines (budget_month, direction, category, planned_value, currency, workspace_id),
         exchange_rates (base_currency, quote_currency, rate_date, rate),
         workspace_settings (reporting_currency, filtered_categories),
-        account_metadata (account_id, liquidity).
+        account_metadata (account_id, liquidity, workspace_id).
 View: accounts (account_id, currency, inserted_at).
 kind is one of: 'income', 'spend', 'transfer'.
-All data is workspace-scoped via RLS. Use standard SQL.`,
+All data is workspace-scoped via RLS. INSERTs must include workspace_id. Use standard SQL.`,
   parameters: z.object({
-    sql: z.string().describe("SELECT query to execute"),
+    sql: z.string().describe("SQL statement to execute (SELECT, INSERT, UPDATE, DELETE)"),
   }),
   execute: async (
     input: { sql: string },
@@ -39,8 +43,8 @@ All data is workspace-scoped via RLS. Use standard SQL.`,
 
     const { userId, workspaceId } = runContext.context;
 
-    if (!isSelectOnly(input.sql)) {
-      throw new Error("Only SELECT or WITH queries are allowed");
+    if (!isDml(input.sql)) {
+      throw new Error("Only SELECT, WITH, INSERT, UPDATE, DELETE statements are allowed");
     }
 
     const result = await withUserContext(userId, workspaceId, async (queryFn) => {
@@ -52,6 +56,9 @@ All data is workspace-scoped via RLS. Use standard SQL.`,
     });
 
     const rows = result.rows.slice(0, MAX_ROWS);
-    return JSON.stringify(rows);
+    if (rows.length > 0) {
+      return JSON.stringify(rows);
+    }
+    return JSON.stringify({ rowCount: result.rowCount });
   },
 });

--- a/apps/web/src/server/chat/openai/tools.ts
+++ b/apps/web/src/server/chat/openai/tools.ts
@@ -1,0 +1,57 @@
+import { tool, type RunContext } from "@openai/agents";
+import { z } from "zod";
+import { withUserContext } from "@/server/db";
+
+export type AgentContext = Readonly<{
+  userId: string;
+  workspaceId: string;
+}>;
+
+const MAX_ROWS = 100;
+const STATEMENT_TIMEOUT_MS = 10_000;
+
+const isSelectOnly = (sql: string): boolean => {
+  const first = sql.trimStart().split(/\s/)[0]?.toUpperCase();
+  return first === "SELECT" || first === "WITH";
+};
+
+export const pgQueryTool = tool({
+  name: "query_database",
+  description: `Execute a read-only SQL query against the expense tracker database.
+Tables: ledger_entries (ts, account_id, amount, currency, kind, category, counterparty, note),
+        budget_lines (budget_month, direction, category, planned_value, currency),
+        exchange_rates (base_currency, quote_currency, rate_date, rate),
+        workspace_settings (reporting_currency, filtered_categories),
+        account_metadata (account_id, liquidity).
+View: accounts (account_id, currency, inserted_at).
+kind is one of: 'income', 'spend', 'transfer'.
+All data is workspace-scoped via RLS. Use standard SQL.`,
+  parameters: z.object({
+    sql: z.string().describe("SELECT query to execute"),
+  }),
+  execute: async (
+    input: { sql: string },
+    runContext?: RunContext<AgentContext>,
+  ): Promise<string> => {
+    if (runContext === undefined) {
+      throw new Error("pgQueryTool: missing run context");
+    }
+
+    const { userId, workspaceId } = runContext.context;
+
+    if (!isSelectOnly(input.sql)) {
+      throw new Error("Only SELECT or WITH queries are allowed");
+    }
+
+    const result = await withUserContext(userId, workspaceId, async (queryFn) => {
+      await queryFn(
+        `SET LOCAL statement_timeout = '${STATEMENT_TIMEOUT_MS}'`,
+        [],
+      );
+      return queryFn(input.sql, []);
+    });
+
+    const rows = result.rows.slice(0, MAX_ROWS);
+    return JSON.stringify(rows);
+  },
+});

--- a/apps/web/src/server/chat/openai/tools.ts
+++ b/apps/web/src/server/chat/openai/tools.ts
@@ -1,35 +1,15 @@
 import { tool, type RunContext } from "@openai/agents";
 import { z } from "zod";
-import { withUserContext } from "@/server/db";
+import { TOOL_DESCRIPTION, execQuery } from "@/server/chat/shared";
 
 export type AgentContext = Readonly<{
   userId: string;
   workspaceId: string;
 }>;
 
-const MAX_ROWS = 100;
-const STATEMENT_TIMEOUT_MS = 10_000;
-
-const ALLOWED_FIRST_KEYWORDS = new Set([
-  "SELECT", "WITH", "INSERT", "UPDATE", "DELETE",
-]);
-
-const isDml = (sql: string): boolean => {
-  const first = sql.trimStart().split(/\s/)[0]?.toUpperCase();
-  return first !== undefined && ALLOWED_FIRST_KEYWORDS.has(first);
-};
-
 export const pgQueryTool = tool({
   name: "query_database",
-  description: `Execute a SQL statement (SELECT, INSERT, UPDATE, DELETE) against the expense tracker database.
-Tables: ledger_entries (ts, account_id, amount, currency, kind, category, counterparty, note, workspace_id),
-        budget_lines (budget_month, direction, category, planned_value, currency, workspace_id),
-        exchange_rates (base_currency, quote_currency, rate_date, rate),
-        workspace_settings (reporting_currency, filtered_categories),
-        account_metadata (account_id, liquidity, workspace_id).
-View: accounts (account_id, currency, inserted_at).
-kind is one of: 'income', 'spend', 'transfer'.
-All data is workspace-scoped via RLS. INSERTs must include workspace_id. Use standard SQL.`,
+  description: TOOL_DESCRIPTION,
   parameters: z.object({
     sql: z.string().describe("SQL statement to execute (SELECT, INSERT, UPDATE, DELETE)"),
   }),
@@ -42,23 +22,7 @@ All data is workspace-scoped via RLS. INSERTs must include workspace_id. Use sta
     }
 
     const { userId, workspaceId } = runContext.context;
-
-    if (!isDml(input.sql)) {
-      throw new Error("Only SELECT, WITH, INSERT, UPDATE, DELETE statements are allowed");
-    }
-
-    const result = await withUserContext(userId, workspaceId, async (queryFn) => {
-      await queryFn(
-        `SET LOCAL statement_timeout = '${STATEMENT_TIMEOUT_MS}'`,
-        [],
-      );
-      return queryFn(input.sql, []);
-    });
-
-    const rows = result.rows.slice(0, MAX_ROWS);
-    if (rows.length > 0) {
-      return JSON.stringify(rows);
-    }
-    return JSON.stringify({ rowCount: result.rowCount });
+    const result = await execQuery(input.sql, userId, workspaceId);
+    return result.json;
   },
 });

--- a/apps/web/src/server/chat/shared.ts
+++ b/apps/web/src/server/chat/shared.ts
@@ -11,7 +11,8 @@ Before any write operation (INSERT, UPDATE, DELETE), you MUST first describe the
 When inserting rows, always include the workspace_id column.
 When the user asks about their finances, write SQL queries to fetch the data.
 Present results clearly with formatting.
-Be concise and direct. If a query returns no data, say so clearly.`;
+Be concise and direct. If a query returns no data, say so clearly.
+You also have web search. Use it to look up current exchange rates, financial news, tax rules, or any other real-time information when the user's question goes beyond the data in the database.`;
 
 export const TOOL_DESCRIPTION = `Execute a SQL statement (SELECT, INSERT, UPDATE, DELETE) against the expense tracker database.
 Tables: ledger_entries (ts, account_id, amount, currency, kind, category, counterparty, note, workspace_id),

--- a/apps/web/src/server/chat/shared.ts
+++ b/apps/web/src/server/chat/shared.ts
@@ -1,0 +1,81 @@
+import type { ContentPart } from "@/server/chat/types";
+import { withUserContext } from "@/server/db";
+
+export const MAX_ROWS = 100;
+export const STATEMENT_TIMEOUT_MS = 10_000;
+
+export const SYSTEM_INSTRUCTIONS = `You are a financial assistant for an expense tracker app.
+You have access to the user's expense database via the query_database tool.
+You can read data (SELECT) and write data (INSERT, UPDATE, DELETE) — for example, adding transactions, updating budgets, or deleting entries.
+Before any write operation (INSERT, UPDATE, DELETE), you MUST first describe the exact changes you plan to make and wait for the user's explicit confirmation. Only execute the write after the user approves. Read queries (SELECT) do not require confirmation.
+When inserting rows, always include the workspace_id column.
+When the user asks about their finances, write SQL queries to fetch the data.
+Present results clearly with formatting.
+Be concise and direct. If a query returns no data, say so clearly.`;
+
+export const TOOL_DESCRIPTION = `Execute a SQL statement (SELECT, INSERT, UPDATE, DELETE) against the expense tracker database.
+Tables: ledger_entries (ts, account_id, amount, currency, kind, category, counterparty, note, workspace_id),
+        budget_lines (budget_month, direction, category, planned_value, currency, workspace_id),
+        exchange_rates (base_currency, quote_currency, rate_date, rate),
+        workspace_settings (reporting_currency, filtered_categories),
+        account_metadata (account_id, liquidity, workspace_id).
+View: accounts (account_id, currency, inserted_at).
+kind is one of: 'income', 'spend', 'transfer'.
+All data is workspace-scoped via RLS. INSERTs must include workspace_id. Use standard SQL.`;
+
+const ALLOWED_FIRST_KEYWORDS = new Set([
+  "SELECT", "WITH", "INSERT", "UPDATE", "DELETE",
+]);
+
+export const isDml = (sql: string): boolean => {
+  const first = sql.trimStart().split(/\s/)[0]?.toUpperCase();
+  return first !== undefined && ALLOWED_FIRST_KEYWORDS.has(first);
+};
+
+export type QueryResult = Readonly<{
+  json: string;
+}>;
+
+export const execQuery = async (
+  sql: string,
+  userId: string,
+  workspaceId: string,
+): Promise<QueryResult> => {
+  if (!isDml(sql)) {
+    throw new Error("Only SELECT, WITH, INSERT, UPDATE, DELETE statements are allowed");
+  }
+
+  const result = await withUserContext(userId, workspaceId, async (queryFn) => {
+    await queryFn(
+      `SET LOCAL statement_timeout = '${STATEMENT_TIMEOUT_MS}'`,
+      [],
+    );
+    return queryFn(sql, []);
+  });
+
+  const rows = result.rows.slice(0, MAX_ROWS);
+  if (rows.length > 0) {
+    return { json: JSON.stringify(rows) };
+  }
+  return { json: JSON.stringify({ rowCount: result.rowCount }) };
+};
+
+export const extractText = (content: ReadonlyArray<ContentPart>): string =>
+  content
+    .filter((p) => p.type === "text")
+    .map((p) => (p.type === "text" ? p.text : ""))
+    .join("");
+
+export const summarizeContent = (content: ReadonlyArray<ContentPart>): string => {
+  const parts: Array<string> = [];
+  for (const p of content) {
+    if (p.type === "text") {
+      parts.push(p.text);
+    } else if (p.type === "image") {
+      parts.push("[attached image]");
+    } else if (p.type === "file") {
+      parts.push(`[attached file: ${p.fileName}]`);
+    }
+  }
+  return parts.join("\n");
+};

--- a/apps/web/src/server/chat/types.ts
+++ b/apps/web/src/server/chat/types.ts
@@ -1,0 +1,32 @@
+export type ChatRole = "user" | "assistant";
+
+export type TextContentPart = Readonly<{
+  type: "text";
+  text: string;
+}>;
+
+export type ImageContentPart = Readonly<{
+  type: "image";
+  mediaType: string;
+  base64Data: string;
+}>;
+
+export type FileContentPart = Readonly<{
+  type: "file";
+  mediaType: string;
+  base64Data: string;
+  fileName: string;
+}>;
+
+export type ContentPart = TextContentPart | ImageContentPart | FileContentPart;
+
+export type ChatMessage = Readonly<{
+  role: ChatRole;
+  content: ReadonlyArray<ContentPart>;
+}>;
+
+export type ChatStreamEvent =
+  | Readonly<{ type: "delta"; text: string }>
+  | Readonly<{ type: "tool_call"; name: string; status: "started" | "completed" }>
+  | Readonly<{ type: "done" }>
+  | Readonly<{ type: "error"; message: string }>;

--- a/apps/web/src/ui/chat/ChatLayoutProvider.tsx
+++ b/apps/web/src/ui/chat/ChatLayoutProvider.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, type ReactElement, type ReactNode } from "react";
+
+type ChatLayoutContextValue = Readonly<{
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+}>;
+
+const STORAGE_KEY = "expense-tracker-chat-open";
+
+const ChatLayoutContext = createContext<ChatLayoutContextValue | null>(null);
+
+type Props = Readonly<{
+  children: ReactNode;
+}>;
+
+export const ChatLayoutProvider = (props: Props): ReactElement => {
+  const { children } = props;
+  const [isOpen, setIsOpenState] = useState<boolean>(false);
+
+  // Restore from localStorage after hydration
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === "true") {
+      setIsOpenState(true);
+    }
+  }, []);
+
+  const setIsOpen = (open: boolean): void => {
+    setIsOpenState(open);
+    localStorage.setItem(STORAGE_KEY, String(open));
+  };
+
+  return (
+    <ChatLayoutContext.Provider value={{ isOpen, setIsOpen }}>
+      {children}
+    </ChatLayoutContext.Provider>
+  );
+};
+
+export const useChatLayout = (): ChatLayoutContextValue => {
+  const ctx = useContext(ChatLayoutContext);
+  if (ctx === null) {
+    throw new Error("useChatLayout must be used within a ChatLayoutProvider");
+  }
+  return ctx;
+};

--- a/apps/web/src/ui/chat/ChatLayoutProvider.tsx
+++ b/apps/web/src/ui/chat/ChatLayoutProvider.tsx
@@ -1,39 +1,45 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState, type ReactElement, type ReactNode } from "react";
+import { createContext, useContext, useState, type ReactElement, type ReactNode } from "react";
 
 type ChatLayoutContextValue = Readonly<{
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
+  chatWidth: number;
+  setChatWidth: (width: number) => void;
 }>;
-
-const STORAGE_KEY = "expense-tracker-chat-open";
 
 const ChatLayoutContext = createContext<ChatLayoutContextValue | null>(null);
 
+const COOKIE_MAX_AGE = "max-age=31536000";
+
+const writeCookie = (name: string, value: string): void => {
+  document.cookie = `${name}=${value}; path=/; ${COOKIE_MAX_AGE}`;
+};
+
 type Props = Readonly<{
   children: ReactNode;
+  initialChatOpen: boolean;
+  initialChatWidth: number;
 }>;
 
 export const ChatLayoutProvider = (props: Props): ReactElement => {
-  const { children } = props;
-  const [isOpen, setIsOpenState] = useState<boolean>(false);
-
-  // Restore from localStorage after hydration
-  useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved === "true") {
-      setIsOpenState(true);
-    }
-  }, []);
+  const { children, initialChatOpen, initialChatWidth } = props;
+  const [isOpen, setIsOpenState] = useState<boolean>(initialChatOpen);
+  const [chatWidth, setChatWidthState] = useState<number>(initialChatWidth);
 
   const setIsOpen = (open: boolean): void => {
     setIsOpenState(open);
-    localStorage.setItem(STORAGE_KEY, String(open));
+    writeCookie("chat-open", String(open));
+  };
+
+  const setChatWidth = (width: number): void => {
+    setChatWidthState(width);
+    writeCookie("chat-width", String(Math.round(width)));
   };
 
   return (
-    <ChatLayoutContext.Provider value={{ isOpen, setIsOpen }}>
+    <ChatLayoutContext.Provider value={{ isOpen, setIsOpen, chatWidth, setChatWidth }}>
       {children}
     </ChatLayoutContext.Provider>
   );

--- a/apps/web/src/ui/chat/ChatLayoutShell.tsx
+++ b/apps/web/src/ui/chat/ChatLayoutShell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { usePathname } from "next/navigation";
 import type { ReactElement, ReactNode } from "react";
 import { useChatLayout } from "./ChatLayoutProvider";
 import { ChatPanel } from "./ChatPanel";
@@ -12,14 +13,16 @@ type Props = Readonly<{
 export const ChatLayoutShell = (props: Props): ReactElement => {
   const { children } = props;
   const { isOpen } = useChatLayout();
+  const pathname = usePathname();
+  const isFullscreenChat = pathname === "/chat";
 
   return (
     <div className="chat-layout-shell">
-      {isOpen && <ChatPanel mode="sidebar" />}
+      {!isFullscreenChat && isOpen && <ChatPanel mode="sidebar" />}
       <div className="chat-main-content">
         {children}
       </div>
-      {!isOpen && <ChatToggle />}
+      {!isFullscreenChat && !isOpen && <ChatToggle />}
     </div>
   );
 };

--- a/apps/web/src/ui/chat/ChatLayoutShell.tsx
+++ b/apps/web/src/ui/chat/ChatLayoutShell.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import type { ReactElement, ReactNode } from "react";
+import { useChatLayout } from "./ChatLayoutProvider";
+import { ChatPanel } from "./ChatPanel";
+import { ChatToggle } from "./ChatToggle";
+
+type Props = Readonly<{
+  children: ReactNode;
+}>;
+
+export const ChatLayoutShell = (props: Props): ReactElement => {
+  const { children } = props;
+  const { isOpen } = useChatLayout();
+
+  return (
+    <div className="chat-layout-shell">
+      {isOpen && <ChatPanel mode="sidebar" />}
+      <div className="chat-main-content">
+        {children}
+      </div>
+      {!isOpen && <ChatToggle />}
+    </div>
+  );
+};

--- a/apps/web/src/ui/chat/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/ChatPanel.tsx
@@ -337,7 +337,7 @@ export const ChatPanel = (props: Props): ReactElement => {
             className="chat-close-btn"
             onClick={() => setIsOpen(false)}
           >
-            &times;
+            &laquo;
           </button>
         )}
       </div>

--- a/apps/web/src/ui/chat/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/ChatPanel.tsx
@@ -390,7 +390,15 @@ export const ChatPanel = (props: Props): ReactElement => {
           <button
             type="button"
             className="chat-attach-btn"
-            onClick={clearHistory}
+            onClick={() => {
+              if (abortRef.current !== null) {
+                abortRef.current.abort();
+                abortRef.current = null;
+              }
+              setIsStreaming(false);
+              setToolStatus(null);
+              clearHistory();
+            }}
           >
             Clear
           </button>

--- a/apps/web/src/ui/chat/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/ChatPanel.tsx
@@ -385,7 +385,7 @@ export const ChatPanel = (props: Props): ReactElement => {
           </div>
         )}
         <div className="chat-controls">
-          <ModelSelector value={selectedModel} onChange={handleModelChange} />
+          <ModelSelector value={selectedModel} onChange={handleModelChange} disabled={messages.length > 0 || isStreaming} />
           <FileAttachment onAttach={handleAttach} />
           <button
             type="button"

--- a/apps/web/src/ui/chat/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/ChatPanel.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+} from "react";
+import type { ChatStreamEvent, ContentPart } from "@/server/chat/types";
+import { DEFAULT_MODEL_ID } from "@/lib/chatModels";
+import { useChatHistory, type StoredMessage } from "@/ui/hooks/useChatHistory";
+import { useChatLayout } from "./ChatLayoutProvider";
+import { ModelSelector } from "./ModelSelector";
+import { FileAttachment, type PendingAttachment } from "./FileAttachment";
+
+type Props = Readonly<{
+  mode: "sidebar" | "fullscreen";
+}>;
+
+const STORAGE_MODEL_KEY = "expense-tracker-chat-model";
+
+const IMAGE_MEDIA_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+const buildContentParts = (
+  text: string,
+  attachments: ReadonlyArray<PendingAttachment>,
+): ReadonlyArray<ContentPart> => {
+  const parts: Array<ContentPart> = [];
+
+  for (const att of attachments) {
+    if (IMAGE_MEDIA_TYPES.has(att.mediaType)) {
+      parts.push({ type: "image", mediaType: att.mediaType, base64Data: att.base64Data });
+    } else {
+      parts.push({
+        type: "file",
+        mediaType: att.mediaType,
+        base64Data: att.base64Data,
+        fileName: att.fileName,
+      });
+    }
+  }
+
+  if (text.trim().length > 0) {
+    parts.push({ type: "text", text: text.trim() });
+  }
+
+  return parts;
+};
+
+const parseSSELine = (line: string): ChatStreamEvent | null => {
+  if (!line.startsWith("data: ")) return null;
+  try {
+    return JSON.parse(line.slice(6)) as ChatStreamEvent;
+  } catch {
+    return null;
+  }
+};
+
+const renderMessageContent = (msg: StoredMessage): string => {
+  const textParts = msg.content.filter((p) => p.type === "text");
+  const fileParts = msg.content.filter((p) => p.type === "file" || p.type === "image");
+  let result = textParts.map((p) => (p.type === "text" ? p.text : "")).join("");
+  if (fileParts.length > 0) {
+    const fileNames = fileParts.map((p) => (p.type === "file" ? p.fileName : "[image]"));
+    result = `[${fileNames.join(", ")}]\n${result}`;
+  }
+  return result;
+};
+
+export const ChatPanel = (props: Props): ReactElement => {
+  const { mode } = props;
+  const { setIsOpen } = useChatLayout();
+  const {
+    messages,
+    appendUserMessage,
+    startAssistantMessage,
+    appendAssistantChunk,
+    finalizeAssistant,
+    markAssistantError,
+    clearHistory,
+  } = useChatHistory();
+
+  const [inputText, setInputText] = useState<string>("");
+  const [selectedModel, setSelectedModel] = useState<string>(DEFAULT_MODEL_ID);
+  const [pendingAttachments, setPendingAttachments] = useState<ReadonlyArray<PendingAttachment>>([]);
+  const [isStreaming, setIsStreaming] = useState<boolean>(false);
+  const [toolStatus, setToolStatus] = useState<string | null>(null);
+
+  const messagesRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const isNearBottomRef = useRef<boolean>(true);
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingScrollRef = useRef<boolean>(false);
+
+  // Restore model from localStorage
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_MODEL_KEY);
+    if (saved !== null) {
+      setSelectedModel(saved);
+    }
+  }, []);
+
+  const handleModelChange = (modelId: string): void => {
+    setSelectedModel(modelId);
+    localStorage.setItem(STORAGE_MODEL_KEY, modelId);
+  };
+
+  // Track whether user is near the bottom of the scroll area
+  useEffect(() => {
+    const el = messagesRef.current;
+    if (el === null) return;
+    const onScroll = (): void => {
+      const threshold = 40;
+      isNearBottomRef.current =
+        el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // Throttled auto-scroll: batches scroll updates during streaming
+  useEffect(() => {
+    if (!isNearBottomRef.current) return;
+    if (isStreaming) {
+      // During streaming, throttle to once per 300ms
+      if (pendingScrollRef.current) return;
+      pendingScrollRef.current = true;
+      scrollTimerRef.current = setTimeout(() => {
+        pendingScrollRef.current = false;
+        const el = messagesRef.current;
+        if (el !== null && isNearBottomRef.current) {
+          el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+        }
+      }, 300);
+    } else {
+      // Not streaming — scroll immediately (new user message, history load)
+      const el = messagesRef.current;
+      if (el !== null) {
+        el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+      }
+    }
+  }, [messages, isStreaming]);
+
+  const handleAttach = useCallback((attachment: PendingAttachment): void => {
+    setPendingAttachments((prev) => [...prev, attachment]);
+  }, []);
+
+  const removeAttachment = useCallback((index: number): void => {
+    setPendingAttachments((prev) => [...prev.slice(0, index), ...prev.slice(index + 1)]);
+  }, []);
+
+  const sendMessage = useCallback(async (): Promise<void> => {
+    if (isStreaming) return;
+    if (inputText.trim().length === 0 && pendingAttachments.length === 0) return;
+
+    const contentParts = buildContentParts(inputText, pendingAttachments);
+    if (contentParts.length === 0) return;
+
+    appendUserMessage(contentParts);
+    setInputText("");
+    setPendingAttachments([]);
+    setIsStreaming(true);
+
+    startAssistantMessage();
+
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+
+    // Build messages for the API from full history + new message
+    const allMessages = [
+      ...messages.map((m) => ({ role: m.role, content: m.content })),
+      { role: "user" as const, content: contentParts },
+    ];
+
+    try {
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: selectedModel, messages: allMessages }),
+        signal: abortController.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        markAssistantError(`Error ${response.status}: ${errorText}`);
+        setIsStreaming(false);
+        return;
+      }
+
+      const reader = response.body?.getReader();
+      if (reader === undefined) {
+        markAssistantError("No response stream available");
+        setIsStreaming(false);
+        return;
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        // Keep the last incomplete line in the buffer
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (trimmed.length === 0) continue;
+          const event = parseSSELine(trimmed);
+          if (event === null) continue;
+
+          if (event.type === "delta") {
+            appendAssistantChunk(event.text);
+          } else if (event.type === "tool_call") {
+            if (event.status === "started") {
+              const label = event.name === "query_database"
+                ? "Querying database..."
+                : event.name === "code_interpreter"
+                  ? "Running code..."
+                  : `Running ${event.name}...`;
+              setToolStatus(label);
+            } else {
+              setToolStatus(null);
+            }
+          } else if (event.type === "error") {
+            markAssistantError(event.message);
+            setIsStreaming(false);
+            setToolStatus(null);
+            return;
+          } else if (event.type === "done") {
+            break;
+          }
+        }
+      }
+
+      finalizeAssistant();
+    } catch (err) {
+      if (abortController.signal.aborted) {
+        finalizeAssistant();
+      } else {
+        const message = err instanceof Error ? err.message : String(err);
+        markAssistantError(`Request failed: ${message}`);
+      }
+    }
+
+    setIsStreaming(false);
+    setToolStatus(null);
+    abortRef.current = null;
+  }, [
+    isStreaming,
+    inputText,
+    pendingAttachments,
+    selectedModel,
+    messages,
+    appendUserMessage,
+    startAssistantMessage,
+    appendAssistantChunk,
+    finalizeAssistant,
+    markAssistantError,
+  ]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void sendMessage();
+    }
+  };
+
+  // Auto-resize textarea
+  const handleInput = (value: string): void => {
+    setInputText(value);
+    const el = textareaRef.current;
+    if (el === null) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+  };
+
+  const rootClass = mode === "sidebar" ? "chat-sidebar" : "chat-sidebar-fullscreen";
+
+  return (
+    <div className={rootClass}>
+      <div className="chat-header">
+        <span className="chat-header-title">AI Chat</span>
+        {mode === "sidebar" && (
+          <button
+            type="button"
+            className="chat-close-btn"
+            onClick={() => setIsOpen(false)}
+          >
+            &times;
+          </button>
+        )}
+      </div>
+
+      <div className="chat-messages" ref={messagesRef}>
+        {messages.length === 0 && (
+          <div className="chat-empty">No messages yet. Start a conversation.</div>
+        )}
+        {messages.map((msg, i) => {
+          const isLastAssistant =
+            isStreaming && msg.role === "assistant" && i === messages.length - 1;
+          return (
+            <div
+              key={`${msg.timestamp}-${i}`}
+              className={`chat-msg chat-msg-${msg.role}${msg.isError ? " chat-msg-error" : ""}`}
+            >
+              {renderMessageContent(msg)}
+              {isLastAssistant && (
+                <span className="chat-streaming-indicator">
+                  {toolStatus !== null ? toolStatus : (
+                    <span className="chat-dots" />
+                  )}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="chat-input-area">
+        {pendingAttachments.length > 0 && (
+          <div className="chat-attachment-preview">
+            {pendingAttachments.map((att, i) => (
+              <span key={`${att.fileName}-${i}`} className="chat-attachment-chip">
+                {att.fileName}
+                <button
+                  type="button"
+                  className="chat-attachment-remove"
+                  onClick={() => removeAttachment(i)}
+                >
+                  &times;
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="chat-controls">
+          <ModelSelector value={selectedModel} onChange={handleModelChange} />
+          <FileAttachment onAttach={handleAttach} />
+          <button
+            type="button"
+            className="chat-attach-btn"
+            onClick={clearHistory}
+          >
+            Clear
+          </button>
+        </div>
+        <div className="chat-input-row">
+          <textarea
+            ref={textareaRef}
+            className="chat-textarea"
+            placeholder="Type a message..."
+            value={inputText}
+            onChange={(e) => handleInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            rows={1}
+          />
+          <button
+            type="button"
+            className="chat-send-btn"
+            disabled={isStreaming}
+            onClick={() => void sendMessage()}
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/ui/chat/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/ChatPanel.tsx
@@ -258,7 +258,7 @@ export const ChatPanel = (props: Props): ReactElement => {
             if (event.status === "started") {
               const label = event.name === "query_database"
                 ? "Querying database..."
-                : event.name === "code_interpreter"
+                : event.name === "code_execution" || event.name === "code_interpreter"
                   ? "Running code..."
                   : `Running ${event.name}...`;
               setToolStatus(label);
@@ -385,7 +385,7 @@ export const ChatPanel = (props: Props): ReactElement => {
           </div>
         )}
         <div className="chat-controls">
-          <ModelSelector value={selectedModel} onChange={handleModelChange} disabled={messages.length > 0 || isStreaming} />
+          <ModelSelector value={selectedModel} onChange={handleModelChange} locked={messages.length > 0 || isStreaming} />
           <FileAttachment onAttach={handleAttach} />
           <button
             type="button"

--- a/apps/web/src/ui/chat/ChatToggle.tsx
+++ b/apps/web/src/ui/chat/ChatToggle.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import type { ReactElement } from "react";
+import { useChatLayout } from "./ChatLayoutProvider";
+
+export const ChatToggle = (): ReactElement => {
+  const { setIsOpen } = useChatLayout();
+
+  return (
+    <button
+      type="button"
+      className="chat-toggle-floating"
+      onClick={() => setIsOpen(true)}
+    >
+      AI Chat
+    </button>
+  );
+};

--- a/apps/web/src/ui/chat/FileAttachment.tsx
+++ b/apps/web/src/ui/chat/FileAttachment.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useRef, type ReactElement } from "react";
+
+export type PendingAttachment = Readonly<{
+  fileName: string;
+  mediaType: string;
+  base64Data: string;
+}>;
+
+type Props = Readonly<{
+  onAttach: (attachment: PendingAttachment) => void;
+}>;
+
+const ACCEPTED_TYPES = "image/*,.pdf,.txt,.csv,.json,.xml,.xlsx,.xls,.md,.html,.py,.js,.ts,.yaml,.yml,.sql,.log,.docx";
+
+const readFileAsBase64 = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      // Strip the data:...;base64, prefix
+      const base64 = result.split(",")[1];
+      resolve(base64);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+
+export const FileAttachment = (props: Props): ReactElement => {
+  const { onAttach } = props;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChange = async (): Promise<void> => {
+    const files = inputRef.current?.files;
+    if (files === null || files === undefined) return;
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      const base64Data = await readFileAsBase64(file);
+      onAttach({
+        fileName: file.name,
+        mediaType: file.type || "application/octet-stream",
+        base64Data,
+      });
+    }
+
+    // Reset input so the same file can be attached again
+    if (inputRef.current !== null) {
+      inputRef.current.value = "";
+    }
+  };
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPTED_TYPES}
+        multiple
+        style={{ display: "none" }}
+        onChange={() => void handleChange()}
+      />
+      <button
+        type="button"
+        className="chat-attach-btn"
+        onClick={() => inputRef.current?.click()}
+      >
+        Attach
+      </button>
+    </>
+  );
+};

--- a/apps/web/src/ui/chat/ModelSelector.tsx
+++ b/apps/web/src/ui/chat/ModelSelector.tsx
@@ -6,7 +6,7 @@ import { CHAT_MODELS, type ChatModelVendor } from "@/lib/chatModels";
 type Props = Readonly<{
   value: string;
   onChange: (modelId: string) => void;
-  disabled: boolean;
+  locked: boolean;
 }>;
 
 const VENDOR_LABELS: Record<ChatModelVendor, string> = {
@@ -17,14 +17,18 @@ const VENDOR_LABELS: Record<ChatModelVendor, string> = {
 const VENDOR_ORDER: ReadonlyArray<ChatModelVendor> = ["anthropic", "openai"];
 
 export const ModelSelector = (props: Props): ReactElement => {
-  const { value, onChange, disabled } = props;
+  const { value, onChange, locked } = props;
+
+  if (locked) {
+    const model = CHAT_MODELS.find((m) => m.id === value);
+    return <span className="chat-model-label">{model?.label ?? value}</span>;
+  }
 
   return (
     <select
       className="chat-model-select"
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      disabled={disabled}
     >
       {VENDOR_ORDER.map((vendor) => {
         const models = CHAT_MODELS.filter((m) => m.vendor === vendor);

--- a/apps/web/src/ui/chat/ModelSelector.tsx
+++ b/apps/web/src/ui/chat/ModelSelector.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { ReactElement } from "react";
+import { CHAT_MODELS } from "@/lib/chatModels";
+
+type Props = Readonly<{
+  value: string;
+  onChange: (modelId: string) => void;
+}>;
+
+export const ModelSelector = (props: Props): ReactElement => {
+  const { value, onChange } = props;
+
+  return (
+    <select
+      className="chat-model-select"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {CHAT_MODELS.map((m) => (
+        <option key={m.id} value={m.id}>
+          {m.label}
+        </option>
+      ))}
+    </select>
+  );
+};

--- a/apps/web/src/ui/chat/ModelSelector.tsx
+++ b/apps/web/src/ui/chat/ModelSelector.tsx
@@ -1,27 +1,44 @@
 "use client";
 
 import type { ReactElement } from "react";
-import { CHAT_MODELS } from "@/lib/chatModels";
+import { CHAT_MODELS, type ChatModelVendor } from "@/lib/chatModels";
 
 type Props = Readonly<{
   value: string;
   onChange: (modelId: string) => void;
+  disabled: boolean;
 }>;
 
+const VENDOR_LABELS: Record<ChatModelVendor, string> = {
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+};
+
+const VENDOR_ORDER: ReadonlyArray<ChatModelVendor> = ["openai", "anthropic"];
+
 export const ModelSelector = (props: Props): ReactElement => {
-  const { value, onChange } = props;
+  const { value, onChange, disabled } = props;
 
   return (
     <select
       className="chat-model-select"
       value={value}
       onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
     >
-      {CHAT_MODELS.map((m) => (
-        <option key={m.id} value={m.id}>
-          {m.label}
-        </option>
-      ))}
+      {VENDOR_ORDER.map((vendor) => {
+        const models = CHAT_MODELS.filter((m) => m.vendor === vendor);
+        if (models.length === 0) return null;
+        return (
+          <optgroup key={vendor} label={VENDOR_LABELS[vendor]}>
+            {models.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.label}
+              </option>
+            ))}
+          </optgroup>
+        );
+      })}
     </select>
   );
 };

--- a/apps/web/src/ui/chat/ModelSelector.tsx
+++ b/apps/web/src/ui/chat/ModelSelector.tsx
@@ -14,7 +14,7 @@ const VENDOR_LABELS: Record<ChatModelVendor, string> = {
   anthropic: "Anthropic",
 };
 
-const VENDOR_ORDER: ReadonlyArray<ChatModelVendor> = ["openai", "anthropic"];
+const VENDOR_ORDER: ReadonlyArray<ChatModelVendor> = ["anthropic", "openai"];
 
 export const ModelSelector = (props: Props): ReactElement => {
   const { value, onChange, disabled } = props;

--- a/apps/web/src/ui/hooks/useChatHistory.ts
+++ b/apps/web/src/ui/hooks/useChatHistory.ts
@@ -1,0 +1,131 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ContentPart } from "@/server/chat/types";
+
+export type StoredMessage = Readonly<{
+  role: "user" | "assistant";
+  content: ReadonlyArray<ContentPart>;
+  timestamp: number;
+  isError: boolean;
+}>;
+
+type ChatHistoryState = Readonly<{
+  messages: ReadonlyArray<StoredMessage>;
+  appendUserMessage: (content: ReadonlyArray<ContentPart>) => void;
+  startAssistantMessage: () => void;
+  appendAssistantChunk: (text: string) => void;
+  finalizeAssistant: () => void;
+  markAssistantError: (errorText: string) => void;
+  clearHistory: () => void;
+}>;
+
+const STORAGE_KEY = "expense-tracker-chat-messages";
+const MAX_MESSAGES = 200;
+
+const loadFromStorage = (): ReadonlyArray<StoredMessage> => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return [];
+    const parsed = JSON.parse(raw) as ReadonlyArray<StoredMessage>;
+    return parsed.slice(-MAX_MESSAGES);
+  } catch {
+    return [];
+  }
+};
+
+const saveToStorage = (messages: ReadonlyArray<StoredMessage>): void => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(messages.slice(-MAX_MESSAGES)));
+  } catch {
+    // localStorage full — silently drop
+  }
+};
+
+export const useChatHistory = (): ChatHistoryState => {
+  const [messages, setMessages] = useState<ReadonlyArray<StoredMessage>>([]);
+  const loadedRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    setMessages(loadFromStorage());
+    loadedRef.current = true;
+  }, []);
+
+  // Persist on every change after initial load
+  useEffect(() => {
+    if (!loadedRef.current) return;
+    saveToStorage(messages);
+  }, [messages]);
+
+  const appendUserMessage = useCallback((content: ReadonlyArray<ContentPart>): void => {
+    const msg: StoredMessage = { role: "user", content, timestamp: Date.now(), isError: false };
+    setMessages((prev) => [...prev, msg]);
+  }, []);
+
+  const startAssistantMessage = useCallback((): void => {
+    const msg: StoredMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "" }],
+      timestamp: Date.now(),
+      isError: false,
+    };
+    setMessages((prev) => [...prev, msg]);
+  }, []);
+
+  const appendAssistantChunk = useCallback((text: string): void => {
+    setMessages((prev) => {
+      if (prev.length === 0) return prev;
+      const last = prev[prev.length - 1];
+      if (last.role !== "assistant") return prev;
+      const textPart = last.content.find((p) => p.type === "text");
+      if (textPart === undefined || textPart.type !== "text") return prev;
+      const updatedContent: ReadonlyArray<ContentPart> = last.content.map((p) =>
+        p.type === "text" ? { ...p, text: p.text + text } : p,
+      );
+      const updated: StoredMessage = { ...last, content: updatedContent };
+      return [...prev.slice(0, -1), updated];
+    });
+  }, []);
+
+  const finalizeAssistant = useCallback((): void => {
+    // Trigger a save by touching state (the useEffect will persist)
+    setMessages((prev) => [...prev]);
+  }, []);
+
+  const markAssistantError = useCallback((errorText: string): void => {
+    setMessages((prev) => {
+      if (prev.length === 0) return prev;
+      const last = prev[prev.length - 1];
+      if (last.role !== "assistant") {
+        const errorMsg: StoredMessage = {
+          role: "assistant",
+          content: [{ type: "text", text: errorText }],
+          timestamp: Date.now(),
+          isError: true,
+        };
+        return [...prev, errorMsg];
+      }
+      const updated: StoredMessage = {
+        ...last,
+        content: [{ type: "text", text: errorText }],
+        isError: true,
+      };
+      return [...prev.slice(0, -1), updated];
+    });
+  }, []);
+
+  const clearHistory = useCallback((): void => {
+    setMessages([]);
+    localStorage.removeItem(STORAGE_KEY);
+  }, []);
+
+  return {
+    messages,
+    appendUserMessage,
+    startAssistantMessage,
+    appendAssistantChunk,
+    finalizeAssistant,
+    markAssistantError,
+    clearHistory,
+  };
+};

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,7 +53,7 @@ export AWS_PROFILE=expense-tracker
 bash scripts/bootstrap.sh --region eu-central-1
 ```
 
-The script runs `cdk bootstrap` (prepares the AWS account) then `cdk deploy` (creates everything), then runs database migrations, then invokes the FX fetcher Lambda to seed exchange rates.
+The script runs `cdk bootstrap` (prepares the AWS account) then `cdk deploy` (creates everything), then runs database migrations, then invokes the FX fetcher Lambda to seed exchange rates. After the first deploy, set AI API keys in Secrets Manager and restart ECS — see step 6.4 in [`infra/aws/README.md`](../infra/aws/README.md#6-post-deploy).
 
 **CI/CD (all subsequent deploys):** `.github/workflows/deploy.yml`
 

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -315,7 +315,7 @@ The script creates DNS CNAMEs for `app.*` and root domain (both proxied via Clou
      --username you@example.com \
      --temporary-password 'TempPass123!'
    ```
-4. **Set AI API keys** — the AI chat feature requires OpenAI and/or Anthropic API keys. CDK creates placeholder secrets in AWS Secrets Manager; replace them with real keys:
+4. **Set AI API keys (first deploy only)** — the AI chat feature requires OpenAI and/or Anthropic API keys. CDK creates placeholder secrets in AWS Secrets Manager on the first deploy; replace them with real keys once:
    ```bash
    aws secretsmanager put-secret-value \
      --secret-id expense-tracker/openai-api-key \
@@ -327,7 +327,7 @@ The script creates DNS CNAMEs for `app.*` and root domain (both proxied via Clou
      --secret-string 'sk-ant-...' \
      --profile expense-tracker
    ```
-   After updating, restart the ECS service to pick up the new values:
+   Then restart the ECS service to pick up the new values:
    ```bash
    aws ecs update-service \
      --cluster <EcsClusterName from output> \
@@ -335,7 +335,7 @@ The script creates DNS CNAMEs for `app.*` and root domain (both proxied via Clou
      --force-new-deployment \
      --profile expense-tracker
    ```
-   Both keys are optional — chat models from vendors without a configured key will return a clear error.
+   This is a one-time step. Subsequent deploys reuse the same secrets — CDK does not overwrite values that are already set. Both keys are optional — chat models from vendors without a configured key will return a clear error.
 
 ## CI/CD (automatic deploys on push)
 

--- a/infra/aws/lib/compute.ts
+++ b/infra/aws/lib/compute.ts
@@ -12,6 +12,8 @@ export interface ComputeProps {
   ecsSg: ec2.SecurityGroup;
   db: rds.DatabaseInstance;
   appDbSecret: cdk.aws_secretsmanager.Secret;
+  openaiApiKeySecret: cdk.aws_secretsmanager.Secret;
+  anthropicApiKeySecret: cdk.aws_secretsmanager.Secret;
   authDomain: string;
   userPoolClientId: string;
   appDomain: string;
@@ -68,6 +70,8 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
     },
     secrets: {
       DB_PASSWORD: ecs.Secret.fromSecretsManager(props.appDbSecret, "password"),
+      OPENAI_API_KEY: ecs.Secret.fromSecretsManager(props.openaiApiKeySecret),
+      ANTHROPIC_API_KEY: ecs.Secret.fromSecretsManager(props.anthropicApiKeySecret),
     },
     logging: ecs.LogDrivers.awsLogs({
       logGroup: webLogGroup,

--- a/infra/aws/lib/database.ts
+++ b/infra/aws/lib/database.ts
@@ -11,6 +11,8 @@ export interface DatabaseProps {
 export interface DatabaseResult {
   db: rds.DatabaseInstance;
   appDbSecret: cdk.aws_secretsmanager.Secret;
+  openaiApiKeySecret: cdk.aws_secretsmanager.Secret;
+  anthropicApiKeySecret: cdk.aws_secretsmanager.Secret;
 }
 
 export function database(scope: Construct, props: DatabaseProps): DatabaseResult {
@@ -63,5 +65,16 @@ export function database(scope: Construct, props: DatabaseProps): DatabaseResult
     },
   });
 
-  return { db, appDbSecret };
+  // --- AI API key secrets (user sets real values in Secrets Manager after deploy) ---
+  const openaiApiKeySecret = new cdk.aws_secretsmanager.Secret(scope, "OpenAiApiKey", {
+    secretName: "expense-tracker/openai-api-key",
+    generateSecretString: { excludePunctuation: true, passwordLength: 32 },
+  });
+
+  const anthropicApiKeySecret = new cdk.aws_secretsmanager.Secret(scope, "AnthropicApiKey", {
+    secretName: "expense-tracker/anthropic-api-key",
+    generateSecretString: { excludePunctuation: true, passwordLength: 32 },
+  });
+
+  return { db, appDbSecret, openaiApiKeySecret, anthropicApiKeySecret };
 }

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -49,6 +49,8 @@ export class ExpenseBudgetTrackerStack extends cdk.Stack {
       ecsSg: net.ecsSg,
       db: dbResult.db,
       appDbSecret: dbResult.appDbSecret,
+      openaiApiKeySecret: dbResult.openaiApiKeySecret,
+      anthropicApiKeySecret: dbResult.anthropicApiKeySecret,
       authDomain,
       userPoolClientId: authResult.userPoolClient.userPoolClientId,
       appDomain,

--- a/infra/docker/compose.yml
+++ b/infra/docker/compose.yml
@@ -49,6 +49,8 @@ services:
       AUTH_PROXY_HEADER: ${AUTH_PROXY_HEADER:-}
       COGNITO_DOMAIN: ${COGNITO_DOMAIN:-}
       COGNITO_CLIENT_ID: ${COGNITO_CLIENT_ID:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Add a resizable chat panel to the web UI with multi-model support (OpenAI GPT-5.2/4.1 and Claude Opus/Sonnet/Haiku)
- Implement AI agents with database query tools, web search, code execution, and file upload support
- Add OpenAI and Anthropic API keys to AWS infrastructure (Secrets Manager → ECS), Docker Compose, and documentation

## Post-merge: set API keys in Secrets Manager

CDK creates placeholder secrets. After the deploy completes, replace them with real keys:

```bash
aws secretsmanager put-secret-value \
  --secret-id expense-tracker/openai-api-key \
  --secret-string 'sk-...' \
  --profile expense-tracker

aws secretsmanager put-secret-value \
  --secret-id expense-tracker/anthropic-api-key \
  --secret-string 'sk-ant-...' \
  --profile expense-tracker
```

Then restart ECS to pick up the new values:

```bash
aws ecs update-service --cluster <cluster> --service <service> --force-new-deployment --profile expense-tracker
```

## Test plan

- [ ] CDK synth/deploy succeeds (new Secrets Manager resources created)
- [ ] ECS web container starts with API key env vars injected
- [ ] Chat panel opens in the UI, model selector works
- [ ] OpenAI and Anthropic chat models respond correctly
- [ ] Database query tool returns financial data
- [ ] Local Docker Compose passes API keys from `.env` to web container

🤖 Generated with [Claude Code](https://claude.com/claude-code)