### PR TITLE
Add public share route shell

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -33,6 +33,24 @@ export const metadata: Metadata = {
 
 export default async function RootLayout(props: Readonly<{ children: React.ReactNode }>) {
   const { children } = props;
+  const headersList = await headers();
+  const requestPath = headersList.get("x-request-path") ?? "";
+  const isPublicMonthlySharePage = requestPath.startsWith("/share/monthly/");
+
+  if (isPublicMonthlySharePage) {
+    const publicLocale = await getLocaleCookie();
+
+    return (
+      <html lang={publicLocale} dir={RTL_LOCALES.has(publicLocale) ? "rtl" : "ltr"}>
+        <body>
+          <I18nProvider locale={publicLocale}>
+            {children}
+          </I18nProvider>
+        </body>
+      </html>
+    );
+  }
+
   const demo = await isDemoMode();
   const { chatOpen, chatWidth } = await readChatCookies();
 
@@ -48,7 +66,6 @@ export default async function RootLayout(props: Readonly<{ children: React.React
     locale = await getLocaleCookie();
   } else {
     try {
-      const headersList = await headers();
       const userId = extractUserIdFromHeaders(headersList);
       const workspaceId = extractWorkspaceIdFromHeaders(headersList);
       if (authEnabled) {

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveWorkspaceIdFromCookie } from "./proxy";
+import { isPublicPath, resolveWorkspaceIdFromCookie } from "./proxy";
 
 test("resolveWorkspaceIdFromCookie returns null for missing cookie values", (): void => {
   assert.equal(resolveWorkspaceIdFromCookie(undefined), null);
@@ -13,4 +13,27 @@ test("resolveWorkspaceIdFromCookie keeps UUID workspace cookies", (): void => {
     resolveWorkspaceIdFromCookie("3c90f5bd-8505-40ae-8d7f-a9f00f4b8fb6"),
     "3c90f5bd-8505-40ae-8d7f-a9f00f4b8fb6",
   );
+});
+
+test("isPublicPath keeps exact public paths public", (): void => {
+  const publicPaths: ReadonlyArray<string> = [
+    "/api/auth/logout",
+    "/api/agent",
+    "/api/live",
+    "/api/health",
+    "/.well-known/agent.json",
+  ];
+
+  for (const pathname of publicPaths) {
+    assert.equal(isPublicPath(pathname), true);
+  }
+});
+
+test("isPublicPath allows only narrow public share prefixes", (): void => {
+  assert.equal(isPublicPath("/share/monthly/token"), true);
+  assert.equal(isPublicPath("/api/share/monthly/token"), true);
+  assert.equal(isPublicPath("/share"), false);
+  assert.equal(isPublicPath("/api/share/monthly-extra/token"), false);
+  assert.equal(isPublicPath("/api/share"), false);
+  assert.equal(isPublicPath("/api/budget-grid"), false);
 });

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -42,6 +42,10 @@ const PUBLIC_PATHS: ReadonlyArray<string> = [
   "/api/health",
   "/.well-known/agent.json",
 ];
+const PUBLIC_PATH_PREFIXES: ReadonlyArray<string> = [
+  "/share/monthly/",
+  "/api/share/monthly/",
+];
 
 const getAuthDomain = (): string => {
   const domain = process.env.AUTH_DOMAIN ?? "";
@@ -217,8 +221,9 @@ const forwardWithIdentity = (
   return response;
 };
 
-const isPublicPath = (pathname: string): boolean =>
-  PUBLIC_PATHS.includes(pathname);
+export const isPublicPath = (pathname: string): boolean =>
+  PUBLIC_PATHS.includes(pathname)
+  || PUBLIC_PATH_PREFIXES.some((prefix: string): boolean => pathname.startsWith(prefix));
 
 export const resolveWorkspaceIdFromCookie = (workspaceCookie: string | undefined): string | null =>
   (workspaceCookie !== undefined && workspaceCookie !== "" && WORKSPACE_ID_RE.test(workspaceCookie))
@@ -306,6 +311,7 @@ export const proxy = async (request: NextRequest): Promise<NextResponse> => {
     headers.delete(WORKSPACE_ID_HEADER);
     headers.delete(USER_EMAIL_HEADER);
     headers.delete(USER_EMAIL_VERIFIED_HEADER);
+    headers.set(REQUEST_PATH_HEADER, request.nextUrl.pathname + request.nextUrl.search);
     headers.set("x-nonce", nonce);
     headers.set("Content-Security-Policy", csp);
     const response = NextResponse.next({ request: { headers } });


### PR DESCRIPTION
## Summary
- open only the future public monthly share route prefixes in the proxy
- forward x-request-path for public requests so the root layout can detect share pages
- render a minimal public shell for /share/monthly/... without private workspace loaders

## Validation
- npx tsx --test src/proxy.test.ts
- cd apps/web && npm run lint