### PR TITLE
[codex] Implement multiline transaction notes

### DIFF
--- a/apps/web/src/ui/charts/ExpenseTreemapChart.module.css
+++ b/apps/web/src/ui/charts/ExpenseTreemapChart.module.css
@@ -57,3 +57,14 @@
   color: #aaa;
   font-size: 11px;
 }
+
+.tooltipNote {
+  display: -webkit-box;
+  max-block-size: 12em;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 8;
+  line-clamp: 8;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}

--- a/apps/web/src/ui/charts/ExpenseTreemapChart.tsx
+++ b/apps/web/src/ui/charts/ExpenseTreemapChart.tsx
@@ -321,7 +321,7 @@ export const ExpenseTreemapChart = (props: Props): ReactElement => {
               {hover.entry.category ?? uncategorizedLabel} · {fmtDate(hover.entry.ts)}
             </div>
             {hover.entry.note !== null && (
-              <div className={cn(styles.tooltipRow, styles.tooltipMuted)}>{hover.entry.note}</div>
+              <div className={cn(styles.tooltipRow, styles.tooltipMuted, styles.tooltipNote)}>{hover.entry.note}</div>
             )}
           </div>
         )}

--- a/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement } from "react";
 import { createPortal } from "react-dom";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
@@ -11,6 +11,68 @@ import styles from "@/ui/tables/budget/BudgetTable.module.css";
 import tableStateStyles from "@/ui/tables/shared/TableStates.module.css";
 
 const POPOVER_WIDTH = 240;
