### PR TITLE
[codex] Fix dictation upload WAF handling

### DIFF
--- a/apps/web/src/i18n/ar.json
+++ b/apps/web/src/i18n/ar.json
@@ -206,6 +206,7 @@
   "chat.dictationUnavailable": "تسجيل الميكروفون غير متاح في هذا المتصفح.",
   "chat.dictationPermissionDenied": "تم رفض الوصول إلى الميكروفون. اسمح به من إعدادات المتصفح ثم حاول مرة أخرى.",
   "chat.dictationNoMicrophone": "لم يتم العثور على ميكروفون للإملاء الصوتي.",
+  "chat.dictationFailed": "تعذر تحويل الصوت إلى نص. حاول مرة أخرى.",
   "chat.exportTitle": "تصدير دردشة الذكاء الاصطناعي",
   "chat.exportTimestampsUtc": "جميع الطوابع الزمنية أدناه بتوقيت UTC",
   "chat.exportedAt": "تم التصدير في",

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -206,6 +206,7 @@
   "chat.dictationUnavailable": "Microphone recording is unavailable in this browser.",
   "chat.dictationPermissionDenied": "Microphone access was denied. Allow it in your browser settings and try again.",
   "chat.dictationNoMicrophone": "No microphone was found for voice dictation.",
+  "chat.dictationFailed": "Audio transcription failed. Please try again.",
   "chat.exportTitle": "AI Chat Export",
   "chat.exportTimestampsUtc": "All timestamps below are in UTC",
   "chat.exportedAt": "Exported at",

--- a/apps/web/src/i18n/es.json
+++ b/apps/web/src/i18n/es.json
@@ -206,6 +206,7 @@
   "chat.dictationUnavailable": "La grabación con micrófono no está disponible en este navegador.",
   "chat.dictationPermissionDenied": "Se denegó el acceso al micrófono. Permítelo en la configuración del navegador e inténtalo de nuevo.",
   "chat.dictationNoMicrophone": "No se encontró ningún micrófono para el dictado por voz.",
+  "chat.dictationFailed": "No se pudo transcribir el audio. Inténtalo de nuevo.",
   "chat.exportTitle": "Exportación del chat con IA",
   "chat.exportTimestampsUtc": "Todas las marcas de tiempo que aparecen a continuación están en UTC",
   "chat.exportedAt": "Exportado el",

--- a/apps/web/src/i18n/fa.json
+++ b/apps/web/src/i18n/fa.json
@@ -206,6 +206,7 @@
   "chat.dictationUnavailable": "ضبط با میکروفون در این مرورگر در دسترس نیست.",
   "chat.dictationPermissionDenied": "دسترسی به میکروفون رد شد. آن را در تنظیمات مرورگر فعال کنید و دوباره تلاش کنید.",
   "chat.dictationNoMicrophone": "برای دیکته صوتی هیچ میکروفونی پیدا نشد.",
+  "chat.dictationFailed": "تبدیل صدا به متن ناموفق بود. دوباره تلاش کنید.",
   "chat.exportTitle": "خروجی گفت‌وگو با هوش مصنوعی",
   "chat.exportTimestampsUtc": "همه زمان‌های زیر بر اساس UTC هستند",
   "chat.exportedAt": "زمان تهیه خروجی",

--- a/apps/web/src/i18n/he.json
+++ b/apps/web/src/i18n/he.json
@@ -206,6 +206,7 @@
   "chat.dictationUnavailable": "הקלטה מהמיקרופון אינה זמינה בדפדפן הזה.",
   "chat.dictationPermissionDenied": "הגישה למיקרופון נדחתה. אפשר אותה בהגדרות הדפדפן ונסה שוב.",
   "chat.dictationNoMicrophone": "לא נמצא מיקרופון זמין להכתבה קולית.",
+  "chat.dictationFailed": "תמלול השמע נכשל. נסה שוב.",
   "chat.exportTitle": "ייצוא שיחת AI",
   "chat.exportTimestampsUtc": "כל חותמות הזמן שלהלן הן ב-UTC",
   "chat.exportedAt": "זמן הייצוא",

--- a/apps/web/src/i18n/ru.json
+++ b/apps/web/src/i18n/ru.json
@@ -206,6 +206,7 @@
   "chat.dictationUnavailable": "Запись с микрофона недоступна в этом браузере.",
   "chat.dictationPermissionDenied": "Доступ к микрофону запрещён. Разрешите его в настройках браузера и попробуйте снова.",
   "chat.dictationNoMicrophone": "Для голосовой диктовки не найден микрофон.",
