### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -13,13 +13,13 @@
   "dependencies": {
     "@expense-budget-tracker/agent-shared": "1.0.0",
     "@hono/node-server": "^2.0.2",
-    "hono": "^4.12.18",
+    "hono": "^4.12.19",
     "pg": "^8.20.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
     "@types/pg": "^8.20.0",
-    "tsx": "^4.22.0",
+    "tsx": "^4.22.1",
     "typescript": "^6.0.3"
   },
   "engines": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,7 @@
     "@types/pg": "^8.20.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "tsx": "^4.22.0",
+    "tsx": "^4.22.1",
     "typescript": "^6.0.3"
   },
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,13 +17,13 @@
       "dependencies": {
         "@expense-budget-tracker/agent-shared": "1.0.0",
         "@hono/node-server": "^2.0.2",
-        "hono": "^4.12.18",
+        "hono": "^4.12.19",
         "pg": "^8.20.0"
       },
       "devDependencies": {
         "@types/node": "^24.12.4",
         "@types/pg": "^8.20.0",
-        "tsx": "^4.22.0",
+        "tsx": "^4.22.1",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -78,7 +78,7 @@
         "@types/pg": "^8.20.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "tsx": "^4.22.0",
+        "tsx": "^4.22.1",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -4050,9 +4050,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4888,9 +4888,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
-      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
+      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5098,7 +5098,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@types/node": "^24.12.4",
-        "tsx": "^4.22.0",
+        "tsx": "^4.22.1",
         "typescript": "^6.0.3"
       },
       "engines": {

--- a/packages/agent-shared/package.json
+++ b/packages/agent-shared/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
-    "tsx": "^4.22.0",
+    "tsx": "^4.22.1",
     "typescript": "^6.0.3"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- updates Hono in the auth service from 4.12.18 to 4.12.19
- updates tsx in auth, web, and agent-shared from 4.22.0 to 4.22.1
- refreshes the root npm lockfile for those package updates

## Validation
- `npm ci` under Node 24.15.0 / npm 11.14.1
- `npm --workspace @expense-budget-tracker/agent-shared run lint`
- `npm --workspace @expense-budget-tracker/agent-shared run build`
- `npm --workspace expense-tracker-auth run build`
- `npm --workspace expense-budget-tracker-sql-api run lint`
- `npm --workspace expense-budget-tracker-sql-api run build`
- `npm --workspace expense-budget-tracker-worker run lint`
- `npm --workspace expense-budget-tracker-worker run build`
- `npm --workspace expense-budget-tracker-aws run build`
- `npm --workspace expense-budget-tracker-web run lint`
- `npm --workspace expense-budget-tracker-web run build`
- `npm audit --workspaces --json` reported 0 vulnerabilities
- compromised dependency/action indicator scan found no matches
- Docker manifests resolved for pinned Node/Postgres images
- `git diff --check`
