### PR TITLE
[codex] Update dependency drift packages

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@expense-budget-tracker/agent-shared": "1.0.0",
     "@hono/node-server": "^1.19.14",
-    "hono": "^4.12.14",
+    "hono": "^4.12.15",
     "pg": "^8.20.0"
   },
   "devDependencies": {

--- a/apps/sql-api/package.json
+++ b/apps/sql-api/package.json
@@ -10,7 +10,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1036.0",
+    "@aws-sdk/client-secrets-manager": "^3.1037.0",
     "@expense-budget-tracker/agent-shared": "1.0.0",
     "pg": "^8.20.0"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,7 @@
     "@opentelemetry/sdk-node": "^0.214.0",
     "aws-jwt-verify": "^5.1.1",
     "d3": "^7.9.0",
-    "i18next": "^26.0.7",
+    "i18next": "^26.0.8",
     "mammoth": "^1.12.0",
     "next": "16.2.4",
     "openai": "^6.34.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -8,8 +8,8 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1036.0",
-    "fast-xml-parser": "^5.7.1",
+    "@aws-sdk/client-secrets-manager": "^3.1037.0",
+    "fast-xml-parser": "^5.7.2",
     "node-cron": "^4.2.1",
     "pg": "^8.20.0"
   },

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -15,7 +15,7 @@
     "synth": "cdk synth"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.250.0",
+    "aws-cdk-lib": "^2.251.0",
     "constructs": "^10.6.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "dependencies": {
         "@expense-budget-tracker/agent-shared": "1.0.0",
         "@hono/node-server": "^1.19.14",
-        "hono": "^4.12.14",
+        "hono": "^4.12.15",
         "pg": "^8.20.0"
       },
       "devDependencies": {
@@ -51,7 +51,7 @@
       "name": "expense-budget-tracker-sql-api",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1036.0",
+        "@aws-sdk/client-secrets-manager": "^3.1037.0",
         "@expense-budget-tracker/agent-shared": "1.0.0",
         "pg": "^8.20.0"
       },
@@ -94,7 +94,7 @@
         "@opentelemetry/sdk-node": "^0.214.0",
         "aws-jwt-verify": "^5.1.1",
         "d3": "^7.9.0",
-        "i18next": "^26.0.7",
+        "i18next": "^26.0.8",
         "mammoth": "^1.12.0",
         "next": "16.2.4",
         "openai": "^6.34.0",
@@ -140,8 +140,8 @@
       "name": "expense-budget-tracker-worker",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1036.0",
-        "fast-xml-parser": "^5.7.1",
+        "@aws-sdk/client-secrets-manager": "^3.1037.0",
+        "fast-xml-parser": "^5.7.2",
         "node-cron": "^4.2.1",
         "pg": "^8.20.0"
       },
@@ -165,6 +165,27 @@
         "undici-types": "~7.16.0"
       }
     },
+    "apps/worker/node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "apps/worker/node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -176,7 +197,7 @@
       "name": "expense-budget-tracker-aws",
       "version": "1.0.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.250.0",
+        "aws-cdk-lib": "^2.251.0",
         "constructs": "^10.6.0"
       },
       "devDependencies": {
@@ -703,9 +724,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.11.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.11.0.tgz",
-      "integrity": "sha512-sAkcWQz2hvblIDHe5pFXxyIPZuhDaYowGIpASK+LSDvknBpP7+y3fib/FMpSPQdyI6ZOmJPEQOnz553H7mPnBA==",
+      "version": "53.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.18.0.tgz",
+      "integrity": "sha512-/fa6rOpokkfa5tVIdhsaexQq5MVVTSsZSD1Tu45YcrdyGRusGrM9RlPMCPrwvMS1UfdVFBhcgO9dl9ODWAWOeQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -864,9 +885,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1036.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1036.0.tgz",
-      "integrity": "sha512-4Q0Rqh1CrNfwmAOrQF9FiuU2QmV51cTSa+rJJNan7/KzYUUlUFmavuWpKH+S3preT8iaTlCT0JyCqO46kg24RA==",
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1037.0.tgz",
+      "integrity": "sha512-SBXVNgXdzFeiuUod1AZXJexTDndPcpSTGOrVDe5Ny81Xq7d3r18th7ZTzvnc7BsD9MQa8SckNgOYscvi/fYZhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -4198,9 +4219,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.250.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.250.0.tgz",
-      "integrity": "sha512-8U8/S9VcmKSc3MHZWiB7P0IecgXoohI8Ya3dgtZMgbzC4mB+MEQmsYBeNgm4vzGQdRos8HjQLnFX1IBlZh7jQA==",
+      "version": "2.251.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.251.0.tgz",
+      "integrity": "sha512-H1Jfz2Oyejn+yG24i+By9fZpYfg+E3h1XnFCF2wnt/MyGOTIePRph7MRGkX73ap10ERSpmd0Ly58OLVykFoSQA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -4219,8 +4240,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.0",
-        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.2",
+        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -4241,7 +4262,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.0",
+      "version": "2.2.2",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -4256,7 +4277,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
@@ -5381,9 +5402,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5399,9 +5420,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.0.7",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.7.tgz",
-      "integrity": "sha512-f7tL/iw0VQsx4nC5oNxBM2RjM8alNys5KzyiQTU6A9TI5TI89py4/Ez1cKFvHiLWsvzOXvuGUES+Kk/A2WiANQ==",
+      "version": "26.0.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.8.tgz",
+      "integrity": "sha512-BRzLom0mhDhV9v0QhgUUHWQJuwFmnr1194xEcNLYD6ym8y8s542n4jXUvRLnhNTbh9PmpU6kGZamyuGHQMsGjw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
## What changed
- bump `hono` in `apps/auth` from `^4.12.14` to `^4.12.15`
- bump `@aws-sdk/client-secrets-manager` in `apps/sql-api` and `apps/worker` from `^3.1036.0` to `^3.1037.0`
- bump `i18next` in `apps/web` from `^26.0.7` to `^26.0.8`
- bump `fast-xml-parser` in `apps/worker` from `^5.7.1` to `^5.7.2`
- bump `aws-cdk-lib` in `infra/aws` from `^2.250.0` to `^2.251.0`
- refresh the root `package-lock.json`

## Why
These were the remaining low-risk dependency drift updates identified in the repo audit.

## Validation
- `npx -y node@24 $(command -v npm) ci`
- `npx -y node@24 $(command -v npm) --workspace @expense-budget-tracker/agent-shared run build`
- `npx -y node@24 $(command -v npm) --workspace apps/auth run build`
- `npx -y node@24 $(command -v npm) --workspace apps/sql-api run lint`
- `npx -y node@24 $(command -v npm) --workspace apps/sql-api run build`
- `npx -y node@24 $(command -v npm) --workspace apps/worker run lint`
- `npx -y node@24 $(command -v npm) --workspace apps/worker run build`
- `npx -y node@24 $(command -v npm) --workspace infra/aws run build`
- `cd apps/web && npx -y node@24 $(command -v npm) run lint && npx -y node@24 $(command -v npm) run build`

## Notes
- `npm audit --omit=dev` still reports pre-existing advisories in transitive `@xmldom/xmldom`, transitive `protobufjs`, `next`/`postcss` advisory metadata, and direct `xlsx` with no fix available.
