### PR TITLE
Cap absurd Retry-After values and inject log into chat loop deps

### DIFF
--- a/apps/web/src/server/chat/logging.test.ts
+++ b/apps/web/src/server/chat/logging.test.ts
@@ -176,3 +176,17 @@ test("parseRetryAfterMs handles numeric seconds, HTTP-date, missing, and malform
 
   assert.equal(parseRetryAfterMs(new Error("not an APIError")), undefined);
 });
+
+test("parseRetryAfterMs rejects numeric values exceeding the 24h sanity cap", (): void => {
+  // ~27 hours, well above any legitimate Retry-After.
+  const headers = new Headers({ "retry-after": "100000" });
+  const error = new OpenAI.APIError(429, {}, "429", headers);
+  assert.equal(parseRetryAfterMs(error), undefined);
+});
+
+test("parseRetryAfterMs rejects HTTP-dates further than 24h in the future", (): void => {
+  const farFutureDate = new Date(Date.now() + 25 * 60 * 60 * 1000).toUTCString();
+  const headers = new Headers({ "retry-after": farFutureDate });
+  const error = new OpenAI.APIError(429, {}, "429", headers);
+  assert.equal(parseRetryAfterMs(error), undefined);
+});

--- a/apps/web/src/server/chat/logging.ts
+++ b/apps/web/src/server/chat/logging.ts
@@ -165,13 +165,32 @@ export const isOpenAITransientError = (error: unknown): boolean =>
   classifyOpenAITransientError(error).retryable;
 
 /**
+ * Parser-level sanity cap. Values above this are treated as malformed (server
+ * misconfiguration / garbage), not as legitimate "wait this long" requests.
+ *
+ * Distinct from the loop's `MODEL_CALL_RETRY_MAX_DELAY_MS` (60 s in
+ * `openai/loop.ts`), which is the retry policy. This 24 h cap only filters
+ * obviously-broken values; the loop's tighter cap still decides whether to
+ * actually wait or surface the error.
+ */
+const RETRY_AFTER_MAX_MS = 24 * 60 * 60 * 1000;
+
+/**
  * Parses the `Retry-After` header from an OpenAI APIError (typically a 429).
  *
  * Per RFC 7231 the value is either a non-negative integer (seconds) or an
  * HTTP-date. An HTTP-date already in the past is intentionally normalised to
  * `0` ms — the spec says the server thinks "wait until that point", and if
- * that point has already passed the answer is "no wait". Returns undefined
- * when the header is missing or unparseable.
+ * that point has already passed the answer is "no wait".
+ *
+ * Returns undefined when the header is missing, unparseable, or specifies a
+ * delay greater than 24 hours. Note the behavioural consequence of the cap:
+ * because the loop only honours `parseRetryAfterMs` when it returns a defined
+ * value, an absurd `Retry-After` (e.g. 27 h) is treated as if the server sent
+ * no header — the loop falls back to its base backoff and will retry instead
+ * of surfacing the error. That is intentional: a server requesting a 24 h+
+ * wait is almost certainly misconfigured, and a quick retry is friendlier
+ * than failing the user's chat turn outright.
  */
 export const parseRetryAfterMs = (error: unknown): number | undefined => {
   if (!(error instanceof OpenAI.APIError)) return undefined;
@@ -181,11 +200,13 @@ export const parseRetryAfterMs = (error: unknown): number | undefined => {
   if (typeof headerValue !== "string" || headerValue.length === 0) return undefined;
   const seconds = Number(headerValue);
   if (Number.isFinite(seconds) && seconds >= 0) {
-    return Math.round(seconds * 1000);
+    const ms = Math.round(seconds * 1000);
+    return ms > RETRY_AFTER_MAX_MS ? undefined : ms;
   }
   const dateMs = Date.parse(headerValue);
   if (Number.isFinite(dateMs)) {
-    return Math.max(0, dateMs - Date.now());
+    const delta = Math.max(0, dateMs - Date.now());
+    return delta > RETRY_AFTER_MAX_MS ? undefined : delta;
   }
   return undefined;
 };

--- a/apps/web/src/server/chat/openai/loop.test.ts
+++ b/apps/web/src/server/chat/openai/loop.test.ts
@@ -31,6 +31,23 @@ const createLoopParams = (): StartOpenAILoopParams => ({
   rootObservation: null,
 });
 
+type LoopDeps = Parameters<typeof runOpenAILoopWithDeps>[2];
+
+const createTestLoopDeps = (overrides: Partial<LoopDeps>): LoopDeps => ({
+  buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
+  getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+  runOneModelCall: async (): Promise<never> => {
+    throw new Error("runOneModelCall was invoked but the test did not override it via createTestLoopDeps");
+  },
+  runOneToolCall: async (): Promise<never> => {
+    throw new Error("runOneToolCall was invoked but the test did not override it via createTestLoopDeps");
+  },
+  getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [],
+  sleep: async (): Promise<void> => {},
+  log: (_event: Parameters<LoopDeps["log"]>[0]): void => {},
+  ...overrides,
+});
+
 const createAssistantReplayItem = (
   text: string,
 ): StoredOpenAIReplayItem => ({
@@ -144,9 +161,7 @@ test("runOpenAILoop waits for async event handling before resolving completion",
         await deltaHandled.promise;
       }
     },
-    {
-      buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-      getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+    createTestLoopDeps({
       runOneModelCall: async (
         _client: OpenAI,
         _callParams: StartOpenAILoopParams,
@@ -170,16 +185,7 @@ test("runOpenAILoop waits for async event handling before resolving completion",
           toolStates: createToolCallStateMap(),
         };
       },
-      runOneToolCall: async (): Promise<Readonly<{
-        output: string;
-        isMutating: boolean;
-        succeeded: boolean;
-      }>> => {
-        throw new Error("runOneToolCall should not be called in the no-tool path");
-      },
-      getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [],
-      sleep: async (): Promise<void> => {},
-    },
+    }),
   );
 
   void runPromise.then((): void => {
@@ -223,9 +229,7 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
     async (event: ChatStreamEvent): Promise<void> => {
       observedEvents.push(event);
     },
-    {
-      buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-      getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+    createTestLoopDeps({
       runOneModelCall: async (
         _client: OpenAI,
         _callParams: StartOpenAILoopParams,
@@ -261,9 +265,7 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
         isMutating: false,
         succeeded: true,
       }),
-      getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [],
-      sleep: async (): Promise<void> => {},
-    },
+    }),
   );
 
   assert.equal(modelCallCount, 2);
@@ -312,9 +314,7 @@ test("runOpenAILoop emits a synthetic final delta and returns the summary replay
     async (event: ChatStreamEvent): Promise<void> => {
       observedEvents.push(event);
     },
-    {
-      buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-      getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+    createTestLoopDeps({
       runOneModelCall: async (
         _client: OpenAI,
         _callParams: StartOpenAILoopParams,
@@ -353,9 +353,7 @@ test("runOpenAILoop emits a synthetic final delta and returns the summary replay
         isMutating: false,
         succeeded: true,
       }),
-      getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [],
-      sleep: async (): Promise<void> => {},
-    },
+    }),
   );
 
   assert.equal(modelCallCount, CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS + 1);
@@ -386,9 +384,7 @@ test("runOpenAILoop retries the same call on a transient OpenAI 5xx error", asyn
   const completion = await runOpenAILoopWithDeps(
     params,
     async (): Promise<void> => {},
-    {
-      buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-      getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+    createTestLoopDeps({
       runOneModelCall: async () => {
         attemptCount += 1;
         if (attemptCount === 1) {
@@ -402,16 +398,8 @@ test("runOpenAILoop retries the same call on a transient OpenAI 5xx error", asyn
           toolStates: createToolCallStateMap(),
         };
       },
-      runOneToolCall: async (): Promise<Readonly<{
-        output: string;
-        isMutating: boolean;
-        succeeded: boolean;
-      }>> => {
-        throw new Error("runOneToolCall should not be called");
-      },
       getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [0, 0],
-      sleep: async (): Promise<void> => {},
-    },
+    }),
   );
 
   assert.equal(attemptCount, 2);
@@ -428,23 +416,13 @@ test("runOpenAILoop retries on ChatModelCallTimeoutError and surfaces the error 
     runOpenAILoopWithDeps(
       params,
       async (): Promise<void> => {},
-      {
-        buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-        getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+      createTestLoopDeps({
         runOneModelCall: async () => {
           attemptCount += 1;
           throw new ChatModelCallTimeoutError(5_000);
         },
-        runOneToolCall: async (): Promise<Readonly<{
-          output: string;
-          isMutating: boolean;
-          succeeded: boolean;
-        }>> => {
-          throw new Error("runOneToolCall should not be called");
-        },
         getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [0, 0],
-        sleep: async (): Promise<void> => {},
-      },
+      }),
     ),
     (error: unknown): boolean => error instanceof ChatModelCallTimeoutError,
   );
@@ -460,23 +438,13 @@ test("runOpenAILoop does NOT retry on a 4xx OpenAI error", async (): Promise<voi
     runOpenAILoopWithDeps(
       params,
       async (): Promise<void> => {},
-      {
-        buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-        getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+      createTestLoopDeps({
         runOneModelCall: async () => {
           attemptCount += 1;
           throw new OpenAI.APIError(400, { message: "bad request" }, "Bad Request", undefined);
         },
-        runOneToolCall: async (): Promise<Readonly<{
-          output: string;
-          isMutating: boolean;
-          succeeded: boolean;
-        }>> => {
-          throw new Error("runOneToolCall should not be called");
-        },
         getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [0, 0],
-        sleep: async (): Promise<void> => {},
-      },
+      }),
     ),
     (error: unknown): boolean => error instanceof OpenAI.APIError && error.status === 400,
   );
@@ -492,23 +460,13 @@ test("runOpenAILoop does NOT retry on a user abort", async (): Promise<void> => 
     runOpenAILoopWithDeps(
       params,
       async (): Promise<void> => {},
-      {
-        buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-        getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+      createTestLoopDeps({
         runOneModelCall: async () => {
           attemptCount += 1;
           throw new OpenAI.APIUserAbortError();
         },
-        runOneToolCall: async (): Promise<Readonly<{
-          output: string;
-          isMutating: boolean;
-          succeeded: boolean;
-        }>> => {
-          throw new Error("runOneToolCall should not be called");
-        },
         getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [0, 0],
-        sleep: async (): Promise<void> => {},
-      },
+      }),
     ),
     (error: unknown): boolean => error instanceof OpenAI.APIUserAbortError,
   );
@@ -523,9 +481,7 @@ test("runOpenAILoop retries on the canonical OpenAI 'An error occurred...' gener
   const completion = await runOpenAILoopWithDeps(
     params,
     async (): Promise<void> => {},
-    {
-      buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-      getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+    createTestLoopDeps({
       runOneModelCall: async () => {
         attemptCount += 1;
         if (attemptCount === 1) {
@@ -541,16 +497,8 @@ test("runOpenAILoop retries on the canonical OpenAI 'An error occurred...' gener
           toolStates: createToolCallStateMap(),
         };
       },
-      runOneToolCall: async (): Promise<Readonly<{
-        output: string;
-        isMutating: boolean;
-        succeeded: boolean;
-      }>> => {
-        throw new Error("runOneToolCall should not be called");
-      },
       getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [0, 0],
-      sleep: async (): Promise<void> => {},
-    },
+    }),
   );
 
   assert.equal(attemptCount, 2);
@@ -565,9 +513,7 @@ test("runOpenAILoop does NOT retry when the failed attempt already emitted a del
     runOpenAILoopWithDeps(
       params,
       async (): Promise<void> => {},
-      {
-        buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-        getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+      createTestLoopDeps({
         runOneModelCall: async (
           _client: OpenAI,
           _callParams: StartOpenAILoopParams,
@@ -585,16 +531,8 @@ test("runOpenAILoop does NOT retry when the failed attempt already emitted a del
           });
           throw new OpenAI.APIError(503, { message: "service unavailable" }, "Service Unavailable", undefined);
         },
-        runOneToolCall: async (): Promise<Readonly<{
-          output: string;
-          isMutating: boolean;
-          succeeded: boolean;
-        }>> => {
-          throw new Error("runOneToolCall should not be called");
-        },
         getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [0, 0],
-        sleep: async (): Promise<void> => {},
-      },
+      }),
     ),
     (error: unknown): boolean => error instanceof OpenAI.APIError && error.status === 503,
   );
@@ -606,67 +544,45 @@ test("runOpenAILoop retries on a 429 RateLimitError and respects the Retry-After
   const params = createLoopParams();
   let attemptCount = 0;
   const observedDelays: Array<number> = [];
-  const originalLog = console.log.bind(console);
-  console.log = (line: string): void => {
-    try {
-      const event: unknown = JSON.parse(line);
-      if (
-        typeof event === "object" && event !== null
-        && (event as { action?: unknown }).action === "model_call_retry"
-      ) {
-        const delay = (event as { delayMs?: unknown }).delayMs;
-        if (typeof delay === "number") observedDelays.push(delay);
-      }
-    } catch {
-      // Non-JSON line — ignore.
-    }
-  };
-  try {
-    const completion = await runOpenAILoopWithDeps(
-      params,
-      async (): Promise<void> => {},
-      {
-        buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-        getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
-        runOneModelCall: async () => {
-          attemptCount += 1;
-          if (attemptCount === 1) {
-            throw new OpenAI.APIError(
-              429,
-              { message: "rate limit exceeded" },
-              "429 rate limit exceeded",
-              new Headers({ "retry-after": "2" }),
-            );
-          }
-          return {
-            finalResponse: createFinalResponse("Recovered after rate limit"),
-            functionCalls: [],
-            replayItems: [createAssistantReplayItem("Recovered after rate limit")],
-            streamedText: "Recovered after rate limit",
-            toolStates: createToolCallStateMap(),
-          };
-        },
-        runOneToolCall: async (): Promise<Readonly<{
-          output: string;
-          isMutating: boolean;
-          succeeded: boolean;
-        }>> => {
-          throw new Error("runOneToolCall should not be called");
-        },
-        getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [0, 0],
-        sleep: async (): Promise<void> => {},
+
+  const completion = await runOpenAILoopWithDeps(
+    params,
+    async (): Promise<void> => {},
+    createTestLoopDeps({
+      runOneModelCall: async () => {
+        attemptCount += 1;
+        if (attemptCount === 1) {
+          throw new OpenAI.APIError(
+            429,
+            { message: "rate limit exceeded" },
+            "429 rate limit exceeded",
+            new Headers({ "retry-after": "2" }),
+          );
+        }
+        return {
+          finalResponse: createFinalResponse("Recovered after rate limit"),
+          functionCalls: [],
+          replayItems: [createAssistantReplayItem("Recovered after rate limit")],
+          streamedText: "Recovered after rate limit",
+          toolStates: createToolCallStateMap(),
+        };
       },
-    );
-    assert.equal(attemptCount, 2);
-    assert.deepEqual(completion.openaiItems.at(-1), createAssistantReplayItem("Recovered after rate limit"));
-    assert.equal(observedDelays.length, 1);
-    assert.ok(
-      observedDelays[0] !== undefined && observedDelays[0] >= 2_000,
-      `expected Retry-After 2s to floor delayMs, observed ${String(observedDelays[0])}`,
-    );
-  } finally {
-    console.log = originalLog;
-  }
+      getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [0, 0],
+      log: (event): void => {
+        if (event.action === "model_call_retry" && typeof event.delayMs === "number") {
+          observedDelays.push(event.delayMs);
+        }
+      },
+    }),
+  );
+
+  assert.equal(attemptCount, 2);
+  assert.deepEqual(completion.openaiItems.at(-1), createAssistantReplayItem("Recovered after rate limit"));
+  assert.equal(observedDelays.length, 1);
+  assert.ok(
+    observedDelays[0] !== undefined && observedDelays[0] >= 2_000,
+    `expected Retry-After 2s to floor delayMs, observed ${String(observedDelays[0])}`,
+  );
 });
 
 test("runOpenAILoop does NOT retry when Retry-After exceeds the max delay cap", async (): Promise<void> => {
@@ -677,9 +593,7 @@ test("runOpenAILoop does NOT retry when Retry-After exceeds the max delay cap", 
     runOpenAILoopWithDeps(
       params,
       async (): Promise<void> => {},
-      {
-        buildChatCompletionInput: async (): Promise<ReadonlyArray<OpenAI.Responses.ResponseInputItem>> => [],
-        getObservedOpenAIClient: (): OpenAI => ({}) as OpenAI,
+      createTestLoopDeps({
         runOneModelCall: async () => {
           attemptCount += 1;
           throw new OpenAI.APIError(
@@ -689,19 +603,68 @@ test("runOpenAILoop does NOT retry when Retry-After exceeds the max delay cap", 
             new Headers({ "retry-after": "120" }),
           );
         },
-        runOneToolCall: async (): Promise<Readonly<{
-          output: string;
-          isMutating: boolean;
-          succeeded: boolean;
-        }>> => {
-          throw new Error("runOneToolCall should not be called");
-        },
         getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [0, 0],
-        sleep: async (): Promise<void> => {},
-      },
+      }),
     ),
     (error: unknown): boolean => error instanceof OpenAI.APIError && error.status === 429,
   );
 
   assert.equal(attemptCount, 1);
+});
+
+test("runOpenAILoop falls back to base backoff when Retry-After exceeds the parser's 24h sanity cap", async (): Promise<void> => {
+  // A header value > 24h is treated as malformed by parseRetryAfterMs and
+  // returns undefined, so the loop never sees the absurd delay and uses base
+  // backoff instead of throwing. Pinning this so the parser-cap behaviour is
+  // not silently changed by future edits.
+  const params = createLoopParams();
+  let attemptCount = 0;
+  const observedDelays: Array<number> = [];
+  const observedRetryAfterMs: Array<number | undefined> = [];
+
+  const completion = await runOpenAILoopWithDeps(
+    params,
+    async (): Promise<void> => {},
+    createTestLoopDeps({
+      runOneModelCall: async () => {
+        attemptCount += 1;
+        if (attemptCount === 1) {
+          throw new OpenAI.APIError(
+            429,
+            { message: "rate limit exceeded" },
+            "429 rate limit exceeded",
+            // ~27 hours — well above the parser's 24h cap.
+            new Headers({ "retry-after": "100000" }),
+          );
+        }
+        return {
+          finalResponse: createFinalResponse("Recovered"),
+          functionCalls: [],
+          replayItems: [createAssistantReplayItem("Recovered")],
+          streamedText: "Recovered",
+          toolStates: createToolCallStateMap(),
+        };
+      },
+      getModelCallRetryBackoffMs: (): ReadonlyArray<number> => [0, 0],
+      log: (event): void => {
+        if (event.action === "model_call_retry") {
+          if (typeof event.delayMs === "number") observedDelays.push(event.delayMs);
+          observedRetryAfterMs.push(event.retryAfterMs);
+        }
+      },
+    }),
+  );
+
+  assert.equal(attemptCount, 2);
+  assert.deepEqual(completion.openaiItems.at(-1), createAssistantReplayItem("Recovered"));
+  assert.equal(observedDelays.length, 1);
+  // Parser dropped the absurd value, so the retry log records no retryAfterMs
+  // and the delay equals the (jittered) base backoff of 0. Use a tight upper
+  // bound so a regression that lets the absurd Retry-After leak through
+  // (e.g. ~100_000_000 ms) is caught here, not just by attemptCount.
+  assert.equal(observedRetryAfterMs[0], undefined);
+  assert.ok(
+    observedDelays[0] !== undefined && observedDelays[0] < 100,
+    `expected near-zero base-backoff delay, observed ${String(observedDelays[0])}`,
+  );
 });

--- a/apps/web/src/server/chat/openai/loop.ts
+++ b/apps/web/src/server/chat/openai/loop.ts
@@ -21,6 +21,7 @@ import {
 } from "@/server/chat/openai/request";
 import {
   runOneModelCall,
+  type ModelCallResult,
 } from "@/server/chat/openai/modelCall";
 import { runOneToolCall } from "@/server/chat/openai/toolExecutor";
 import {
@@ -29,13 +30,17 @@ import {
   parseRetryAfterMs,
 } from "@/server/chat/logging";
 import type { ChatStreamEvent, ContentPart } from "@/server/chat/types";
-import { log } from "@/server/logger";
+import { log as serverLog } from "@/server/logger";
 
 export const CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS = 30;
 const TOOL_LIMIT_FALLBACK_ITEM_ID = "tool-limit-summary";
 
 const MODEL_CALL_RETRY_BACKOFF_MS: ReadonlyArray<number> = [5_000, 20_000];
 const MODEL_CALL_RETRY_JITTER = 0.2;
+// Loop-level retry policy cap: if the server's Retry-After exceeds this,
+// surface the error instead of waiting. Distinct from the parser-level 24h
+// sanity cap in logging.ts (which filters obviously-malformed values before
+// they ever reach this check).
 const MODEL_CALL_RETRY_MAX_DELAY_MS = 60_000;
 
 const computeRetryDelayMs = (
@@ -81,6 +86,7 @@ type OpenAILoopDependencies = Readonly<{
   runOneToolCall: typeof runOneToolCall;
   getModelCallRetryBackoffMs: () => ReadonlyArray<number>;
   sleep: (ms: number, signal: AbortSignal | undefined) => Promise<void>;
+  log: typeof serverLog;
 }>;
 
 export type OpenAILoopCompletion = Readonly<{
@@ -120,6 +126,7 @@ const DEFAULT_OPENAI_LOOP_DEPENDENCIES: OpenAILoopDependencies = {
   runOneToolCall,
   getModelCallRetryBackoffMs: (): ReadonlyArray<number> => MODEL_CALL_RETRY_BACKOFF_MS,
   sleep: sleepWithAbort,
+  log: serverLog,
 };
 
 const createInputTextMessage = (
@@ -218,6 +225,7 @@ type RunOneModelCallWithRetryArgs = Readonly<{
   runOneModelCallFn: typeof runOneModelCall;
   backoffMs: ReadonlyArray<number>;
   sleep: (ms: number, signal: AbortSignal | undefined) => Promise<void>;
+  log: typeof serverLog;
   client: OpenAI;
   params: StartOpenAILoopParams;
   emitEvent: OpenAILoopEventHandler;
@@ -228,8 +236,8 @@ type RunOneModelCallWithRetryArgs = Readonly<{
 
 const runOneModelCallWithRetry = async (
   args: RunOneModelCallWithRetryArgs,
-): Promise<Awaited<ReturnType<typeof runOneModelCall>>> => {
-  const { runOneModelCallFn, backoffMs, sleep, client, params, emitEvent, request, promptCacheKey, callIndex } = args;
+): Promise<ModelCallResult> => {
+  const { runOneModelCallFn, backoffMs, sleep, log, client, params, emitEvent, request, promptCacheKey, callIndex } = args;
   const maxAttempts = backoffMs.length + 1;
   for (let attempt = 1; attempt < maxAttempts; attempt += 1) {
     const { trackingEmit, hasEmitted } = wrapEmitEventWithTracking(emitEvent);
@@ -291,6 +299,7 @@ const completeToolLimitSummaryTurn = async (
   runOneModelCallFn: typeof runOneModelCall,
   backoffMs: ReadonlyArray<number>,
   sleep: (ms: number, signal: AbortSignal | undefined) => Promise<void>,
+  log: typeof serverLog,
   client: OpenAI,
   baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
   continuationItems: Array<StoredOpenAIReplayItem>,
@@ -311,6 +320,7 @@ const completeToolLimitSummaryTurn = async (
     runOneModelCallFn,
     backoffMs,
     sleep,
+    log,
     client,
     params,
     emitEvent,
@@ -373,6 +383,7 @@ const runLoopWithDeps = async (
       runOneModelCallFn: dependencies.runOneModelCall,
       backoffMs: retryBackoffMs,
       sleep: dependencies.sleep,
+      log: dependencies.log,
       client,
       params,
       emitEvent,
@@ -432,6 +443,7 @@ const runLoopWithDeps = async (
         dependencies.runOneModelCall,
         retryBackoffMs,
         dependencies.sleep,
+        dependencies.log,
         client,
         baseInput,
         continuationItems,


### PR DESCRIPTION
## Summary

- `parseRetryAfterMs` treats `Retry-After` values >24h as malformed (returns `undefined`), so the loop falls back to its base backoff instead of either honoring garbage delays or surfacing a transient as fatal.
- `OpenAILoopDependencies` gains a `log` hook so tests can observe retry events without mutating `console.log`.
- Return type of `runOneModelCallWithRetry` simplified from `Promise<Awaited<ReturnType<typeof runOneModelCall>>>` to `Promise<ModelCallResult>`.
- New `createTestLoopDeps(overrides)` helper removes 11 duplicated dep blocks in `loop.test.ts`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `node --test --import tsx 'src/server/chat/openai/loop.test.ts' 'src/server/chat/logging.test.ts'` — 24/24 pass (incl. 3 new: 2 logging cap cases + 1 loop fallback case)
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)