### PR TITLE
[codex] Move Resend setup scripts into provider folder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,8 +60,8 @@ ALLOWED_REDIRECT_URIS=http://localhost:3000
 
 # --- Resend email delivery setup (local setup scripts only) ---
 
-# Runtime send-only API key copied into AWS Secrets Manager by scripts/setup-resend-secret.sh
-# when you create the key manually. Prefer scripts/create-resend-runtime-key.sh for first setup.
+# Runtime send-only API key copied into AWS Secrets Manager by scripts/resend/setup-resend-secret.sh
+# when you create the key manually. Prefer scripts/resend/create-resend-runtime-key.sh for first setup.
 # RESEND_API_KEY=re_...
 # Admin API key used locally by Resend setup scripts. Never deploy it.
 # RESEND_ADMIN_API_KEY=re_...

--- a/docs/resend-setup.md
+++ b/docs/resend-setup.md
@@ -31,7 +31,7 @@ Keep these values in root `.env` or export them in the current shell:
 1. Create or reuse the Resend transactional domain, write its DNS records to Cloudflare, and verify it when needed:
 
 ```bash
-bash scripts/setup-resend-domain.sh --domain yourdomain.com --subdomain mail
+bash scripts/resend/setup-resend-domain.sh --domain yourdomain.com --subdomain mail
 ```
 
 This script:
@@ -48,7 +48,7 @@ If DNS is still propagating, the script exits non-zero with the current Resend s
 2. Create a separate domain-scoped send-only API key and store it in AWS Secrets Manager:
 
 ```bash
-bash scripts/create-resend-runtime-key.sh --domain yourdomain.com --subdomain mail --region eu-central-1 --profile expense-tracker
+bash scripts/resend/create-resend-runtime-key.sh --domain yourdomain.com --subdomain mail --region eu-central-1 --profile expense-tracker
 ```
 
 This confirms the AWS caller identity, creates AWS secret `expense-tracker/resend-api-key`, and prints its ARN. Use that ARN as CDK context `resendApiKeySecretArn`.
@@ -56,7 +56,7 @@ This confirms the AWS caller identity, creates AWS secret `expense-tracker/resen
 To rotate an existing runtime key, pass the non-secret id of the previous Resend key so the script can delete it after AWS Secrets Manager is updated:
 
 ```bash
-bash scripts/create-resend-runtime-key.sh --domain yourdomain.com --subdomain mail --region eu-central-1 --profile expense-tracker --rotate-secret --previous-api-key-id <previous_resend_api_key_id>
+bash scripts/resend/create-resend-runtime-key.sh --domain yourdomain.com --subdomain mail --region eu-central-1 --profile expense-tracker --rotate-secret --previous-api-key-id <previous_resend_api_key_id>
 ```
 
 If the AWS secret already exists and `--previous-api-key-id` is missing, the script fails before creating a new key. The AWS secret stores only the raw runtime token, so the previous key id must come from the Resend dashboard or API.
@@ -64,7 +64,7 @@ If the AWS secret already exists and `--previous-api-key-id` is missing, the scr
 If you already created a send-only runtime key manually, export it as `RESEND_API_KEY` and run:
 
 ```bash
-bash scripts/setup-resend-secret.sh --domain yourdomain.com --subdomain mail --region eu-central-1 --profile expense-tracker
+bash scripts/resend/setup-resend-secret.sh --domain yourdomain.com --subdomain mail --region eu-central-1 --profile expense-tracker
 ```
 
 3. Populate deploy-time config:
@@ -81,7 +81,7 @@ bash scripts/setup-resend-secret.sh --domain yourdomain.com --subdomain mail --r
 Preview DNS changes without mutating Resend or Cloudflare:
 
 ```bash
-bash scripts/setup-resend-domain.sh --domain yourdomain.com --subdomain mail --dry-run
+bash scripts/resend/setup-resend-domain.sh --domain yourdomain.com --subdomain mail --dry-run
 ```
 
 ## Notes

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -263,7 +263,7 @@ RESEND_ADMIN_API_KEY=re_...
 
 ```bash
 set -a; source scripts/cloudflare/.env; set +a
-bash scripts/setup-resend-domain.sh \
+bash scripts/resend/setup-resend-domain.sh \
   --domain yourdomain.com \
   --subdomain mail
 ```
@@ -273,14 +273,14 @@ The script creates or reuses `mail.yourdomain.com`, writes the required DNS reco
 3. Create the domain-scoped send-only runtime API key and store it in AWS Secrets Manager:
 
 ```bash
