### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -13,13 +13,13 @@
   "dependencies": {
     "@expense-budget-tracker/agent-shared": "1.0.0",
     "@hono/node-server": "^2.0.3",
-    "hono": "^4.12.19",
+    "hono": "^4.12.21",
     "pg": "^8.21.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
     "@types/pg": "^8.20.0",
-    "tsx": "^4.22.2",
+    "tsx": "^4.22.3",
     "typescript": "^6.0.3"
   },
   "engines": {

--- a/apps/sql-api/package.json
+++ b/apps/sql-api/package.json
@@ -10,7 +10,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1049.0",
+    "@aws-sdk/client-secrets-manager": "^3.1050.0",
     "@expense-budget-tracker/agent-shared": "1.0.0",
     "pg": "^8.21.0"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,9 +37,9 @@
     "@types/d3": "^7.4.3",
     "@types/node": "^24.12.4",
     "@types/pg": "^8.20.0",
-    "@types/react": "^19.2.14",
+    "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
-    "tsx": "^4.22.2",
+    "tsx": "^4.22.3",
     "typescript": "^6.0.3"
   },
   "engines": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -8,7 +8,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1049.0",
+    "@aws-sdk/client-secrets-manager": "^3.1050.0",
     "fast-xml-parser": "^5.8.0",
     "node-cron": "^4.2.1",
     "pg": "^8.21.0"

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -16,13 +16,13 @@
   },
   "dependencies": {
     "@aws-crypto/client-node": "^5.0.0",
-    "@aws-sdk/client-secrets-manager": "^3.1049.0",
-    "aws-cdk-lib": "^2.254.0",
+    "@aws-sdk/client-secrets-manager": "^3.1050.0",
+    "aws-cdk-lib": "^2.256.0",
     "constructs": "^10.6.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
-    "aws-cdk": "^2.1122.0",
+    "aws-cdk": "^2.1123.0",
     "esbuild": "^0.28.0",
     "typescript": "^6.0.3"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,13 +17,13 @@
       "dependencies": {
         "@expense-budget-tracker/agent-shared": "1.0.0",
         "@hono/node-server": "^2.0.3",
-        "hono": "^4.12.19",
+        "hono": "^4.12.21",
         "pg": "^8.21.0"
       },
       "devDependencies": {
         "@types/node": "^24.12.4",
         "@types/pg": "^8.20.0",
-        "tsx": "^4.22.2",
+        "tsx": "^4.22.3",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -34,7 +34,7 @@
       "name": "expense-budget-tracker-sql-api",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1049.0",
+        "@aws-sdk/client-secrets-manager": "^3.1050.0",
         "@expense-budget-tracker/agent-shared": "1.0.0",
         "pg": "^8.21.0"
       },
@@ -76,9 +76,9 @@
         "@types/d3": "^7.4.3",
         "@types/node": "^24.12.4",
         "@types/pg": "^8.20.0",
-        "@types/react": "^19.2.14",
+        "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
-        "tsx": "^4.22.2",
+        "tsx": "^4.22.3",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -89,7 +89,7 @@
       "name": "expense-budget-tracker-worker",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1049.0",
+        "@aws-sdk/client-secrets-manager": "^3.1050.0",
         "fast-xml-parser": "^5.8.0",
         "node-cron": "^4.2.1",
         "pg": "^8.21.0"
@@ -109,13 +109,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-crypto/client-node": "^5.0.0",
-        "@aws-sdk/client-secrets-manager": "^3.1049.0",
-        "aws-cdk-lib": "^2.254.0",
+        "@aws-sdk/client-secrets-manager": "^3.1050.0",
+        "aws-cdk-lib": "^2.256.0",
         "constructs": "^10.6.0"
       },
       "devDependencies": {
         "@types/node": "^24.12.4",
-        "aws-cdk": "^2.1122.0",
+        "aws-cdk": "^2.1123.0",
         "esbuild": "^0.28.0",
         "typescript": "^6.0.3"
       },
