### PR TITLE
[codex] Clean up MetricRow props

### DIFF
--- a/apps/web/src/ui/tables/budget/table/sections/BudgetDerivedSection.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/BudgetDerivedSection.tsx
@@ -74,8 +74,6 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
         currentMonth={currentMonth}
         currentYear={currentYear}
         yearComputed={yearComputed}
-        numberFormat={numberFormat}
-        derivedMaskClass={derivedMaskClass}
         loadingKind="subtotal"
         rowClassName={styles.directionRow}
         renderPastYear={(year, yearData) => {
@@ -179,8 +177,6 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
         currentMonth={currentMonth}
         currentYear={currentYear}
         yearComputed={yearComputed}
-        numberFormat={numberFormat}
-        derivedMaskClass={derivedMaskClass}
         loadingKind="subtotal"
         rowClassName={styles.categoryRow}
         renderPastYear={(year, yearData) => (
@@ -260,8 +256,6 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
         currentMonth={currentMonth}
         currentYear={currentYear}
         yearComputed={yearComputed}
-        numberFormat={numberFormat}
-        derivedMaskClass={derivedMaskClass}
         loadingKind="subtotal"
         rowClassName={styles.directionRow}
         renderPastYear={(year, yearData) => {

--- a/apps/web/src/ui/tables/budget/table/sections/derived/MetricRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/derived/MetricRow.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactElement } from "react";
 
-import type { NumberFormat } from "@/lib/locale";
 import {
   type ColumnEntry,
   type YearTotalComputed,
@@ -20,8 +19,6 @@ type MetricRowProps = Readonly<{
   currentMonth: string;
   currentYear: string;
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
-  numberFormat: NumberFormat;
-  derivedMaskClass: string;
   renderPastYear: (year: string, yearData: YearTotalComputed) => ReactElement;
   renderFutureYear: (year: string, yearData: YearTotalComputed) => ReactElement;
   renderCurrentYear: (year: string, yearData: YearTotalComputed) => ReactElement;


### PR DESCRIPTION
Removes unused props from the derived budget table MetricRow component.\n\nWhat changed:\n- Removed unused numberFormat and derivedMaskClass from MetricRowProps.\n- Removed matching prop passes from BudgetDerivedSection.\n\nWhy:\n- Keeps the row helper contract focused on values it actually uses.\n\nValidation:\n- git diff --check\n- cd apps/web && npm run lint\n- cd apps/web && npm run build