### PR TITLE
[codex] refresh balances after chat changes

### DIFF
--- a/apps/web/src/app/balances/page.tsx
+++ b/apps/web/src/app/balances/page.tsx
@@ -17,10 +17,13 @@ export const dynamic = "force-dynamic";
 
 async function BalancesData() {
   const demo = await isDemoMode();
+  // A route refresh regenerates this token so the client table can confirm the
+  // latest no-store balance summary without relying only on the RSC payload.
+  const refreshToken = crypto.randomUUID();
 
   if (demo) {
     const { accounts, totals, conversionWarnings } = getDemoBalancesSummary();
-    return <BalancesTable accounts={accounts} totals={totals} conversionWarnings={conversionWarnings} reportingCurrency="USD" />;
+    return <BalancesTable accounts={accounts} totals={totals} conversionWarnings={conversionWarnings} reportingCurrency="USD" refreshToken={refreshToken} />;
   }
 
   const headersList = await headers();
@@ -31,7 +34,7 @@ async function BalancesData() {
     getReportCurrency(userId, workspaceId),
   ]);
 
-  return <BalancesTable accounts={accounts} totals={totals} conversionWarnings={conversionWarnings} reportingCurrency={reportingCurrency} />;
+  return <BalancesTable accounts={accounts} totals={totals} conversionWarnings={conversionWarnings} reportingCurrency={reportingCurrency} refreshToken={refreshToken} />;
 }
 
 export default async function BalancesDashboardPage() {

--- a/apps/web/src/i18n/ar.json
+++ b/apps/web/src/i18n/ar.json
@@ -109,6 +109,7 @@
   "balances.conversionSingular": "هذه العملة",
   "balances.conversionPlural": "هذه العملات",
   "balances.saveFailed": "فشل الحفظ",
+  "balances.loadFailed": "فشل تحديث الأرصدة",
   "budget.category": "الفئة",
   "budget.remainder": "المتبقي",
   "budget.fxAdjust": "تعديل سعر الصرف",

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -109,6 +109,7 @@
   "balances.conversionSingular": "this currency",
   "balances.conversionPlural": "these currencies",
   "balances.saveFailed": "Save failed",
+  "balances.loadFailed": "Failed to refresh balances",
   "budget.category": "Category",
   "budget.remainder": "Remainder",
   "budget.fxAdjust": "FX adjust",

--- a/apps/web/src/i18n/es.json
+++ b/apps/web/src/i18n/es.json
@@ -109,6 +109,7 @@
   "balances.conversionSingular": "esta moneda",
   "balances.conversionPlural": "estas monedas",
   "balances.saveFailed": "No se pudo guardar",
+  "balances.loadFailed": "No se pudieron actualizar los saldos",
   "budget.category": "Categoría",
   "budget.remainder": "Remanente",
   "budget.fxAdjust": "Ajuste por tipo de cambio",

--- a/apps/web/src/i18n/fa.json
+++ b/apps/web/src/i18n/fa.json
@@ -109,6 +109,7 @@
   "balances.conversionSingular": "این ارز",
   "balances.conversionPlural": "این ارزها",
   "balances.saveFailed": "ذخیره ناموفق",
+  "balances.loadFailed": "به‌روزرسانی موجودی‌ها ناموفق بود",
   "budget.category": "دسته‌بندی",
   "budget.remainder": "مانده",
   "budget.fxAdjust": "تعدیل نرخ ارز",

--- a/apps/web/src/i18n/he.json
+++ b/apps/web/src/i18n/he.json
@@ -109,6 +109,7 @@
   "balances.conversionSingular": "מטבע זה",
   "balances.conversionPlural": "מטבעות אלה",
   "balances.saveFailed": "השמירה נכשלה",
+  "balances.loadFailed": "רענון היתרות נכשל",
   "budget.category": "קטגוריה",
   "budget.remainder": "יתרה",
   "budget.fxAdjust": "התאמת מט״ח",

--- a/apps/web/src/i18n/ru.json
+++ b/apps/web/src/i18n/ru.json
@@ -109,6 +109,7 @@
   "balances.conversionSingular": "этой валюте",
   "balances.conversionPlural": "этих валютах",
   "balances.saveFailed": "Не удалось сохранить",
+  "balances.loadFailed": "Не удалось обновить балансы",
   "budget.category": "Категория",
   "budget.remainder": "Остаток",
   "budget.fxAdjust": "Валютная корректировка",

--- a/apps/web/src/i18n/uk.json
+++ b/apps/web/src/i18n/uk.json
@@ -109,6 +109,7 @@
   "balances.conversionSingular": "цій валюті",
   "balances.conversionPlural": "цих валютах",
   "balances.saveFailed": "Помилка збереження",
+  "balances.loadFailed": "Не вдалося оновити баланси",
   "budget.category": "Категорія",
   "budget.remainder": "Залишок",
   "budget.fxAdjust": "Курсове коригування",

--- a/apps/web/src/i18n/zh.json
+++ b/apps/web/src/i18n/zh.json
@@ -109,6 +109,7 @@
   "balances.conversionSingular": "该币种",
   "balances.conversionPlural": "这些币种",
   "balances.saveFailed": "保存失败",
+  "balances.loadFailed": "刷新余额失败",
   "budget.category": "分类",
   "budget.remainder": "结余",
   "budget.fxAdjust": "汇兑差额",

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerState.test.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerState.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createInitialChatSessionControllerState,
+  reduceChatSessionControllerState,
+  shouldRefreshMainContentForVersion,
+} from "./chatSessionControllerState";
+
+test("server_session_created initializes main content invalidation baseline", (): void => {
+  const state = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "server_session_created", sessionId: "session-1" },
+  );
+
+  assert.equal(state.currentSessionId, "session-1");
+  assert.equal(state.lastMainContentInvalidationVersion, 0);
+});
+
+test("snapshot recovery refreshes after a missed first live invalidation", (): void => {
+  const state = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "server_session_created", sessionId: "session-1" },
+  );
+
+  assert.equal(shouldRefreshMainContentForVersion(state, "snapshot", 1), true);
+});
+
+test("initial historical snapshot does not refresh without an invalidation baseline", (): void => {
+  const state = createInitialChatSessionControllerState();
+
+  assert.equal(shouldRefreshMainContentForVersion(state, "snapshot", 1), false);
+});

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerState.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerState.ts
@@ -45,7 +45,8 @@ export type ChatSessionControllerAction =
   | Readonly<{ type: "stop_completed" }>
   | Readonly<{ type: "stopped_session_cleared"; sessionId: string }>
   | Readonly<{ type: "conversation_cleared"; sessionId: string }>
