### PR TITLE
[codex] Add OpenAI safety identifiers

### DIFF
--- a/apps/web/src/server/chat/openai/loop.test.ts
+++ b/apps/web/src/server/chat/openai/loop.test.ts
@@ -13,7 +13,10 @@ import {
   applyToolCallStarted,
   createToolCallStateMap,
 } from "@/server/chat/openai/toolCalls";
+import type { OpenAIResponsesRequest } from "@/server/chat/openai/request";
 import type { ChatStreamEvent } from "@/server/chat/types";
+
+const EXPECTED_USER_1_SAFETY_IDENTIFIER = "v1_xsKJ5J6cBbIUWGA4e3O8sY30P7CaHkpKlxPHbIi7VBs";
 
 const createLoopParams = (): StartOpenAILoopParams => ({
   requestId: "req-loop",
@@ -210,6 +213,7 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
   const toolCall = createFunctionCall("call-1", "query_database", "{\"sql\":\"select 1\"}");
   const toolOutput = "{\"ok\":true}";
   let modelCallCount = 0;
+  const openAIRequests: Array<OpenAIResponsesRequest> = [];
 
   const completion = await runOpenAILoopWithDeps(
     params,
@@ -219,8 +223,14 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
     {
       buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
       getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
-      runOneModelCall: async () => {
+      runOneModelCall: async (
+        _client: OpenAI,
+        _callParams: StartOpenAILoopParams,
+        _emitEvent: OpenAILoopEventHandler,
+        request: OpenAIResponsesRequest,
+      ) => {
         modelCallCount += 1;
+        openAIRequests.push(request);
         if (modelCallCount === 1) {
           return {
             finalResponse: createFinalResponse(""),
@@ -252,6 +262,17 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
   );
 
   assert.equal(modelCallCount, 2);
+  assert.deepEqual(
+    openAIRequests.map((request) => request.safety_identifier),
+    [
+      EXPECTED_USER_1_SAFETY_IDENTIFIER,
+      EXPECTED_USER_1_SAFETY_IDENTIFIER,
+    ],
+  );
+  assert.deepEqual(
+    openAIRequests.map((request) => request.prompt_cache_key),
+    ["session-1", "session-1"],
+  );
   assert.deepEqual(observedEvents, [
     {
       type: "tool_call",
@@ -279,6 +300,7 @@ test("runOpenAILoop emits a synthetic final delta and returns the summary replay
   const params = createLoopParams();
   const observedEvents: Array<ChatStreamEvent> = [];
   let modelCallCount = 0;
+  const openAIRequests: Array<OpenAIResponsesRequest> = [];
 
   const completion = await runOpenAILoopWithDeps(
     params,
@@ -292,11 +314,12 @@ test("runOpenAILoop emits a synthetic final delta and returns the summary replay
         _client: OpenAI,
         _callParams: StartOpenAILoopParams,
         _emitEvent: OpenAILoopEventHandler,
-        _request,
+        request: OpenAIResponsesRequest,
         _promptCacheKey: string,
         callIndex: number,
       ) => {
         modelCallCount += 1;
+        openAIRequests.push(request);
         if (callIndex <= CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS) {
           const callId = `call-${String(callIndex)}`;
           return {
@@ -329,6 +352,11 @@ test("runOpenAILoop emits a synthetic final delta and returns the summary replay
   );
 
   assert.equal(modelCallCount, CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS + 1);
+  assert.equal(
+    openAIRequests.every((request) => request.safety_identifier === EXPECTED_USER_1_SAFETY_IDENTIFIER),
+    true,
+  );
+  assert.deepEqual(openAIRequests.at(-1)?.tools, []);
   assert.deepEqual(observedEvents.slice(-2), [
     {
       type: "delta",

--- a/apps/web/src/server/chat/openai/loop.ts
+++ b/apps/web/src/server/chat/openai/loop.ts
@@ -169,6 +169,7 @@ const completeToolLimitSummaryTurn = async (
     buildOpenAIResponsesRequestWithOptions(
       baseInput,
       continuationItems,
+      params.userId,
       params.sessionId,
       params.timezone,
       [],
@@ -226,6 +227,7 @@ const runLoopWithDeps = async (
       buildOpenAIResponsesRequest(
         baseInput,
         continuationItems,
+        params.userId,
         params.sessionId,
         params.timezone,
       ),

--- a/apps/web/src/server/chat/openai/request.ts
+++ b/apps/web/src/server/chat/openai/request.ts
@@ -8,6 +8,7 @@ import {
   toOpenAIResponseInputItem,
   type StoredOpenAIReplayItem,
 } from "@/server/chat/openai/replayItems";
+import { buildOpenAISafetyIdentifier } from "@/server/chat/openai/safetyIdentifier";
 import { OPENAI_CHAT_TOOLS } from "@/server/chat/openai/tools";
 
 export type OpenAIResponsesRequest = Readonly<{
@@ -21,6 +22,7 @@ export type OpenAIResponsesRequest = Readonly<{
     summary: typeof CHAT_MODEL_REASONING_SUMMARY;
   }>;
   prompt_cache_key: string;
+  safety_identifier: string;
 }>;
 
 type ChatResponseLogEvent = Readonly<{
@@ -59,6 +61,7 @@ export const buildPromptCacheKey = (
 export const buildOpenAIResponsesRequest = (
   baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
   continuationItems: ReadonlyArray<StoredOpenAIReplayItem>,
+  userId: string,
   sessionId: string,
   timezone: string,
 ): OpenAIResponsesRequest => ({
@@ -72,11 +75,13 @@ export const buildOpenAIResponsesRequest = (
     summary: CHAT_MODEL_REASONING_SUMMARY,
   },
   prompt_cache_key: buildPromptCacheKey(sessionId),
+  safety_identifier: buildOpenAISafetyIdentifier(userId),
 });
 
 export const buildOpenAIResponsesRequestWithOptions = (
   baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
   continuationItems: ReadonlyArray<StoredOpenAIReplayItem>,
+  userId: string,
   sessionId: string,
   timezone: string,
   tools: ReadonlyArray<OpenAI.Responses.Tool>,
@@ -92,6 +97,7 @@ export const buildOpenAIResponsesRequestWithOptions = (
     summary: CHAT_MODEL_REASONING_SUMMARY,
   },
   prompt_cache_key: buildPromptCacheKey(sessionId),
+  safety_identifier: buildOpenAISafetyIdentifier(userId),
 });
 
 const getResponseStopReason = (

--- a/apps/web/src/server/chat/openai/safetyIdentifier.test.ts
+++ b/apps/web/src/server/chat/openai/safetyIdentifier.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildOpenAISafetyIdentifier } from "@/server/chat/openai/safetyIdentifier";
+
+test("buildOpenAISafetyIdentifier hashes user IDs into stable non-PII identifiers", (): void => {
+  assert.equal(
+    buildOpenAISafetyIdentifier("user-1"),
+    "v1_xsKJ5J6cBbIUWGA4e3O8sY30P7CaHkpKlxPHbIi7VBs",
+  );
+  assert.equal(
+    buildOpenAISafetyIdentifier("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+    "v1_j0AMJXYR7V0wwOZgesYQdDB9-iTPcKjpLD6BR9Z9LHA",
+  );
+});
+
+test("buildOpenAISafetyIdentifier rejects empty user IDs", (): void => {
+  assert.throws(
+    () => buildOpenAISafetyIdentifier(""),
+    /Cannot build OpenAI safety identifier from an empty userId/,
+  );
+});

--- a/apps/web/src/server/chat/openai/safetyIdentifier.ts
+++ b/apps/web/src/server/chat/openai/safetyIdentifier.ts
@@ -1,0 +1,17 @@
+import { createHash } from "node:crypto";
+
+const SAFETY_IDENTIFIER_VERSION = "v1";
+
+export const buildOpenAISafetyIdentifier = (
+  userId: string,
+): string => {
+  if (userId.length === 0) {
+    throw new Error("Cannot build OpenAI safety identifier from an empty userId");
+  }
+
+  const digest = createHash("sha256")
+    .update(userId, "utf8")
+    .digest("base64url");
+
+  return `${SAFETY_IDENTIFIER_VERSION}_${digest}`;
+};


### PR DESCRIPTION
## Summary
- Hash the resolved app user id into a stable OpenAI `safety_identifier` for Responses API calls.
- Thread the identifier through normal chat model calls, post-tool continuation calls, and the tool-limit summary call.
- Add focused tests for deterministic hashing and request payload propagation.

## Validation
- `npm run lint --prefix apps/web`
- `npm run build --prefix apps/web`
- `cd apps/web && npx tsx --test src/server/chat/openai/safetyIdentifier.test.ts src/server/chat/openai/loop.test.ts`
- `git --no-pager diff --check`
- Subagent review: 3/3 approve, no findings.