### PR TITLE
Add authenticated monthly share settings API

### DIFF
--- a/apps/web/src/app/api/community-monthly-category-share-route.test.ts
+++ b/apps/web/src/app/api/community-monthly-category-share-route.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  postEnableMonthlyCategoryShareRouteWithDeps,
+  putMonthlyCategoryShareItemsRouteWithDeps,
+  type MonthlyCategoryShareRouteDependencies,
+} from "@/server/api/monthlyCategoryShareSettings";
+import type { MonthlyCategoryShareSettingsResponse } from "@/server/community/monthlyCategoryShareTypes";
+
+const createResponsePayload = (): MonthlyCategoryShareSettingsResponse => ({
+  settings: {
+    enabled: false,
+    indexingEnabled: false,
+    displayLabel: "",
+    monthFrom: "2026-01",
+    monthTo: null,
+  },
+  dashboardUrl: "http://localhost/community/monthly-category-share/token",
+  jsonUrl: "http://localhost/api/community/monthly-category-share/public/token",
+  selectedItems: [],
+  availableSpendCategories: ["Food"],
+});
+
+const createDependencies = (
+  overrides: Partial<MonthlyCategoryShareRouteDependencies>,
+): MonthlyCategoryShareRouteDependencies => ({
+  getMonthlyCategoryShareSettings: overrides.getMonthlyCategoryShareSettings ?? (async () => {
+    throw new Error("Unexpected getMonthlyCategoryShareSettings call");
+  }),
+  updateMonthlyCategoryShareSettings: overrides.updateMonthlyCategoryShareSettings ?? (async () => {
+    throw new Error("Unexpected updateMonthlyCategoryShareSettings call");
+  }),
+  replaceMonthlyCategoryShareItems: overrides.replaceMonthlyCategoryShareItems ?? (async () => {
+    throw new Error("Unexpected replaceMonthlyCategoryShareItems call");
+  }),
+  enableMonthlyCategoryShare: overrides.enableMonthlyCategoryShare ?? (async () => {
+    throw new Error("Unexpected enableMonthlyCategoryShare call");
+  }),
+  disableMonthlyCategoryShare: overrides.disableMonthlyCategoryShare ?? (async () => {
+    throw new Error("Unexpected disableMonthlyCategoryShare call");
+  }),
+  updateMonthlyCategoryShareIndexing: overrides.updateMonthlyCategoryShareIndexing ?? (async () => {
+    throw new Error("Unexpected updateMonthlyCategoryShareIndexing call");
+  }),
+  rotateMonthlyCategoryShareToken: overrides.rotateMonthlyCategoryShareToken ?? (async () => {
+    throw new Error("Unexpected rotateMonthlyCategoryShareToken call");
+  }),
+  getUserSettings: overrides.getUserSettings ?? (async () => {
+    throw new Error("Unexpected getUserSettings call");
+  }),
+});
+
+const createJsonRequest = (
+  path: string,
+  method: string,
+  body: unknown,
+  cookie: string | null,
+): Request => {
+  const headers = new Headers({ "content-type": "application/json" });
+  headers.set("x-user-id", "user-1");
+  headers.set("x-workspace-id", "workspace-1");
+  if (cookie !== null) {
+    headers.set("cookie", cookie);
+  }
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+    body: JSON.stringify(body),
+  });
+};
+
+test("postEnableMonthlyCategoryShareRouteWithDeps rejects a phrase from the wrong locale", async (): Promise<void> => {
+  let enableCalled = false;
+  const response = await postEnableMonthlyCategoryShareRouteWithDeps(
+    createJsonRequest(
+      "/api/community/monthly-category-share/enable",
+      "POST",
+      { confirmationPhrase: "make public" },
+      "locale=ru",
+    ),
+    createDependencies({
+      getUserSettings: async () => ({
+        locale: "ru",
+        numberFormat: "1,234.56",
+        dateFormat: "YYYY-MM-DD",
+      }),
+      enableMonthlyCategoryShare: async () => {
+        enableCalled = true;
+        return createResponsePayload();
+      },
+    }),
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(await response.text(), "Confirmation phrase does not match");
+  assert.equal(enableCalled, false);
+});
+
+test("postEnableMonthlyCategoryShareRouteWithDeps accepts the localized public-link phrase", async (): Promise<void> => {
+  const originalCorsOrigin = process.env.CORS_ORIGIN;
+  delete process.env.CORS_ORIGIN;
+  let receivedContext: ReadonlyArray<string> | null = null;
+  try {
+    const response = await postEnableMonthlyCategoryShareRouteWithDeps(
+      createJsonRequest(
+        "/api/community/monthly-category-share/enable",
+        "POST",
+        { confirmationPhrase: "make public" },
+        "locale=en",
+      ),
+      createDependencies({
+        getUserSettings: async () => ({
+          locale: "en",
+          numberFormat: "1,234.56",
+          dateFormat: "YYYY-MM-DD",
+        }),
+        enableMonthlyCategoryShare: async (userId, workspaceId, appOrigin) => {
+          receivedContext = [userId, workspaceId, appOrigin];
+          return createResponsePayload();
+        },
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(receivedContext, ["user-1", "workspace-1", "http://localhost"]);
+    assert.deepEqual(await response.json(), createResponsePayload());
+  } finally {
+    if (originalCorsOrigin === undefined) {
+      delete process.env.CORS_ORIGIN;
+    } else {
+      process.env.CORS_ORIGIN = originalCorsOrigin;
+    }
+  }
+});
+
+test("putMonthlyCategoryShareItemsRouteWithDeps rejects income selections in V1", async (): Promise<void> => {
+  let replaceCalled = false;
+  const response = await putMonthlyCategoryShareItemsRouteWithDeps(
+    createJsonRequest(
+      "/api/community/monthly-category-share/items",
+      "PUT",
+      {
+        items: [
+          { direction: "income", category: "Salary", accessLevel: "monthly_values" },
+        ],
+      },
+      "locale=en",
+    ),
+    createDependencies({
+      replaceMonthlyCategoryShareItems: async () => {
+        replaceCalled = true;
+        return createResponsePayload();
+      },
+    }),
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(await response.text(), "items[].direction must be 'spend'");
+  assert.equal(replaceCalled, false);
+});
+
+test("putMonthlyCategoryShareItemsRouteWithDeps requires explicit item access levels", async (): Promise<void> => {
+  let replaceCalled = false;
+  const response = await putMonthlyCategoryShareItemsRouteWithDeps(
+    createJsonRequest(
+      "/api/community/monthly-category-share/items",
+      "PUT",
+      {
+        items: [
+          { direction: "spend", category: "Food" },
+        ],
+      },
+      "locale=en",
+    ),
+    createDependencies({
+      replaceMonthlyCategoryShareItems: async () => {
+        replaceCalled = true;
+        return createResponsePayload();
+      },
+    }),
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(await response.text(), "items[].accessLevel must be 'category_only' or 'monthly_values'");
+  assert.equal(replaceCalled, false);
+});

--- a/apps/web/src/app/api/community/monthly-category-share/disable/route.ts
+++ b/apps/web/src/app/api/community/monthly-category-share/disable/route.ts
@@ -1,0 +1,7 @@
+import {
+  DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES,
+  postDisableMonthlyCategoryShareRouteWithDeps,
+} from "@/server/api/monthlyCategoryShareSettings";
+
+export const POST = async (request: Request): Promise<Response> =>
+  postDisableMonthlyCategoryShareRouteWithDeps(request, DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES);

--- a/apps/web/src/app/api/community/monthly-category-share/enable/route.ts
+++ b/apps/web/src/app/api/community/monthly-category-share/enable/route.ts
@@ -1,0 +1,7 @@
+import {
+  DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES,
+  postEnableMonthlyCategoryShareRouteWithDeps,
+} from "@/server/api/monthlyCategoryShareSettings";
+
+export const POST = async (request: Request): Promise<Response> =>
+  postEnableMonthlyCategoryShareRouteWithDeps(request, DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES);

--- a/apps/web/src/app/api/community/monthly-category-share/indexing/route.ts
+++ b/apps/web/src/app/api/community/monthly-category-share/indexing/route.ts
@@ -1,0 +1,7 @@
+import {
+  DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES,
+  putMonthlyCategoryShareIndexingRouteWithDeps,
+} from "@/server/api/monthlyCategoryShareSettings";
+
+export const PUT = async (request: Request): Promise<Response> =>
+  putMonthlyCategoryShareIndexingRouteWithDeps(request, DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES);

--- a/apps/web/src/app/api/community/monthly-category-share/items/route.ts
+++ b/apps/web/src/app/api/community/monthly-category-share/items/route.ts
@@ -1,0 +1,7 @@
+import {
+  DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES,
+  putMonthlyCategoryShareItemsRouteWithDeps,
+} from "@/server/api/monthlyCategoryShareSettings";
+
+export const PUT = async (request: Request): Promise<Response> =>
+  putMonthlyCategoryShareItemsRouteWithDeps(request, DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES);

--- a/apps/web/src/app/api/community/monthly-category-share/rotate-token/route.ts
+++ b/apps/web/src/app/api/community/monthly-category-share/rotate-token/route.ts
@@ -1,0 +1,7 @@
+import {
+  DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES,
+  postRotateMonthlyCategoryShareTokenRouteWithDeps,
+} from "@/server/api/monthlyCategoryShareSettings";
+
+export const POST = async (request: Request): Promise<Response> =>
+  postRotateMonthlyCategoryShareTokenRouteWithDeps(request, DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES);

--- a/apps/web/src/app/api/community/monthly-category-share/route.ts
+++ b/apps/web/src/app/api/community/monthly-category-share/route.ts
@@ -1,0 +1,11 @@
+import {
+  DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES,
+  getMonthlyCategoryShareSettingsRouteWithDeps,
+  putMonthlyCategoryShareSettingsRouteWithDeps,
+} from "@/server/api/monthlyCategoryShareSettings";
+
+export const GET = async (request: Request): Promise<Response> =>
+  getMonthlyCategoryShareSettingsRouteWithDeps(request, DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES);
+
+export const PUT = async (request: Request): Promise<Response> =>
+  putMonthlyCategoryShareSettingsRouteWithDeps(request, DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES);

--- a/apps/web/src/server/api/monthlyCategoryShareSettings.ts
+++ b/apps/web/src/server/api/monthlyCategoryShareSettings.ts
@@ -1,0 +1,415 @@
+import { z } from "zod";
+
+import type { SupportedLocale } from "@/lib/locale";
+import { getLocaleFromRequest } from "@/lib/localeCookie";
+import { t } from "@/i18n/serverT";
+import { createBadRequestError } from "@/server/api/errors";
+import { handleRoute } from "@/server/api/handleRoute";
+import { parseJsonBody } from "@/server/api/validation";
+import {
+  disableMonthlyCategoryShare,
+  enableMonthlyCategoryShare,
+  getMonthlyCategoryShareSettings,
+  MonthlyCategoryShareRequestError,
+  replaceMonthlyCategoryShareItems,
+  rotateMonthlyCategoryShareToken,
+  updateMonthlyCategoryShareIndexing,
+  updateMonthlyCategoryShareSettings,
+} from "@/server/community/monthlyCategoryShares";
+import type {
+  MonthlyCategoryShareIndexingUpdate,
+  MonthlyCategoryShareItem,
+  MonthlyCategoryShareSettingsPatch,
+  MonthlyCategoryShareSettingsResponse,
+} from "@/server/community/monthlyCategoryShareTypes";
+import { getUserSettings } from "@/server/userSettings";
+import { extractUserId, extractWorkspaceId } from "@/server/userId";
+
+type JsonObject = Readonly<Record<string, unknown>>;
+
+type MonthlyCategoryShareRouteContext = Readonly<{
+  userId: string;
+  workspaceId: string;
+  appOrigin: string;
+  initialLocale: SupportedLocale;
+}>;
+
+export type MonthlyCategoryShareRouteDependencies = Readonly<{
+  getMonthlyCategoryShareSettings: typeof getMonthlyCategoryShareSettings;
+  updateMonthlyCategoryShareSettings: typeof updateMonthlyCategoryShareSettings;
+  replaceMonthlyCategoryShareItems: typeof replaceMonthlyCategoryShareItems;
+  enableMonthlyCategoryShare: typeof enableMonthlyCategoryShare;
+  disableMonthlyCategoryShare: typeof disableMonthlyCategoryShare;
+  updateMonthlyCategoryShareIndexing: typeof updateMonthlyCategoryShareIndexing;
+  rotateMonthlyCategoryShareToken: typeof rotateMonthlyCategoryShareToken;
+  getUserSettings: typeof getUserSettings;
+}>;
+
+type ConfirmationPhraseBody = Readonly<{
+  confirmationPhrase: string;
+}>;
+
+type IndexingBody = Readonly<{
+  indexingEnabled: boolean;
+  confirmationPhrase?: string;
+}>;
+
+const DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES: MonthlyCategoryShareRouteDependencies = {
+  getMonthlyCategoryShareSettings,
+  updateMonthlyCategoryShareSettings,
+  replaceMonthlyCategoryShareItems,
+  enableMonthlyCategoryShare,
+  disableMonthlyCategoryShare,
+  updateMonthlyCategoryShareIndexing,
+  rotateMonthlyCategoryShareToken,
+  getUserSettings,
+};
+
+export { DEFAULT_MONTHLY_CATEGORY_SHARE_ROUTE_DEPENDENCIES };
+
+const MONTH_PATTERN = /^\d{4}-(?:0[1-9]|1[0-2])$/u;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/u;
+const DISPLAY_LABEL_MAX_LENGTH = 80;
+const CATEGORY_MAX_LENGTH = 200;
+
+const hasOwn = (input: JsonObject, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(input, key);
+
+const assertJsonObject = (input: unknown, message: string): JsonObject => {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    throw createBadRequestError(message);
+  }
+  return input as JsonObject;
+};
+
+const parseDisplayLabel = (value: unknown): string => {
+  if (typeof value !== "string") {
+    throw createBadRequestError("displayLabel must be a string");
+  }
+  if (value.length > DISPLAY_LABEL_MAX_LENGTH) {
+    throw createBadRequestError("displayLabel must be 80 characters or fewer");
+  }
+  if (CONTROL_CHARACTER_PATTERN.test(value)) {
+    throw createBadRequestError("displayLabel must be plain text without control characters");
+  }
+  return value;
+};
+
+const parseNullableMonth = (value: unknown, fieldName: string): string | null => {
+  if (value === null) return null;
+  if (typeof value !== "string" || !MONTH_PATTERN.test(value)) {
+    throw createBadRequestError(`${fieldName} must be null or a month in YYYY-MM format`);
+  }
+  return value;
+};
+
+export const parseMonthlyCategoryShareSettingsBody = (
+  input: unknown,
+): MonthlyCategoryShareSettingsPatch => {
+  const body = assertJsonObject(input, "Invalid monthly category share settings request body");
+  const hasDisplayLabel = hasOwn(body, "displayLabel");
+  const hasMonthFrom = hasOwn(body, "monthFrom");
+  const hasMonthTo = hasOwn(body, "monthTo");
+
+  if (!hasDisplayLabel && !hasMonthFrom && !hasMonthTo) {
+    throw createBadRequestError("No fields to update");
+  }
+
+  const displayLabel = hasDisplayLabel ? parseDisplayLabel(body.displayLabel) : undefined;
+  const monthFrom = hasMonthFrom ? parseNullableMonth(body.monthFrom, "monthFrom") : undefined;
+  const monthTo = hasMonthTo ? parseNullableMonth(body.monthTo, "monthTo") : undefined;
+
+  if (monthFrom !== undefined && monthTo !== undefined && monthFrom !== null && monthTo !== null && monthTo < monthFrom) {
+    throw createBadRequestError("monthTo must be the same as or after monthFrom");
+  }
+
+  return {
+    displayLabel,
+    monthFrom,
+    monthTo,
+    hasDisplayLabel,
+    hasMonthFrom,
+    hasMonthTo,
+  };
+};
+
+const parseCategory = (value: unknown): string => {
+  if (typeof value !== "string" || value.length === 0 || value.length > CATEGORY_MAX_LENGTH) {
+    throw createBadRequestError("items[].category must be a non-empty string of 200 characters or fewer");
+  }
+  return value;
+};
+
+const parseItem = (input: unknown): MonthlyCategoryShareItem => {
+  const item = assertJsonObject(input, "items[] must be an object");
+  if (item.direction !== "spend") {
+    throw createBadRequestError("items[].direction must be 'spend'");
+  }
+  if (item.accessLevel !== "category_only" && item.accessLevel !== "monthly_values") {
+    throw createBadRequestError("items[].accessLevel must be 'category_only' or 'monthly_values'");
+  }
+  return {
+    direction: "spend",
+    category: parseCategory(item.category),
+    accessLevel: item.accessLevel,
+  };
+};
+
+export const parseMonthlyCategoryShareItemsBody = (
+  input: unknown,
+): ReadonlyArray<MonthlyCategoryShareItem> => {
+  const body = assertJsonObject(input, "Invalid monthly category share items request body");
+  if (!Array.isArray(body.items)) {
+    throw createBadRequestError("items must be an array");
+  }
+
+  const seenCategories = new Set<string>();
+  const selectedItems = body.items.map((item: unknown): MonthlyCategoryShareItem => {
+    const parsed = parseItem(item);
+    if (seenCategories.has(parsed.category)) {
+      throw createBadRequestError(`Duplicate monthly category share item: ${parsed.category}`);
+    }
+    seenCategories.add(parsed.category);
+    return parsed;
+  });
+
+  return selectedItems;
+};
+
+const parseConfirmationPhraseBody = (input: unknown): ConfirmationPhraseBody => {
+  const body = assertJsonObject(input, "Invalid monthly category share confirmation request body");
+  if (typeof body.confirmationPhrase !== "string") {
+    throw createBadRequestError("confirmationPhrase must be a string");
+  }
+  return { confirmationPhrase: body.confirmationPhrase };
+};
+
+const parseIndexingBody = (input: unknown): IndexingBody => {
+  const body = assertJsonObject(input, "Invalid monthly category share indexing request body");
+  if (typeof body.indexingEnabled !== "boolean") {
+    throw createBadRequestError("indexingEnabled must be a boolean");
+  }
+  if (hasOwn(body, "confirmationPhrase") && typeof body.confirmationPhrase !== "string") {
+    throw createBadRequestError("confirmationPhrase must be a string");
+  }
+  if (body.indexingEnabled && typeof body.confirmationPhrase !== "string") {
+    throw createBadRequestError("confirmationPhrase is required when enabling search indexing");
+  }
+  return {
+    indexingEnabled: body.indexingEnabled,
+    confirmationPhrase: typeof body.confirmationPhrase === "string" ? body.confirmationPhrase : undefined,
+  };
+};
+
+const assertConfirmationPhrase = (
+  locale: SupportedLocale,
+  translationKey: string,
+  confirmationPhrase: string,
+): void => {
+  if (confirmationPhrase !== t(locale, translationKey)) {
+    throw createBadRequestError("Confirmation phrase does not match");
+  }
+};
+
+const getAppOrigin = (request: Request): string => {
+  const configuredOrigin = process.env.CORS_ORIGIN ?? "";
+  if (configuredOrigin !== "") {
+    return new URL(configuredOrigin).origin;
+  }
+  return new URL(request.url).origin;
+};
+
+const extractRouteContext = (request: Request): MonthlyCategoryShareRouteContext => ({
+  userId: extractUserId(request),
+  workspaceId: extractWorkspaceId(request),
+  appOrigin: getAppOrigin(request),
+  initialLocale: getLocaleFromRequest(request),
+});
+
+const getAuthenticatedUserLocale = async (
+  context: MonthlyCategoryShareRouteContext,
+  dependencies: MonthlyCategoryShareRouteDependencies,
+): Promise<SupportedLocale> => {
+  const settings = await dependencies.getUserSettings(
+    context.userId,
+    context.workspaceId,
+    context.initialLocale,
+  );
+  return settings.locale;
+};
+
+const handleMonthlyCategoryShareRoute = async (
+  route: string,
+  method: string,
+  internalErrorMessage: string,
+  run: () => Promise<Response>,
+): Promise<Response> =>
+  handleRoute(
+    { route, method, internalErrorMessage },
+    async (): Promise<Response> => {
+      try {
+        return await run();
+      } catch (error) {
+        if (error instanceof MonthlyCategoryShareRequestError) {
+          throw createBadRequestError(error.message);
+        }
+        throw error;
+      }
+    },
+  );
+
+export const getMonthlyCategoryShareSettingsRouteWithDeps = async (
+  request: Request,
+  dependencies: MonthlyCategoryShareRouteDependencies,
+): Promise<Response> =>
+  handleMonthlyCategoryShareRoute(
+    "/api/community/monthly-category-share",
+    "GET",
+    "Monthly category share settings query failed",
+    async (): Promise<Response> => {
+      const context = extractRouteContext(request);
+      const result = await dependencies.getMonthlyCategoryShareSettings(
+        context.userId,
+        context.workspaceId,
+        context.appOrigin,
+      );
+      return Response.json(result);
+    },
+  );
+
+export const putMonthlyCategoryShareSettingsRouteWithDeps = async (
+  request: Request,
+  dependencies: MonthlyCategoryShareRouteDependencies,
+): Promise<Response> =>
+  handleMonthlyCategoryShareRoute(
+    "/api/community/monthly-category-share",
+    "PUT",
+    "Monthly category share settings update failed",
+    async (): Promise<Response> => {
+      const params = parseMonthlyCategoryShareSettingsBody(await parseJsonBody(request, z.unknown()));
+      const context = extractRouteContext(request);
+      const result = await dependencies.updateMonthlyCategoryShareSettings(
+        context.userId,
+        context.workspaceId,
+        params,
+        context.appOrigin,
+      );
+      return Response.json(result);
+    },
+  );
+
+export const putMonthlyCategoryShareItemsRouteWithDeps = async (
+  request: Request,
+  dependencies: MonthlyCategoryShareRouteDependencies,
+): Promise<Response> =>
+  handleMonthlyCategoryShareRoute(
+    "/api/community/monthly-category-share/items",
+    "PUT",
+    "Monthly category share items update failed",
+    async (): Promise<Response> => {
+      const selectedItems = parseMonthlyCategoryShareItemsBody(await parseJsonBody(request, z.unknown()));
+      const context = extractRouteContext(request);
+      const result = await dependencies.replaceMonthlyCategoryShareItems(
+        context.userId,
+        context.workspaceId,
+        selectedItems,
+        context.appOrigin,
+      );
+      return Response.json(result);
+    },
+  );
+
+export const postEnableMonthlyCategoryShareRouteWithDeps = async (
+  request: Request,
+  dependencies: MonthlyCategoryShareRouteDependencies,
+): Promise<Response> =>
+  handleMonthlyCategoryShareRoute(
+    "/api/community/monthly-category-share/enable",
+    "POST",
+    "Monthly category share enable failed",
+    async (): Promise<Response> => {
+      const body = parseConfirmationPhraseBody(await parseJsonBody(request, z.unknown()));
+      const context = extractRouteContext(request);
+      const locale = await getAuthenticatedUserLocale(context, dependencies);
+      assertConfirmationPhrase(locale, "publicShare.confirmPublicLinkPhrase", body.confirmationPhrase);
+      const result = await dependencies.enableMonthlyCategoryShare(
+        context.userId,
+        context.workspaceId,
+        context.appOrigin,
+      );
+      return Response.json(result);
+    },
+  );
+
+export const postDisableMonthlyCategoryShareRouteWithDeps = async (
+  request: Request,
+  dependencies: MonthlyCategoryShareRouteDependencies,
+): Promise<Response> =>
+  handleMonthlyCategoryShareRoute(
+    "/api/community/monthly-category-share/disable",
+    "POST",
+    "Monthly category share disable failed",
+    async (): Promise<Response> => {
+      const context = extractRouteContext(request);
+      const result = await dependencies.disableMonthlyCategoryShare(
+        context.userId,
+        context.workspaceId,
+        context.appOrigin,
+      );
+      return Response.json(result);
+    },
+  );
+
+export const putMonthlyCategoryShareIndexingRouteWithDeps = async (
+  request: Request,
+  dependencies: MonthlyCategoryShareRouteDependencies,
+): Promise<Response> =>
+  handleMonthlyCategoryShareRoute(
+    "/api/community/monthly-category-share/indexing",
+    "PUT",
+    "Monthly category share indexing update failed",
+    async (): Promise<Response> => {
+      const body = parseIndexingBody(await parseJsonBody(request, z.unknown()));
+      const context = extractRouteContext(request);
+      if (body.indexingEnabled) {
+        if (body.confirmationPhrase === undefined) {
+          throw new Error("Indexing confirmation phrase missing after request validation");
+        }
+        const locale = await getAuthenticatedUserLocale(context, dependencies);
+        assertConfirmationPhrase(
+          locale,
+          "publicShare.confirmSearchIndexingPhrase",
+          body.confirmationPhrase,
+        );
+      }
+      const params: MonthlyCategoryShareIndexingUpdate = { indexingEnabled: body.indexingEnabled };
+      const result = await dependencies.updateMonthlyCategoryShareIndexing(
+        context.userId,
+        context.workspaceId,
+        params.indexingEnabled,
+        context.appOrigin,
+      );
+      return Response.json(result);
+    },
+  );
+
+export const postRotateMonthlyCategoryShareTokenRouteWithDeps = async (
+  request: Request,
+  dependencies: MonthlyCategoryShareRouteDependencies,
+): Promise<Response> =>
+  handleMonthlyCategoryShareRoute(
+    "/api/community/monthly-category-share/rotate-token",
+    "POST",
+    "Monthly category share token rotation failed",
+    async (): Promise<Response> => {
+      const context = extractRouteContext(request);
+      const result = await dependencies.rotateMonthlyCategoryShareToken(
+        context.userId,
+        context.workspaceId,
+        context.appOrigin,
+      );
+      return Response.json(result);
+    },
+  );
+
+export type { MonthlyCategoryShareSettingsResponse };

--- a/apps/web/src/server/community/monthlyCategoryShareTypes.ts
+++ b/apps/web/src/server/community/monthlyCategoryShareTypes.ts
@@ -1,0 +1,40 @@
+export const MONTHLY_CATEGORY_SHARE_ACCESS_LEVELS = ["category_only", "monthly_values"] as const;
+export type MonthlyCategoryShareAccessLevel = (typeof MONTHLY_CATEGORY_SHARE_ACCESS_LEVELS)[number];
+
+export const MONTHLY_CATEGORY_SHARE_DIRECTIONS = ["spend"] as const;
+export type MonthlyCategoryShareDirection = (typeof MONTHLY_CATEGORY_SHARE_DIRECTIONS)[number];
+
+export type MonthlyCategoryShareSettings = Readonly<{
+  enabled: boolean;
+  indexingEnabled: boolean;
+  displayLabel: string;
+  monthFrom: string | null;
+  monthTo: string | null;
+}>;
+
+export type MonthlyCategoryShareItem = Readonly<{
+  direction: MonthlyCategoryShareDirection;
+  category: string;
+  accessLevel: MonthlyCategoryShareAccessLevel;
+}>;
+
+export type MonthlyCategoryShareSettingsResponse = Readonly<{
+  settings: MonthlyCategoryShareSettings;
+  dashboardUrl: string | null;
+  jsonUrl: string | null;
+  selectedItems: ReadonlyArray<MonthlyCategoryShareItem>;
+  availableSpendCategories: ReadonlyArray<string>;
+}>;
+
+export type MonthlyCategoryShareSettingsPatch = Readonly<{
+  displayLabel?: string;
+  monthFrom?: string | null;
+  monthTo?: string | null;
+  hasDisplayLabel: boolean;
+  hasMonthFrom: boolean;
+  hasMonthTo: boolean;
+}>;
+
+export type MonthlyCategoryShareIndexingUpdate = Readonly<{
+  indexingEnabled: boolean;
+}>;

--- a/apps/web/src/server/community/monthlyCategoryShares.ts
+++ b/apps/web/src/server/community/monthlyCategoryShares.ts
@@ -1,0 +1,560 @@
+import { withUserContext } from "@/server/db";
+import type { QueryFn } from "@/server/db/contextRunner";
+import {
+  type MonthlyCategoryShareAccessLevel,
+  type MonthlyCategoryShareItem,
+  type MonthlyCategoryShareSettings,
+  type MonthlyCategoryShareSettingsPatch,
+  type MonthlyCategoryShareSettingsResponse,
+} from "@/server/community/monthlyCategoryShareTypes";
+import { generateMonthlyCategoryShareToken } from "@/server/community/shareTokens";
+
+type ShareRow = Readonly<{
+  share_id: string;
+  enabled: boolean;
+  indexing_enabled: boolean;
+  display_label: string;
+  month_from: Date | string | null;
+  month_to: Date | string | null;
+  blocked_at: Date | string | null;
+  public_token: string | null;
+}>;
+
+type ShareItemRow = Readonly<{
+  direction: string;
+  category: string;
+  access_level: string;
+}>;
+
+type CategoryRow = Readonly<{
+  category: string;
+}>;
+
+export class MonthlyCategoryShareRequestError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "MonthlyCategoryShareRequestError";
+  }
+}
+
+const MONTH_DATE_PATTERN = /^(\d{4})-(\d{2})-01$/u;
+const TOKEN_INSERT_ATTEMPTS = 3;
+
+const createDefaultSettings = (): MonthlyCategoryShareSettings => ({
+  enabled: false,
+  indexingEnabled: false,
+  displayLabel: "",
+  monthFrom: null,
+  monthTo: null,
+});
+
+const formatDateAsMonth = (value: Date | string | null, fieldName: string): string | null => {
+  if (value === null) return null;
+
+  if (value instanceof Date) {
+    const year = String(value.getUTCFullYear()).padStart(4, "0");
+    const month = String(value.getUTCMonth() + 1).padStart(2, "0");
+    return `${year}-${month}`;
+  }
+
+  const dateOnly = value.slice(0, 10);
+  if (!MONTH_DATE_PATTERN.test(dateOnly)) {
+    throw new Error(`Invalid ${fieldName} stored for monthly category share: ${value}`);
+  }
+  return dateOnly.slice(0, 7);
+};
+
+const toDateParameter = (month: string | null): string | null =>
+  month === null ? null : `${month}-01`;
+
+const requireDisplayLabelPatchValue = (value: string | undefined): string => {
+  if (value === undefined) {
+    throw new Error("Monthly category share patch has hasDisplayLabel=true without displayLabel");
+  }
+  return value;
+};
+
+const requireMonthPatchValue = (value: string | null | undefined, fieldName: string): string | null => {
+  if (value === undefined) {
+    throw new Error(`Monthly category share patch has ${fieldName} flag without ${fieldName}`);
+  }
+  return value;
+};
+
+const parseAccessLevel = (raw: string): MonthlyCategoryShareAccessLevel => {
+  if (raw === "category_only" || raw === "monthly_values") {
+    return raw;
+  }
+  throw new Error(`Invalid monthly category share access level stored: ${raw}`);
+};
+
+const mapShareSettings = (share: ShareRow | null): MonthlyCategoryShareSettings => {
+  if (share === null) return createDefaultSettings();
+  return {
+    enabled: share.enabled,
+    indexingEnabled: share.indexing_enabled,
+    displayLabel: share.display_label,
+    monthFrom: formatDateAsMonth(share.month_from, "month_from"),
+    monthTo: formatDateAsMonth(share.month_to, "month_to"),
+  };
+};
+
+const mapItem = (row: ShareItemRow): MonthlyCategoryShareItem => {
+  if (row.direction !== "spend") {
+    throw new Error(`Invalid V1 monthly category share direction stored: ${row.direction}`);
+  }
+  return {
+    direction: "spend",
+    category: row.category,
+    accessLevel: parseAccessLevel(row.access_level),
+  };
+};
+
+const buildDashboardUrl = (appOrigin: string, publicToken: string): string =>
+  `${appOrigin}/community/monthly-category-share/${encodeURIComponent(publicToken)}`;
+
+const buildJsonUrl = (appOrigin: string, publicToken: string): string =>
+  `${appOrigin}/api/community/monthly-category-share/public/${encodeURIComponent(publicToken)}`;
+
+const buildResponse = (
+  share: ShareRow | null,
+  selectedItems: ReadonlyArray<MonthlyCategoryShareItem>,
+  availableSpendCategories: ReadonlyArray<string>,
+  appOrigin: string,
+): MonthlyCategoryShareSettingsResponse => ({
+  settings: mapShareSettings(share),
+  dashboardUrl: share?.public_token === null || share?.public_token === undefined
+    ? null
+    : buildDashboardUrl(appOrigin, share.public_token),
+  jsonUrl: share?.public_token === null || share?.public_token === undefined
+    ? null
+    : buildJsonUrl(appOrigin, share.public_token),
+  selectedItems,
+  availableSpendCategories,
+});
+
+const getShareByWorkspace = async (queryFn: QueryFn, workspaceId: string): Promise<ShareRow | null> => {
+  const result = await queryFn(
+    `
+      SELECT
+        share.share_id,
+        share.enabled,
+        share.indexing_enabled,
+        share.display_label,
+        share.month_from,
+        share.month_to,
+        share.blocked_at,
+        key.public_token
+      FROM community.monthly_category_shares AS share
+      LEFT JOIN community.monthly_category_share_keys AS key
+        ON key.share_id = share.share_id
+       AND key.revoked_at IS NULL
+      WHERE share.workspace_id = $1
+    `,
+    [workspaceId],
+  );
+  if (result.rows.length === 0) return null;
+  return result.rows[0] as ShareRow;
+};
+
+const getLockedShareByWorkspace = async (queryFn: QueryFn, workspaceId: string): Promise<ShareRow | null> => {
+  const result = await queryFn(
+    `
+      SELECT share_id
+      FROM community.monthly_category_shares
+      WHERE workspace_id = $1
+      FOR UPDATE
+    `,
+    [workspaceId],
+  );
+  if (result.rows.length === 0) return null;
+  return getShareByWorkspace(queryFn, workspaceId);
+};
+
+const ensureShareByWorkspace = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+): Promise<ShareRow> => {
+  await queryFn(
+    `
+      INSERT INTO community.monthly_category_shares (workspace_id, created_by_user_id)
+      VALUES ($1, $2)
+      ON CONFLICT (workspace_id) DO UPDATE
+      SET updated_at = community.monthly_category_shares.updated_at
+    `,
+    [workspaceId, userId],
+  );
+  const share = await getShareByWorkspace(queryFn, workspaceId);
+  if (share === null) {
+    throw new Error(`Failed to create monthly category share for workspace ${workspaceId}`);
+  }
+  return share;
+};
+
+const getActiveTokenByShareId = async (queryFn: QueryFn, shareId: string): Promise<string | null> => {
+  const result = await queryFn(
+    `
+      SELECT public_token
+      FROM community.monthly_category_share_keys
+      WHERE share_id = $1
+        AND revoked_at IS NULL
+    `,
+    [shareId],
+  );
+  const row = result.rows[0] as { public_token: string } | undefined;
+  return row === undefined ? null : row.public_token;
+};
+
+const listShareItems = async (
+  queryFn: QueryFn,
+  shareId: string,
+): Promise<ReadonlyArray<MonthlyCategoryShareItem>> => {
+  const result = await queryFn(
+    `
+      SELECT direction, category, access_level
+      FROM community.monthly_category_share_items
+      WHERE share_id = $1
+        AND direction = 'spend'
+      ORDER BY category
+    `,
+    [shareId],
+  );
+  return result.rows.map((row: ShareItemRow): MonthlyCategoryShareItem => mapItem(row));
+};
+
+const listAvailableSpendCategories = async (queryFn: QueryFn): Promise<ReadonlyArray<string>> => {
+  const result = await queryFn(
+    `
+      SELECT DISTINCT category
+      FROM ledger_entries
+      WHERE kind = 'spend'
+        AND category IS NOT NULL
+        AND category <> ''
+      ORDER BY category
+    `,
+    [],
+  );
+  return result.rows.map((row: CategoryRow): string => row.category);
+};
+
+const readResponse = async (
+  queryFn: QueryFn,
+  share: ShareRow | null,
+  appOrigin: string,
+): Promise<MonthlyCategoryShareSettingsResponse> => {
+  const selectedItems = share === null ? [] : await listShareItems(queryFn, share.share_id);
+  const availableSpendCategories = await listAvailableSpendCategories(queryFn);
+  return buildResponse(share, selectedItems, availableSpendCategories, appOrigin);
+};
+
+const assertUpdateRange = (share: ShareRow, params: MonthlyCategoryShareSettingsPatch): void => {
+  const currentSettings = mapShareSettings(share);
+  const monthFrom = params.hasMonthFrom
+    ? requireMonthPatchValue(params.monthFrom, "monthFrom")
+    : currentSettings.monthFrom;
+  const monthTo = params.hasMonthTo
+    ? requireMonthPatchValue(params.monthTo, "monthTo")
+    : currentSettings.monthTo;
+
+  if (monthFrom !== null && monthTo !== null && monthTo < monthFrom) {
+    throw new MonthlyCategoryShareRequestError("monthTo must be the same as or after monthFrom");
+  }
+
+  if (share.enabled && monthFrom === null) {
+    throw new MonthlyCategoryShareRequestError("monthFrom is required while public sharing is enabled");
+  }
+};
+
+const updateShareSettingsRow = async (
+  queryFn: QueryFn,
+  share: ShareRow,
+  workspaceId: string,
+  params: MonthlyCategoryShareSettingsPatch,
+): Promise<ShareRow> => {
+  const setClauses: Array<string> = [];
+  const values: Array<unknown> = [share.share_id];
+
+  if (params.hasDisplayLabel) {
+    values.push(requireDisplayLabelPatchValue(params.displayLabel));
+    setClauses.push(`display_label = $${values.length}`);
+  }
+  if (params.hasMonthFrom) {
+    values.push(toDateParameter(requireMonthPatchValue(params.monthFrom, "monthFrom")));
+    setClauses.push(`month_from = $${values.length}::date`);
+  }
+  if (params.hasMonthTo) {
+    values.push(toDateParameter(requireMonthPatchValue(params.monthTo, "monthTo")));
+    setClauses.push(`month_to = $${values.length}::date`);
+  }
+
+  if (setClauses.length === 0) {
+    throw new Error("Monthly category share settings update called without fields");
+  }
+
+  setClauses.push("updated_at = now()");
+
+  await queryFn(
+    `
+      UPDATE community.monthly_category_shares
+      SET ${setClauses.join(", ")}
+      WHERE share_id = $1
+    `,
+    values,
+  );
+
+  const updated = await getShareByWorkspace(queryFn, workspaceId);
+  if (updated === null) {
+    throw new Error(`Monthly category share missing after settings update: shareId=${share.share_id}`);
+  }
+  return updated;
+};
+
+const assertItemsAreValid = (
+  selectedItems: ReadonlyArray<MonthlyCategoryShareItem>,
+  availableSpendCategories: ReadonlyArray<string>,
+): void => {
+  const available = new Set<string>(availableSpendCategories);
+  const seen = new Set<string>();
+
+  for (const item of selectedItems) {
+    if (item.direction !== "spend") {
+      throw new MonthlyCategoryShareRequestError("Only spend categories can be shared in V1");
+    }
+    if (seen.has(item.category)) {
+      throw new MonthlyCategoryShareRequestError(`Duplicate monthly category share item: ${item.category}`);
+    }
+    seen.add(item.category);
+    if (!available.has(item.category)) {
+      throw new MonthlyCategoryShareRequestError(`Category is not available as a spend category: ${item.category}`);
+    }
+  }
+};
+
+const replaceShareItems = async (
+  queryFn: QueryFn,
+  shareId: string,
+  selectedItems: ReadonlyArray<MonthlyCategoryShareItem>,
+): Promise<void> => {
+  await queryFn(
+    "DELETE FROM community.monthly_category_share_items WHERE share_id = $1",
+    [shareId],
+  );
+
+  if (selectedItems.length > 0) {
+    await queryFn(
+      `
+        INSERT INTO community.monthly_category_share_items (
+          share_id,
+          direction,
+          category,
+          access_level
+        )
+        SELECT $1, item.direction, item.category, item.access_level
+        FROM unnest($2::text[], $3::text[], $4::text[]) AS item(direction, category, access_level)
+      `,
+      [
+        shareId,
+        selectedItems.map((item: MonthlyCategoryShareItem): string => item.direction),
+        selectedItems.map((item: MonthlyCategoryShareItem): string => item.category),
+        selectedItems.map((item: MonthlyCategoryShareItem): string => item.accessLevel),
+      ],
+    );
+  }
+
+  await queryFn(
+    "UPDATE community.monthly_category_shares SET updated_at = now() WHERE share_id = $1",
+    [shareId],
+  );
+};
+
+const ensureActiveToken = async (
+  queryFn: QueryFn,
+  share: ShareRow,
+  createToken: () => string,
+): Promise<string> => {
+  if (share.public_token !== null) {
+    return share.public_token;
+  }
+
+  for (let attempt = 1; attempt <= TOKEN_INSERT_ATTEMPTS; attempt++) {
+    const result = await queryFn(
+      `
+        INSERT INTO community.monthly_category_share_keys (share_id, public_token)
+        VALUES ($1, $2)
+        ON CONFLICT DO NOTHING
+        RETURNING public_token
+      `,
+      [share.share_id, createToken()],
+    );
+    const row = result.rows[0] as { public_token: string } | undefined;
+    if (row !== undefined) {
+      return row.public_token;
+    }
+    const activeToken = await getActiveTokenByShareId(queryFn, share.share_id);
+    if (activeToken !== null) {
+      return activeToken;
+    }
+  }
+
+  throw new Error(`Failed to create unique monthly category share token: shareId=${share.share_id}`);
+};
+
+export const getMonthlyCategoryShareSettings = async (
+  userId: string,
+  workspaceId: string,
+  appOrigin: string,
+): Promise<MonthlyCategoryShareSettingsResponse> =>
+  withUserContext(userId, workspaceId, async (queryFn) => {
+    const share = await getShareByWorkspace(queryFn, workspaceId);
+    return readResponse(queryFn, share, appOrigin);
+  });
+
+export const updateMonthlyCategoryShareSettings = async (
+  userId: string,
+  workspaceId: string,
+  params: MonthlyCategoryShareSettingsPatch,
+  appOrigin: string,
+): Promise<MonthlyCategoryShareSettingsResponse> =>
+  withUserContext(userId, workspaceId, async (queryFn) => {
+    const share = await ensureShareByWorkspace(queryFn, userId, workspaceId);
+    assertUpdateRange(share, params);
+    const updated = await updateShareSettingsRow(queryFn, share, workspaceId, params);
+    return readResponse(queryFn, updated, appOrigin);
+  });
+
+export const replaceMonthlyCategoryShareItems = async (
+  userId: string,
+  workspaceId: string,
+  selectedItems: ReadonlyArray<MonthlyCategoryShareItem>,
+  appOrigin: string,
+): Promise<MonthlyCategoryShareSettingsResponse> =>
+  withUserContext(userId, workspaceId, async (queryFn) => {
+    const share = await ensureShareByWorkspace(queryFn, userId, workspaceId);
+    const availableSpendCategories = await listAvailableSpendCategories(queryFn);
+    assertItemsAreValid(selectedItems, availableSpendCategories);
+    await replaceShareItems(queryFn, share.share_id, selectedItems);
+    const updated = await getShareByWorkspace(queryFn, workspaceId);
+    if (updated === null) {
+      throw new Error(`Monthly category share missing after item replacement: shareId=${share.share_id}`);
+    }
+    return buildResponse(updated, selectedItems, availableSpendCategories, appOrigin);
+  });
+
+export const enableMonthlyCategoryShare = async (
+  userId: string,
+  workspaceId: string,
+  appOrigin: string,
+): Promise<MonthlyCategoryShareSettingsResponse> =>
+  withUserContext(userId, workspaceId, async (queryFn) => {
+    const share = await getLockedShareByWorkspace(queryFn, workspaceId);
+    if (share === null || share.month_from === null) {
+      throw new MonthlyCategoryShareRequestError("monthFrom is required before enabling public sharing");
+    }
+
+    await ensureActiveToken(queryFn, share, generateMonthlyCategoryShareToken);
+    await queryFn(
+      "UPDATE community.monthly_category_shares SET enabled = true, updated_at = now() WHERE share_id = $1",
+      [share.share_id],
+    );
+    const updated = await getShareByWorkspace(queryFn, workspaceId);
+    if (updated === null) {
+      throw new Error(`Monthly category share missing after enable: shareId=${share.share_id}`);
+    }
+    return readResponse(queryFn, updated, appOrigin);
+  });
+
+export const disableMonthlyCategoryShare = async (
+  userId: string,
+  workspaceId: string,
+  appOrigin: string,
+): Promise<MonthlyCategoryShareSettingsResponse> =>
+  withUserContext(userId, workspaceId, async (queryFn) => {
+    const share = await getShareByWorkspace(queryFn, workspaceId);
+    if (share === null) {
+      return readResponse(queryFn, null, appOrigin);
+    }
+
+    await queryFn(
+      `
+        UPDATE community.monthly_category_shares
+        SET enabled = false,
+            indexing_enabled = false,
+            updated_at = now()
+        WHERE share_id = $1
+      `,
+      [share.share_id],
+    );
+    const updated = await getShareByWorkspace(queryFn, workspaceId);
+    if (updated === null) {
+      throw new Error(`Monthly category share missing after disable: shareId=${share.share_id}`);
+    }
+    return readResponse(queryFn, updated, appOrigin);
+  });
+
+export const updateMonthlyCategoryShareIndexing = async (
+  userId: string,
+  workspaceId: string,
+  indexingEnabled: boolean,
+  appOrigin: string,
+): Promise<MonthlyCategoryShareSettingsResponse> =>
+  withUserContext(userId, workspaceId, async (queryFn) => {
+    const share = await getShareByWorkspace(queryFn, workspaceId);
+    if (share === null) {
+      if (indexingEnabled) {
+        throw new MonthlyCategoryShareRequestError("Public sharing must be enabled before search indexing can be enabled");
+      }
+      return readResponse(queryFn, null, appOrigin);
+    }
+
+    if (indexingEnabled && !share.enabled) {
+      throw new MonthlyCategoryShareRequestError("Public sharing must be enabled before search indexing can be enabled");
+    }
+
+    await queryFn(
+      `
+        UPDATE community.monthly_category_shares
+        SET indexing_enabled = $2,
+            updated_at = now()
+        WHERE share_id = $1
+      `,
+      [share.share_id, indexingEnabled],
+    );
+    const updated = await getShareByWorkspace(queryFn, workspaceId);
+    if (updated === null) {
+      throw new Error(`Monthly category share missing after indexing update: shareId=${share.share_id}`);
+    }
+    return readResponse(queryFn, updated, appOrigin);
+  });
+
+export const rotateMonthlyCategoryShareToken = async (
+  userId: string,
+  workspaceId: string,
+  appOrigin: string,
+): Promise<MonthlyCategoryShareSettingsResponse> =>
+  withUserContext(userId, workspaceId, async (queryFn) => {
+    await ensureShareByWorkspace(queryFn, userId, workspaceId);
+    const share = await getLockedShareByWorkspace(queryFn, workspaceId);
+    if (share === null) {
+      throw new Error(`Failed to lock monthly category share for token rotation: workspaceId=${workspaceId}`);
+    }
+    await queryFn(
+      `
+        UPDATE community.monthly_category_share_keys
+        SET revoked_at = now()
+        WHERE share_id = $1
+          AND revoked_at IS NULL
+      `,
+      [share.share_id],
+    );
+    await ensureActiveToken(
+      queryFn,
+      { ...share, public_token: null },
+      generateMonthlyCategoryShareToken,
+    );
+    const updated = await getShareByWorkspace(queryFn, workspaceId);
+    if (updated === null) {
+      throw new Error(`Monthly category share missing after token rotation: shareId=${share.share_id}`);
+    }
+    return readResponse(queryFn, updated, appOrigin);
+  });

--- a/apps/web/src/server/community/shareTokens.ts
+++ b/apps/web/src/server/community/shareTokens.ts
@@ -1,0 +1,6 @@
+import { randomBytes } from "node:crypto";
+
+const MONTHLY_CATEGORY_SHARE_TOKEN_BYTES = 32;
+
+export const generateMonthlyCategoryShareToken = (): string =>
+  randomBytes(MONTHLY_CATEGORY_SHARE_TOKEN_BYTES).toString("base64url");


### PR DESCRIPTION
## Summary
- add authenticated monthly category share settings API routes
- add server-side share settings, item access, indexing, enable/disable, and token rotation helpers
- add focused API route tests for confirmation phrases and item validation

## Checks
- npx tsx --test src/app/api/community-monthly-category-share-route.test.ts
- npm run lint
- npm run build