-  | Readonly<{ type: "server_session_accepted"; sessionId: string }>;
+  | Readonly<{ type: "server_session_accepted"; sessionId: string }>
+  | Readonly<{ type: "server_session_created"; sessionId: string }>;
 
 const mergeInvalidationVersion = (
   previousVersion: number | null,
@@ -166,6 +167,7 @@ export const reduceChatSessionControllerState = (
         runState: "idle",
         isLiveStreamConnected: false,
         isStopping: false,
+        lastMainContentInvalidationVersion: 0,
         stoppedSessionIds: state.currentSessionId === null
           ? state.stoppedSessionIds
           : removeStoppedSession(state.stoppedSessionIds, state.currentSessionId),
@@ -174,6 +176,12 @@ export const reduceChatSessionControllerState = (
       return {
         ...state,
         currentSessionId: action.sessionId,
+      };
+    case "server_session_created":
+      return {
+        ...state,
+        currentSessionId: action.sessionId,
+        lastMainContentInvalidationVersion: 0,
       };
     default:
       return state;

--- a/apps/web/src/ui/chat/session/controller/useChatSessionController.ts
+++ b/apps/web/src/ui/chat/session/controller/useChatSessionController.ts
@@ -50,6 +50,10 @@ import {
   type ChatMainContentInvalidationSource,
   type ChatSessionControllerAction,
 } from "./chatSessionControllerState";
+import {
+  getMainContentInvalidationSourceId,
+  publishMainContentInvalidation,
+} from "../invalidation/mainContentInvalidationChannel";
 
 type UseChatSessionControllerParams = Readonly<{
   mode: "sidebar" | "fullscreen";
@@ -112,6 +116,7 @@ export const useChatSessionController = (
   const stateRef = useRef(state);
   const abortRef = useRef<AbortController | null>(null);
   const pendingSessionIdRef = useRef<Promise<string> | null>(null);
+  const invalidationSourceIdRef = useRef<string | null>(null);
 
   const dispatchAction = useCallback((
     action: ChatSessionControllerAction,
@@ -126,6 +131,29 @@ export const useChatSessionController = (
 
   const isAssistantRunActive = selectIsAssistantRunActive(state);
   const composerAction = selectComposerAction(state);
+
+  const getInvalidationSourceId = useCallback((): string => {
+    if (invalidationSourceIdRef.current === null) {
+      invalidationSourceIdRef.current = getMainContentInvalidationSourceId();
+    }
+
+    return invalidationSourceIdRef.current;
+  }, []);
+
+  const refreshMainContent = useCallback((nextVersion: number): void => {
+    publishMainContentInvalidation({
+      workspaceId,
+      version: nextVersion,
+      sourceId: getInvalidationSourceId(),
+      emittedAt: Date.now(),
+    });
+
+    if (mode === "sidebar") {
+      startTransition(() => {
+        router.refresh();
+      });
+    }
+  }, [getInvalidationSourceId, mode, router, workspaceId]);
 
   const applyMainContentInvalidationVersion = useCallback((
     nextVersion: number,
@@ -143,14 +171,12 @@ export const useChatSessionController = (
       version: nextVersion,
     });
 
-    if (!shouldRefresh || mode !== "sidebar") {
+    if (!shouldRefresh) {
       return;
     }
 
-    startTransition(() => {
-      router.refresh();
-    });
-  }, [dispatchAction, mode, router]);
+    refreshMainContent(nextVersion);
+  }, [dispatchAction, refreshMainContent]);
 
   const loadChatSnapshot = useCallback(async (
     sessionId: string | undefined,
@@ -184,17 +210,15 @@ export const useChatSessionController = (
       replaceMessages(payload.messages);
     }
 
-    if (shouldRefresh && mode === "sidebar") {
-      startTransition(() => {
-        router.refresh();
-      });
+    if (shouldRefresh) {
+      refreshMainContent(payload.mainContentInvalidationVersion);
     }
 
     return {
       ...payload,
       runState: effectiveRunState,
     };
-  }, [dispatchAction, mode, replaceMessages, router, t]);
+  }, [dispatchAction, refreshMainContent, replaceMessages, t]);
 
   useEffect(() => {
     if (!state.isHistoryLoaded) {
@@ -379,7 +403,7 @@ export const useChatSessionController = (
       .then((writableSessionId) => {
         if (stateRef.current.currentSessionId !== writableSessionId) {
           dispatchAction({
-            type: "server_session_accepted",
+            type: "server_session_created",
             sessionId: writableSessionId,
           });
         }

--- a/apps/web/src/ui/chat/session/invalidation/mainContentInvalidationChannel.test.ts
+++ b/apps/web/src/ui/chat/session/invalidation/mainContentInvalidationChannel.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getAcceptedMainContentInvalidationMessage,
+  getMainContentInvalidationMessageKey,
+  publishMainContentInvalidation,
+  type MainContentInvalidationMessage,
+} from "./mainContentInvalidationChannel";
+
+const createMessage = (
+  overrides: Readonly<Partial<MainContentInvalidationMessage>>,
+): MainContentInvalidationMessage => ({
+  type: "main_content_invalidation",
+  workspaceId: "workspace-1",
+  version: 1,
+  sourceId: "source-other",
+  emittedAt: 1_000,
+  ...overrides,
+});
+
+test("getAcceptedMainContentInvalidationMessage accepts a valid unseen workspace message", (): void => {
+  const message = createMessage({});
+
+  assert.deepEqual(
+    getAcceptedMainContentInvalidationMessage(message, {
+      workspaceId: "workspace-1",
+      sourceId: "source-self",
+      seenMessageKeys: new Set<string>(),
+    }),
+    message,
+  );
+});
+
+test("getAcceptedMainContentInvalidationMessage ignores malformed messages", (): void => {
+  assert.equal(
+    getAcceptedMainContentInvalidationMessage({ type: "other" }, {
+      workspaceId: "workspace-1",
+      sourceId: "source-self",
+      seenMessageKeys: new Set<string>(),
+    }),
+    null,
+  );
+});
+
+test("getAcceptedMainContentInvalidationMessage ignores other workspaces and own source", (): void => {
+  assert.equal(
+    getAcceptedMainContentInvalidationMessage(createMessage({ workspaceId: "workspace-2" }), {
+      workspaceId: "workspace-1",
+      sourceId: "source-self",
+      seenMessageKeys: new Set<string>(),
+    }),
+    null,
+  );
+
+  assert.equal(
+    getAcceptedMainContentInvalidationMessage(createMessage({ sourceId: "source-self" }), {
+      workspaceId: "workspace-1",
+      sourceId: "source-self",
+      seenMessageKeys: new Set<string>(),
+    }),
+    null,
+  );
+});
+
+test("getAcceptedMainContentInvalidationMessage ignores already seen messages", (): void => {
+  const message = createMessage({});
+  const seenMessageKeys = new Set<string>([getMainContentInvalidationMessageKey(message)]);
+
+  assert.equal(
+    getAcceptedMainContentInvalidationMessage(message, {
+      workspaceId: "workspace-1",
+      sourceId: "source-self",
+      seenMessageKeys,
+    }),
+    null,
+  );
+});
+
+test("publishMainContentInvalidation does not throw when browser transports fail", (): void => {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const originalBroadcastChannel = Object.getOwnPropertyDescriptor(globalThis, "BroadcastChannel");
+
+  class ThrowingBroadcastChannel {
+    constructor() {
+      throw new Error("BroadcastChannel unavailable");
+    }
+  }
+
+  Object.defineProperty(globalThis, "BroadcastChannel", {
+    configurable: true,
+    value: ThrowingBroadcastChannel,
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage: {
+        setItem: (): void => {
+          throw new Error("Storage denied");
+        },
+      },
+    },
+  });
+
+  try {
+    assert.doesNotThrow(() => {
+      publishMainContentInvalidation({
+        workspaceId: "workspace-1",
+        version: 1,
+        sourceId: "source-self",
+        emittedAt: 1_000,
+      });
+    });
+  } finally {
+    if (originalBroadcastChannel === undefined) {
+      Reflect.deleteProperty(globalThis, "BroadcastChannel");
+    } else {
+      Object.defineProperty(globalThis, "BroadcastChannel", originalBroadcastChannel);
+    }
+
+    if (originalWindow === undefined) {
+      Reflect.deleteProperty(globalThis, "window");
+    } else {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    }
+  }
+});

--- a/apps/web/src/ui/chat/session/invalidation/mainContentInvalidationChannel.ts
+++ b/apps/web/src/ui/chat/session/invalidation/mainContentInvalidationChannel.ts
@@ -1,0 +1,232 @@
+"use client";
+
+export type MainContentInvalidationMessage = Readonly<{
+  type: "main_content_invalidation";
+  workspaceId: string;
+  version: number;
+  sourceId: string;
+  emittedAt: number;
+}>;
+
+export type MainContentInvalidationSubscription = Readonly<{
+  unsubscribe: () => void;
+}>;
+
+type MainContentInvalidationTarget = Readonly<{
+  workspaceId: string;
+  sourceId: string;
+  seenMessageKeys: ReadonlySet<string>;
+}>;
+
+type MainContentInvalidationPublishParams = Readonly<{
+  workspaceId: string;
+  version: number;
+  sourceId: string;
+  emittedAt: number;
+}>;
+
+type MainContentInvalidationSubscribeParams = Readonly<{
+  workspaceId: string;
+  sourceId: string;
+  seenMessageKeys: ReadonlySet<string>;
+  onMessage: (message: MainContentInvalidationMessage) => void;
+}>;
+
+const CHANNEL_NAME = "expense-tracker-main-content-invalidation";
+const STORAGE_KEY = "expense-tracker-main-content-invalidation";
+
+let browserSourceId: string | null = null;
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value >= 0;
+
+const isFiniteNonNegativeNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0;
+
+const isString = (value: unknown): value is string =>
+  typeof value === "string";
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const getStorage = (): Storage | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const createBrowserSourceId = (): string => {
+  if (typeof crypto === "undefined" || typeof crypto.randomUUID !== "function") {
+    throw new Error("Browser crypto.randomUUID is unavailable for main content invalidation");
+  }
+
+  return crypto.randomUUID();
+};
+
+const parseStoredMessage = (rawValue: string): unknown => {
+  try {
+    return JSON.parse(rawValue) as unknown;
+  } catch {
+    return null;
+  }
+};
+
+export const getMainContentInvalidationSourceId = (): string => {
+  if (browserSourceId === null) {
+    browserSourceId = createBrowserSourceId();
+  }
+
+  return browserSourceId;
+};
+
+export const parseMainContentInvalidationMessage = (
+  value: unknown,
+): MainContentInvalidationMessage | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if (
+    value.type !== "main_content_invalidation"
+    || !isString(value.workspaceId)
+    || !isNonNegativeInteger(value.version)
+    || !isNonEmptyString(value.sourceId)
+    || !isFiniteNonNegativeNumber(value.emittedAt)
+  ) {
+    return null;
+  }
+
+  return {
+    type: "main_content_invalidation",
+    workspaceId: value.workspaceId,
+    version: value.version,
+    sourceId: value.sourceId,
+    emittedAt: value.emittedAt,
+  };
+};
+
+export const getMainContentInvalidationMessageKey = (
+  message: MainContentInvalidationMessage,
+): string =>
+  `${message.sourceId}:${message.version}:${message.emittedAt}`;
+
+export const getAcceptedMainContentInvalidationMessage = (
+  value: unknown,
+  target: MainContentInvalidationTarget,
+): MainContentInvalidationMessage | null => {
+  const message = parseMainContentInvalidationMessage(value);
+  if (message === null) {
+    return null;
+  }
+
+  if (
+    message.workspaceId !== target.workspaceId
+    || message.sourceId === target.sourceId
+    || target.seenMessageKeys.has(getMainContentInvalidationMessageKey(message))
+  ) {
+    return null;
+  }
+
+  return message;
+};
+
+const publishBroadcastMessage = (
+  message: MainContentInvalidationMessage,
+): void => {
+  if (typeof BroadcastChannel === "undefined") {
+    return;
+  }
+
+  try {
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    channel.postMessage(message);
+    channel.close();
+  } catch {
+    // Broadcast delivery is best-effort; the caller still performs local refresh.
+  }
+};
+
+const publishStorageMessage = (
+  message: MainContentInvalidationMessage,
+): void => {
+  const storage = getStorage();
+  if (storage === null) {
+    return;
+  }
+
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(message));
+  } catch {
+    // Storage delivery is best-effort; denied storage must not block refresh.
+  }
+};
+
+export const publishMainContentInvalidation = (
+  params: MainContentInvalidationPublishParams,
+): void => {
+  const message: MainContentInvalidationMessage = {
+    type: "main_content_invalidation",
+    workspaceId: params.workspaceId,
+    version: params.version,
+    sourceId: params.sourceId,
+    emittedAt: params.emittedAt,
+  };
+
+  publishBroadcastMessage(message);
+  publishStorageMessage(message);
+};
+
+export const subscribeToMainContentInvalidation = (
+  params: MainContentInvalidationSubscribeParams,
+): MainContentInvalidationSubscription => {
+  if (typeof window === "undefined") {
+    return {
+      unsubscribe: (): void => {},
+    };
+  }
+
+  const handleValue = (value: unknown): void => {
+    const message = getAcceptedMainContentInvalidationMessage(value, {
+      workspaceId: params.workspaceId,
+      sourceId: params.sourceId,
+      seenMessageKeys: params.seenMessageKeys,
+    });
+    if (message !== null) {
+      params.onMessage(message);
+    }
+  };
+
+  const broadcastChannel = typeof BroadcastChannel !== "undefined"
+    ? new BroadcastChannel(CHANNEL_NAME)
+    : null;
+  const handleBroadcastMessage = (event: MessageEvent<unknown>): void => {
+    handleValue(event.data);
+  };
+  const handleStorageMessage = (event: StorageEvent): void => {
+    if (event.key !== STORAGE_KEY || event.newValue === null) {
+      return;
+    }
+
+    handleValue(parseStoredMessage(event.newValue));
+  };
+
+  broadcastChannel?.addEventListener("message", handleBroadcastMessage);
+  window.addEventListener("storage", handleStorageMessage);
+
+  return {
+    unsubscribe: (): void => {
+      broadcastChannel?.removeEventListener("message", handleBroadcastMessage);
+      broadcastChannel?.close();
+      window.removeEventListener("storage", handleStorageMessage);
+    },
+  };
+};

--- a/apps/web/src/ui/chat/shell/layout/ChatLayoutShell.tsx
+++ b/apps/web/src/ui/chat/shell/layout/ChatLayoutShell.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { startTransition, useEffect, useRef } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import type { ReactElement, ReactNode } from "react";
 
 import { cn } from "@/lib/cn";
 
+import {
+  getMainContentInvalidationMessageKey,
+  getMainContentInvalidationSourceId,
+  subscribeToMainContentInvalidation,
+} from "../../session/invalidation/mainContentInvalidationChannel";
 import { useChatLayout } from "./ChatLayoutProvider";
 import { ChatPanel } from "../panel/ChatPanel";
 import { ChatToggle } from "./ChatToggle";
@@ -19,7 +25,32 @@ export const ChatLayoutShell = (props: Props): ReactElement => {
   const { children, workspaceId } = props;
   const { isOpen } = useChatLayout();
   const pathname = usePathname();
+  const router = useRouter();
   const isFullscreenChat = pathname === "/chat";
+  const invalidationSourceIdRef = useRef<string | null>(null);
+  const seenInvalidationMessageKeysRef = useRef<Set<string>>(new Set<string>());
+
+  useEffect(() => {
+    if (invalidationSourceIdRef.current === null) {
+      invalidationSourceIdRef.current = getMainContentInvalidationSourceId();
+    }
+
+    const sourceId = invalidationSourceIdRef.current;
+    const seenMessageKeys = seenInvalidationMessageKeysRef.current;
+    const subscription = subscribeToMainContentInvalidation({
+      workspaceId,
+      sourceId,
+      seenMessageKeys,
+      onMessage: (message): void => {
+        seenMessageKeys.add(getMainContentInvalidationMessageKey(message));
+        startTransition(() => {
+          router.refresh();
+        });
+      },
+    });
+
+    return () => subscription.unsubscribe();
+  }, [router, workspaceId]);
 
   return (
     <div className={styles.layoutShell}>

--- a/apps/web/src/ui/tables/balances/BalancesTable.tsx
+++ b/apps/web/src/ui/tables/balances/BalancesTable.tsx
@@ -7,11 +7,12 @@ import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
 import { fetchWithCsrf } from "@/lib/csrf";
+import { buildLiveDataUrl, fetchLiveData } from "@/lib/liveDataFetch";
 import alertStyles from "@/ui/Alert.module.css";
 import controlsStyles from "@/ui/Controls.module.css";
 import { useCopyToast } from "@/ui/hooks/useCopyToast";
 
-import type { AccountRow, ConversionWarning, CurrencyTotal } from "@/server/balances/getBalancesSummary";
+import type { AccountRow, BalancesSummaryResult, ConversionWarning, CurrencyTotal } from "@/server/balances/getBalancesSummary";
 import { useFilteredMode } from "@/ui/FilteredModeProvider";
 
 import { useFormat } from "@/ui/FormatProvider";
@@ -31,6 +32,13 @@ type Props = Readonly<{
   totals: ReadonlyArray<CurrencyTotal>;
   conversionWarnings: ReadonlyArray<ConversionWarning>;
   reportingCurrency: string;
+  refreshToken: string;
+}>;
+
+type BalancesSummaryState = Readonly<{
+  accounts: ReadonlyArray<AccountRow>;
+  totals: ReadonlyArray<CurrencyTotal>;
+  conversionWarnings: ReadonlyArray<ConversionWarning>;
 }>;
 
 type TotalsSortKey = "currency" | "balance" | "balancePositive" | "balanceNegative" | "balanceReport";
@@ -182,8 +190,24 @@ const saveLiquidity = async (accountId: string, liquidity: string): Promise<void
   }
 };
 
+const fetchBalancesSummary = async (
+  refreshToken: string,
+): Promise<BalancesSummaryState> => {
+  const response = await fetchLiveData(buildLiveDataUrl("/api/balances-summary", new URLSearchParams(), refreshToken));
+  if (!response.ok) {
+    throw new Error(`Balances summary refresh failed: ${response.status} ${await response.text()}`);
+  }
+
+  const payload = await response.json() as BalancesSummaryResult;
+  return {
+    accounts: payload.accounts,
+    totals: payload.totals,
+    conversionWarnings: payload.conversionWarnings,
+  };
+};
+
 export const BalancesTable = (props: Props): ReactElement => {
-  const { accounts: accountsProp, totals, conversionWarnings, reportingCurrency } = props;
+  const { accounts: accountsProp, totals: totalsProp, conversionWarnings: conversionWarningsProp, reportingCurrency, refreshToken } = props;
   const { effectiveAllowlist } = useFilteredMode();
   const { numberFormat } = useFormat();
   const { t } = useTranslation();
@@ -192,11 +216,50 @@ export const BalancesTable = (props: Props): ReactElement => {
   const { toastMessage, copyToClipboard } = useCopyToast();
 
   const [localAccounts, setLocalAccounts] = useState<ReadonlyArray<AccountRow>>(accountsProp);
+  const [localTotals, setLocalTotals] = useState<ReadonlyArray<CurrencyTotal>>(totalsProp);
+  const [localConversionWarnings, setLocalConversionWarnings] = useState<ReadonlyArray<ConversionWarning>>(conversionWarningsProp);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const refreshTokenRef = useRef<string>(refreshToken);
 
   useEffect(() => {
     setLocalAccounts(accountsProp);
-  }, [accountsProp]);
+    setLocalTotals(totalsProp);
+    setLocalConversionWarnings(conversionWarningsProp);
+    setLoadError(null);
+  }, [accountsProp, conversionWarningsProp, totalsProp]);
+
+  useEffect(() => {
+    if (refreshTokenRef.current === refreshToken) {
+      return;
+    }
+
+    refreshTokenRef.current = refreshToken;
+    let ignoreResult = false;
+
+    fetchBalancesSummary(refreshToken)
+      .then((summary) => {
+        if (ignoreResult) {
+          return;
+        }
+
+        setLocalAccounts(summary.accounts);
+        setLocalTotals(summary.totals);
+        setLocalConversionWarnings(summary.conversionWarnings);
+        setLoadError(null);
+      })
+      .catch((err) => {
+        if (ignoreResult) {
+          return;
+        }
+
+        setLoadError(err instanceof Error ? err.message : String(err));
+      });
+
+    return () => {
+      ignoreResult = true;
+    };
+  }, [refreshToken]);
 
   const totalsSort = useTableSort("multi", "balanceReport", "desc", TOTALS_SORT_DEFAULTS);
   const liquiditySort = useTableSort("multi", "liquidity", "asc", LIQUIDITY_SORT_DEFAULTS);
@@ -243,14 +306,14 @@ export const BalancesTable = (props: Props): ReactElement => {
   }, []);
 
   const sortedTotals = useMemo<ReadonlyArray<CurrencyTotal>>(
-    () => [...totals].filter((t) => t.balance !== 0).sort((a, b) => {
+    () => [...localTotals].filter((t) => t.balance !== 0).sort((a, b) => {
       for (const entry of totalsSort.sort) {
         const cmp = compareTotals(a, b, entry.key as TotalsSortKey, entry.dir);
         if (cmp !== 0) return cmp;
       }
       return 0;
     }),
-    [totals, totalsSort.sort],
+    [localTotals, totalsSort.sort],
   );
 
   const sortedLiquidityTotals = useMemo<ReadonlyArray<LiquidityTotal>>(() => {
@@ -312,7 +375,7 @@ export const BalancesTable = (props: Props): ReactElement => {
   const totalUsd = useMemo<number | null>(() => {
     let sum = 0;
     let hasNull = false;
-    for (const t of totals) {
+    for (const t of localTotals) {
       if (t.balanceReport === null) {
         hasNull = true;
       } else {
@@ -321,31 +384,41 @@ export const BalancesTable = (props: Props): ReactElement => {
     }
     if (hasNull) return null;
     return sum;
-  }, [totals]);
+  }, [localTotals]);
 
   const totalPositiveUsd = useMemo<number>(() => {
     let sum = 0;
-    for (const t of totals) {
+    for (const t of localTotals) {
       if (t.balanceReport !== null && t.balanceReport > 0) sum += t.balanceReport;
       else if (t.balanceReport === null && t.balance > 0) sum += t.balancePositive;
     }
     return sum;
-  }, [totals]);
+  }, [localTotals]);
 
   const totalNegativeUsd = useMemo<number>(() => {
     let sum = 0;
-    for (const t of totals) {
+    for (const t of localTotals) {
       if (t.balanceReport !== null && t.balanceReport < 0) sum += t.balanceReport;
       else if (t.balanceReport === null && t.balance < 0) sum += t.balanceNegative;
     }
     return sum;
-  }, [totals]);
+  }, [localTotals]);
 
   if (localAccounts.length === 0) {
-    return <p className={tableStyles.empty}>{t("balances.noData")}</p>;
+    return (
+      <>
+        {loadError !== null && (
+          <div className={alertStyles.alert}>
+            <strong>{t("balances.loadFailed")}</strong>
+            <span>{loadError}</span>
+          </div>
+        )}
+        <p className={tableStyles.empty}>{t("balances.noData")}</p>
+      </>
+    );
   }
 
-  const currencyList = conversionWarnings.map((w) => w.currency).join(", ");
+  const currencyList = localConversionWarnings.map((w) => w.currency).join(", ");
 
   const totalsColumns: ReadonlyArray<ColumnDef<CurrencyTotal>> = [
     {
@@ -630,16 +703,22 @@ export const BalancesTable = (props: Props): ReactElement => {
 
   return (
     <>
-      {conversionWarnings.length > 0 && (
+      {localConversionWarnings.length > 0 && (
         <div className={alertStyles.alert}>
           <strong>{t("balances.conversionTitle")}</strong>
           <span>
             {t("balances.conversionMessage", {
               currencies: currencyList,
-              qualifier: conversionWarnings.length === 1 ? t("balances.conversionSingular") : t("balances.conversionPlural"),
+              qualifier: localConversionWarnings.length === 1 ? t("balances.conversionSingular") : t("balances.conversionPlural"),
               currency: reportingCurrency,
             })}
           </span>
+        </div>
+      )}
+      {loadError !== null && (
+        <div className={alertStyles.alert}>
+          <strong>{t("balances.loadFailed")}</strong>
+          <span>{loadError}</span>
         </div>
       )}
       {saveError !== null && (


### PR DESCRIPTION
## What changed

- Added route-refresh-backed balance summary refetching on `/balances` with visible refresh errors.
- Added a browser main-content invalidation channel for chat-driven mutations across sidebar, fullscreen chat, and tabs.
- Fixed the new chat session invalidation baseline so missed live events can still refresh main content from snapshot recovery.
- Added focused tests for chat invalidation state and browser invalidation filtering.

## Why

Chat-driven database mutations could update server state while the balances screen continued showing the previous summary. The fix makes refresh propagation predictable and keeps the balances table in sync after route refreshes.

## Validation

- `node --import tsx --test apps/web/src/ui/chat/session/controller/chatSessionControllerState.test.ts`
- `node --import tsx --test apps/web/src/ui/chat/session/invalidation/mainContentInvalidationChannel.test.ts`
- `cd apps/web && npm run lint`
- `cd apps/web && npm run build`