-bash scripts/create-resend-runtime-key.sh \
+bash scripts/resend/create-resend-runtime-key.sh \
   --domain yourdomain.com \
   --subdomain mail \
   --region eu-central-1 \
   --profile expense-tracker
 ```
 
-This confirms the AWS caller identity, creates `expense-tracker/resend-api-key`, and prints the ARN for `resendApiKeySecretArn`. To rotate an existing runtime key, rerun the command with `--rotate-secret --previous-api-key-id <resend_key_id>` so the old key can be deleted after AWS Secrets Manager is updated. If you manually create the runtime key instead, export it as `RESEND_API_KEY` and run `bash scripts/setup-resend-secret.sh --domain yourdomain.com --subdomain mail --region eu-central-1 --profile expense-tracker`.
+This confirms the AWS caller identity, creates `expense-tracker/resend-api-key`, and prints the ARN for `resendApiKeySecretArn`. To rotate an existing runtime key, rerun the command with `--rotate-secret --previous-api-key-id <resend_key_id>` so the old key can be deleted after AWS Secrets Manager is updated. If you manually create the runtime key instead, export it as `RESEND_API_KEY` and run `bash scripts/resend/setup-resend-secret.sh --domain yourdomain.com --subdomain mail --region eu-central-1 --profile expense-tracker`.
 
 Keep the printed secret ARN and derived sender email for the next step:
 

--- a/infra/aws/bin/app.ts
+++ b/infra/aws/bin/app.ts
@@ -45,7 +45,7 @@ if (!githubRepo) {
 
 const resendApiKeySecretArn = app.node.tryGetContext("resendApiKeySecretArn") as string | undefined;
 if (!resendApiKeySecretArn) {
-  throw new Error("Missing required context: 'resendApiKeySecretArn'. Set it in cdk.context.local.json after running scripts/create-resend-runtime-key.sh");
+  throw new Error("Missing required context: 'resendApiKeySecretArn'. Set it in cdk.context.local.json after running scripts/resend/create-resend-runtime-key.sh");
 }
 
 const resendSenderEmail = app.node.tryGetContext("resendSenderEmail") as string | undefined;

--- a/scripts/resend/create-resend-runtime-key.sh
+++ b/scripts/resend/create-resend-runtime-key.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ROOT_ENV_FILE="${ROOT_DIR}/.env"
 
 if [[ -f "$ROOT_ENV_FILE" ]]; then
@@ -199,7 +199,7 @@ if [[ -n "$SECRET_ARN" && "$SECRET_ARN" != "None" && "$ROTATE_SECRET" == "true" 
   echo "ERROR: --rotate-secret requires --previous-api-key-id when the AWS secret already exists." >&2
   echo "The current AWS secret value contains only the Resend token, not its non-secret key id." >&2
   echo "Find the active runtime key id in the Resend dashboard or API, then rerun:" >&2
-  echo "  bash scripts/create-resend-runtime-key.sh --rotate-secret --previous-api-key-id <resend_key_id> --domain ${DOMAIN} --subdomain ${SUBDOMAIN} --region ${REGION} --profile ${PROFILE}" >&2
+  echo "  bash scripts/resend/create-resend-runtime-key.sh --rotate-secret --previous-api-key-id <resend_key_id> --domain ${DOMAIN} --subdomain ${SUBDOMAIN} --region ${REGION} --profile ${PROFILE}" >&2
   exit 1
 fi
 
@@ -220,7 +220,7 @@ PY
 )"
 
 if [[ -z "$DOMAIN_ID" ]]; then
-  echo "ERROR: Resend domain ${FULL_DOMAIN} was not found. Run scripts/setup-resend-domain.sh first." >&2
+  echo "ERROR: Resend domain ${FULL_DOMAIN} was not found. Run scripts/resend/setup-resend-domain.sh first." >&2
   exit 1
 fi
 

--- a/scripts/resend/setup-resend-domain.sh
+++ b/scripts/resend/setup-resend-domain.sh
@@ -5,9 +5,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ROOT_ENV_FILE="${ROOT_DIR}/.env"
-CLOUDFLARE_ENV_FILE="${SCRIPT_DIR}/cloudflare/.env"
+CLOUDFLARE_ENV_FILE="${ROOT_DIR}/scripts/cloudflare/.env"
 
 if [[ -f "$ROOT_ENV_FILE" ]]; then
   set -a

--- a/scripts/resend/setup-resend-secret.sh
+++ b/scripts/resend/setup-resend-secret.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ROOT_ENV_FILE="${ROOT_DIR}/.env"
 
 if [[ -f "$ROOT_ENV_FILE" ]]; then


### PR DESCRIPTION
## Summary

- Move Resend operational scripts into `scripts/resend/`.
- Update script root/env path calculations after the move.
- Update documentation, env template comments, and CDK error text to use the new paths.

## Validation

- `bash -n scripts/resend/setup-resend-domain.sh`
- `bash -n scripts/resend/create-resend-runtime-key.sh`
- `bash -n scripts/resend/setup-resend-secret.sh`
- `rg --hidden -n "scripts/(setup-resend-domain|create-resend-runtime-key|setup-resend-secret)\\.sh" .` returned no stale root-level paths.