@@ -136,16 +136,16 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.24.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.24.0.tgz",
-      "integrity": "sha512-rCwsd0Y9z4CUmV5FhzjbO2MprXjKG0rxCACuLEY40lD+wInvgcHer0lSDo7Xq9Sxe/IoNe/Wxb2YP3GgxvT3GA==",
+      "version": "53.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.25.0.tgz",
+      "integrity": "sha512-E6Fw6VsG/b8cVwvmbtD9AEkzBWgTaKa6IHNn7CGLli4rdrodnsMmmxwj5Ttml2A82b5coWdNmqsr5nZ0ltKWMw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
+        "jsonschema": "^1.5.0",
         "semver": "^7.8.0"
       },
       "engines": {
@@ -153,7 +153,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -507,9 +507,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1049.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1049.0.tgz",
-      "integrity": "sha512-SHj5WzvYis2OBhbGY83WyFluUMl4DU6ZuJPrlAECfvr2lkRI4uiLd7a3MSmdZ5FlINcURLrPqhyHdzvZHCy3qw==",
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1050.0.tgz",
+      "integrity": "sha512-mVOzxK4inCJgbGSQTeENYaACA9qGikru07b3HJyrKEeLVhuLKmo5csVzvKuz++ROdhX9gR7WzzJkoDOO5Xy/EQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1478,9 +1478,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1496,9 +1493,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1516,9 +1510,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1534,9 +1525,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1554,9 +1542,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1572,9 +1557,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1592,9 +1574,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1611,9 +1590,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1629,9 +1605,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1655,9 +1628,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1679,9 +1649,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1705,9 +1672,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1729,9 +1693,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1755,9 +1716,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1780,9 +1738,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1804,9 +1759,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2020,9 +1972,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,9 +1987,6 @@
       "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2058,9 +2004,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2076,9 +2019,6 @@
       "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3196,9 +3136,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3297,9 +3237,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1122.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1122.0.tgz",
-      "integrity": "sha512-AI2Ks9qioWLvBPD4IoEtTet3wUG/o/q6U3WR3VCQKH5sNYLLPALo8o9sermNpMnfd1OQkqhL20tp4cEyojrIZg==",
+      "version": "2.1123.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1123.0.tgz",
+      "integrity": "sha512-s4kN0Dk75TMAqnITGuWk39hzGeHAUhCcYx4Yf2eWT1QSMsOnHs4seOmeL8eXpk8oSp19NJOyF4m6XBP6fux+7A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3310,9 +3250,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.254.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
-      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
+      "version": "2.256.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.256.0.tgz",
+      "integrity": "sha512-MtA5XOSWs+yDA42lW9cO8i+IeCHQt2EwmdPyqWf3li6mF/ptzNxnFjth6rFa5Ms+8v2VzB5cdAS+Ly1ZDGs3fg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -3331,8 +3271,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.3",
-        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -3353,18 +3293,18 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -4442,9 +4382,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.19",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
-      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5371,9 +5311,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.2.tgz",
-      "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5607,7 +5547,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@types/node": "^24.12.4",
-        "tsx": "^4.22.2",
+        "tsx": "^4.22.3",
         "typescript": "^6.0.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "mammoth": {
       "@xmldom/xmldom": "0.9.10"
     },
-    "postcss": "8.5.14"
+    "postcss": "8.5.15"
   }
 }

--- a/packages/agent-shared/package.json
+++ b/packages/agent-shared/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
-    "tsx": "^4.22.2",
+    "tsx": "^4.22.3",
     "typescript": "^6.0.3"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- update direct dependency drift across auth, web, sql-api, worker, infra, and shared packages
- refresh the root lockfile and postcss override to current stable versions available for this repo
- keep Node 24.15.0, PostgreSQL 18.4, Docker images, and GitHub Actions refs unchanged because they are already aligned

## Validation
- npx -p node@24.15.0 -c 'npm --workspace @expense-budget-tracker/agent-shared run build && npm --workspace @expense-budget-tracker/agent-shared run lint'
- npx -p node@24.15.0 -c 'npm --workspace expense-tracker-auth run build'
- npx -p node@24.15.0 -c 'npm --workspace expense-budget-tracker-sql-api run lint && npm --workspace expense-budget-tracker-sql-api run build'
- npx -p node@24.15.0 -c 'npm --workspace expense-budget-tracker-worker run lint && npm --workspace expense-budget-tracker-worker run build'
- npx -p node@24.15.0 -c 'npm --workspace expense-budget-tracker-aws run build'
- npx -p node@24.15.0 -c 'cd apps/web && npm run lint && npm run build'
- git diff --check

## Residual
- npm audit still reports bundled brace-expansion@5.0.5 inside latest aws-cdk-lib@2.256.0; npm audit fix cannot change bundled CDK dependencies automatically