+  "chat.dictationFailed": "Не удалось распознать аудио. Попробуйте ещё раз.",
   "chat.exportTitle": "Экспорт чата с ИИ",
   "chat.exportTimestampsUtc": "Все метки времени ниже указаны в UTC",
   "chat.exportedAt": "Экспортировано",

--- a/apps/web/src/i18n/uk.json
+++ b/apps/web/src/i18n/uk.json
@@ -206,6 +206,7 @@
   "chat.dictationUnavailable": "Запис з мікрофона недоступний у цьому браузері.",
   "chat.dictationPermissionDenied": "Доступ до мікрофона заборонено. Дозвольте його в налаштуваннях браузера та спробуйте ще раз.",
   "chat.dictationNoMicrophone": "Для голосового диктування не знайдено мікрофон.",
+  "chat.dictationFailed": "Не вдалося розпізнати аудіо. Спробуйте ще раз.",
   "chat.exportTitle": "Експорт чату із ШІ",
   "chat.exportTimestampsUtc": "Усі мітки часу нижче вказані в UTC",
   "chat.exportedAt": "Експортовано",

--- a/apps/web/src/i18n/zh.json
+++ b/apps/web/src/i18n/zh.json
@@ -206,6 +206,7 @@
   "chat.dictationUnavailable": "当前浏览器不支持麦克风录音。",
   "chat.dictationPermissionDenied": "麦克风权限被拒绝。请在浏览器设置中允许后重试。",
   "chat.dictationNoMicrophone": "未检测到可用于语音输入的麦克风。",
+  "chat.dictationFailed": "音频转写失败。请重试。",
   "chat.exportTitle": "AI 聊天记录导出",
   "chat.exportTimestampsUtc": "以下所有时间戳均为 UTC 时间",
   "chat.exportedAt": "导出时间",

--- a/apps/web/src/server/chat/transcriptions.test.ts
+++ b/apps/web/src/server/chat/transcriptions.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { ApiRouteError } from "@/server/api/errors";
-import { parseChatTranscriptionUpload } from "@/server/chat/transcriptions";
+import {
+  MAX_CHAT_TRANSCRIPTION_FILE_SIZE_BYTES,
+  parseChatTranscriptionUpload,
+} from "@/server/chat/transcriptions";
 
 const createTranscriptionRequest = (
   formData: FormData,
@@ -24,5 +27,29 @@ test("parseChatTranscriptionUpload requires a session id", async (): Promise<voi
       error instanceof ApiRouteError
       && error.status === 400
       && error.message === "sessionId is required",
+  );
+});
+
+test("parseChatTranscriptionUpload rejects audio above the transcription size limit", async (): Promise<void> => {
+  const formData = new FormData();
+  formData.append(
+    "file",
+    new File(
+      [new Uint8Array(MAX_CHAT_TRANSCRIPTION_FILE_SIZE_BYTES + 1)],
+      "audio.webm",
+      { type: "audio/webm" },
+    ),
+  );
+  formData.append("source", "web");
+  formData.append("sessionId", "session-1");
+
+  await assert.rejects(
+    async (): Promise<void> => {
+      await parseChatTranscriptionUpload(createTranscriptionRequest(formData));
+    },
+    (error: unknown) =>
+      error instanceof ApiRouteError
+      && error.status === 400
+      && error.message === "Audio file is too large (20.0 MB). Maximum allowed size is 20 MB.",
   );
 });