+const POPOVER_VIEWPORT_MARGIN = 8;
+const POPOVER_CELL_GAP = 4;
+
+type PopoverPosition = Readonly<{
+  top: number;
+  left: number;
+}>;
+
+type PopoverSize = Readonly<{
+  width: number;
+  height: number;
+}>;
+
+type TextDirection = "ltr" | "rtl";
+
+const getClampedCoordinate = (preferred: number, min: number, max: number): number => {
+  const normalizedMax = Math.max(min, max);
+  return Math.min(Math.max(preferred, min), normalizedMax);
+};
+
+const getViewportPopoverWidth = (viewportWidth: number): number => (
+  Math.min(POPOVER_WIDTH, Math.max(1, viewportWidth - (POPOVER_VIEWPORT_MARGIN * 2)))
+);
+
+const getDocumentDirection = (): TextDirection => (
+  document.documentElement.dir === "rtl" ? "rtl" : "ltr"
+);
+
+const getPreferredPopoverLeft = (cellRect: DOMRect, popoverWidth: number, textDirection: TextDirection): number => (
+  textDirection === "rtl" ? cellRect.left : cellRect.right - popoverWidth
+);
+
+const getPopoverPosition = (
+  cellRect: DOMRect,
+  popoverSize: PopoverSize,
+  viewportWidth: number,
+  viewportHeight: number,
+  textDirection: TextDirection,
+): PopoverPosition => {
+  const preferredLeft = getPreferredPopoverLeft(cellRect, popoverSize.width, textDirection);
+  const left = getClampedCoordinate(
+    preferredLeft,
+    POPOVER_VIEWPORT_MARGIN,
+    viewportWidth - popoverSize.width - POPOVER_VIEWPORT_MARGIN,
+  );
+
+  const belowTop = cellRect.bottom + POPOVER_CELL_GAP;
+  const aboveTop = cellRect.top - popoverSize.height - POPOVER_CELL_GAP;
+  const belowFits = belowTop + popoverSize.height <= viewportHeight - POPOVER_VIEWPORT_MARGIN;
+  const aboveFits = aboveTop >= POPOVER_VIEWPORT_MARGIN;
+  const preferredTop = belowFits || !aboveFits ? belowTop : aboveTop;
+  const top = getClampedCoordinate(
+    preferredTop,
+    POPOVER_VIEWPORT_MARGIN,
+    viewportHeight - popoverSize.height - POPOVER_VIEWPORT_MARGIN,
+  );
+
+  return {
+    top: Math.round(top),
+    left: Math.round(left),
+  };
+};
 
 export type BudgetPlanCellProps = Readonly<{
   month: string;
@@ -42,7 +104,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
   const [modifierInput, setModifierInput] = useState<string>("");
   const [commentInput, setCommentInput] = useState<string>("");
   const [isLoadingComment, setIsLoadingComment] = useState<boolean>(false);
-  const [popoverPos, setPopoverPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const [popoverPos, setPopoverPos] = useState<PopoverPosition>({ top: 0, left: 0 });
 
   const cellRef = useRef<HTMLTableCellElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -63,9 +125,13 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
 
     const rect = cellRef.current?.getBoundingClientRect();
     if (rect !== undefined && rect !== null) {
-      let left = rect.right - POPOVER_WIDTH;
-      if (left < 0) left = rect.left;
-      setPopoverPos({ top: rect.bottom + 4, left });
+      setPopoverPos(getPopoverPosition(
+        rect,
+        { width: getViewportPopoverWidth(window.innerWidth), height: 0 },
+        window.innerWidth,
+        window.innerHeight,
+        getDocumentDirection(),
+      ));
     }
     setIsOpen(true);
 
@@ -81,6 +147,55 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       .catch((error) => console.error(error))
       .finally(() => setIsLoadingComment(false));
   };
+
+  const updatePopoverPosition = useCallback((): void => {
+    const cell = cellRef.current;
+    const popover = popoverRef.current;
+    if (cell === null || popover === null) return;
+
+    const cellRect = cell.getBoundingClientRect();
+    const popoverRect = popover.getBoundingClientRect();
+    const nextPosition = getPopoverPosition(
+      cellRect,
+      { width: popoverRect.width, height: popoverRect.height },
+      window.innerWidth,
+      window.innerHeight,
+      getDocumentDirection(),
+    );
+
+    setPopoverPos((currentPosition) => (
+      currentPosition.top === nextPosition.top && currentPosition.left === nextPosition.left
+        ? currentPosition
+        : nextPosition
+    ));
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    updatePopoverPosition();
+  }, [isOpen, isLoadingComment, updatePopoverPosition]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleViewportChange = (): void => {
+      updatePopoverPosition();
+    };
+
+    const resizeObserver = new ResizeObserver(handleViewportChange);
+    if (popoverRef.current !== null) {
+      resizeObserver.observe(popoverRef.current);
+    }
+
+    window.addEventListener("resize", handleViewportChange);
+    window.addEventListener("scroll", handleViewportChange, true);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("scroll", handleViewportChange, true);
+    };
+  }, [isOpen, updatePopoverPosition]);
 
   useEffect(() => {
     if (isOpen && adjustInputRef.current !== null) {
@@ -277,7 +392,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
             : (
               <textarea
                 className={styles.popoverComment}
-                rows={2}
+                rows={3}
                 placeholder={t("budget.popoverNote")}
                 value={commentInput}
                 onChange={(e) => setCommentInput(e.target.value)}

--- a/apps/web/src/ui/tables/budget/BudgetTable.module.css
+++ b/apps/web/src/ui/tables/budget/BudgetTable.module.css
@@ -255,10 +255,14 @@ tbody tr:last-child .currentMonthActual {
 .popover {
   position: fixed;
   z-index: 200;
-  width: 240px;
+  box-sizing: border-box;
+  inline-size: min(240px, max(1px, calc(100vw - 16px)));
+  max-block-size: max(1px, calc(100dvh - 16px));
+  overflow-y: auto;
   background: var(--bg);
   border: 1px solid var(--panel-border);
-  padding: 10px 12px;
+  padding-block: 10px;
+  padding-inline: 12px;
   font-size: 13px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 }
@@ -345,8 +349,12 @@ tbody tr:last-child .currentMonthActual {
 
 .popoverComment {
   display: block;
-  width: 100%;
-  padding: 4px 6px;
+  box-sizing: border-box;
+  inline-size: 100%;
+  min-height: calc(3 * 1.4em + 8px);
+  max-height: 180px;
+  padding-block: 4px;
+  padding-inline: 6px;
   border: none;
   outline: 1px solid var(--panel-border);
   background: var(--bg);
@@ -354,7 +362,7 @@ tbody tr:last-child .currentMonthActual {
   font-family: inherit;
   font-size: 12px;
   line-height: 1.4;
-  resize: none;
+  resize: vertical;
 }
 
 .popoverComment:focus {

--- a/apps/web/src/ui/tables/editable/EditableNote.tsx
+++ b/apps/web/src/ui/tables/editable/EditableNote.tsx
@@ -1,0 +1,105 @@
+import { type ReactElement } from "react";
+import { useEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/cn";
+
+import { CellTextareaOverlay } from "@/ui/tables/overlays/CellTextareaOverlay";
+import styles from "@/ui/tables/shared/TableUi.module.css";
+
+type Rect = Readonly<{ top: number; left: number; width: number; height: number }>;
+
+type Props = Readonly<{
+  entryId: string;
+  currentValue: string | null;
+  maskClass: string;
+  onCommit: (entryId: string, newValue: string | null, oldValue: string | null) => void;
+  cellClass: string;
+  hints: ReadonlyArray<string>;
+}>;
+
+const NOTE_EDITOR_ROWS = 3;
+const NOTE_MAX_LENGTH = 1000;
+
+export const EditableNote = (props: Props): ReactElement => {
+  const { entryId, currentValue, maskClass, onCommit, cellClass, hints } = props;
+
+  const [editing, setEditing] = useState<boolean>(false);
+  const [rect, setRect] = useState<Rect | null>(null);
+  const cellRef = useRef<HTMLTableCellElement | null>(null);
+
+  const startEditing = (): void => {
+    if (cellRef.current === null) return;
+    setRect(readElementRect(cellRef.current));
+    setEditing(true);
+  };
+
+  const handleCommit = (newValue: string | null): void => {
+    setEditing(false);
+    setRect(null);
+    if (newValue === currentValue) return;
+    onCommit(entryId, newValue, currentValue);
+  };
+
+  const handleCancel = (): void => {
+    setEditing(false);
+    setRect(null);
+  };
+
+  const isMasked = maskClass.length > 0;
+
+  useEffect(() => {
+    if (!editing) return;
+
+    const refreshPosition = (): void => {
+      if (cellRef.current === null) return;
+      const nextRect = readElementRect(cellRef.current);
+      setRect((currentRect) => (
+        currentRect !== null && areRectsEqual(currentRect, nextRect) ? currentRect : nextRect
+      ));
+    };
+
+    window.addEventListener("resize", refreshPosition);
+    window.addEventListener("scroll", refreshPosition, true);
+    return () => {
+      window.removeEventListener("resize", refreshPosition);
+      window.removeEventListener("scroll", refreshPosition, true);
+    };
+  }, [editing]);
+
+  return (
+    <td
+      ref={cellRef}
+      className={cn(styles.cell, cellClass, !isMasked ? styles.editable : "", maskClass)}
+      onClick={isMasked || editing ? undefined : startEditing}
+    >
+      <span className={styles.cellMultilinePreview}>
+        {currentValue === null || currentValue.length === 0 ? "\u2014" : currentValue}
+      </span>
+      {editing && rect !== null && (
+        <CellTextareaOverlay
+          currentValue={currentValue}
+          rect={rect}
+          hints={hints}
+          rows={NOTE_EDITOR_ROWS}
+          maxLength={NOTE_MAX_LENGTH}
+          onCommit={handleCommit}
+          onCancel={handleCancel}
+        />
+      )}
+    </td>
+  );
+};
+
+const readElementRect = (element: HTMLElement): Rect => {
+  const rect = element.getBoundingClientRect();
+  return { top: rect.top, left: rect.left, width: rect.width, height: rect.height };
+};
+
+const areRectsEqual = (left: Rect, right: Rect): boolean => {
+  return (
+    left.top === right.top
+    && left.left === right.left
+    && left.width === right.width
+    && left.height === right.height
+  );
+};

--- a/apps/web/src/ui/tables/overlays/CellTextareaOverlay.tsx
+++ b/apps/web/src/ui/tables/overlays/CellTextareaOverlay.tsx
@@ -1,0 +1,163 @@
+import { type ReactElement } from "react";
+import { createPortal } from "react-dom";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/cn";
+
+import styles from "@/ui/tables/shared/TableUi.module.css";
+
+type Rect = Readonly<{ top: number; left: number; width: number; height: number }>;
+
+type OverlayPosition = Readonly<{ top: number; left: number; width: number; maxHeight: number }>;
+
+type Props = Readonly<{
+  currentValue: string | null;
+  rect: Rect;
+  hints: ReadonlyArray<string>;
+  rows: number;
+  maxLength: number;
+  onCommit: (value: string | null) => void;
+  onCancel: () => void;
+}>;
+
+const OVERLAY_GUTTER = 8;
+const OVERLAY_MIN_WIDTH = 420;
+const OVERLAY_MAX_WIDTH = 680;
+const OVERLAY_MIN_HEIGHT = 180;
+
+export const CellTextareaOverlay = (props: Props): ReactElement => {
+  const { currentValue, rect, hints, rows, maxLength, onCommit, onCancel } = props;
+
+  const [inputValue, setInputValue] = useState<string>(currentValue ?? "");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const closedRef = useRef<boolean>(false);
+
+  const filteredHints = filterHints(hints, inputValue);
+  const position = resolveOverlayPosition(rect);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea === null) return;
+    const selectionIndex = textarea.value.length;
+    textarea.focus();
+    textarea.setSelectionRange(selectionIndex, selectionIndex);
+  }, []);
+
+  const commit = useCallback((raw: string): void => {
+    if (closedRef.current) return;
+    closedRef.current = true;
+    const trimmed = raw.trim();
+    onCommit(trimmed.length > 0 ? trimmed : null);
+  }, [onCommit]);
+
+  const cancel = useCallback((): void => {
+    if (closedRef.current) return;
+    closedRef.current = true;
+    onCancel();
+  }, [onCancel]);
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent): void => {
+      if (overlayRef.current !== null && !overlayRef.current.contains(e.target as Node)) {
+        commit(inputValue);
+      }
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [commit, inputValue]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    e.stopPropagation();
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.nativeEvent.stopImmediatePropagation();
+      cancel();
+    }
+  };
+
+  const stopOverlayMouseEvent = (e: React.MouseEvent<HTMLDivElement>): void => {
+    e.stopPropagation();
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLDivElement>): void => {
+    const nextTarget = e.relatedTarget;
+    if (isEventTargetInsideOverlay(overlayRef.current, nextTarget)) {
+      return;
+    }
+    commit(inputValue);
+  };
+
+  const overlay = (
+    <div
+      ref={overlayRef}
+      className={styles.textareaOverlay}
+      style={{
+        top: position.top,
+        left: position.left,
+        width: position.width,
+        maxHeight: position.maxHeight,
+      }}
+      onBlur={handleBlur}
+      onMouseDown={stopOverlayMouseEvent}
+      onClick={stopOverlayMouseEvent}
+      onKeyDown={handleKeyDown}
+    >
+      <textarea
+        ref={textareaRef}
+        className={styles.textareaEditor}
+        rows={rows}
+        maxLength={maxLength}
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+      />
+      {filteredHints.length > 0 && (
+        <div className={styles.textareaHints}>
+          {filteredHints.map((hint) => (
+            <button
+              key={hint}
+              className={cn(styles.textareaHint, hint === currentValue ? styles.textareaHintActive : "")}
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => commit(hint)}
+            >
+              {hint}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  return createPortal(overlay, document.body) as ReactElement;
+};
+
+const resolveOverlayPosition = (rect: Rect): OverlayPosition => {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const availableWidth = Math.max(0, viewportWidth - OVERLAY_GUTTER * 2);
+  const preferredWidth = Math.max(rect.width, OVERLAY_MIN_WIDTH);
+  const width = Math.min(preferredWidth, OVERLAY_MAX_WIDTH, availableWidth);
+  const maxLeft = Math.max(OVERLAY_GUTTER, viewportWidth - width - OVERLAY_GUTTER);
+  const left = Math.min(Math.max(rect.left, OVERLAY_GUTTER), maxLeft);
+  const maxTop = Math.max(OVERLAY_GUTTER, viewportHeight - OVERLAY_MIN_HEIGHT - OVERLAY_GUTTER);
+  const top = Math.min(Math.max(rect.top, OVERLAY_GUTTER), maxTop);
+  const maxHeight = Math.max(OVERLAY_MIN_HEIGHT, viewportHeight - top - OVERLAY_GUTTER);
+  return { top, left, width, maxHeight };
+};
+
+const filterHints = (
+  hints: ReadonlyArray<string>,
+  input: string,
+): ReadonlyArray<string> => {
+  const query = input.trim().toLowerCase();
+  if (query.length === 0) return hints;
+  return hints.filter((hint) => hint.toLowerCase().includes(query));
+};
+
+const isEventTargetInsideOverlay = (
+  overlay: HTMLDivElement | null,
+  target: EventTarget | null,
+): boolean => {
+  return overlay !== null && target instanceof Node && overlay.contains(target);
+};

--- a/apps/web/src/ui/tables/shared/TableUi.module.css
+++ b/apps/web/src/ui/tables/shared/TableUi.module.css
@@ -44,6 +44,16 @@
   font-variant-numeric: tabular-nums;
 }
 
+.cellMultilinePreview {
+  display: -webkit-box;
+  overflow: hidden;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
 .cellRight {
   text-align: end;
   min-width: 90px;
@@ -167,6 +177,68 @@
 }
 
 .selectOptionActive {
+  font-weight: 650;
+}
+
+.textareaOverlay {
+  position: fixed;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--text);
+  box-shadow: 0 0 0 1px var(--panel-border), 0 4px 12px rgba(0, 0, 0, 0.12);
+  box-sizing: border-box;
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.textareaEditor {
+  display: block;
+  width: 100%;
+  min-height: calc(3 * 1.4em + 12px);
+  max-height: 220px;
+  padding: 6px 10px;
+  border: none;
+  border-bottom: 1px solid var(--panel-border);
+  background: var(--bg);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+  outline: none;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.textareaHints {
+  flex: 1;
+  overflow-y: auto;
+  max-height: 160px;
+  padding: 4px 0;
+}
+
+.textareaHint {
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: none;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  text-align: start;
+  cursor: var(--cursor-pointer);
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.textareaHint:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.textareaHintActive {
   font-weight: 650;
 }
 

--- a/apps/web/src/ui/tables/transactions/TransactionsTable.module.css
+++ b/apps/web/src/ui/tables/transactions/TransactionsTable.module.css
@@ -44,14 +44,16 @@
 }
 
 .cellNote {
-  max-width: 300px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  width: clamp(360px, 40vw, 680px);
+  min-width: 360px;
+  max-width: 680px;
+  white-space: normal;
+  vertical-align: top;
 }
 
 .cellDelete {
   width: 24px;
-  display: inline-block;
+  min-width: 24px;
   text-align: center;
 }
 

--- a/apps/web/src/ui/tables/transactions/transactionColumns.tsx
+++ b/apps/web/src/ui/tables/transactions/transactionColumns.tsx
@@ -8,6 +8,7 @@ import { EditableAmount } from "@/ui/tables/editable/EditableAmount";
 import { EditableCategory } from "@/ui/tables/editable/EditableCategory";
 import { EditableDateTime } from "@/ui/tables/editable/EditableDateTime";
 import { EditableKind } from "@/ui/tables/editable/EditableKind";
+import { EditableNote } from "@/ui/tables/editable/EditableNote";
 import { EditableText } from "@/ui/tables/editable/EditableText";
 import type { ColumnDef } from "@/ui/tables/shared/data-table/types";
 import { formatAmount, formatDateTime } from "@/ui/tables/shared/format";
@@ -177,7 +178,7 @@ export const editableNoteColumn = (
   key: "note",
   header: "Note",
   renderCell: (row: LedgerEntry): ReactElement => (
-    <EditableText
+    <EditableNote
       key="note"
       entryId={row.entryId}
       currentValue={row.note}
@@ -197,7 +198,7 @@ export const editableDeleteColumn = (
   key: "delete",
   header: "",
   renderCell: (row: LedgerEntry): ReactElement => (
-    <span className={transactionStyles.cellDelete}>
+    <td key="delete" className={cn(tableStyles.cell, transactionStyles.cellDelete)}>
       <button
         type="button"
         className={transactionStyles.deleteButton}
@@ -205,7 +206,7 @@ export const editableDeleteColumn = (
       >
         &#x2715;
       </button>
-    </span>
+    </td>
   ),
   rightAlign: false,
   sortKey: null,
@@ -279,7 +280,9 @@ export const buildTransactionColumns = (maskClass: string, fmt: FormatParams): R
     key: "note",
     header: fmt.t("table.note"),
     renderCell: (row: LedgerEntry): ReactElement => (
-      <td key="note" className={cn(tableStyles.cell, transactionStyles.cellNote, maskClass)}>{row.note ?? ""}</td>
+      <td key="note" className={cn(tableStyles.cell, transactionStyles.cellNote, maskClass)}>
+        <span className={tableStyles.cellMultilinePreview}>{row.note ?? ""}</span>
+      </td>
     ),
     rightAlign: false,
     sortKey: null,


### PR DESCRIPTION
## Summary
- Add a dedicated multiline transaction note editor and compact wrapped note previews.
- Apply note rendering consistently across transaction tables, drilldown, non-editable columns, and treemap tooltips.
- Lightly improve budget comment textarea sizing and popover viewport handling.

## Validation
- cd apps/web && npm run lint
- cd apps/web && npm run build
- git --no-pager diff --check