### PR TITLE
[codex] Rename chat clear button to new

### DIFF
--- a/apps/web/src/i18n/ar.json
+++ b/apps/web/src/i18n/ar.json
@@ -161,7 +161,7 @@
   "budget.popoverFill": "ملء الأشهر →",
   "budget.popoverNote": "ملاحظة",
   "chat.title": "دردشة الذكاء الاصطناعي",
-  "chat.clear": "مسح",
+  "chat.new": "جديد",
   "chat.send": "إرسال",
   "chat.stop": "إيقاف",
   "chat.attach": "إرفاق",

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -161,7 +161,7 @@
   "budget.popoverFill": "Fill months →",
   "budget.popoverNote": "Note",
   "chat.title": "AI Chat",
-  "chat.clear": "Clear",
+  "chat.new": "New",
   "chat.send": "Send",
   "chat.stop": "Stop",
   "chat.attach": "Attach",

--- a/apps/web/src/i18n/es.json
+++ b/apps/web/src/i18n/es.json
@@ -161,7 +161,7 @@
   "budget.popoverFill": "Copiar a los meses siguientes →",
   "budget.popoverNote": "Nota",
   "chat.title": "Chat con IA",
-  "chat.clear": "Borrar",
+  "chat.new": "Nuevo",
   "chat.send": "Enviar",
   "chat.stop": "Detener",
   "chat.attach": "Adjuntar",

--- a/apps/web/src/i18n/fa.json
+++ b/apps/web/src/i18n/fa.json
@@ -161,7 +161,7 @@
   "budget.popoverFill": "پر کردن ماه‌ها →",
   "budget.popoverNote": "یادداشت",
   "chat.title": "گفت‌وگو با هوش مصنوعی",
-  "chat.clear": "پاک کردن",
+  "chat.new": "جدید",
   "chat.send": "ارسال",
   "chat.stop": "توقف",
   "chat.attach": "پیوست",

--- a/apps/web/src/i18n/he.json
+++ b/apps/web/src/i18n/he.json
@@ -161,7 +161,7 @@
   "budget.popoverFill": "מלא חודשים →",
   "budget.popoverNote": "הערה",
   "chat.title": "צ׳אט עם AI",
-  "chat.clear": "נקה",
+  "chat.new": "חדש",
   "chat.send": "שלח",
   "chat.stop": "עצור",
   "chat.attach": "צרף",

--- a/apps/web/src/i18n/ru.json
+++ b/apps/web/src/i18n/ru.json
@@ -161,7 +161,7 @@
   "budget.popoverFill": "Заполнить до конца года →",
   "budget.popoverNote": "Примечание",
   "chat.title": "Чат с ИИ",
-  "chat.clear": "Очистить",
+  "chat.new": "Новый",
   "chat.send": "Отправить",
   "chat.stop": "Остановить",
   "chat.attach": "Прикрепить",

--- a/apps/web/src/i18n/uk.json
+++ b/apps/web/src/i18n/uk.json
@@ -161,7 +161,7 @@
   "budget.popoverFill": "Заповнити наступні місяці →",
   "budget.popoverNote": "Нотатка",
   "chat.title": "Чат із ШІ",
-  "chat.clear": "Очистити",
+  "chat.new": "Новий",
   "chat.send": "Надіслати",
   "chat.stop": "Зупинити",
   "chat.attach": "Прикріпити",

--- a/apps/web/src/i18n/zh.json
+++ b/apps/web/src/i18n/zh.json
@@ -161,7 +161,7 @@
   "budget.popoverFill": "应用到后续月份 →",
   "budget.popoverNote": "备注",
   "chat.title": "AI 对话",
-  "chat.clear": "清空",
+  "chat.new": "新建",
   "chat.send": "发送",
   "chat.stop": "停止",
   "chat.attach": "添加附件",

--- a/apps/web/src/ui/chat/shell/panel/ChatPanelHeader.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatPanelHeader.tsx
@@ -57,7 +57,7 @@ export const ChatPanelHeader = (props: Props): ReactElement => {
           onClick={onClearConversation}
           disabled={transcriptActionsDisabled}
         >
-          {t("chat.clear")}
+          {t("chat.new")}
         </button>
         {mode === "sidebar" && (
           <button


### PR DESCRIPTION
## Summary

- Rename the AI chat reset button label from Clear to New.
- Add localized `chat.new` labels in every supported web locale.
- Leave the underlying clear/reset behavior unchanged.

## Validation

- `cd apps/web && npm run lint`
- `cd apps/web && npm run build`
- Subagent review found no issues and verified the diff, locale coverage, JSON key parity, and `git --no-pager diff --check`.