--- a/apps/web/src/server/chat/transcriptions.ts
+++ b/apps/web/src/server/chat/transcriptions.ts
@@ -41,6 +41,7 @@ type OpenAIErrorMetadata = Readonly<{
 const CHAT_TRANSCRIPTION_MODEL = "gpt-4o-transcribe";
 const CHAT_TRANSCRIPTION_GENERIC_ERROR_MESSAGE = "Audio transcription failed. Please try again.";
 const CHAT_TRANSCRIPTION_INVALID_AUDIO_ERROR_MESSAGE = "We couldn’t process that recording. Please try again.";
+export const MAX_CHAT_TRANSCRIPTION_FILE_SIZE_BYTES = 20 * 1024 * 1024;
 const SUPPORTED_AUDIO_FILE_EXTENSIONS = new Set(["m4a", "wav", "webm"]);
 const SUPPORTED_AUDIO_MEDIA_TYPES = new Set([
   "audio/mp4",
@@ -100,6 +101,15 @@ export const parseChatTranscriptionUpload = async (request: Request): Promise<Ch
 
   if (fileValue.size <= 0) {
     throw new ApiRouteError(400, "file must not be empty");
+  }
+
+  if (fileValue.size > MAX_CHAT_TRANSCRIPTION_FILE_SIZE_BYTES) {
+    const sizeMb = (fileValue.size / (1024 * 1024)).toFixed(1);
+    const limitMb = (MAX_CHAT_TRANSCRIPTION_FILE_SIZE_BYTES / (1024 * 1024)).toFixed(0);
+    throw new ApiRouteError(
+      400,
+      `Audio file is too large (${sizeMb} MB). Maximum allowed size is ${limitMb} MB.`,
+    );
   }
 
   if (!isSupportedAudioUpload(fileValue)) {

--- a/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
@@ -416,7 +416,7 @@ export const ChatPanel = (props: Props): ReactElement => {
       }
 
       const sessionId = await ensureWritableSessionId();
-      const transcription = await transcribeChatAudio(audioBlob, sessionId);
+      const transcription = await transcribeChatAudio(audioBlob, sessionId, t);
       if (isMountedRef.current) {
         acceptServerSessionId(transcription.sessionId);
         setInputText((currentText) => {

--- a/apps/web/src/ui/chat/stream/hooks/chatDictation.test.ts
+++ b/apps/web/src/ui/chat/stream/hooks/chatDictation.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sanitizeChatTranscriptionErrorText } from "./chatDictation";
+
+const t = (key: string): string => {
+  if (key === "chat.dictationFailed") {
+    return "Audio transcription failed. Please try again.";
+  }
+
+  throw new Error(`Unexpected translation key: ${key}`);
+};
+
+test("sanitizeChatTranscriptionErrorText hides HTML edge responses", (): void => {
+  const sanitizedMessage = sanitizeChatTranscriptionErrorText(
+    "<html><head><title>403 Forbidden</title></head><body>blocked</body></html>",
+    "text/html",
+    t,
+  );
+
+  assert.equal(sanitizedMessage, "Audio transcription failed. Please try again.");
+});
+
+test("sanitizeChatTranscriptionErrorText hides HTML edge fragments", (): void => {
+  const sanitizedMessage = sanitizeChatTranscriptionErrorText(
+    "<h1>403 Forbidden</h1>",
+    null,
+    t,
+  );
+
+  assert.equal(sanitizedMessage, "Audio transcription failed. Please try again.");
+});
+
+test("sanitizeChatTranscriptionErrorText hides text/html edge responses without tags", (): void => {
+  const sanitizedMessage = sanitizeChatTranscriptionErrorText(
+    "403 Forbidden",
+    "text/html; charset=utf-8",
+    t,
+  );
+
+  assert.equal(sanitizedMessage, "Audio transcription failed. Please try again.");
+});
+
+test("sanitizeChatTranscriptionErrorText preserves plain route errors", (): void => {
+  const sanitizedMessage = sanitizeChatTranscriptionErrorText(
+    "Unsupported audio file type. Use m4a, wav, or webm.",
+    "text/plain",
+    t,
+  );
+
+  assert.equal(sanitizedMessage, "Unsupported audio file type. Use m4a, wav, or webm.");
+});

--- a/apps/web/src/ui/chat/stream/hooks/chatDictation.ts
+++ b/apps/web/src/ui/chat/stream/hooks/chatDictation.ts
@@ -2,6 +2,8 @@
 
 import { fetchWithCsrf } from "@/lib/csrf";
 
+type ChatTranslation = (key: string) => string;
+
 export type ChatDictationState = "idle" | "requesting_permission" | "recording" | "transcribing";
 
 export type ChatDraftSelection = Readonly<{
@@ -99,9 +101,42 @@ type ChatTranscriptionResponse = Readonly<{
   sessionId: string;
 }>;
 
+const isHtmlContentType = (contentType: string | null): boolean => {
+  if (contentType === null) {
+    return false;
+  }
+
+  const normalizedContentType = contentType.trim().toLowerCase();
+  return normalizedContentType === "text/html" || normalizedContentType.startsWith("text/html;");
+};
+
+const isHtmlLikeErrorText = (raw: string): boolean => {
+  const normalizedRaw = raw.trim().toLowerCase();
+  return (
+    normalizedRaw === ""
+    || normalizedRaw.includes("<html")
+    || normalizedRaw.includes("<!doctype")
+    || normalizedRaw.startsWith("<!--")
+    || /^<\/?[a-z][a-z0-9-]*(?:\s|>|\/>)/.test(normalizedRaw)
+  );
+};
+
+export const sanitizeChatTranscriptionErrorText = (
+  raw: string,
+  contentType: string | null,
+  t: ChatTranslation,
+): string => {
+  if (isHtmlContentType(contentType) || isHtmlLikeErrorText(raw)) {
+    return t("chat.dictationFailed");
+  }
+
+  return raw;
+};
+
 export const transcribeChatAudio = async (
   blob: Blob,
   sessionId: string,
+  t: ChatTranslation,
 ): Promise<ChatTranscriptionResponse> => {
   const mediaType = normalizeAudioMediaType(blob.type === "" ? "audio/webm" : blob.type);
   const file = new File([blob], `chat-dictation.${extensionForAudioMediaType(mediaType)}`, {
@@ -118,15 +153,19 @@ export const transcribeChatAudio = async (
   });
   if (!response.ok) {
     const message = await response.text();
-    throw new Error(message);
+    throw new Error(sanitizeChatTranscriptionErrorText(
+      message,
+      response.headers.get("content-type"),
+      t,
+    ));
   }
 
   const payload = await response.json() as ChatTranscriptionResponse;
   if (typeof payload.text !== "string" || payload.text.trim() === "") {
-    throw new Error("Audio transcription failed. Please try again.");
+    throw new Error(t("chat.dictationFailed"));
   }
   if (typeof payload.sessionId !== "string" || payload.sessionId.trim() === "") {
-    throw new Error("Audio transcription failed. Please try again.");
+    throw new Error(t("chat.dictationFailed"));
   }
 
   return payload;

--- a/infra/aws/lib/ingress.ts
+++ b/infra/aws/lib/ingress.ts
@@ -23,6 +23,129 @@ export interface IngressResult {
   accessLogsBucket: s3.Bucket;
 }
 
+type ByteMatchPositionalConstraint = "EXACTLY" | "STARTS_WITH";
+
+const noneTextTransformation = (): wafv2.CfnWebACL.TextTransformationProperty => ({
+  priority: 0,
+  type: "NONE",
+});
+
+const lowercaseTextTransformation = (): wafv2.CfnWebACL.TextTransformationProperty => ({
+  priority: 0,
+  type: "LOWERCASE",
+});
+
+const byteMatchStatement = (
+  fieldToMatch: wafv2.CfnWebACL.FieldToMatchProperty,
+  positionalConstraint: ByteMatchPositionalConstraint,
+  searchString: string,
+  textTransformation: wafv2.CfnWebACL.TextTransformationProperty,
+): wafv2.CfnWebACL.StatementProperty => ({
+  byteMatchStatement: {
+    fieldToMatch,
+    positionalConstraint,
+    searchString,
+    textTransformations: [textTransformation],
+  },
+});
+
+const methodIs = (method: string): wafv2.CfnWebACL.StatementProperty =>
+  byteMatchStatement({ method: {} }, "EXACTLY", method, noneTextTransformation());
+
+const uriPathIs = (path: string): wafv2.CfnWebACL.StatementProperty =>
+  byteMatchStatement({ uriPath: {} }, "EXACTLY", path, noneTextTransformation());
+
+const singleHeaderField = (headerName: string): wafv2.CfnWebACL.FieldToMatchProperty => ({
+  singleHeader: { Name: headerName },
+});
+
+const headerIs = (
+  headerName: string,
+  headerValue: string,
+): wafv2.CfnWebACL.StatementProperty =>
+  byteMatchStatement(
+    singleHeaderField(headerName),
+    "EXACTLY",
+    headerValue.toLowerCase(),
+    lowercaseTextTransformation(),
+  );
+
+const headerStartsWith = (
+  headerName: string,
+  headerPrefix: string,
+): wafv2.CfnWebACL.StatementProperty =>
+  byteMatchStatement(
+    singleHeaderField(headerName),
+    "STARTS_WITH",
+    headerPrefix.toLowerCase(),
+    lowercaseTextTransformation(),
+  );
+
+const hasLabel = (label: string): wafv2.CfnWebACL.StatementProperty => ({
+  labelMatchStatement: {
+    scope: "LABEL",
+    key: label,
+  },
+});
+
+const andStatement = (
+  statements: ReadonlyArray<wafv2.CfnWebACL.StatementProperty>,
+): wafv2.CfnWebACL.StatementProperty => ({
+  andStatement: {
+    statements: [...statements],
+  },
+});
+
+const orStatement = (
+  statements: ReadonlyArray<wafv2.CfnWebACL.StatementProperty>,
+): wafv2.CfnWebACL.StatementProperty => ({
+  orStatement: {
+    statements: [...statements],
+  },
+});
+
+const notStatement = (
+  statement: wafv2.CfnWebACL.StatementProperty,
+): wafv2.CfnWebACL.StatementProperty => ({
+  notStatement: {
+    statement,
+  },
+});
+
+const blockLabeledRequestUnless = (
+  name: string,
+  priority: number,
+  label: string,
+  allowedRequest: wafv2.CfnWebACL.StatementProperty,
+  metricName: string,
+): wafv2.CfnWebACL.RuleProperty => ({
+  name,
+  priority,
+  action: { block: {} },
+  statement: andStatement([
+    hasLabel(label),
+    notStatement(allowedRequest),
+  ]),
+  visibilityConfig: {
+    sampledRequestsEnabled: true,
+    cloudWatchMetricsEnabled: true,
+    metricName,
+  },
+});
+
+const postRequestToApp = (
+  appDomain: string,
+  path: string,
+  contentTypePrefix: string,
+): wafv2.CfnWebACL.StatementProperty =>
+  andStatement([
+    methodIs("POST"),
+    uriPathIs(path),
+    headerIs("host", appDomain),
+    headerIs("origin", `https://${appDomain}`),
+    headerStartsWith("content-type", contentTypePrefix),
+  ]);
+
 export function ingress(scope: Construct, props: IngressProps): IngressResult {
   // --- ALB ---
   const alb = new elbv2.ApplicationLoadBalancer(scope, "Alb", {
@@ -112,6 +235,13 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
   //
   // WAF is kept for managed rule sets (SQLi, XSS, known bad inputs) which inspect
   // request content and work correctly regardless of source IP.
+  const chatJsonRequest = postRequestToApp(props.appDomain, "/api/chat", "application/json");
+  const chatTranscriptionUploadRequest = postRequestToApp(
+    props.appDomain,
+    "/api/chat/transcriptions",
+    "multipart/form-data",
+  );
+
   const waf = new wafv2.CfnWebACL(scope, "Waf", {
     scope: "REGIONAL",
     defaultAction: { allow: {} },
@@ -129,11 +259,17 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
           managedRuleGroupStatement: {
             vendorName: "AWS",
             name: "AWSManagedRulesCommonRuleSet",
-            excludedRules: [
+            ruleActionOverrides: [
+              {
+                name: "CrossSiteScripting_BODY",
+                actionToUse: { count: {} },
+              },
               // SizeRestrictions_BODY blocks requests with body > 8 KB.
-              // The /api/chat endpoint sends base64-encoded images (several MB).
-              // Cloudflare enforces its own upload limits upstream.
-              { name: "SizeRestrictions_BODY" },
+              // Large app payloads are re-blocked below except for explicit upload routes.
+              {
+                name: "SizeRestrictions_BODY",
+                actionToUse: { count: {} },
+              },
             ],
           },
         },
@@ -143,9 +279,23 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
           metricName: "expense-tracker-common-rules",
         },
       },
+      blockLabeledRequestUnless(
+        "BlockUnexpectedXssBodyMatches",
+        1,
+        "awswaf:managed:aws:core-rule-set:CrossSiteScripting_Body",
+        chatTranscriptionUploadRequest,
+        "expense-tracker-xss-body-reblock",
+      ),
+      blockLabeledRequestUnless(
+        "BlockUnexpectedBodySizeMatches",
+        2,
+        "awswaf:managed:aws:core-rule-set:SizeRestrictions_Body",
+        orStatement([chatJsonRequest, chatTranscriptionUploadRequest]),
+        "expense-tracker-size-body-reblock",
+      ),
       {
         name: "AWSManagedKnownBadInputs",
-        priority: 1,
+        priority: 3,
         overrideAction: { none: {} },
         statement: {
           managedRuleGroupStatement: {


### PR DESCRIPTION
## Summary

- Treat dictation upload WAF false positives as counted CRS matches and re-block by AWS WAF labels outside narrow legitimate request shapes.
- Add a deterministic 20 MiB transcription upload limit below OpenAI's 25 MB audio limit.
- Sanitize WAF/edge HTML responses so browser alerts show a clean localized dictation error while preserving plain route errors.

## Validation

- `cd apps/web && npx tsx --test src/server/chat/transcriptions.test.ts src/app/api/chat/transcriptions/route.test.ts src/ui/chat/stream/hooks/chatDictation.test.ts`
- `cd apps/web && npm run lint && npm run build`
- `cd infra/aws && npm run build && npm run synth`
- `cd infra/aws && npm run diff`
- `git diff --check`

Subagent review found and verified fixes for CloudFormation `SingleHeader.Name` casing and broader HTML error sanitization.