### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@expense-budget-tracker/agent-shared": "1.0.0",
-    "@hono/node-server": "^2.0.1",
+    "@hono/node-server": "^2.0.2",
     "hono": "^4.12.18",
     "pg": "^8.20.0"
   },

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -15,7 +15,7 @@
     "synth": "cdk synth"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.253.0",
+    "aws-cdk-lib": "^2.253.1",
     "constructs": "^10.6.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expense-budget-tracker/agent-shared": "1.0.0",
-        "@hono/node-server": "^2.0.1",
+        "@hono/node-server": "^2.0.2",
         "hono": "^4.12.18",
         "pg": "^8.20.0"
       },
@@ -189,7 +189,7 @@
       "name": "expense-budget-tracker-aws",
       "version": "1.0.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.253.0",
+        "aws-cdk-lib": "^2.253.1",
         "constructs": "^10.6.0"
       },
       "devDependencies": {
@@ -1904,9 +1904,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.1.tgz",
-      "integrity": "sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.2.tgz",
+      "integrity": "sha512-tXlTi1h/4V7sDe7i97IVP+9re9ZU7wXZZggnR5ucCRclf1+AX6YhGStrR5w8bLj+3Mlyl0pKfBh9gqTqqnGKfQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -4230,9 +4230,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.253.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.253.0.tgz",
-      "integrity": "sha512-36nNLOz0WJDWraEzU7zlmYY8nsM+YEroBWpRZ84LZPaeEe4Ozy4RhBvdCz/jIGYtLbtiFnfk+przNW2NNRjz5Q==",
+      "version": "2.253.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.253.1.tgz",
+      "integrity": "sha512-vy+hA15/ZfSQpivkNdlIn2ZDA2hesp3WJgmtIZJDFwu6xzwv7wH7glbAdu5xCHGcOjepOaTKZSvCPC6sN+0/Vw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",


### PR DESCRIPTION
## Summary
- update @hono/node-server in apps/auth from 2.0.1 to 2.0.2
- update aws-cdk-lib in infra/aws from 2.253.0 to 2.253.1
- refresh the root npm lockfile for those dependency changes

## Validation
- npx -y -p node@24.15.0 node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js ci
- npx -y -p node@24.15.0 node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js --workspace expense-tracker-auth run build
- npx -y -p node@24.15.0 node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js --workspace expense-budget-tracker-aws run build

## Notes
- npm audit still reports xlsx advisories with no npm fix and aws-cdk-lib bundled fast-uri; aws-cdk-lib is already at the latest published version.