### PR TITLE
[codex] Update AWS credentials action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary
- Pin the AWS credentials GitHub Action to the latest stable v6.1.1 release instead of the floating v6 tag.

## Validation
- Previously ran dependency drift validation under Node 24.15.0 / npm 11.9.0: npm ci, workspace builds/lints, web production build, git diff --check, and workflow YAML parse.

## Notes
- No package manifests or lockfiles changed; direct npm dependencies were already current.