### PR TITLE
[codex] Keep transaction note previews single-line

### DIFF
--- a/apps/web/src/ui/tables/editable/EditableNote.tsx
+++ b/apps/web/src/ui/tables/editable/EditableNote.tsx
@@ -72,7 +72,7 @@ export const EditableNote = (props: Props): ReactElement => {
       className={cn(styles.cell, cellClass, !isMasked ? styles.editable : "", maskClass)}
       onClick={isMasked || editing ? undefined : startEditing}
     >
-      <span className={styles.cellMultilinePreview}>
+      <span className={styles.cellSingleLinePreview}>
         {currentValue === null || currentValue.length === 0 ? "\u2014" : currentValue}
       </span>
       {editing && rect !== null && (

--- a/apps/web/src/ui/tables/shared/TableUi.module.css
+++ b/apps/web/src/ui/tables/shared/TableUi.module.css
@@ -40,18 +40,21 @@
 }
 
 .cell {
-  padding: 4px 10px;
+  --table-cell-padding-inline: 10px;
+
+  padding-block: 4px;
+  padding-inline: var(--table-cell-padding-inline);
   font-variant-numeric: tabular-nums;
 }
 
-.cellMultilinePreview {
-  display: -webkit-box;
+.cellSingleLinePreview {
+  display: block;
+  inline-size: var(--cell-single-line-preview-inline-size, 100%);
+  max-inline-size: 100%;
+  min-inline-size: 0;
   overflow: hidden;
-  line-height: 1.35;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .cellRight {

--- a/apps/web/src/ui/tables/transactions/TransactionsTable.module.css
+++ b/apps/web/src/ui/tables/transactions/TransactionsTable.module.css
@@ -44,11 +44,16 @@
 }
 
 .cellNote {
-  width: clamp(360px, 40vw, 680px);
-  min-width: 360px;
-  max-width: 680px;
-  white-space: normal;
-  vertical-align: top;
+  --transaction-note-inline-size: clamp(360px, 40vw, 680px);
+  --cell-single-line-preview-inline-size: calc(
+    var(--transaction-note-inline-size) -
+    var(--table-cell-padding-inline) -
+    var(--table-cell-padding-inline)
+  );
+
+  inline-size: var(--transaction-note-inline-size);
+  min-inline-size: var(--transaction-note-inline-size);
+  max-inline-size: var(--transaction-note-inline-size);
 }
 
 .cellDelete {

--- a/apps/web/src/ui/tables/transactions/transactionColumns.tsx
+++ b/apps/web/src/ui/tables/transactions/transactionColumns.tsx
@@ -281,7 +281,9 @@ export const buildTransactionColumns = (maskClass: string, fmt: FormatParams): R
     header: fmt.t("table.note"),
     renderCell: (row: LedgerEntry): ReactElement => (
       <td key="note" className={cn(tableStyles.cell, transactionStyles.cellNote, maskClass)}>
-        <span className={tableStyles.cellMultilinePreview}>{row.note ?? ""}</span>
+        <span className={tableStyles.cellSingleLinePreview}>
+          {row.note === null || row.note.length === 0 ? "\u2014" : row.note}
+        </span>
       </td>
     ),
     rightAlign: false,


### PR DESCRIPTION
## Summary
- Keep transaction note cells to a single-line ellipsis preview in table display mode.
- Preserve the multiline textarea overlay for editing.
- Keep non-editable note cells consistent with editable cells for empty notes.

## Validation
- git --no-pager diff --check
- cd apps/web && npm run lint
- cd apps/web && npm run build