### PR TITLE
Fix run-scoped chat lifecycle races

### DIFF
--- a/apps/web/src/app/api/chat/stop/route.test.ts
+++ b/apps/web/src/app/api/chat/stop/route.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { stopChatRouteWithDeps } from "@/app/api/chat/stop/route";
+import type { ChatSessionSnapshot } from "@/server/chat/store";
+
+type StopChatRouteDependencies = Parameters<typeof stopChatRouteWithDeps>[1];
+
+const createHeaders = (): Headers =>
+  new Headers({
+    "content-type": "application/json",
+    "x-user-id": "user-1",
+    "x-workspace-id": "workspace-1",
+  });
+
+const createStopRequest = (
+  sessionId: string,
+): Request =>
+  new Request("http://localhost/api/chat/stop", {
+    method: "POST",
+    headers: createHeaders(),
+    body: JSON.stringify({ sessionId }),
+  });
+
+const createSnapshot = (
+  sessionId: string,
+  overrides: Partial<ChatSessionSnapshot> = {},
+): ChatSessionSnapshot => ({
+  sessionId,
+  runState: "idle",
+  updatedAt: 0,
+  activeRunId: null,
+  activeRunHeartbeatAt: null,
+  mainContentInvalidationVersion: 0,
+  messages: [],
+  ...overrides,
+});
+
+const createStopDependencies = (
+  overrides: Partial<StopChatRouteDependencies>,
+): StopChatRouteDependencies => ({
+  getChatSessionSnapshot: overrides.getChatSessionSnapshot ?? (async (
+    _userId,
+    _workspaceId,
+    sessionId,
+  ): Promise<ChatSessionSnapshot> => createSnapshot(sessionId ?? "session-1")),
+  stopActiveChatRun: overrides.stopActiveChatRun ?? (() => ({ stopped: false })),
+  cancelActiveChatRunByUser: overrides.cancelActiveChatRunByUser ?? (async () => "not_running"),
+  markActiveChatRunCancellationPersisted:
+    overrides.markActiveChatRunCancellationPersisted ?? (() => undefined),
+  hasActiveChatSessionRun: overrides.hasActiveChatSessionRun ?? (() => false),
+  log: overrides.log ?? (() => undefined),
+});
+
+test("stopChatRouteWithDeps returns public stop state and marks the stopped local run persisted", async (): Promise<void> => {
+  let markedRun: ReadonlyArray<string> | null = null;
+
+  const response = await stopChatRouteWithDeps(
+    createStopRequest("client-session"),
+    createStopDependencies({
+      getChatSessionSnapshot: async (_userId, _workspaceId, sessionId): Promise<ChatSessionSnapshot> => {
+        assert.equal(sessionId, "client-session");
+        return createSnapshot("session-1", {
+          runState: "running",
+          activeRunId: "run-stopped",
+          activeRunHeartbeatAt: 1_000,
+        });
+      },
+      stopActiveChatRun: (sessionId, activeRunId) => {
+        assert.equal(sessionId, "session-1");
+        assert.equal(activeRunId, "run-stopped");
+        return { stopped: true, activeRunId: "run-stopped" };
+      },
+      cancelActiveChatRunByUser: async (userId, workspaceId, sessionId, activeRunId) => {
+        assert.equal(userId, "user-1");
+        assert.equal(workspaceId, "workspace-1");
+        assert.equal(sessionId, "session-1");
+        assert.equal(activeRunId, "run-stopped");
+        return "cancelled";
+      },
+      markActiveChatRunCancellationPersisted: (sessionId, activeRunId) => {
+        markedRun = [sessionId, activeRunId];
+      },
+      hasActiveChatSessionRun: (sessionId) => {
+        assert.equal(sessionId, "session-1");
+        return false;
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    sessionId: "session-1",
+    stopped: true,
+    stillRunning: false,
+  });
+  assert.deepEqual(markedRun, ["session-1", "run-stopped"]);
+});
+
+test("stopChatRouteWithDeps reports stillRunning from session-level local state", async (): Promise<void> => {
+  let markCalled = false;
+
+  const response = await stopChatRouteWithDeps(
+    createStopRequest("session-1"),
+    createStopDependencies({
+      stopActiveChatRun: () => ({ stopped: false }),
+      cancelActiveChatRunByUser: async () => "not_running",
+      markActiveChatRunCancellationPersisted: () => {
+        markCalled = true;
+      },
+      hasActiveChatSessionRun: () => true,
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    sessionId: "session-1",
+    stopped: false,
+    stillRunning: true,
+  });
+  assert.equal(markCalled, false);
+});

--- a/apps/web/src/app/api/chat/stop/route.ts
+++ b/apps/web/src/app/api/chat/stop/route.ts
@@ -1,7 +1,7 @@
 import { handleRoute } from "@/server/api/handleRoute";
 import { ApiRouteError } from "@/server/api/errors";
 import {
-  hasActiveChatRun,
+  hasActiveChatSessionRun,
   markActiveChatRunCancellationPersisted,
   stopActiveChatRun,
 } from "@/server/chat/runtime";
@@ -43,7 +43,7 @@ type StopChatRouteDependencies = Readonly<{
   stopActiveChatRun: typeof stopActiveChatRun;
   cancelActiveChatRunByUser: typeof cancelActiveChatRunByUser;
   markActiveChatRunCancellationPersisted: typeof markActiveChatRunCancellationPersisted;
-  hasActiveChatRun: typeof hasActiveChatRun;
+  hasActiveChatSessionRun: typeof hasActiveChatSessionRun;
   log: typeof log;
 }>;
 
@@ -52,7 +52,7 @@ const DEFAULT_STOP_CHAT_ROUTE_DEPENDENCIES: StopChatRouteDependencies = {
   stopActiveChatRun,
   cancelActiveChatRunByUser,
   markActiveChatRunCancellationPersisted,
-  hasActiveChatRun,
+  hasActiveChatSessionRun,
   log,
 };
 
@@ -67,12 +67,20 @@ export const stopChatRouteWithDeps = async (
       const body = parseStopChatRequestBody(await request.json());
 
       let sessionId: string;
+      let expectedActiveRunId: string | null = null;
       try {
-        sessionId = await dependencies.getChatSessionSnapshot(
+        const snapshot = await dependencies.getChatSessionSnapshot(
           context.userId,
           context.workspaceId,
           body.sessionId,
-        ).then((snapshot) => snapshot.sessionId);
+        );
+        sessionId = snapshot.sessionId;
+        if (snapshot.runState === "running" && snapshot.activeRunId === null) {
+          throw new Error(`Chat stop failed: running session has no activeRunId, sessionId=${sessionId}`);
+        }
+        expectedActiveRunId = snapshot.runState === "running"
+          ? snapshot.activeRunId
+          : null;
       } catch (error) {
         if (error instanceof ChatSessionNotFoundError) {
           throw new ApiRouteError(404, error.message);
@@ -80,17 +88,22 @@ export const stopChatRouteWithDeps = async (
         throw error;
       }
 
-      const stoppedRuntimeRun = dependencies.stopActiveChatRun(sessionId);
-      const persistedCancelledRun = await dependencies.cancelActiveChatRunByUser(
-        context.userId,
-        context.workspaceId,
-        sessionId,
-      );
-      if (persistedCancelledRun) {
-        dependencies.markActiveChatRunCancellationPersisted(sessionId);
+      const stoppedRuntimeRun = expectedActiveRunId === null
+        ? { stopped: false } as const
+        : dependencies.stopActiveChatRun(sessionId, expectedActiveRunId);
+      const persistedCancelResult = expectedActiveRunId === null
+        ? "not_running"
+        : await dependencies.cancelActiveChatRunByUser(
+          context.userId,
+          context.workspaceId,
+          sessionId,
+          expectedActiveRunId,
+        );
+      if (stoppedRuntimeRun.stopped) {
+        dependencies.markActiveChatRunCancellationPersisted(sessionId, stoppedRuntimeRun.activeRunId);
       }
 
-      const stopped = stoppedRuntimeRun || persistedCancelledRun;
+      const stopped = stoppedRuntimeRun.stopped || persistedCancelResult === "cancelled";
       if (stopped) {
         dependencies.log({
           domain: "chat",
@@ -105,7 +118,7 @@ export const stopChatRouteWithDeps = async (
         ok: true,
         sessionId,
         stopped,
-        stillRunning: dependencies.hasActiveChatRun(sessionId),
+        stillRunning: dependencies.hasActiveChatSessionRun(sessionId),
       });
     },
   );

--- a/apps/web/src/server/chat/http/routeHandlers.test.ts
+++ b/apps/web/src/server/chat/http/routeHandlers.test.ts
@@ -12,6 +12,7 @@ import {
   ChatSessionConflictError,
   ChatSessionNotFoundError,
 } from "@/server/chat/store";
+import type { ChatRunStartReservation } from "@/server/chat/runtime";
 import type { ChatStreamEvent, ContentPart } from "@/server/chat/types";
 
 const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
@@ -29,6 +30,7 @@ const createSnapshot = (
   sessionId: "session-1",
   runState: "idle",
   updatedAt: 100,
+  activeRunId: null,
   activeRunHeartbeatAt: null,
   mainContentInvalidationVersion: 0,
   messages: [],
@@ -39,6 +41,7 @@ const createPreparedRun = (
   sessionId: string,
 ): PreparedChatRun => ({
   sessionId,
+  activeRunId: `run-${sessionId}`,
   assistantItem: {
     itemId: "assistant-1",
     sessionId,
@@ -52,6 +55,13 @@ const createPreparedRun = (
   },
   localMessages: [],
   turnInput: [{ type: "text", text: "Hello" }],
+});
+
+const createReservation = (
+  sessionId: string,
+): ChatRunStartReservation => ({
+  sessionId,
+  reservationId: Symbol(sessionId),
 });
 
 const createChatRequest = (
@@ -69,6 +79,8 @@ const createPostDependencies = (
 ): Parameters<typeof postChatRouteWithDeps>[1] => ({
   getLocaleFromRequest: overrides.getLocaleFromRequest ?? (() => "en" as SupportedLocale),
   resolveSnapshotWithRunRecovery: overrides.resolveSnapshotWithRunRecovery ?? (async () => createSnapshot()),
+  reserveChatRunStart: overrides.reserveChatRunStart ?? ((sessionId) => createReservation(sessionId)),
+  releaseChatRunStartReservation: overrides.releaseChatRunStartReservation ?? (() => undefined),
   prepareChatRun: overrides.prepareChatRun ?? (async (
     _userId: string,
     _workspaceId: string,
@@ -191,6 +203,101 @@ test("postChatRouteWithDeps maps chat session conflicts to 409", async (): Promi
   });
 });
 
+test("postChatRouteWithDeps returns 409 without preparing DB run when local reservation is denied", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    let prepareCalled = false;
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies({
+        reserveChatRunStart: () => null,
+        prepareChatRun: async (): Promise<PreparedChatRun> => {
+          prepareCalled = true;
+          return createPreparedRun("session-1");
+        },
+      }),
+    );
+
+    assert.equal(response.status, 409);
+    assert.equal(await response.text(), "Chat session already has an active response");
+    assert.equal(prepareCalled, false);
+  });
+});
+
+test("postChatRouteWithDeps releases the local reservation when DB prepare fails", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    const reservation = createReservation("session-1");
+    let releasedReservation: ChatRunStartReservation | null = null;
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies({
+        reserveChatRunStart: () => reservation,
+        releaseChatRunStartReservation: (released) => {
+          releasedReservation = released;
+        },
+        prepareChatRun: async (): Promise<PreparedChatRun> => {
+          throw new ChatSessionConflictError("session-1");
+        },
+      }),
+    );
+
+    assert.equal(response.status, 409);
+    assert.equal(await response.text(), "Chat session already has an active response");
+    assert.equal(releasedReservation, reservation);
+  });
+});
+
+test("postChatRouteWithDeps consumes the reservation when runtime starts successfully", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    const reservation = createReservation("session-1");
+    let released = false;
+    let startedWith: Readonly<{
+      activeRunId: string;
+      reservation: ChatRunStartReservation;
+    }> | null = null;
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies({
+        reserveChatRunStart: () => reservation,
+        releaseChatRunStartReservation: () => {
+          released = true;
+        },
+        prepareChatRun: async () => createPreparedRun("session-1"),
+        startPersistedChatRun: (params, startReservation) => {
+          startedWith = {
+            activeRunId: params.activeRunId,
+            reservation: startReservation,
+          };
+          return (async function* (): AsyncGenerator<ChatStreamEvent> {
+            yield { type: "done" };
+          })();
+        },
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(startedWith, {
+      activeRunId: "run-session-1",
+      reservation,
+    });
+    assert.equal(released, false);
+  });
+});
+
 test("postChatRouteWithDeps rejects missing session ids", async (): Promise<void> => {
   await withOpenAiApiKey("test-key", async (): Promise<void> => {
     const response = await postChatRouteWithDeps(
@@ -222,6 +329,56 @@ test("getChatRouteWithDeps maps missing sessions to 404", async (): Promise<void
 
   assert.equal(response.status, 404);
   assert.equal(await response.text(), "Chat session not found: missing");
+});
+
+test("getChatRouteWithDeps does not serialize internal active run fields", async (): Promise<void> => {
+  const publicContent: ReadonlyArray<ContentPart> = [{ type: "text", text: "Hello" }];
+  const response = await getChatRouteWithDeps(
+    new Request("http://localhost/api/chat?sessionId=session-1", {
+      method: "GET",
+      headers: createHeaders(),
+    }),
+    {
+      resolveSnapshotWithRunRecovery: async () => createSnapshot({
+        runState: "running",
+        activeRunId: "run-1",
+        activeRunHeartbeatAt: 1_000,
+        messages: [{
+          itemId: "assistant-1",
+          sessionId: "session-1",
+          role: "assistant",
+          content: publicContent,
+          openaiItems: [{
+            type: "function_call",
+            call_id: "call-1",
+            name: "lookup_transactions",
+            arguments: "{}",
+          }],
+          state: "completed",
+          timestamp: 123,
+          updatedAt: 456,
+          isError: false,
+          isStopped: false,
+        }],
+      }),
+    },
+  );
+
+  const body = await response.json() as Record<string, unknown>;
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    sessionId: "session-1",
+    runState: "running",
+    updatedAt: 100,
+    mainContentInvalidationVersion: 0,
+    messages: [{
+      role: "assistant",
+      content: publicContent,
+      timestamp: 123,
+      isError: false,
+      isStopped: false,
+    }],
+  });
 });
 
 test("postChatRouteWithDeps returns SSE headers for successful runs", async (): Promise<void> => {
@@ -281,9 +438,13 @@ test("deleteChatRouteWithDeps creates a fresh session when the latest session ha
       getChatSessionSnapshot: async () => createSnapshot({
         sessionId: "session-1",
         messages: [{
+          itemId: "item-1",
+          sessionId: "session-1",
           role: "user",
           content: [{ type: "text", text: "Hello" }],
+          state: "completed",
           timestamp: 0,
+          updatedAt: 0,
           isError: false,
           isStopped: false,
         }],

--- a/apps/web/src/server/chat/http/routeHandlers.ts
+++ b/apps/web/src/server/chat/http/routeHandlers.ts
@@ -20,7 +20,11 @@ import {
   CHAT_STREAM_HEARTBEAT_INTERVAL_MS,
   createChatEventStream,
 } from "@/server/chat/http/sse";
-import { startPersistedChatRun } from "@/server/chat/runtime";
+import {
+  releaseChatRunStartReservation,
+  reserveChatRunStart,
+  startPersistedChatRun,
+} from "@/server/chat/runtime";
 import {
   ChatSessionConflictError,
   ChatSessionNotFoundError,
@@ -43,6 +47,8 @@ type GetChatRouteDependencies = Readonly<{
 type PostChatRouteDependencies = Readonly<{
   getLocaleFromRequest: typeof getLocaleFromRequest;
   resolveSnapshotWithRunRecovery: typeof resolveSnapshotWithRunRecovery;
+  reserveChatRunStart: typeof reserveChatRunStart;
+  releaseChatRunStartReservation: typeof releaseChatRunStartReservation;
   prepareChatRun: typeof prepareChatRun;
   startPersistedChatRun: typeof startPersistedChatRun;
   isServerDraining: typeof isServerDraining;
@@ -62,6 +68,8 @@ const DEFAULT_GET_CHAT_ROUTE_DEPENDENCIES: GetChatRouteDependencies = {
 const DEFAULT_POST_CHAT_ROUTE_DEPENDENCIES: PostChatRouteDependencies = {
   getLocaleFromRequest,
   resolveSnapshotWithRunRecovery,
+  reserveChatRunStart,
+  releaseChatRunStartReservation,
   prepareChatRun,
   startPersistedChatRun,
   isServerDraining,
@@ -160,25 +168,21 @@ export const postChatRouteWithDeps = async (
       snapshot.sessionId,
     );
 
-    const preparedRun = await dependencies.prepareChatRun(
-      context.userId,
-      context.workspaceId,
-      snapshot.sessionId,
-      body.content,
-    );
-    const locale = dependencies.getLocaleFromRequest(request);
+    const reservation = dependencies.reserveChatRunStart(snapshot.sessionId);
+    if (reservation === null) {
+      throw new ChatSessionConflictError(snapshot.sessionId);
+    }
 
-    const events = dependencies.startPersistedChatRun({
-      requestId,
-      userId: context.userId,
-      workspaceId: context.workspaceId,
-      sessionId: preparedRun.sessionId,
-      locale,
-      timezone: body.timezone,
-      assistantItemId: preparedRun.assistantItem.itemId,
-      localMessages: preparedRun.localMessages,
-      turnInput: preparedRun.turnInput,
-      diagnostics: {
+    let runtimeStarted = false;
+    try {
+      const preparedRun = await dependencies.prepareChatRun(
+        context.userId,
+        context.workspaceId,
+        snapshot.sessionId,
+        body.content,
+      );
+      const locale = dependencies.getLocaleFromRequest(request);
+      const runtimeParams = {
         requestId,
         userId: context.userId,
         workspaceId: context.workspaceId,
@@ -187,25 +191,43 @@ export const postChatRouteWithDeps = async (
         messageCount: diagnostics.messageCount,
         hasAttachments: diagnostics.hasAttachments,
         attachmentFileNames: diagnostics.attachmentFileNames,
-      },
-    });
+      };
+      const events = dependencies.startPersistedChatRun({
+        requestId,
+        userId: context.userId,
+        workspaceId: context.workspaceId,
+        sessionId: preparedRun.sessionId,
+        activeRunId: preparedRun.activeRunId,
+        locale,
+        timezone: body.timezone,
+        assistantItemId: preparedRun.assistantItem.itemId,
+        localMessages: preparedRun.localMessages,
+        turnInput: preparedRun.turnInput,
+        diagnostics: runtimeParams,
+      }, reservation);
+      runtimeStarted = true;
 
-    const stream = createChatEventStream({
-      events,
-      heartbeatIntervalMs: CHAT_STREAM_HEARTBEAT_INTERVAL_MS,
-      onStreamError: (error: string): void => {
-        dependencies.log(createChatErrorLogEvent(diagnostics, "stream", error));
-      },
-    });
+      const stream = createChatEventStream({
+        events,
+        heartbeatIntervalMs: CHAT_STREAM_HEARTBEAT_INTERVAL_MS,
+        onStreamError: (error: string): void => {
+          dependencies.log(createChatErrorLogEvent(diagnostics, "stream", error));
+        },
+      });
 
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-        "X-Chat-Session-Id": preparedRun.sessionId,
-      },
-    });
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+          "X-Chat-Session-Id": preparedRun.sessionId,
+        },
+      });
+    } finally {
+      if (!runtimeStarted) {
+        dependencies.releaseChatRunStartReservation(reservation);
+      }
+    }
   } catch (error) {
     if (
       error instanceof ChatSessionNotFoundError

--- a/apps/web/src/server/chat/http/sessionRecovery.test.ts
+++ b/apps/web/src/server/chat/http/sessionRecovery.test.ts
@@ -4,7 +4,7 @@ import {
   CHAT_STREAM_INTERRUPTED_ERROR,
   resolveSnapshotWithRunRecoveryWithDeps,
 } from "@/server/chat/http/sessionRecovery";
-import type { ChatSessionSnapshot } from "@/server/chat/store";
+import type { ChatSessionSnapshot, PersistedChatMessageItem } from "@/server/chat/store";
 
 const createSnapshot = (
   overrides: Partial<ChatSessionSnapshot> = {},
@@ -12,10 +12,25 @@ const createSnapshot = (
   sessionId: "session-1",
   runState: "idle",
   updatedAt: 0,
+  activeRunId: null,
   activeRunHeartbeatAt: null,
   mainContentInvalidationVersion: 0,
   messages: [],
   ...overrides,
+});
+
+const createMessage = (
+  state: PersistedChatMessageItem["state"],
+): PersistedChatMessageItem => ({
+  itemId: `assistant-${state}`,
+  sessionId: "session-1",
+  role: "assistant",
+  content: [{ type: "text", text: "Answer" }],
+  state,
+  isError: state === "error",
+  isStopped: state === "cancelled",
+  timestamp: 0,
+  updatedAt: 0,
 });
 
 test("resolveSnapshotWithRunRecoveryWithDeps returns non-running snapshots unchanged", async (): Promise<void> => {
@@ -29,8 +44,9 @@ test("resolveSnapshotWithRunRecoveryWithDeps returns non-running snapshots uncha
     {
       getChatSessionSnapshot: async () => snapshot,
       hasActiveChatRun: () => false,
-      markChatSessionInterrupted: async () => {
+      recoverStaleChatSession: async () => {
         interrupted = true;
+        return "interrupted";
       },
       now: () => 1_000,
     },
@@ -40,9 +56,14 @@ test("resolveSnapshotWithRunRecoveryWithDeps returns non-running snapshots uncha
   assert.equal(interrupted, false);
 });
 
-test("resolveSnapshotWithRunRecoveryWithDeps keeps running snapshots when a local runtime run exists", async (): Promise<void> => {
-  const snapshot = createSnapshot({ runState: "running", activeRunHeartbeatAt: 0 });
+test("resolveSnapshotWithRunRecoveryWithDeps keeps stale running snapshots when a matching local runtime run exists", async (): Promise<void> => {
+  const snapshot = createSnapshot({
+    runState: "running",
+    activeRunId: "run-1",
+    activeRunHeartbeatAt: 0,
+  });
   let interrupted = false;
+  let localActiveRunArgs: ReadonlyArray<string> | null = null;
 
   const result = await resolveSnapshotWithRunRecoveryWithDeps(
     "user-1",
@@ -50,16 +71,62 @@ test("resolveSnapshotWithRunRecoveryWithDeps keeps running snapshots when a loca
     "session-1",
     {
       getChatSessionSnapshot: async () => snapshot,
-      hasActiveChatRun: () => true,
-      markChatSessionInterrupted: async () => {
+      hasActiveChatRun: (sessionId, activeRunId) => {
+        localActiveRunArgs = [sessionId, activeRunId];
+        return true;
+      },
+      recoverStaleChatSession: async () => {
         interrupted = true;
+        return "interrupted";
       },
       now: () => 100_000,
     },
   );
 
   assert.equal(result, snapshot);
+  assert.deepEqual(localActiveRunArgs, ["session-1", "run-1"]);
   assert.equal(interrupted, false);
+});
+
+test("resolveSnapshotWithRunRecoveryWithDeps recovers stale snapshots when the local runtime run id differs", async (): Promise<void> => {
+  const initialSnapshot = createSnapshot({
+    runState: "running",
+    activeRunId: "run-1",
+    activeRunHeartbeatAt: 0,
+    messages: [createMessage("in_progress")],
+  });
+  const recoveredSnapshot = createSnapshot({
+    runState: "interrupted",
+    updatedAt: 1,
+  });
+  let callCount = 0;
+  let localActiveRunArgs: ReadonlyArray<string> | null = null;
+  let expectedActiveRunId: string | null = null;
+
+  const result = await resolveSnapshotWithRunRecoveryWithDeps(
+    "user-1",
+    "workspace-1",
+    "session-1",
+    {
+      getChatSessionSnapshot: async () => {
+        callCount += 1;
+        return callCount === 1 ? initialSnapshot : recoveredSnapshot;
+      },
+      hasActiveChatRun: (sessionId, activeRunId) => {
+        localActiveRunArgs = [sessionId, activeRunId];
+        return false;
+      },
+      recoverStaleChatSession: async (_userId, _workspaceId, params) => {
+        expectedActiveRunId = params.expectedActiveRunId;
+        return "interrupted";
+      },
+      now: () => 100_000,
+    },
+  );
+
+  assert.equal(result, recoveredSnapshot);
+  assert.deepEqual(localActiveRunArgs, ["session-1", "run-1"]);
+  assert.equal(expectedActiveRunId, "run-1");
 });
 
 test("resolveSnapshotWithRunRecoveryWithDeps keeps running snapshots with fresh heartbeats", async (): Promise<void> => {
@@ -73,8 +140,9 @@ test("resolveSnapshotWithRunRecoveryWithDeps keeps running snapshots with fresh 
     {
       getChatSessionSnapshot: async () => snapshot,
       hasActiveChatRun: () => false,
-      markChatSessionInterrupted: async () => {
+      recoverStaleChatSession: async () => {
         interrupted = true;
+        return "interrupted";
       },
       now: () => 30_000,
     },
@@ -84,10 +152,12 @@ test("resolveSnapshotWithRunRecoveryWithDeps keeps running snapshots with fresh 
   assert.equal(interrupted, false);
 });
 
-test("resolveSnapshotWithRunRecoveryWithDeps marks stale runs interrupted and refetches the snapshot", async (): Promise<void> => {
+test("resolveSnapshotWithRunRecoveryWithDeps recovers stale runs and refetches the snapshot", async (): Promise<void> => {
   const initialSnapshot = createSnapshot({
     runState: "running",
+    activeRunId: "run-1",
     activeRunHeartbeatAt: 0,
+    messages: [createMessage("in_progress")],
   });
   const recoveredSnapshot = createSnapshot({
     runState: "interrupted",
@@ -108,8 +178,15 @@ test("resolveSnapshotWithRunRecoveryWithDeps marks stale runs interrupted and re
         return callCount === 1 ? initialSnapshot : recoveredSnapshot;
       },
       hasActiveChatRun: () => false,
-      markChatSessionInterrupted: async (userId, workspaceId, sessionId, message) => {
-        interruptedArgs = [userId, workspaceId, sessionId, message];
+      recoverStaleChatSession: async (userId, workspaceId, params) => {
+        interruptedArgs = [
+          userId,
+          workspaceId,
+          params.sessionId,
+          params.expectedActiveRunId,
+          params.errorMessage,
+        ];
+        return "interrupted";
       },
       now: () => 60_000,
     },
@@ -119,6 +196,110 @@ test("resolveSnapshotWithRunRecoveryWithDeps marks stale runs interrupted and re
   assert.deepEqual(requestedSessionIds, ["session-1", "session-1"]);
   assert.deepEqual(
     interruptedArgs,
-    ["user-1", "workspace-1", "session-1", CHAT_STREAM_INTERRUPTED_ERROR],
+    ["user-1", "workspace-1", "session-1", "run-1", CHAT_STREAM_INTERRUPTED_ERROR],
   );
+});
+
+test("resolveSnapshotWithRunRecoveryWithDeps passes the observed stale run id when the refetched session changed", async (): Promise<void> => {
+  const initialSnapshot = createSnapshot({
+    runState: "running",
+    activeRunId: "run-1",
+    activeRunHeartbeatAt: 0,
+    messages: [createMessage("in_progress")],
+  });
+  const changedRunSnapshot = createSnapshot({
+    runState: "running",
+    activeRunId: "run-2",
+    activeRunHeartbeatAt: 1,
+    messages: [createMessage("in_progress")],
+  });
+  let callCount = 0;
+  let expectedActiveRunId: string | null = null;
+
+  const result = await resolveSnapshotWithRunRecoveryWithDeps(
+    "user-1",
+    "workspace-1",
+    "session-1",
+    {
+      getChatSessionSnapshot: async () => {
+        callCount += 1;
+        return callCount === 1 ? initialSnapshot : changedRunSnapshot;
+      },
+      hasActiveChatRun: () => false,
+      recoverStaleChatSession: async (_userId, _workspaceId, params) => {
+        expectedActiveRunId = params.expectedActiveRunId;
+        return "run_changed";
+      },
+      now: () => 60_000,
+    },
+  );
+
+  assert.equal(result, changedRunSnapshot);
+  assert.equal(expectedActiveRunId, "run-1");
+});
+
+test("resolveSnapshotWithRunRecoveryWithDeps delegates completed stale run recovery without changing response shape", async (): Promise<void> => {
+  const initialSnapshot = createSnapshot({
+    runState: "running",
+    activeRunId: "run-1",
+    activeRunHeartbeatAt: 0,
+    messages: [createMessage("completed")],
+  });
+  const recoveredSnapshot = createSnapshot({
+    runState: "idle",
+    updatedAt: 1,
+    messages: [createMessage("completed")],
+  });
+  let recoveryResult: string | null = null;
+  let callCount = 0;
+
+  const result = await resolveSnapshotWithRunRecoveryWithDeps(
+    "user-1",
+    "workspace-1",
+    "session-1",
+    {
+      getChatSessionSnapshot: async () => {
+        callCount += 1;
+        return callCount === 1 ? initialSnapshot : recoveredSnapshot;
+      },
+      hasActiveChatRun: () => false,
+      recoverStaleChatSession: async () => {
+        recoveryResult = "completed_recovered";
+        return "completed_recovered";
+      },
+      now: () => 60_000,
+    },
+  );
+
+  assert.equal(result, recoveredSnapshot);
+  assert.equal(recoveryResult, "completed_recovered");
+});
+
+test("resolveSnapshotWithRunRecoveryWithDeps rejects stale running snapshots without an active run id", async (): Promise<void> => {
+  const initialSnapshot = createSnapshot({
+    runState: "running",
+    activeRunId: null,
+    activeRunHeartbeatAt: 0,
+    messages: [createMessage("in_progress")],
+  });
+  let recoveryCalled = false;
+
+  await assert.rejects(
+    resolveSnapshotWithRunRecoveryWithDeps(
+      "user-1",
+      "workspace-1",
+      "session-1",
+      {
+        getChatSessionSnapshot: async () => initialSnapshot,
+        hasActiveChatRun: () => false,
+        recoverStaleChatSession: async () => {
+          recoveryCalled = true;
+          return "interrupted";
+        },
+        now: () => 60_000,
+      },
+    ),
+    /running session has no activeRunId, sessionId=session-1/,
+  );
+  assert.equal(recoveryCalled, false);
 });

--- a/apps/web/src/server/chat/http/sessionRecovery.ts
+++ b/apps/web/src/server/chat/http/sessionRecovery.ts
@@ -7,14 +7,14 @@ import {
   ChatSessionConflictError,
   ChatSessionNotFoundError,
   getChatSessionSnapshot,
-  markChatSessionInterrupted,
+  recoverStaleChatSession,
   type ChatSessionSnapshot,
 } from "@/server/chat/store";
 
 export type SessionRecoveryDependencies = Readonly<{
   getChatSessionSnapshot: typeof getChatSessionSnapshot;
   hasActiveChatRun: typeof hasActiveChatRun;
-  markChatSessionInterrupted: typeof markChatSessionInterrupted;
+  recoverStaleChatSession: typeof recoverStaleChatSession;
   now: () => number;
 }>;
 
@@ -23,8 +23,16 @@ export const CHAT_STREAM_INTERRUPTED_ERROR = "This response stopped because the 
 const DEFAULT_SESSION_RECOVERY_DEPENDENCIES: SessionRecoveryDependencies = {
   getChatSessionSnapshot,
   hasActiveChatRun,
-  markChatSessionInterrupted,
+  recoverStaleChatSession,
   now: (): number => Date.now(),
+};
+
+const requireSnapshotActiveRunId = (snapshot: ChatSessionSnapshot): string => {
+  if (snapshot.activeRunId === null) {
+    throw new Error(`Chat stale run recovery failed: running session has no activeRunId, sessionId=${snapshot.sessionId}`);
+  }
+
+  return snapshot.activeRunId;
 };
 
 export const mapStoreErrorToRouteError = (error: unknown): never => {
@@ -51,10 +59,6 @@ export const resolveSnapshotWithRunRecoveryWithDeps = async (
     return snapshot;
   }
 
-  if (dependencies.hasActiveChatRun(snapshot.sessionId)) {
-    return snapshot;
-  }
-
   const heartbeatAgeMs = snapshot.activeRunHeartbeatAt === null
     ? Number.POSITIVE_INFINITY
     : dependencies.now() - snapshot.activeRunHeartbeatAt;
@@ -63,11 +67,19 @@ export const resolveSnapshotWithRunRecoveryWithDeps = async (
     return snapshot;
   }
 
-  await dependencies.markChatSessionInterrupted(
+  const expectedActiveRunId = requireSnapshotActiveRunId(snapshot);
+  if (dependencies.hasActiveChatRun(snapshot.sessionId, expectedActiveRunId)) {
+    return snapshot;
+  }
+
+  await dependencies.recoverStaleChatSession(
     userId,
     workspaceId,
-    snapshot.sessionId,
-    CHAT_STREAM_INTERRUPTED_ERROR,
+    {
+      sessionId: snapshot.sessionId,
+      expectedActiveRunId,
+      errorMessage: CHAT_STREAM_INTERRUPTED_ERROR,
+    },
   );
 
   snapshot = await dependencies.getChatSessionSnapshot(userId, workspaceId, snapshot.sessionId);

--- a/apps/web/src/server/chat/runtime.test.ts
+++ b/apps/web/src/server/chat/runtime.test.ts
@@ -5,13 +5,54 @@ import type { StoredOpenAIReplayItem } from "@/server/chat/openai/replayItems";
 import {
   clearActiveChatRunForTests,
   createActiveChatRunForTests,
+  hasActiveChatRun,
+  markActiveChatRunCancellationPersisted,
+  releaseChatRunStartReservation,
+  reserveChatRunStart,
   runPersistedChatSessionWithDeps,
+  startPersistedChatRunWithDeps,
   stopActiveChatRun,
+  type ChatRunStartReservation,
   type ChatRuntimeDependencies,
   type StartPersistedChatRunParams,
 } from "@/server/chat/runtime";
+import { ChatSessionRunTransitionError } from "@/server/chat/store";
 import type { PersistedChatMessageItem } from "@/server/chat/store/shared";
 import type { ChatStreamEvent } from "@/server/chat/types";
+
+type ActiveRunPayload = Readonly<{ activeRunId: string }>;
+
+type Deferred = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+}>;
+
+const createDeferred = (): Deferred => {
+  let resolvePromise: (() => void) | null = null;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  if (resolvePromise === null) {
+    throw new Error("Deferred promise resolver was not initialized");
+  }
+
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+};
+
+const requireReservation = (
+  sessionId: string,
+): ChatRunStartReservation => {
+  const reservation = reserveChatRunStart(sessionId);
+  if (reservation === null) {
+    throw new Error(`Expected chat run start reservation for sessionId=${sessionId}`);
+  }
+
+  return reservation;
+};
 
 const createRunParams = (
   sessionId: string,
@@ -20,6 +61,7 @@ const createRunParams = (
   userId: "user-1",
   workspaceId: "workspace-1",
   sessionId,
+  activeRunId: `run-${sessionId}`,
   locale: "en",
   timezone: "Europe/Madrid",
   assistantItemId: "assistant-1",
@@ -53,6 +95,7 @@ const createRuntimeDependencies = (
   overrides: Readonly<Partial<ChatRuntimeDependencies>>,
   recorded: {
     readonly updatePayloads: Array<unknown>;
+    readonly heartbeatPayloads: Array<unknown>;
     cancelledPayload: unknown;
     terminalErrorPayload: unknown;
     completedPayload: unknown;
@@ -90,7 +133,14 @@ const createRuntimeDependencies = (
   ): Promise<void> => {
     recorded.terminalErrorPayload = payload;
   }),
-  touchChatSessionHeartbeat: overrides.touchChatSessionHeartbeat ?? (async (): Promise<void> => undefined),
+  touchChatSessionHeartbeat: overrides.touchChatSessionHeartbeat ?? (async (
+    userId,
+    workspaceId,
+    sessionId,
+    activeRunId,
+  ): Promise<void> => {
+    recorded.heartbeatPayloads.push({ userId, workspaceId, sessionId, activeRunId });
+  }),
   updateAssistantMessageItem: overrides.updateAssistantMessageItem ?? (async (
     _userId,
     _workspaceId,
@@ -99,7 +149,7 @@ const createRuntimeDependencies = (
     recorded.updatePayloads.push(payload);
     return {
       itemId: payload.itemId,
-      sessionId: "session-test",
+      sessionId: payload.sessionId,
       role: "assistant",
       content: payload.content,
       state: payload.state,
@@ -127,12 +177,13 @@ test("runPersistedChatSessionWithDeps persists stopped state for user aborts wit
   const params = createRunParams(sessionId);
   const recorded = {
     updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
     cancelledPayload: null as unknown,
     terminalErrorPayload: null as unknown,
     completedPayload: null as unknown,
   };
 
-  createActiveChatRunForTests(sessionId);
+  createActiveChatRunForTests(sessionId, params.activeRunId);
 
   try {
     await runPersistedChatSessionWithDeps(
@@ -146,7 +197,10 @@ test("runPersistedChatSessionWithDeps persists stopped state for user aborts wit
             openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
           }>> => {
             await onEvent(createDeltaEvent("Partial answer"));
-            assert.equal(stopActiveChatRun(sessionId), true);
+            assert.deepEqual(stopActiveChatRun(sessionId, params.activeRunId), {
+              stopped: true,
+              activeRunId: params.activeRunId,
+            });
             const abortError = new Error("User aborted");
             abortError.name = "AbortError";
             throw abortError;
@@ -161,6 +215,7 @@ test("runPersistedChatSessionWithDeps persists stopped state for user aborts wit
 
   assert.equal(recorded.updatePayloads.length, 1);
   assert.notEqual(recorded.cancelledPayload, null);
+  assert.equal((recorded.cancelledPayload as ActiveRunPayload).activeRunId, params.activeRunId);
   assert.equal(recorded.terminalErrorPayload, null);
   assert.equal(recorded.completedPayload, null);
 });
@@ -169,31 +224,503 @@ test("runPersistedChatSessionWithDeps persists terminal errors when the provider
   const params = createRunParams("session-provider-error");
   const recorded = {
     updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
     cancelledPayload: null as unknown,
     terminalErrorPayload: null as unknown,
     completedPayload: null as unknown,
   };
 
-  await runPersistedChatSessionWithDeps(
-    params,
-    createRuntimeDependencies(
-      {
-        runOpenAILoop: async (
-          _loopParams,
-          onEvent,
-        ): Promise<Readonly<{
-          openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
-        }>> => {
-          await onEvent(createDeltaEvent("Partial answer"));
-          throw new Error("Provider stream failed");
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+  try {
+    await runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          runOpenAILoop: async (
+            _loopParams,
+            onEvent,
+          ): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            await onEvent(createDeltaEvent("Partial answer"));
+            throw new Error("Provider stream failed");
+          },
         },
-      },
-      recorded,
-    ),
-  );
+        recorded,
+      ),
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+  }
 
   assert.equal(recorded.updatePayloads.length, 1);
+  assert.equal((recorded.updatePayloads[0] as ActiveRunPayload).activeRunId, params.activeRunId);
+  assert.equal((recorded.updatePayloads[0] as { sessionId: string }).sessionId, params.sessionId);
   assert.equal(recorded.cancelledPayload, null);
   assert.notEqual(recorded.terminalErrorPayload, null);
+  assert.equal((recorded.terminalErrorPayload as ActiveRunPayload).activeRunId, params.activeRunId);
   assert.equal(recorded.completedPayload, null);
+});
+
+test("runPersistedChatSessionWithDeps skips terminal error persistence when provider error lost the active-run race", async (): Promise<void> => {
+  const params = createRunParams("session-provider-transition-miss");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          runOpenAILoop: async (): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            throw new Error("Provider stream failed");
+          },
+          persistAssistantTerminalError: async (): Promise<void> => {
+            throw new ChatSessionRunTransitionError({
+              sessionId: params.sessionId,
+              activeRunId: params.activeRunId,
+              operation: "persist assistant terminal error",
+              targetState: "idle",
+            });
+          },
+        },
+        recorded,
+      ),
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.completedPayload, null);
+  assert.equal(recorded.cancelledPayload, null);
+});
+
+test("runPersistedChatSessionWithDeps skips cancellation persistence when user abort lost the active-run race", async (): Promise<void> => {
+  const sessionId = "session-cancel-transition-miss";
+  const params = createRunParams(sessionId);
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  createActiveChatRunForTests(sessionId, params.activeRunId);
+
+  try {
+    await runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          runOpenAILoop: async (
+            _loopParams,
+            _onEvent,
+          ): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            assert.deepEqual(stopActiveChatRun(sessionId, params.activeRunId), {
+              stopped: true,
+              activeRunId: params.activeRunId,
+            });
+            const abortError = new Error("User aborted");
+            abortError.name = "AbortError";
+            throw abortError;
+          },
+          persistAssistantCancelled: async (): Promise<void> => {
+            throw new ChatSessionRunTransitionError({
+              sessionId: params.sessionId,
+              activeRunId: params.activeRunId,
+              operation: "persist assistant cancellation",
+              targetState: "idle",
+            });
+          },
+        },
+        recorded,
+      ),
+    );
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+    console.log = originalLog;
+  }
+
+  assert.equal(recorded.cancelledPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.completedPayload, null);
+});
+
+test("hasActiveChatRun matches the stored active run id", (): void => {
+  const sessionId = "session-local-active-run";
+  const activeRunId = "run-local-active";
+
+  createActiveChatRunForTests(sessionId, activeRunId);
+
+  try {
+    assert.equal(hasActiveChatRun(sessionId, activeRunId), true);
+    assert.equal(hasActiveChatRun(sessionId, "run-other"), false);
+    assert.equal(hasActiveChatRun("session-other", activeRunId), false);
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+  }
+});
+
+test("reserveChatRunStart rejects active and requested local runs before DB prepare", (): void => {
+  const sessionId = "session-reserve-blocked";
+  const activeRunId = "run-current";
+
+  createActiveChatRunForTests(sessionId, activeRunId);
+
+  try {
+    assert.equal(reserveChatRunStart(sessionId), null);
+    assert.deepEqual(stopActiveChatRun(sessionId, activeRunId), {
+      stopped: true,
+      activeRunId,
+    });
+    assert.equal(reserveChatRunStart(sessionId), null);
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+  }
+});
+
+test("reserveChatRunStart can be released before runtime start", (): void => {
+  const sessionId = "session-reserve-release";
+  const reservation = requireReservation(sessionId);
+
+  releaseChatRunStartReservation(reservation);
+
+  const secondReservation = requireReservation(sessionId);
+  releaseChatRunStartReservation(secondReservation);
+});
+
+test("stopActiveChatRun ignores mismatched active run ids", (): void => {
+  const sessionId = "session-stop-mismatch";
+  const activeRunId = "run-current";
+
+  createActiveChatRunForTests(sessionId, activeRunId);
+
+  try {
+    assert.deepEqual(stopActiveChatRun(sessionId, "run-other"), { stopped: false });
+    assert.equal(hasActiveChatRun(sessionId, activeRunId), true);
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+  }
+});
+
+test("markActiveChatRunCancellationPersisted ignores mismatched active run ids", (): void => {
+  const sessionId = "session-mark-mismatch";
+  const activeRunId = "run-current";
+
+  createActiveChatRunForTests(sessionId, activeRunId);
+
+  try {
+    markActiveChatRunCancellationPersisted(sessionId, "run-stale");
+    assert.equal(hasActiveChatRun(sessionId, activeRunId), true);
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+  }
+});
+
+test("startPersistedChatRunWithDeps replaces persisted local stop state without old cleanup removing the new run", async (): Promise<void> => {
+  const sessionId = "session-replace-persisted";
+  const oldParams = {
+    ...createRunParams(sessionId),
+    activeRunId: "run-old",
+  };
+  const newParams = {
+    ...createRunParams(sessionId),
+    requestId: "req-session-replace-persisted-new",
+    activeRunId: "run-new",
+  };
+  const oldLoopStarted = createDeferred();
+  const oldRelease = createDeferred();
+  const newRelease = createDeferred();
+  const oldRecorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const newRecorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  createActiveChatRunForTests(sessionId, oldParams.activeRunId);
+
+  try {
+    const oldRun = runPersistedChatSessionWithDeps(
+      oldParams,
+      createRuntimeDependencies(
+        {
+          runOpenAILoop: async (): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            oldLoopStarted.resolve();
+            await oldRelease.promise;
+            const abortError = new Error("User aborted");
+            abortError.name = "AbortError";
+            throw abortError;
+          },
+          persistAssistantTerminalError: async (): Promise<void> => {
+            throw new ChatSessionRunTransitionError({
+              sessionId,
+              activeRunId: oldParams.activeRunId,
+              operation: "persist assistant terminal error",
+              targetState: "idle",
+            });
+          },
+        },
+        oldRecorded,
+      ),
+    );
+
+    await oldLoopStarted.promise;
+    assert.deepEqual(stopActiveChatRun(sessionId, oldParams.activeRunId), {
+      stopped: true,
+      activeRunId: oldParams.activeRunId,
+    });
+    markActiveChatRunCancellationPersisted(sessionId, oldParams.activeRunId);
+
+    const newReservation = requireReservation(sessionId);
+    const newEvents = startPersistedChatRunWithDeps(
+      newParams,
+      newReservation,
+      createRuntimeDependencies(
+        {
+          runOpenAILoop: async (): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            await newRelease.promise;
+            return { openaiItems: [] };
+          },
+        },
+        newRecorded,
+      ),
+    );
+
+    assert.equal(hasActiveChatRun(sessionId, oldParams.activeRunId), false);
+    assert.equal(hasActiveChatRun(sessionId, newParams.activeRunId), true);
+
+    oldRelease.resolve();
+    await oldRun;
+    assert.equal(hasActiveChatRun(sessionId, newParams.activeRunId), true);
+
+    newRelease.resolve();
+    assert.deepEqual(await newEvents.next(), {
+      done: true,
+      value: undefined,
+    });
+    assert.equal(hasActiveChatRun(sessionId, newParams.activeRunId), false);
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+    console.log = originalLog;
+  }
+});
+
+test("late done from a replaced run does not close the newer stream", async (): Promise<void> => {
+  const sessionId = "session-late-done";
+  const oldParams = {
+    ...createRunParams(sessionId),
+    activeRunId: "run-old",
+  };
+  const newParams = {
+    ...createRunParams(sessionId),
+    requestId: "req-session-late-done-new",
+    activeRunId: "run-new",
+  };
+  const oldLoopStarted = createDeferred();
+  const oldEmitDone = createDeferred();
+  const newRelease = createDeferred();
+  const oldRecorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const newRecorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+
+  createActiveChatRunForTests(sessionId, oldParams.activeRunId);
+
+  try {
+    const oldRun = runPersistedChatSessionWithDeps(
+      oldParams,
+      createRuntimeDependencies(
+        {
+          runOpenAILoop: async (
+            _loopParams,
+            onEvent,
+          ): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            oldLoopStarted.resolve();
+            await oldEmitDone.promise;
+            await onEvent({ type: "done" });
+            return { openaiItems: [] };
+          },
+        },
+        oldRecorded,
+      ),
+    );
+
+    await oldLoopStarted.promise;
+    assert.deepEqual(stopActiveChatRun(sessionId, oldParams.activeRunId), {
+      stopped: true,
+      activeRunId: oldParams.activeRunId,
+    });
+    markActiveChatRunCancellationPersisted(sessionId, oldParams.activeRunId);
+
+    const newReservation = requireReservation(sessionId);
+    const newEvents = startPersistedChatRunWithDeps(
+      newParams,
+      newReservation,
+      createRuntimeDependencies(
+        {
+          runOpenAILoop: async (): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            await newRelease.promise;
+            return { openaiItems: [] };
+          },
+        },
+        newRecorded,
+      ),
+    );
+
+    const nextEvent = newEvents.next();
+    oldEmitDone.resolve();
+    await oldRun;
+    assert.equal(oldRecorded.completedPayload, null);
+    assert.equal(oldRecorded.terminalErrorPayload, null);
+
+    const pending = { pending: true } as const;
+    const observed = await Promise.race<IteratorResult<ChatStreamEvent> | typeof pending>([
+      nextEvent,
+      new Promise<typeof pending>((resolve) => {
+        setTimeout(() => resolve(pending), 20);
+      }),
+    ]);
+    assert.deepEqual(observed, pending);
+    assert.equal(hasActiveChatRun(sessionId, newParams.activeRunId), true);
+
+    newRelease.resolve();
+    assert.deepEqual(await nextEvent, {
+      done: true,
+      value: undefined,
+    });
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+  }
+});
+
+test("runPersistedChatSessionWithDeps passes the same active run id to heartbeat and completion", async (): Promise<void> => {
+  const params = createRunParams("session-success");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+  try {
+    await runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          runOpenAILoop: async (
+            _loopParams,
+            onEvent,
+          ): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            await onEvent(createDeltaEvent("Done"));
+            return { openaiItems: [] };
+          },
+        },
+        recorded,
+      ),
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+  }
+
+  assert.deepEqual(recorded.heartbeatPayloads, [{
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    sessionId: params.sessionId,
+    activeRunId: params.activeRunId,
+  }]);
+  assert.equal(recorded.updatePayloads.length, 1);
+  assert.equal((recorded.updatePayloads[0] as ActiveRunPayload).activeRunId, params.activeRunId);
+  assert.equal((recorded.updatePayloads[0] as { sessionId: string }).sessionId, params.sessionId);
+  assert.notEqual(recorded.completedPayload, null);
+  assert.equal((recorded.completedPayload as ActiveRunPayload).activeRunId, params.activeRunId);
+  assert.equal((recorded.completedPayload as { sessionId: string }).sessionId, params.sessionId);
+  assert.equal(recorded.cancelledPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+});
+
+test("runPersistedChatSessionWithDeps skips terminal error persistence when completion lost the active-run race", async (): Promise<void> => {
+  const params = createRunParams("session-transition-miss");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          completeChatRun: async (): Promise<void> => {
+            throw new ChatSessionRunTransitionError({
+              sessionId: params.sessionId,
+              activeRunId: params.activeRunId,
+              operation: "complete chat run",
+              targetState: "idle",
+            });
+          },
+        },
+        recorded,
+      ),
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.cancelledPayload, null);
 });

--- a/apps/web/src/server/chat/runtime.ts
+++ b/apps/web/src/server/chat/runtime.ts
@@ -14,6 +14,7 @@ import { runOpenAILoop } from "@/server/chat/openai/loop";
 import { startChatTurnObservation } from "@/server/chat/openai/langfuse";
 import {
   buildUserStoppedAssistantContent,
+  ChatSessionRunTransitionError,
   completeChatRun,
   INTERRUPTED_TOOL_CALL_OUTPUT,
   persistAssistantCancelled,
@@ -55,6 +56,7 @@ export type StartPersistedChatRunParams = Readonly<{
   userId: string;
   workspaceId: string;
   sessionId: string;
+  activeRunId: string;
   locale: SupportedLocale;
   timezone: string;
   assistantItemId: string;
@@ -70,11 +72,21 @@ type ChatRunSubscriber = Readonly<{
 }>;
 
 type ActiveChatRun = {
+  activeRunId: string;
   subscribers: Set<ChatRunSubscriber>;
   abortController: AbortController;
   stopRequestedByUser: boolean;
   cancellationState: "active" | "requested" | "persisted";
 };
+
+export type StopActiveChatRunResult =
+  | Readonly<{ stopped: true; activeRunId: string }>
+  | Readonly<{ stopped: false }>;
+
+export type ChatRunStartReservation = Readonly<{
+  sessionId: string;
+  reservationId: symbol;
+}>;
 
 export type ChatRuntimeDependencies = Readonly<{
   runOpenAILoop: typeof runOpenAILoop;
@@ -90,6 +102,7 @@ export type ChatRuntimeDependencies = Readonly<{
 }>;
 
 const activeChatRuns = new Map<string, ActiveChatRun>();
+const chatRunStartReservations = new Map<string, symbol>();
 
 const DEFAULT_CHAT_RUNTIME_DEPENDENCIES: ChatRuntimeDependencies = {
   runOpenAILoop,
@@ -151,17 +164,35 @@ const createReasoningSummaryContentPart = (
   },
 });
 
+const isCurrentActiveChatRun = (
+  sessionId: string,
+  activeRunId: string,
+): boolean => {
+  const activeRun = activeChatRuns.get(sessionId);
+  return activeRun?.cancellationState === "active" && activeRun.activeRunId === activeRunId;
+};
+
 const broadcastChatEvent = (
   sessionId: string,
+  activeRunId: string,
   event: ChatStreamEvent,
 ): void => {
-  const activeRun = activeChatRuns.get(sessionId);
-  if (activeRun === undefined || activeRun.cancellationState !== "active") {
+  if (!isCurrentActiveChatRun(sessionId, activeRunId)) {
     return;
   }
 
+  const activeRun = activeChatRuns.get(sessionId);
+  if (activeRun === undefined) {
+    return;
+  }
   for (const subscriber of activeRun.subscribers) {
     subscriber.push(event);
+  }
+};
+
+const closeRunSubscribers = (activeRun: ActiveChatRun): void => {
+  for (const subscriber of activeRun.subscribers) {
+    subscriber.close();
   }
 };
 
@@ -171,13 +202,47 @@ const closeSubscribers = (sessionId: string): void => {
     return;
   }
 
-  for (const subscriber of activeRun.subscribers) {
-    subscriber.close();
+  closeRunSubscribers(activeRun);
+};
+
+const closeActiveChatRunIfCurrent = (
+  sessionId: string,
+  activeRunId: string,
+): void => {
+  const activeRun = activeChatRuns.get(sessionId);
+  if (activeRun === undefined || activeRun.activeRunId !== activeRunId) {
+    return;
   }
+
+  closeRunSubscribers(activeRun);
+  activeChatRuns.delete(sessionId);
 };
 
 const getActiveChatRun = (sessionId: string): ActiveChatRun | undefined =>
   activeChatRuns.get(sessionId);
+
+const getCurrentActiveChatRun = (
+  sessionId: string,
+  activeRunId: string,
+): ActiveChatRun | undefined => {
+  const activeRun = activeChatRuns.get(sessionId);
+  if (activeRun === undefined || activeRun.activeRunId !== activeRunId) {
+    return undefined;
+  }
+
+  return activeRun;
+};
+
+const consumeChatRunStartReservation = (
+  reservation: ChatRunStartReservation,
+): void => {
+  const currentReservationId = chatRunStartReservations.get(reservation.sessionId);
+  if (currentReservationId !== reservation.reservationId) {
+    throw new Error(`Chat run start reservation is not active: sessionId=${reservation.sessionId}`);
+  }
+
+  chatRunStartReservations.delete(reservation.sessionId);
+};
 
 const createChatRunSubscriber = (
   sessionId: string,
@@ -270,6 +335,24 @@ const logChatRunError = (
   log(createChatErrorLogEvent(diagnostics, stage, message));
 };
 
+const logRunTransitionSkipped = (
+  error: ChatSessionRunTransitionError,
+  params: StartPersistedChatRunParams,
+): void => {
+  log({
+    domain: "chat",
+    action: "run_transition_skipped",
+    requestId: params.requestId,
+    sessionId: params.sessionId,
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    activeRunId: params.activeRunId,
+    operation: error.operation,
+    ...(error.targetState === undefined ? {} : { targetState: error.targetState }),
+    error: error.message,
+  });
+};
+
 const applyAssistantDelta = (
   content: ReadonlyArray<ContentPart>,
   event: Extract<ChatStreamEvent, { type: "delta" }>,
@@ -289,10 +372,14 @@ const updateAssistantInProgress = async (
   dependencies: ChatRuntimeDependencies,
   userId: string,
   workspaceId: string,
+  sessionId: string,
+  activeRunId: string,
   assistantItemId: string,
   assistantContent: ReadonlyArray<ContentPart>,
 ): Promise<void> => {
   await dependencies.updateAssistantMessageItem(userId, workspaceId, {
+    sessionId,
+    activeRunId,
     itemId: assistantItemId,
     content: assistantContent,
     state: "in_progress",
@@ -319,6 +406,8 @@ const persistToolCallProgress = async (
   dependencies: ChatRuntimeDependencies,
   userId: string,
   workspaceId: string,
+  sessionId: string,
+  activeRunId: string,
   assistantItemId: string,
   assistantContent: ReadonlyArray<ContentPart>,
   event: Extract<ChatStreamEvent, { type: "tool_call" }>,
@@ -329,6 +418,8 @@ const persistToolCallProgress = async (
       dependencies,
       userId,
       workspaceId,
+      sessionId,
+      activeRunId,
       assistantItemId,
       assistantContent,
     );
@@ -341,6 +432,8 @@ const persistToolCallProgress = async (
       dependencies,
       userId,
       workspaceId,
+      sessionId,
+      activeRunId,
       assistantItemId,
       assistantContent,
     );
@@ -355,6 +448,8 @@ const persistToolCallProgress = async (
     workspaceId,
     {
       itemId: assistantItemId,
+      sessionId,
+      activeRunId,
       content: assistantContent,
       state: "in_progress",
     },
@@ -393,34 +488,51 @@ export const runPersistedChatSessionWithDeps = async (
   let isFinalized = false;
   const seenInvalidationVersions = new Map<string, number>();
   const heartbeatTimer = setInterval(() => {
-    void dependencies.touchChatSessionHeartbeat(params.userId, params.workspaceId, params.sessionId).catch((error) => {
+    void dependencies.touchChatSessionHeartbeat(
+      params.userId,
+      params.workspaceId,
+      params.sessionId,
+      params.activeRunId,
+    ).catch((error) => {
       logChatRunError(params.diagnostics, "stream", error);
     });
   }, CHAT_RUN_HEARTBEAT_INTERVAL_MS);
 
   const persistUserCancellationIfNeeded = async (): Promise<boolean> => {
     const activeRun = getActiveChatRun(params.sessionId);
-    if (activeRun === undefined || activeRun.stopRequestedByUser !== true) {
+    if (
+      activeRun === undefined
+      || activeRun.activeRunId !== params.activeRunId
+      || activeRun.stopRequestedByUser !== true
+    ) {
       return false;
     }
 
     if (activeRun.cancellationState === "persisted") {
+      isFinalized = true;
       return true;
     }
 
     assistantContent = buildUserStoppedAssistantContent(assistantContent);
     await dependencies.persistAssistantCancelled(params.userId, params.workspaceId, {
       sessionId: params.sessionId,
+      activeRunId: params.activeRunId,
       assistantItemId: params.assistantItemId,
       assistantContent,
     });
     activeRun.cancellationState = "persisted";
+    isFinalized = true;
     return true;
   };
 
   try {
     await dependencies.beginTaskProtection();
-    await dependencies.touchChatSessionHeartbeat(params.userId, params.workspaceId, params.sessionId);
+    await dependencies.touchChatSessionHeartbeat(
+      params.userId,
+      params.workspaceId,
+      params.sessionId,
+      params.activeRunId,
+    );
 
     await dependencies.startChatTurnObservation(
       {
@@ -439,12 +551,18 @@ export const runPersistedChatSessionWithDeps = async (
             return;
           }
 
+          if (!isCurrentActiveChatRun(params.sessionId, params.activeRunId)) {
+            return;
+          }
+
           if (event.type === "delta") {
             assistantContent = applyAssistantDelta(assistantContent, event);
             await updateAssistantInProgress(
               dependencies,
               params.userId,
               params.workspaceId,
+              params.sessionId,
+              params.activeRunId,
               params.assistantItemId,
               assistantContent,
             );
@@ -454,12 +572,14 @@ export const runPersistedChatSessionWithDeps = async (
               dependencies,
               params.userId,
               params.workspaceId,
+              params.sessionId,
+              params.activeRunId,
               params.assistantItemId,
               assistantContent,
               event,
               seenInvalidationVersions,
             );
-            broadcastChatEvent(params.sessionId, eventToBroadcast);
+            broadcastChatEvent(params.sessionId, params.activeRunId, eventToBroadcast);
             return;
           } else if (event.type === "reasoning_summary") {
             assistantContent = upsertReasoningSummaryContent(
@@ -470,6 +590,8 @@ export const runPersistedChatSessionWithDeps = async (
               dependencies,
               params.userId,
               params.workspaceId,
+              params.sessionId,
+              params.activeRunId,
               params.assistantItemId,
               assistantContent,
             );
@@ -477,6 +599,7 @@ export const runPersistedChatSessionWithDeps = async (
             assistantContent = finalizeAssistantToolCalls(assistantContent);
             await dependencies.persistAssistantTerminalError(params.userId, params.workspaceId, {
               sessionId: params.sessionId,
+              activeRunId: params.activeRunId,
               assistantItemId: params.assistantItemId,
               assistantContent,
               errorMessage: event.message,
@@ -485,7 +608,7 @@ export const runPersistedChatSessionWithDeps = async (
             isFinalized = true;
           }
 
-          broadcastChatEvent(params.sessionId, event);
+          broadcastChatEvent(params.sessionId, params.activeRunId, event);
         };
 
         const completion = await dependencies.runOpenAILoop({
@@ -498,10 +621,15 @@ export const runPersistedChatSessionWithDeps = async (
           localMessages: params.localMessages,
           turnInput: params.turnInput,
           rootObservation,
-          signal: getActiveChatRun(params.sessionId)?.abortController.signal,
+          signal: getCurrentActiveChatRun(params.sessionId, params.activeRunId)?.abortController.signal,
         }, handleOpenAILoopEvent);
 
         if (await persistUserCancellationIfNeeded()) {
+          return;
+        }
+
+        if (!isCurrentActiveChatRun(params.sessionId, params.activeRunId)) {
+          isFinalized = true;
           return;
         }
 
@@ -517,6 +645,8 @@ export const runPersistedChatSessionWithDeps = async (
         params.userId,
         params.workspaceId,
         {
+          sessionId: params.sessionId,
+          activeRunId: params.activeRunId,
           assistantItemId: params.assistantItemId,
           assistantContent,
           assistantOpenAIItems,
@@ -526,10 +656,19 @@ export const runPersistedChatSessionWithDeps = async (
     }
   } catch (error) {
     const activeRun = getActiveChatRun(params.sessionId);
-    const stoppedByUser = activeRun?.stopRequestedByUser === true;
+    const stoppedByUser = activeRun?.activeRunId === params.activeRunId && activeRun.stopRequestedByUser === true;
 
     if (stoppedByUser && isUserAbortError(error)) {
-      await persistUserCancellationIfNeeded();
+      try {
+        await persistUserCancellationIfNeeded();
+      } catch (persistError) {
+        if (persistError instanceof ChatSessionRunTransitionError) {
+          logRunTransitionSkipped(persistError, params);
+          return;
+        }
+
+        throw persistError;
+      }
       log({
         domain: "chat",
         action: "run_cancelled",
@@ -542,21 +681,35 @@ export const runPersistedChatSessionWithDeps = async (
       return;
     }
 
+    if (error instanceof ChatSessionRunTransitionError) {
+      logRunTransitionSkipped(error, params);
+      return;
+    }
+
     const message = error instanceof Error ? error.message : String(error);
     assistantContent = finalizeAssistantToolCalls(assistantContent);
-    await dependencies.persistAssistantTerminalError(params.userId, params.workspaceId, {
-      sessionId: params.sessionId,
-      assistantItemId: params.assistantItemId,
-      assistantContent,
-      errorMessage: message,
-      sessionState: "idle",
-    });
-    broadcastChatEvent(params.sessionId, { type: "error", message });
+    try {
+      await dependencies.persistAssistantTerminalError(params.userId, params.workspaceId, {
+        sessionId: params.sessionId,
+        activeRunId: params.activeRunId,
+        assistantItemId: params.assistantItemId,
+        assistantContent,
+        errorMessage: message,
+        sessionState: "idle",
+      });
+    } catch (persistError) {
+      if (persistError instanceof ChatSessionRunTransitionError) {
+        logRunTransitionSkipped(persistError, params);
+        return;
+      }
+
+      throw persistError;
+    }
+    broadcastChatEvent(params.sessionId, params.activeRunId, { type: "error", message });
     logChatRunError(params.diagnostics, "agent", error);
   } finally {
     clearInterval(heartbeatTimer);
-    closeSubscribers(params.sessionId);
-    activeChatRuns.delete(params.sessionId);
+    closeActiveChatRunIfCurrent(params.sessionId, params.activeRunId);
     await dependencies.endTaskProtection();
   }
 };
@@ -566,50 +719,109 @@ const runPersistedChatSession = async (
 ): Promise<void> =>
   runPersistedChatSessionWithDeps(params, DEFAULT_CHAT_RUNTIME_DEPENDENCIES);
 
-export const hasActiveChatRun = (sessionId: string): boolean =>
+export const hasActiveChatRun = (sessionId: string, activeRunId: string): boolean => {
+  return isCurrentActiveChatRun(sessionId, activeRunId);
+};
+
+export const hasActiveChatSessionRun = (sessionId: string): boolean =>
   activeChatRuns.get(sessionId)?.cancellationState === "active";
 
-export const startPersistedChatRun = (
+export const reserveChatRunStart = (
+  sessionId: string,
+): ChatRunStartReservation | null => {
+  if (chatRunStartReservations.has(sessionId)) {
+    return null;
+  }
+
+  const existingRun = activeChatRuns.get(sessionId);
+  if (existingRun !== undefined) {
+    if (existingRun.cancellationState !== "persisted") {
+      return null;
+    }
+
+    closeRunSubscribers(existingRun);
+    activeChatRuns.delete(sessionId);
+  }
+
+  const reservationId = Symbol(sessionId);
+  chatRunStartReservations.set(sessionId, reservationId);
+  return { sessionId, reservationId };
+};
+
+export const releaseChatRunStartReservation = (
+  reservation: ChatRunStartReservation,
+): void => {
+  if (chatRunStartReservations.get(reservation.sessionId) !== reservation.reservationId) {
+    return;
+  }
+
+  chatRunStartReservations.delete(reservation.sessionId);
+};
+
+export const startPersistedChatRunWithDeps = (
   params: StartPersistedChatRunParams,
+  reservation: ChatRunStartReservation,
+  dependencies: ChatRuntimeDependencies,
 ): AsyncGenerator<ChatStreamEvent> => {
-  if (activeChatRuns.has(params.sessionId)) {
-    throw new Error(`Chat session already has an active in-process run: ${params.sessionId}`);
+  consumeChatRunStartReservation(reservation);
+
+  const existingRun = activeChatRuns.get(params.sessionId);
+  if (existingRun !== undefined) {
+    if (existingRun.cancellationState !== "persisted") {
+      throw new Error(`Chat session already has an active in-process run: ${params.sessionId}`);
+    }
+
+    closeRunSubscribers(existingRun);
+    activeChatRuns.delete(params.sessionId);
   }
 
   const abortController = new AbortController();
   const subscriber = createChatRunSubscriber(params.sessionId);
   activeChatRuns.set(params.sessionId, {
+    activeRunId: params.activeRunId,
     subscribers: new Set([subscriber]),
     abortController,
     stopRequestedByUser: false,
     cancellationState: "active",
   });
 
-  void runPersistedChatSession(params);
+  void runPersistedChatSessionWithDeps(params, dependencies);
 
   return subscriber.createIterator();
 };
 
+export const startPersistedChatRun = (
+  params: StartPersistedChatRunParams,
+  reservation: ChatRunStartReservation,
+): AsyncGenerator<ChatStreamEvent> =>
+  startPersistedChatRunWithDeps(params, reservation, DEFAULT_CHAT_RUNTIME_DEPENDENCIES);
+
 export const stopActiveChatRun = (
   sessionId: string,
-): boolean => {
+  expectedActiveRunId: string,
+): StopActiveChatRunResult => {
   const activeRun = activeChatRuns.get(sessionId);
-  if (activeRun === undefined || activeRun.cancellationState !== "active") {
-    return false;
+  if (
+    activeRun === undefined
+    || activeRun.activeRunId !== expectedActiveRunId
+    || activeRun.cancellationState !== "active"
+  ) {
+    return { stopped: false };
   }
 
   activeRun.stopRequestedByUser = true;
   activeRun.cancellationState = "requested";
   activeRun.abortController.abort();
   closeSubscribers(sessionId);
-  return true;
+  return { stopped: true, activeRunId: activeRun.activeRunId };
 };
 
 export const markActiveChatRunCancellationPersisted = (
   sessionId: string,
+  activeRunId: string,
 ): void => {
   const activeRun = activeChatRuns.get(sessionId);
-  if (activeRun === undefined) {
+  if (activeRun === undefined || activeRun.activeRunId !== activeRunId) {
     return;
   }
 
@@ -618,12 +830,14 @@ export const markActiveChatRunCancellationPersisted = (
 
 export const createActiveChatRunForTests = (
   sessionId: string,
+  activeRunId: string,
 ): void => {
   if (activeChatRuns.has(sessionId)) {
     throw new Error(`Active chat run already exists for tests: ${sessionId}`);
   }
 
   activeChatRuns.set(sessionId, {
+    activeRunId,
     subscribers: new Set(),
     abortController: new AbortController(),
     stopRequestedByUser: false,
@@ -635,4 +849,5 @@ export const clearActiveChatRunForTests = (
   sessionId: string,
 ): void => {
   activeChatRuns.delete(sessionId);
+  chatRunStartReservations.delete(sessionId);
 };

--- a/apps/web/src/server/chat/store.ts
+++ b/apps/web/src/server/chat/store.ts
@@ -1,14 +1,22 @@
 export type {
   ChatItemState,
   ChatSessionRunState,
+  ChatSessionTerminalState,
   ChatSessionSnapshot,
   PersistedChatMessageItem,
   PreparedChatRun,
+  UserCancelChatRunResult,
 } from "./store/shared";
+
+export type {
+  RecoverStaleChatSessionParams,
+  StaleChatSessionRecoveryResult,
+} from "./store/lifecycleStore";
 
 export {
   ChatSessionConflictError,
   ChatSessionNotFoundError,
+  ChatSessionRunTransitionError,
   FAILED_TOOL_CALL_OUTPUT,
   INTERRUPTED_TOOL_CALL_OUTPUT,
   STOPPED_BY_USER_TOOL_OUTPUT,
@@ -16,9 +24,14 @@ export {
 
 export {
   createFreshChatSession,
+  completeChatSessionRunWithQuery,
   getChatSessionId,
   getLatestChatSessionId,
+  lockActiveChatSessionRunWithQuery,
+  lockRequestedChatSessionWithQuery,
+  startChatSessionRunWithQuery,
   touchChatSessionHeartbeat,
+  touchChatSessionHeartbeatWithQuery,
 } from "./store/sessionStore";
 
 export {
@@ -35,8 +48,11 @@ export {
   cancelActiveChatRunByUser,
   cancelActiveChatRunByUserWithQuery,
   completeChatRun,
+  completeChatRunWithQuery,
   markChatSessionInterrupted,
   persistAssistantCancelled,
   persistAssistantTerminalError,
   prepareChatRun,
+  recoverStaleChatSession,
+  recoverStaleChatSessionWithQuery,
 } from "./store/lifecycleStore";

--- a/apps/web/src/server/chat/store/lifecycleStore.test.ts
+++ b/apps/web/src/server/chat/store/lifecycleStore.test.ts
@@ -1,0 +1,424 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { QueryResult } from "pg";
+import {
+  cancelActiveChatRunByUserWithQuery,
+  completeChatRunWithQuery,
+  persistAssistantCancelledWithQuery,
+  persistAssistantTerminalErrorWithQuery,
+  recoverStaleChatSessionWithQuery,
+} from "@/server/chat/store/lifecycleStore";
+import { updateAssistantMessageItemWithQuery } from "@/server/chat/store/messageStore";
+import { ChatSessionRunTransitionError } from "@/server/chat/store/shared";
+import type { QueryFn } from "@/server/db/contextRunner";
+
+type RecordedQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<unknown>;
+}>;
+
+type SessionStatus = "idle" | "running" | "interrupted";
+
+type AssistantState = "in_progress" | "completed";
+
+type StaleRecoveryQueryOptions = Readonly<{
+  sessionStatus: SessionStatus;
+  activeRunId: string | null;
+  lastAssistantState: AssistantState | null;
+  recordedQueries: Array<RecordedQuery>;
+}>;
+
+type UserCancelQueryOptions = Readonly<{
+  sessionStatus: SessionStatus;
+  activeRunId: string | null;
+  recordedQueries: Array<RecordedQuery>;
+}>;
+
+const createQueryResult = (
+  rows: ReadonlyArray<unknown>,
+): QueryResult => ({
+  command: "SELECT",
+  rowCount: rows.length,
+  oid: 0,
+  fields: [],
+  rows: [...rows],
+});
+
+const createSessionRow = (
+  status: SessionStatus,
+  activeRunId: string | null,
+): Readonly<Record<string, string | null>> => ({
+  session_id: "session-1",
+  status,
+  active_run_id: activeRunId,
+  active_run_heartbeat_at: activeRunId === null ? null : "2026-05-02T13:00:00.000Z",
+  main_content_invalidation_version: "0",
+  updated_at: "2026-05-02T13:00:00.000Z",
+});
+
+const createChatItemRow = (
+  state: "in_progress" | "completed" | "error" | "cancelled",
+): Readonly<Record<string, unknown>> => ({
+  item_id: `assistant-${state}`,
+  session_id: "session-1",
+  state,
+  payload: {
+    role: "assistant",
+    content: [{ type: "text", text: "Answer" }],
+  },
+  created_at: "2026-05-02T13:00:00.000Z",
+  updated_at: "2026-05-02T13:00:00.000Z",
+});
+
+const createStaleRecoveryQueryFn = (options: StaleRecoveryQueryOptions): QueryFn => async (
+  text,
+  params,
+): Promise<QueryResult> => {
+  options.recordedQueries.push({ text, params });
+
+  if (text.includes("FROM public.chat_sessions") && text.includes("WHERE user_id = $1")) {
+    return createQueryResult([createSessionRow(options.sessionStatus, options.activeRunId)]);
+  }
+
+  if (text.includes("FROM public.chat_items") && text.includes("ORDER BY item_order ASC")) {
+    return options.lastAssistantState === null
+      ? createQueryResult([])
+      : createQueryResult([createChatItemRow(options.lastAssistantState)]);
+  }
+
+  if (text.includes("UPDATE public.chat_items")) {
+    return createQueryResult([createChatItemRow("completed")]);
+  }
+
+  if (text.includes("INSERT INTO public.chat_items")) {
+    return createQueryResult([createChatItemRow("error")]);
+  }
+
+  if (text.includes("UPDATE public.chat_sessions")) {
+    return createQueryResult([createSessionRow(params[2] === "interrupted" ? "interrupted" : "idle", null)]);
+  }
+
+  throw new Error(`Unexpected query: ${text}`);
+};
+
+const createActiveRunWriteQueryFn = (
+  activeRunMatches: boolean,
+  recordedQueries: Array<RecordedQuery>,
+): QueryFn => async (text, params): Promise<QueryResult> => {
+  recordedQueries.push({ text, params });
+
+  if (
+    text.includes("FROM public.chat_sessions")
+    && text.includes("active_run_id = $2")
+    && text.includes("status = 'running'")
+    && text.includes("FOR UPDATE")
+  ) {
+    return activeRunMatches
+      ? createQueryResult([createSessionRow("running", "run-1")])
+      : createQueryResult([]);
+  }
+
+  if (text.includes("UPDATE public.chat_items")) {
+    return createQueryResult([createChatItemRow("completed")]);
+  }
+
+  if (text.includes("INSERT INTO public.chat_items")) {
+    return createQueryResult([createChatItemRow("error")]);
+  }
+
+  if (text.includes("UPDATE public.chat_sessions")) {
+    return createQueryResult([createSessionRow(params[2] === "interrupted" ? "interrupted" : "idle", null)]);
+  }
+
+  throw new Error(`Unexpected query: ${text}`);
+};
+
+const createUserCancelQueryFn = (options: UserCancelQueryOptions): QueryFn => async (
+  text,
+  params,
+): Promise<QueryResult> => {
+  options.recordedQueries.push({ text, params });
+
+  if (text.includes("FROM public.chat_sessions") && text.includes("WHERE user_id = $1")) {
+    return createQueryResult([createSessionRow(options.sessionStatus, options.activeRunId)]);
+  }
+
+  if (text.includes("FROM public.chat_sessions") && text.includes("WHERE session_id = $1") && text.includes("FOR UPDATE")) {
+    return createQueryResult([createSessionRow(options.sessionStatus, options.activeRunId)]);
+  }
+
+  if (text.includes("FROM public.chat_items") && text.includes("ORDER BY item_order ASC")) {
+    return createQueryResult([createChatItemRow("in_progress")]);
+  }
+
+  if (text.includes("UPDATE public.chat_items")) {
+    return createQueryResult([createChatItemRow("cancelled")]);
+  }
+
+  if (text.includes("UPDATE public.chat_sessions")) {
+    return createQueryResult([createSessionRow("idle", null)]);
+  }
+
+  throw new Error(`Unexpected query: ${text}`);
+};
+
+const createTerminalRunParams = (): Readonly<{
+  sessionId: string;
+  activeRunId: string;
+  assistantItemId: string;
+  assistantContent: ReadonlyArray<{ type: "text"; text: string }>;
+}> => ({
+  sessionId: "session-1",
+  activeRunId: "run-1",
+  assistantItemId: "assistant-1",
+  assistantContent: [{ type: "text", text: "Answer" }],
+});
+
+const withSuppressedConsoleLog = async (
+  run: () => Promise<void>,
+): Promise<void> => {
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  try {
+    await run();
+  } finally {
+    console.log = originalLog;
+  }
+};
+
+test("completeChatRunWithQuery locks the active run before updating the assistant item", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  await completeChatRunWithQuery(
+    createActiveRunWriteQueryFn(true, recordedQueries),
+    createTerminalRunParams(),
+  );
+
+  assert.match(recordedQueries[0].text, /FOR UPDATE/);
+  assert.match(recordedQueries[0].text, /active_run_id = \$2/);
+  assert.equal(recordedQueries[1].text.includes("UPDATE public.chat_items"), true);
+  assert.equal(recordedQueries[2].text.includes("UPDATE public.chat_sessions"), true);
+});
+
+test("persistAssistantTerminalErrorWithQuery locks the active run before updating chat items", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const params = createTerminalRunParams();
+
+  await persistAssistantTerminalErrorWithQuery(
+    createActiveRunWriteQueryFn(true, recordedQueries),
+    {
+      ...params,
+      errorMessage: "Provider failed",
+      sessionState: "idle",
+    },
+  );
+
+  assert.match(recordedQueries[0].text, /FOR UPDATE/);
+  assert.equal(recordedQueries[1].text.includes("UPDATE public.chat_items"), true);
+  assert.equal(recordedQueries.at(-1)?.text.includes("UPDATE public.chat_sessions"), true);
+});
+
+test("persistAssistantCancelledWithQuery locks the active run before updating the assistant item", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  await persistAssistantCancelledWithQuery(
+    createActiveRunWriteQueryFn(true, recordedQueries),
+    createTerminalRunParams(),
+  );
+
+  assert.match(recordedQueries[0].text, /FOR UPDATE/);
+  assert.equal(recordedQueries[1].text.includes("UPDATE public.chat_items"), true);
+  assert.equal(recordedQueries[2].text.includes("UPDATE public.chat_sessions"), true);
+});
+
+test("updateAssistantMessageItemWithQuery does not update chat items when the active run changed", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  await assert.rejects(
+    updateAssistantMessageItemWithQuery(
+      createActiveRunWriteQueryFn(false, recordedQueries),
+      {
+        sessionId: "session-1",
+        activeRunId: "run-1",
+        itemId: "assistant-1",
+        content: [{ type: "text", text: "Answer" }],
+        state: "in_progress",
+      },
+    ),
+    ChatSessionRunTransitionError,
+  );
+
+  assert.equal(recordedQueries.length, 1);
+  assert.match(recordedQueries[0].text, /FOR UPDATE/);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_items")), false);
+});
+
+test("cancelActiveChatRunByUserWithQuery cancels the matching expected active run", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  const result = await cancelActiveChatRunByUserWithQuery(
+    createUserCancelQueryFn({
+      sessionStatus: "running",
+      activeRunId: "run-1",
+      recordedQueries,
+    }),
+    "user-1",
+    "workspace-1",
+    "session-1",
+    "run-1",
+  );
+
+  assert.equal(result, "cancelled");
+  assert.equal(recordedQueries.some((query) => query.text.includes("FROM public.chat_items")), true);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_items")), true);
+  assert.deepEqual(recordedQueries.at(-1)?.params, ["session-1", "run-1", "idle"]);
+});
+
+test("cancelActiveChatRunByUserWithQuery skips item writes when the active run changed", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  const result = await cancelActiveChatRunByUserWithQuery(
+    createUserCancelQueryFn({
+      sessionStatus: "running",
+      activeRunId: "run-2",
+      recordedQueries,
+    }),
+    "user-1",
+    "workspace-1",
+    "session-1",
+    "run-1",
+  );
+
+  assert.equal(result, "run_changed");
+  assert.equal(recordedQueries.some((query) => query.text.includes("FROM public.chat_items")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_items")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_sessions")), false);
+});
+
+test("cancelActiveChatRunByUserWithQuery skips item writes when the session is not running", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  const result = await cancelActiveChatRunByUserWithQuery(
+    createUserCancelQueryFn({
+      sessionStatus: "idle",
+      activeRunId: null,
+      recordedQueries,
+    }),
+    "user-1",
+    "workspace-1",
+    "session-1",
+    "run-1",
+  );
+
+  assert.equal(result, "not_running");
+  assert.equal(recordedQueries.some((query) => query.text.includes("FROM public.chat_items")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_items")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_sessions")), false);
+});
+
+test("recoverStaleChatSessionWithQuery interrupts stale in-progress assistant messages", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  const result = await recoverStaleChatSessionWithQuery(
+    createStaleRecoveryQueryFn({
+      sessionStatus: "running",
+      activeRunId: "run-1",
+      lastAssistantState: "in_progress",
+      recordedQueries,
+    }),
+    "user-1",
+    "workspace-1",
+    {
+      sessionId: "session-1",
+      expectedActiveRunId: "run-1",
+      errorMessage: "interrupted",
+    },
+  );
+
+  assert.equal(result, "interrupted");
+  assert.match(recordedQueries[0].text, /FOR UPDATE/);
+  assert.match(recordedQueries[0].text, /WHERE user_id = \$1/);
+  assert.match(recordedQueries[0].text, /AND workspace_id = \$2/);
+  assert.match(recordedQueries[0].text, /AND session_id = \$3/);
+  assert.deepEqual(recordedQueries[0].params, ["user-1", "workspace-1", "session-1"]);
+  assert.equal(recordedQueries.some((query) => query.text.includes("INSERT INTO public.chat_items")), true);
+  assert.deepEqual(recordedQueries.at(-1)?.params, ["session-1", "run-1", "interrupted"]);
+});
+
+test("recoverStaleChatSessionWithQuery recovers completed stale runs without inserting fake errors", async (): Promise<void> => {
+  await withSuppressedConsoleLog(async (): Promise<void> => {
+    const recordedQueries: Array<RecordedQuery> = [];
+
+    const result = await recoverStaleChatSessionWithQuery(
+      createStaleRecoveryQueryFn({
+        sessionStatus: "running",
+        activeRunId: "run-1",
+        lastAssistantState: "completed",
+        recordedQueries,
+      }),
+      "user-1",
+      "workspace-1",
+      {
+        sessionId: "session-1",
+        expectedActiveRunId: "run-1",
+        errorMessage: "interrupted",
+      },
+    );
+
+    assert.equal(result, "completed_recovered");
+    assert.equal(recordedQueries.some((query) => query.text.includes("INSERT INTO public.chat_items")), false);
+    assert.deepEqual(recordedQueries.at(-1)?.params, ["session-1", "run-1", "idle"]);
+  });
+});
+
+test("recoverStaleChatSessionWithQuery skips recovery when the active run changed", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  const result = await recoverStaleChatSessionWithQuery(
+    createStaleRecoveryQueryFn({
+      sessionStatus: "running",
+      activeRunId: "run-2",
+      lastAssistantState: "in_progress",
+      recordedQueries,
+    }),
+    "user-1",
+    "workspace-1",
+    {
+      sessionId: "session-1",
+      expectedActiveRunId: "run-1",
+      errorMessage: "interrupted",
+    },
+  );
+
+  assert.equal(result, "run_changed");
+  assert.equal(recordedQueries.some((query) => query.text.includes("FROM public.chat_items")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_items")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("INSERT INTO public.chat_items")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_sessions")), false);
+});
+
+test("recoverStaleChatSessionWithQuery skips recovery when the session is already finalized", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  const result = await recoverStaleChatSessionWithQuery(
+    createStaleRecoveryQueryFn({
+      sessionStatus: "idle",
+      activeRunId: null,
+      lastAssistantState: "in_progress",
+      recordedQueries,
+    }),
+    "user-1",
+    "workspace-1",
+    {
+      sessionId: "session-1",
+      expectedActiveRunId: "run-1",
+      errorMessage: "interrupted",
+    },
+  );
+
+  assert.equal(result, "not_running");
+  assert.equal(recordedQueries.some((query) => query.text.includes("FROM public.chat_items")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_items")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("INSERT INTO public.chat_items")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_sessions")), false);
+});

--- a/apps/web/src/server/chat/store/lifecycleStore.ts
+++ b/apps/web/src/server/chat/store/lifecycleStore.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
 import { finalizePendingToolCallContent } from "@/lib/chatHistory";
 import { withUserContext } from "@/server/db";
 import type { QueryFn } from "@/server/db/contextRunner";
 import type { ContentPart } from "@/server/chat/types";
+import { log } from "@/server/logger";
 import {
   ChatSessionConflictError,
   FAILED_TOOL_CALL_OUTPUT,
@@ -13,6 +15,7 @@ import {
   type PersistedChatMessageItem,
   type PersistAssistantTerminalErrorParams,
   type PreparedChatRun,
+  type UserCancelChatRunResult,
   type UserStoppedChatRunUpdatePlan,
 } from "./shared";
 import {
@@ -22,10 +25,14 @@ import {
 } from "./messageStore";
 import { buildLocalChatMessages } from "./snapshotStore";
 import {
+  completeChatSessionRunWithQuery,
+  lockActiveChatSessionRunWithQuery,
   lockChatSessionWithQuery,
+  lockRequestedChatSessionWithQuery,
+  requireActiveRunId,
   resolveLatestOrCreateChatSessionWithQuery,
   resolveRequestedChatSessionWithQuery,
-  updateChatSessionStatusWithQuery,
+  startChatSessionRunWithQuery,
 } from "./sessionStore";
 
 export const buildUserStoppedAssistantContent = (
@@ -85,6 +92,7 @@ export const prepareChatRunWithQuery = async (
     throw new ChatSessionConflictError(sessionRow.session_id);
   }
 
+  const activeRunId = randomUUID();
   await insertChatItemWithQuery(queryFn, {
     sessionId: sessionRow.session_id,
     role: "user",
@@ -100,10 +108,11 @@ export const prepareChatRunWithQuery = async (
     content: [],
   });
 
-  await updateChatSessionStatusWithQuery(queryFn, sessionRow.session_id, "running", new Date());
+  await startChatSessionRunWithQuery(queryFn, sessionRow.session_id, activeRunId, new Date());
 
   return {
     sessionId: sessionRow.session_id,
+    activeRunId,
     assistantItem,
     localMessages: buildLocalChatMessages(persistedMessages),
     turnInput: content,
@@ -119,26 +128,51 @@ export const prepareChatRun = async (
   withUserContext(userId, workspaceId, async (queryFn) =>
     prepareChatRunWithQuery(queryFn, userId, workspaceId, requestedSessionId, content));
 
+export const completeChatRunWithQuery = async (
+  queryFn: QueryFn,
+  params: CompleteChatRunParams,
+): Promise<void> => {
+  await lockActiveChatSessionRunWithQuery(
+    queryFn,
+    params.sessionId,
+    params.activeRunId,
+    "complete chat run",
+  );
+  await updateChatItemWithQuery(queryFn, {
+    sessionId: params.sessionId,
+    itemId: params.assistantItemId,
+    content: params.assistantContent,
+    state: "completed",
+    assistantOpenAIItems: params.assistantOpenAIItems,
+  });
+
+  await completeChatSessionRunWithQuery(
+    queryFn,
+    params.sessionId,
+    params.activeRunId,
+    "idle",
+  );
+};
+
 export const completeChatRun = async (
   userId: string,
   workspaceId: string,
   params: CompleteChatRunParams,
 ): Promise<void> =>
-  withUserContext(userId, workspaceId, async (queryFn) => {
-    const updatedAssistant = await updateChatItemWithQuery(queryFn, {
-      itemId: params.assistantItemId,
-      content: params.assistantContent,
-      state: "completed",
-      assistantOpenAIItems: params.assistantOpenAIItems,
-    });
-
-    await updateChatSessionStatusWithQuery(queryFn, updatedAssistant.sessionId, "idle", null);
-  });
+  withUserContext(userId, workspaceId, async (queryFn) =>
+    completeChatRunWithQuery(queryFn, params));
 
 export const persistAssistantTerminalErrorWithQuery = async (
   queryFn: QueryFn,
   params: PersistAssistantTerminalErrorParams,
 ): Promise<void> => {
+  await lockActiveChatSessionRunWithQuery(
+    queryFn,
+    params.sessionId,
+    params.activeRunId,
+    "persist assistant terminal error",
+  );
+
   const finalizedAssistantContent = finalizePendingToolCallContent(
     params.assistantContent,
     INCOMPLETE_TOOL_CALL_PROVIDER_STATUS,
@@ -147,6 +181,7 @@ export const persistAssistantTerminalErrorWithQuery = async (
 
   if (finalizedAssistantContent.length === 0) {
     await updateChatItemWithQuery(queryFn, {
+      sessionId: params.sessionId,
       itemId: params.assistantItemId,
       content: [{ type: "text", text: params.errorMessage }],
       state: "error",
@@ -154,6 +189,7 @@ export const persistAssistantTerminalErrorWithQuery = async (
     });
   } else {
     await updateChatItemWithQuery(queryFn, {
+      sessionId: params.sessionId,
       itemId: params.assistantItemId,
       content: finalizedAssistantContent,
       state: "completed",
@@ -167,7 +203,12 @@ export const persistAssistantTerminalErrorWithQuery = async (
     });
   }
 
-  await updateChatSessionStatusWithQuery(queryFn, params.sessionId, params.sessionState, null);
+  await completeChatSessionRunWithQuery(
+    queryFn,
+    params.sessionId,
+    params.activeRunId,
+    params.sessionState,
+  );
 };
 
 export const persistAssistantTerminalError = async (
@@ -182,14 +223,27 @@ export const persistAssistantCancelledWithQuery = async (
   queryFn: QueryFn,
   params: PersistAssistantCancelledParams,
 ): Promise<void> => {
+  await lockActiveChatSessionRunWithQuery(
+    queryFn,
+    params.sessionId,
+    params.activeRunId,
+    "persist assistant cancellation",
+  );
+
   await updateChatItemWithQuery(queryFn, {
+    sessionId: params.sessionId,
     itemId: params.assistantItemId,
     content: buildUserStoppedAssistantContent(params.assistantContent),
     state: "cancelled",
     assistantOpenAIItems: params.assistantOpenAIItems,
   });
 
-  await updateChatSessionStatusWithQuery(queryFn, params.sessionId, "idle", null);
+  await completeChatSessionRunWithQuery(
+    queryFn,
+    params.sessionId,
+    params.activeRunId,
+    "idle",
+  );
 };
 
 export const persistAssistantCancelled = async (
@@ -205,12 +259,17 @@ export const cancelActiveChatRunByUserWithQuery = async (
   userId: string,
   workspaceId: string,
   sessionId: string,
-): Promise<boolean> => {
+  expectedActiveRunId: string,
+): Promise<UserCancelChatRunResult> => {
   await resolveRequestedChatSessionWithQuery(queryFn, userId, workspaceId, sessionId);
 
   const lockedSession = await lockChatSessionWithQuery(queryFn, sessionId);
   if (lockedSession.status !== "running") {
-    return false;
+    return "not_running";
+  }
+  const activeRunId = requireActiveRunId(lockedSession, "cancel active run");
+  if (activeRunId !== expectedActiveRunId) {
+    return "run_changed";
   }
 
   const messages = await listChatMessagesWithQuery(queryFn, sessionId);
@@ -218,6 +277,7 @@ export const cancelActiveChatRunByUserWithQuery = async (
 
   if (updatePlan.assistantItem !== null && updatePlan.assistantContent !== null) {
     await updateChatItemWithQuery(queryFn, {
+      sessionId,
       itemId: updatePlan.assistantItem.itemId,
       content: updatePlan.assistantContent,
       state: "cancelled",
@@ -225,31 +285,57 @@ export const cancelActiveChatRunByUserWithQuery = async (
     });
   }
 
-  await updateChatSessionStatusWithQuery(queryFn, sessionId, updatePlan.sessionState, null);
-  return true;
+  await completeChatSessionRunWithQuery(
+    queryFn,
+    sessionId,
+    expectedActiveRunId,
+    updatePlan.sessionState,
+  );
+  return "cancelled";
 };
 
 export const cancelActiveChatRunByUser = async (
   userId: string,
   workspaceId: string,
   sessionId: string,
-): Promise<boolean> =>
+  expectedActiveRunId: string,
+): Promise<UserCancelChatRunResult> =>
   withUserContext(userId, workspaceId, async (queryFn) =>
-    cancelActiveChatRunByUserWithQuery(queryFn, userId, workspaceId, sessionId));
+    cancelActiveChatRunByUserWithQuery(queryFn, userId, workspaceId, sessionId, expectedActiveRunId));
 
-export const markChatSessionInterruptedWithQuery = async (
+export type StaleChatSessionRecoveryResult =
+  | "interrupted"
+  | "completed_recovered"
+  | "not_running"
+  | "run_changed";
+
+export type RecoverStaleChatSessionParams = Readonly<{
+  sessionId: string;
+  expectedActiveRunId: string;
+  errorMessage: string;
+}>;
+
+export const recoverStaleChatSessionWithQuery = async (
   queryFn: QueryFn,
   userId: string,
   workspaceId: string,
-  sessionId: string,
-  errorMessage: string,
-): Promise<void> => {
-  const sessionRow = await resolveRequestedChatSessionWithQuery(queryFn, userId, workspaceId, sessionId);
+  params: RecoverStaleChatSessionParams,
+): Promise<StaleChatSessionRecoveryResult> => {
+  const sessionRow = await lockRequestedChatSessionWithQuery(
+    queryFn,
+    userId,
+    workspaceId,
+    params.sessionId,
+  );
   if (sessionRow.status !== "running") {
-    return;
+    return "not_running";
   }
 
-  const persistedMessages = await listChatMessagesWithQuery(queryFn, sessionId);
+  if (sessionRow.active_run_id !== params.expectedActiveRunId) {
+    return "run_changed";
+  }
+
+  const persistedMessages = await listChatMessagesWithQuery(queryFn, params.sessionId);
   const lastMessage = persistedMessages[persistedMessages.length - 1];
 
   if (lastMessage !== undefined && lastMessage.role === "assistant" && lastMessage.state === "in_progress") {
@@ -261,40 +347,60 @@ export const markChatSessionInterruptedWithQuery = async (
 
     if (lastMessage.content.length === 0) {
       await updateChatItemWithQuery(queryFn, {
+        sessionId: params.sessionId,
         itemId: lastMessage.itemId,
-        content: [{ type: "text", text: errorMessage }],
+        content: [{ type: "text", text: params.errorMessage }],
         state: "error",
       });
     } else {
       await updateChatItemWithQuery(queryFn, {
+        sessionId: params.sessionId,
         itemId: lastMessage.itemId,
         content: finalizedAssistantContent,
         state: "completed",
       });
       await insertChatItemWithQuery(queryFn, {
-        sessionId,
+        sessionId: params.sessionId,
         role: "assistant",
         state: "error",
-        content: [{ type: "text", text: errorMessage }],
+        content: [{ type: "text", text: params.errorMessage }],
       });
     }
+    await completeChatSessionRunWithQuery(
+      queryFn,
+      params.sessionId,
+      params.expectedActiveRunId,
+      "interrupted",
+    );
+    return "interrupted";
   } else {
-    await insertChatItemWithQuery(queryFn, {
-      sessionId,
-      role: "assistant",
-      state: "error",
-      content: [{ type: "text", text: errorMessage }],
+    await completeChatSessionRunWithQuery(
+      queryFn,
+      params.sessionId,
+      params.expectedActiveRunId,
+      "idle",
+    );
+    log({
+      domain: "chat",
+      action: "stale_completed_run_recovered",
+      sessionId: params.sessionId,
+      userId,
+      workspaceId,
+      activeRunId: params.expectedActiveRunId,
+      lastMessageRole: lastMessage?.role,
+      lastMessageState: lastMessage?.state,
     });
+    return "completed_recovered";
   }
-
-  await updateChatSessionStatusWithQuery(queryFn, sessionId, "interrupted", null);
 };
 
-export const markChatSessionInterrupted = async (
+export const recoverStaleChatSession = async (
   userId: string,
   workspaceId: string,
-  sessionId: string,
-  errorMessage: string,
-): Promise<void> =>
+  params: RecoverStaleChatSessionParams,
+): Promise<StaleChatSessionRecoveryResult> =>
   withUserContext(userId, workspaceId, async (queryFn) =>
-    markChatSessionInterruptedWithQuery(queryFn, userId, workspaceId, sessionId, errorMessage));
+    recoverStaleChatSessionWithQuery(queryFn, userId, workspaceId, params));
+
+export const markChatSessionInterruptedWithQuery = recoverStaleChatSessionWithQuery;
+export const markChatSessionInterrupted = recoverStaleChatSession;

--- a/apps/web/src/server/chat/store/messageStore.ts
+++ b/apps/web/src/server/chat/store/messageStore.ts
@@ -6,10 +6,13 @@ import {
   type ChatItemState,
   type InsertChatItemParams,
   type PersistedChatMessageItem,
+  type RunScopedUpdateChatMessageItemAndInvalidateMainContentParams,
+  type RunScopedUpdateChatMessageItemParams,
   type UpdateChatMessageItemAndInvalidateMainContentParams,
   type UpdateChatMessageItemParams,
 } from "./shared";
 import type { StoredOpenAIReplayItem } from "@/server/chat/openai/replayItems";
+import { lockActiveChatSessionRunWithQuery } from "./sessionStore";
 
 type ChatItemPayload = Readonly<{
   role: "user" | "assistant";
@@ -68,10 +71,11 @@ const INSERT_CHAT_ITEM_SQL = `
 const UPDATE_CHAT_ITEM_SQL = `
   WITH updated_item AS (
     UPDATE public.chat_items
-    SET payload = $2::jsonb,
-        state = $3,
+    SET payload = $3::jsonb,
+        state = $4,
         updated_at = now()
     WHERE item_id = $1
+      AND session_id = $2
     RETURNING item_id, session_id, state, payload, created_at, updated_at
   ),
   touched_session AS (
@@ -86,10 +90,11 @@ const UPDATE_CHAT_ITEM_SQL = `
 const UPDATE_CHAT_ITEM_AND_INVALIDATE_MAIN_CONTENT_SQL = `
   WITH updated_item AS (
     UPDATE public.chat_items
-    SET payload = $2::jsonb,
-        state = $3,
+    SET payload = $3::jsonb,
+        state = $4,
         updated_at = now()
     WHERE item_id = $1
+      AND session_id = $2
     RETURNING item_id, session_id, state, payload, created_at, updated_at
   ),
   invalidated_session AS (
@@ -176,6 +181,7 @@ export const updateChatItemWithQuery = async (
 ): Promise<PersistedChatMessageItem> => {
   const result = await queryFn(UPDATE_CHAT_ITEM_SQL, [
     params.itemId,
+    params.sessionId,
     JSON.stringify(toChatItemPayload("assistant", params.content, params.assistantOpenAIItems)),
     params.state,
   ]);
@@ -194,6 +200,7 @@ export const updateChatItemAndInvalidateMainContentWithQuery = async (
 }>> => {
   const result = await queryFn(UPDATE_CHAT_ITEM_AND_INVALIDATE_MAIN_CONTENT_SQL, [
     params.itemId,
+    params.sessionId,
     JSON.stringify(toChatItemPayload("assistant", params.content, params.assistantOpenAIItems)),
     params.state,
   ]);
@@ -224,25 +231,46 @@ export const listChatMessages = async (
 export const updateAssistantMessageItem = async (
   userId: string,
   workspaceId: string,
-  params: UpdateChatMessageItemParams,
-): Promise<PersistedChatMessageItem> => {
-  const result = await queryAs(userId, workspaceId, UPDATE_CHAT_ITEM_SQL, [
-    params.itemId,
-    JSON.stringify(toChatItemPayload("assistant", params.content, params.assistantOpenAIItems)),
-    params.state,
-  ]);
+  params: RunScopedUpdateChatMessageItemParams,
+): Promise<PersistedChatMessageItem> =>
+  withUserContext(userId, workspaceId, async (queryFn) =>
+    updateAssistantMessageItemWithQuery(queryFn, params));
 
-  return mapChatItemRow(
-    requireChatItemRow(result.rows[0] as ChatItemRow | undefined, "update"),
+export const updateAssistantMessageItemWithQuery = async (
+  queryFn: QueryFn,
+  params: RunScopedUpdateChatMessageItemParams,
+): Promise<PersistedChatMessageItem> => {
+  await lockActiveChatSessionRunWithQuery(
+    queryFn,
+    params.sessionId,
+    params.activeRunId,
+    "update assistant message",
   );
+  return updateChatItemWithQuery(queryFn, params);
+};
+
+export const updateAssistantMessageItemAndInvalidateMainContentWithQuery = async (
+  queryFn: QueryFn,
+  params: RunScopedUpdateChatMessageItemAndInvalidateMainContentParams,
+): Promise<Readonly<{
+  item: PersistedChatMessageItem;
+  mainContentInvalidationVersion: number;
+}>> => {
+  await lockActiveChatSessionRunWithQuery(
+    queryFn,
+    params.sessionId,
+    params.activeRunId,
+    "update assistant message and invalidate main content",
+  );
+  return updateChatItemAndInvalidateMainContentWithQuery(queryFn, params);
 };
 
 export const updateAssistantMessageItemAndInvalidateMainContent = async (
   userId: string,
   workspaceId: string,
-  params: UpdateChatMessageItemAndInvalidateMainContentParams,
+  params: RunScopedUpdateChatMessageItemAndInvalidateMainContentParams,
 ): Promise<number> => {
   const result = await withUserContext(userId, workspaceId, async (queryFn) =>
-    updateChatItemAndInvalidateMainContentWithQuery(queryFn, params));
+    updateAssistantMessageItemAndInvalidateMainContentWithQuery(queryFn, params));
   return result.mainContentInvalidationVersion;
 };

--- a/apps/web/src/server/chat/store/sessionStore.test.ts
+++ b/apps/web/src/server/chat/store/sessionStore.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { QueryResult } from "pg";
+import { ChatSessionRunTransitionError } from "@/server/chat/store";
+import {
+  completeChatSessionRunWithQuery,
+  lockActiveChatSessionRunWithQuery,
+  touchChatSessionHeartbeatWithQuery,
+} from "@/server/chat/store/sessionStore";
+import type { QueryFn } from "@/server/db/contextRunner";
+
+const createQueryResult = (
+  rows: ReadonlyArray<unknown>,
+): QueryResult => ({
+  command: "UPDATE",
+  rowCount: rows.length,
+  oid: 0,
+  fields: [],
+  rows: [...rows],
+});
+
+const createSessionRow = (
+  status: "idle" | "running" | "interrupted",
+  activeRunId: string | null,
+): Readonly<Record<string, string | null>> => ({
+  session_id: "session-1",
+  status,
+  active_run_id: activeRunId,
+  active_run_heartbeat_at: activeRunId === null ? null : "2026-05-02T13:00:00.000Z",
+  main_content_invalidation_version: "0",
+  updated_at: "2026-05-02T13:00:00.000Z",
+});
+
+test("touchChatSessionHeartbeatWithQuery only touches heartbeat for the matching active run", async (): Promise<void> => {
+  let queryText = "";
+  let queryParams: ReadonlyArray<unknown> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    queryText = text;
+    queryParams = params;
+    return createQueryResult([createSessionRow("running", "run-1")]);
+  };
+
+  const touched = await touchChatSessionHeartbeatWithQuery(
+    queryFn,
+    "session-1",
+    "run-1",
+    new Date("2026-05-02T13:00:00.000Z"),
+  );
+
+  assert.equal(touched, true);
+  assert.equal(queryText.includes("status = $2"), false);
+  assert.match(queryText, /SET active_run_heartbeat_at = \$3/);
+  assert.match(queryText, /AND active_run_id = \$2/);
+  assert.match(queryText, /AND status = 'running'/);
+  assert.deepEqual(queryParams, ["session-1", "run-1", "2026-05-02T13:00:00.000Z"]);
+});
+
+test("completeChatSessionRunWithQuery requires the matching active run id", async (): Promise<void> => {
+  let queryText = "";
+  let queryParams: ReadonlyArray<unknown> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    queryText = text;
+    queryParams = params;
+    return createQueryResult([createSessionRow("idle", null)]);
+  };
+
+  await completeChatSessionRunWithQuery(queryFn, "session-1", "run-1", "idle");
+
+  assert.match(queryText, /SET status = \$3/);
+  assert.match(queryText, /active_run_id = NULL/);
+  assert.match(queryText, /active_run_heartbeat_at = NULL/);
+  assert.match(queryText, /AND active_run_id = \$2/);
+  assert.match(queryText, /AND status = 'running'/);
+  assert.deepEqual(queryParams, ["session-1", "run-1", "idle"]);
+});
+
+test("lockActiveChatSessionRunWithQuery locks the matching running active run", async (): Promise<void> => {
+  let queryText = "";
+  let queryParams: ReadonlyArray<unknown> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    queryText = text;
+    queryParams = params;
+    return createQueryResult([createSessionRow("running", "run-1")]);
+  };
+
+  const row = await lockActiveChatSessionRunWithQuery(
+    queryFn,
+    "session-1",
+    "run-1",
+    "test lock",
+  );
+
+  assert.equal(row.active_run_id, "run-1");
+  assert.match(queryText, /WHERE session_id = \$1/);
+  assert.match(queryText, /AND active_run_id = \$2/);
+  assert.match(queryText, /AND status = 'running'/);
+  assert.match(queryText, /FOR UPDATE/);
+  assert.deepEqual(queryParams, ["session-1", "run-1"]);
+});
+
+test("completeChatSessionRunWithQuery raises when the guarded final transition updates no rows", async (): Promise<void> => {
+  const queryFn: QueryFn = async (): Promise<QueryResult> =>
+    createQueryResult([]);
+
+  await assert.rejects(
+    completeChatSessionRunWithQuery(queryFn, "session-1", "run-1", "idle"),
+    (error: unknown): boolean =>
+      error instanceof ChatSessionRunTransitionError
+      && error.sessionId === "session-1"
+      && error.activeRunId === "run-1"
+      && error.targetState === "idle",
+  );
+});

--- a/apps/web/src/server/chat/store/sessionStore.ts
+++ b/apps/web/src/server/chat/store/sessionStore.ts
@@ -1,22 +1,25 @@
 import { queryAs, withUserContext } from "@/server/db";
 import type { QueryFn } from "@/server/db/contextRunner";
 import {
+  ChatSessionRunTransitionError,
   ChatSessionNotFoundError,
   parseMainContentInvalidationVersion,
   type ChatSessionRunState,
+  type ChatSessionTerminalState,
   type ChatSessionSnapshot,
 } from "./shared";
 
 export type ChatSessionRow = Readonly<{
   session_id: string;
   status: ChatSessionRunState;
+  active_run_id: string | null;
   active_run_heartbeat_at: string | null;
   main_content_invalidation_version: string;
   updated_at: string;
 }>;
 
 const SELECT_SESSION_SQL = `
-  SELECT session_id, status, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+  SELECT session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
   FROM public.chat_sessions
   WHERE user_id = $1
     AND workspace_id = $2
@@ -24,14 +27,32 @@ const SELECT_SESSION_SQL = `
 `;
 
 const SELECT_SESSION_FOR_UPDATE_SQL = `
-  SELECT session_id, status, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+  SELECT session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
   FROM public.chat_sessions
   WHERE session_id = $1
   FOR UPDATE
 `;
 
+const SELECT_REQUESTED_SESSION_FOR_UPDATE_SQL = `
+  SELECT session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+  FROM public.chat_sessions
+  WHERE user_id = $1
+    AND workspace_id = $2
+    AND session_id = $3
+  FOR UPDATE
+`;
+
+const SELECT_ACTIVE_SESSION_RUN_FOR_UPDATE_SQL = `
+  SELECT session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+  FROM public.chat_sessions
+  WHERE session_id = $1
+    AND active_run_id = $2
+    AND status = 'running'
+  FOR UPDATE
+`;
+
 const SELECT_LATEST_SESSION_SQL = `
-  SELECT session_id, status, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+  SELECT session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
   FROM public.chat_sessions
   WHERE user_id = $1
     AND workspace_id = $2
@@ -44,27 +65,53 @@ const INSERT_SESSION_SQL = `
     user_id,
     workspace_id,
     status,
+    active_run_id,
     active_run_heartbeat_at,
     main_content_invalidation_version,
     updated_at
   )
-  VALUES ($1, $2, 'idle', NULL, 0, now())
-  RETURNING session_id, status, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+  VALUES ($1, $2, 'idle', NULL, NULL, 0, now())
+  RETURNING session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
 `;
 
-const UPDATE_CHAT_SESSION_STATUS_SQL = `
+const START_CHAT_SESSION_RUN_SQL = `
   UPDATE public.chat_sessions
-  SET status = $2,
+  SET status = 'running',
+      active_run_id = $2,
       active_run_heartbeat_at = $3,
       updated_at = now()
   WHERE session_id = $1
-  RETURNING session_id, status, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+    AND status <> 'running'
+  RETURNING session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+`;
+
+const COMPLETE_CHAT_SESSION_RUN_SQL = `
+  UPDATE public.chat_sessions
+  SET status = $3,
+      active_run_id = NULL,
+      active_run_heartbeat_at = NULL,
+      updated_at = now()
+  WHERE session_id = $1
+    AND active_run_id = $2
+    AND status = 'running'
+  RETURNING session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+`;
+
+const TOUCH_CHAT_SESSION_HEARTBEAT_SQL = `
+  UPDATE public.chat_sessions
+  SET active_run_heartbeat_at = $3,
+      updated_at = now()
+  WHERE session_id = $1
+    AND active_run_id = $2
+    AND status = 'running'
+  RETURNING session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
 `;
 
 export const mapSessionRow = (row: ChatSessionRow): ChatSessionSnapshot => ({
   sessionId: row.session_id,
   runState: row.status,
   updatedAt: new Date(row.updated_at).getTime(),
+  activeRunId: row.active_run_id,
   activeRunHeartbeatAt: row.active_run_heartbeat_at === null
     ? null
     : new Date(row.active_run_heartbeat_at).getTime(),
@@ -81,6 +128,35 @@ export const requireSessionRow = (
 ): ChatSessionRow => {
   if (row === undefined) {
     throw new Error(`Chat session ${operation} failed: query returned no row`);
+  }
+
+  return row;
+};
+
+export const requireActiveRunId = (
+  row: ChatSessionRow,
+  operation: string,
+): string => {
+  if (row.active_run_id === null) {
+    throw new Error(`Chat session ${operation} failed: running session has no active_run_id, sessionId=${row.session_id}`);
+  }
+
+  return row.active_run_id;
+};
+
+const requireSessionRunTransitionRow = (
+  row: ChatSessionRow | undefined,
+  sessionId: string,
+  activeRunId: string,
+  targetState: ChatSessionTerminalState,
+): ChatSessionRow => {
+  if (row === undefined) {
+    throw new ChatSessionRunTransitionError({
+      sessionId,
+      activeRunId,
+      operation: "final state transition",
+      targetState,
+    });
   }
 
   return row;
@@ -141,17 +217,85 @@ export const lockChatSessionWithQuery = async (
   return requireSessionRow(result.rows[0] as ChatSessionRow | undefined, "lock");
 };
 
-export const updateChatSessionStatusWithQuery = async (
+export const lockRequestedChatSessionWithQuery = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+): Promise<ChatSessionRow> => {
+  const result = await queryFn(SELECT_REQUESTED_SESSION_FOR_UPDATE_SQL, [userId, workspaceId, sessionId]);
+  const row = result.rows[0] as ChatSessionRow | undefined;
+  if (row === undefined) {
+    throw new ChatSessionNotFoundError(sessionId);
+  }
+
+  return row;
+};
+
+export const lockActiveChatSessionRunWithQuery = async (
   queryFn: QueryFn,
   sessionId: string,
-  status: ChatSessionRunState,
+  activeRunId: string,
+  operation: string,
+): Promise<ChatSessionRow> => {
+  const result = await queryFn(SELECT_ACTIVE_SESSION_RUN_FOR_UPDATE_SQL, [sessionId, activeRunId]);
+  const row = result.rows[0] as ChatSessionRow | undefined;
+  if (row === undefined) {
+    throw new ChatSessionRunTransitionError({
+      sessionId,
+      activeRunId,
+      operation,
+    });
+  }
+
+  return row;
+};
+
+export const startChatSessionRunWithQuery = async (
+  queryFn: QueryFn,
+  sessionId: string,
+  activeRunId: string,
   heartbeatAt: Date | null,
 ): Promise<void> => {
-  await queryFn(UPDATE_CHAT_SESSION_STATUS_SQL, [
+  const result = await queryFn(START_CHAT_SESSION_RUN_SQL, [
     sessionId,
-    status,
+    activeRunId,
     heartbeatAt === null ? null : heartbeatAt.toISOString(),
   ]);
+  requireSessionRow(result.rows[0] as ChatSessionRow | undefined, "start run");
+};
+
+export const completeChatSessionRunWithQuery = async (
+  queryFn: QueryFn,
+  sessionId: string,
+  activeRunId: string,
+  targetState: ChatSessionTerminalState,
+): Promise<void> => {
+  const result = await queryFn(COMPLETE_CHAT_SESSION_RUN_SQL, [
+    sessionId,
+    activeRunId,
+    targetState,
+  ]);
+  requireSessionRunTransitionRow(
+    result.rows[0] as ChatSessionRow | undefined,
+    sessionId,
+    activeRunId,
+    targetState,
+  );
+};
+
+export const touchChatSessionHeartbeatWithQuery = async (
+  queryFn: QueryFn,
+  sessionId: string,
+  activeRunId: string,
+  heartbeatAt: Date,
+): Promise<boolean> => {
+  const result = await queryFn(TOUCH_CHAT_SESSION_HEARTBEAT_SQL, [
+    sessionId,
+    activeRunId,
+    heartbeatAt.toISOString(),
+  ]);
+  return result.rows.length > 0;
 };
 
 export const getChatSessionId = async (
@@ -186,10 +330,11 @@ export const touchChatSessionHeartbeat = async (
   userId: string,
   workspaceId: string,
   sessionId: string,
+  activeRunId: string,
 ): Promise<void> => {
-  await queryAs(userId, workspaceId, UPDATE_CHAT_SESSION_STATUS_SQL, [
+  await queryAs(userId, workspaceId, TOUCH_CHAT_SESSION_HEARTBEAT_SQL, [
     sessionId,
-    "running",
+    activeRunId,
     new Date().toISOString(),
   ]);
 };

--- a/apps/web/src/server/chat/store/shared.ts
+++ b/apps/web/src/server/chat/store/shared.ts
@@ -1,4 +1,3 @@
-import type { StoredMessage } from "@/lib/chatHistory";
 import type {
   ServerChatMessage,
   StoredOpenAIReplayItem,
@@ -6,6 +5,7 @@ import type {
 import type { ContentPart } from "@/server/chat/types";
 
 export type ChatSessionRunState = "idle" | "running" | "interrupted";
+export type ChatSessionTerminalState = Exclude<ChatSessionRunState, "running">;
 export type ChatItemState = "in_progress" | "completed" | "error" | "cancelled";
 
 export const INCOMPLETE_TOOL_CALL_PROVIDER_STATUS = "incomplete";
@@ -27,6 +27,32 @@ export class ChatSessionConflictError extends Error {
   }
 }
 
+export class ChatSessionRunTransitionError extends Error {
+  public readonly sessionId: string;
+  public readonly activeRunId: string;
+  public readonly operation: string;
+  public readonly targetState: ChatSessionTerminalState | undefined;
+
+  public constructor(params: Readonly<{
+    sessionId: string;
+    activeRunId: string;
+    operation: string;
+    targetState?: ChatSessionTerminalState;
+  }>) {
+    super([
+      `Chat session run transition failed: operation=${params.operation}`,
+      `sessionId=${params.sessionId}`,
+      `activeRunId=${params.activeRunId}`,
+      ...(params.targetState === undefined ? [] : [`targetState=${params.targetState}`]),
+    ].join(", "));
+    this.name = "ChatSessionRunTransitionError";
+    this.sessionId = params.sessionId;
+    this.activeRunId = params.activeRunId;
+    this.operation = params.operation;
+    this.targetState = params.targetState;
+  }
+}
+
 export type PersistedChatMessageItem = Readonly<{
   itemId: string;
   sessionId: string;
@@ -44,13 +70,15 @@ export type ChatSessionSnapshot = Readonly<{
   sessionId: string;
   runState: ChatSessionRunState;
   updatedAt: number;
+  activeRunId: string | null;
   activeRunHeartbeatAt: number | null;
   mainContentInvalidationVersion: number;
-  messages: ReadonlyArray<StoredMessage>;
+  messages: ReadonlyArray<PersistedChatMessageItem>;
 }>;
 
 export type PreparedChatRun = Readonly<{
   sessionId: string;
+  activeRunId: string;
   assistantItem: PersistedChatMessageItem;
   localMessages: ReadonlyArray<ServerChatMessage>;
   turnInput: ReadonlyArray<ContentPart>;
@@ -65,6 +93,7 @@ export type InsertChatItemParams = Readonly<{
 }>;
 
 export type UpdateChatMessageItemParams = Readonly<{
+  sessionId: string;
   itemId: string;
   content: ReadonlyArray<ContentPart>;
   state: ChatItemState;
@@ -72,29 +101,42 @@ export type UpdateChatMessageItemParams = Readonly<{
 }>;
 
 export type UpdateChatMessageItemAndInvalidateMainContentParams = Readonly<{
+  sessionId: string;
   itemId: string;
   content: ReadonlyArray<ContentPart>;
   state: ChatItemState;
   assistantOpenAIItems?: ReadonlyArray<StoredOpenAIReplayItem>;
 }>;
 
+export type RunScopedUpdateChatMessageItemParams = UpdateChatMessageItemParams & Readonly<{
+  activeRunId: string;
+}>;
+
+export type RunScopedUpdateChatMessageItemAndInvalidateMainContentParams = UpdateChatMessageItemAndInvalidateMainContentParams & Readonly<{
+  activeRunId: string;
+}>;
+
 export type PersistAssistantTerminalErrorParams = Readonly<{
   sessionId: string;
+  activeRunId: string;
   assistantItemId: string;
   assistantContent: ReadonlyArray<ContentPart>;
   assistantOpenAIItems?: ReadonlyArray<StoredOpenAIReplayItem>;
   errorMessage: string;
-  sessionState: ChatSessionRunState;
+  sessionState: ChatSessionTerminalState;
 }>;
 
 export type PersistAssistantCancelledParams = Readonly<{
   sessionId: string;
+  activeRunId: string;
   assistantItemId: string;
   assistantContent: ReadonlyArray<ContentPart>;
   assistantOpenAIItems?: ReadonlyArray<StoredOpenAIReplayItem>;
 }>;
 
 export type CompleteChatRunParams = Readonly<{
+  sessionId: string;
+  activeRunId: string;
   assistantItemId: string;
   assistantContent: ReadonlyArray<ContentPart>;
   assistantOpenAIItems?: ReadonlyArray<StoredOpenAIReplayItem>;
@@ -104,8 +146,13 @@ export type UserStoppedChatRunUpdatePlan = Readonly<{
   assistantItem: PersistedChatMessageItem | null;
   assistantContent: ReadonlyArray<ContentPart> | null;
   assistantOpenAIItems: ReadonlyArray<StoredOpenAIReplayItem> | null;
-  sessionState: ChatSessionRunState;
+  sessionState: ChatSessionTerminalState;
 }>;
+
+export type UserCancelChatRunResult =
+  | "cancelled"
+  | "not_running"
+  | "run_changed";
 
 export const parseMainContentInvalidationVersion = (
   rawValue: string,

--- a/apps/web/src/server/chat/store/snapshotStore.ts
+++ b/apps/web/src/server/chat/store/snapshotStore.ts
@@ -1,4 +1,3 @@
-import type { StoredMessage } from "@/lib/chatHistory";
 import { withUserContext } from "@/server/db";
 import type { ServerChatMessage } from "@/server/chat/openai/replayItems";
 import {
@@ -11,17 +10,6 @@ import {
   resolveRequestedChatSessionWithQuery,
 } from "./sessionStore";
 import { listChatMessages } from "./messageStore";
-
-const mapPersistedMessagesToStoredMessages = (
-  messages: ReadonlyArray<PersistedChatMessageItem>,
-): ReadonlyArray<StoredMessage> =>
-  messages.map((message) => ({
-    role: message.role,
-    content: message.content,
-    timestamp: message.timestamp,
-    isError: message.isError,
-    isStopped: message.isStopped,
-  }));
 
 export const buildLocalChatMessages = (
   messages: ReadonlyArray<PersistedChatMessageItem>,
@@ -46,6 +34,6 @@ export const getChatSessionSnapshot = async (
 
   return {
     ...mapSessionRow(sessionRow),
-    messages: mapPersistedMessagesToStoredMessages(messages),
+    messages,
   };
 };

--- a/apps/web/src/server/logger.ts
+++ b/apps/web/src/server/logger.ts
@@ -93,6 +93,28 @@ type ChatEvent =
   }>
   | Readonly<{
     domain: "chat";
+    action: "stale_completed_run_recovered";
+    sessionId: string;
+    userId: string;
+    workspaceId: string;
+    activeRunId: string;
+    lastMessageRole?: "user" | "assistant";
+    lastMessageState?: "in_progress" | "completed" | "error" | "cancelled";
+  }>
+  | Readonly<{
+    domain: "chat";
+    action: "run_transition_skipped";
+    requestId: string;
+    sessionId: string;
+    userId: string;
+    workspaceId: string;
+    activeRunId: string;
+    operation: string;
+    targetState?: "idle" | "interrupted";
+    error: string;
+  }>
+  | Readonly<{
+    domain: "chat";
     action: "error";
     vendor: ChatVendor;
     stage: ChatErrorStage;

--- a/db/migrations/0043_chat_sessions_active_run_id.sql
+++ b/db/migrations/0043_chat_sessions_active_run_id.sql
@@ -1,0 +1,7 @@
+ALTER TABLE public.chat_sessions
+ADD COLUMN active_run_id TEXT NULL;
+
+UPDATE public.chat_sessions
+SET active_run_id = gen_random_uuid()::text
+WHERE status = 'running'
+  AND active_run_id IS NULL;


### PR DESCRIPTION
## Summary
- add active_run_id-backed monotonic chat run state and guarded lifecycle writes
- make recovery, stop, runtime admission, and SSE delivery scoped by activeRunId
- add tests for stale recovery, run-scoped stop/send, guarded store behavior, and public response shapes

## Verification
- cd apps/web && npx tsx --test src/server/chat/runtime.test.ts src/server/chat/http/sessionRecovery.test.ts src/server/chat/http/routeHandlers.test.ts src/app/api/chat/stop/route.test.ts src/server/chat/store/lifecycleStore.test.ts src/server/chat/store/sessionStore.test.ts
- cd apps/web && npm run lint
- git --no-pager diff --check