### PR TITLE
[codex] Add public monthly share JSON API

### DIFF
--- a/apps/web/src/app/api/share-monthly-route.test.ts
+++ b/apps/web/src/app/api/share-monthly-route.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getPublicMonthlyShareRouteWithDeps,
+  OPTIONS,
+} from "@/app/api/share/monthly/[token]/route";
+import type { PublicMonthlyCategoryShare } from "@/server/community/publicMonthlyCategoryShareTypes";
+
+const SHARE: PublicMonthlyCategoryShare = {
+  label: "Shared spend",
+  currency: "USD",
+  availableMonthFrom: "2025-01",
+  availableMonthTo: "2025-12",
+  loadedMonthFrom: "2025-03",
+  loadedMonthTo: "2025-04",
+  categories: [
+    { category: "Groceries", accessLevel: "monthly_values" },
+    { category: "Travel", accessLevel: "category_only" },
+  ],
+  cells: [
+    { month: "2025-03", category: "Groceries", amount: 120.5 },
+  ],
+  yearTotals: [
+    { year: "2025", category: "Groceries", amount: 120.5 },
+  ],
+};
+
+const createContext = (token: string): { params: Promise<{ token: string }> } => ({
+  params: Promise.resolve({ token }),
+});
+
+const createGetRequest = (query: string): Request =>
+  new Request(`http://localhost/api/share/monthly/token-1${query}`, { method: "GET" });
+
+test("getPublicMonthlyShareRouteWithDeps returns public JSON with CORS and no-store headers", async (): Promise<void> => {
+  const calls: Array<Readonly<{ token: string; monthFrom: string; monthTo: string }>> = [];
+  const response = await getPublicMonthlyShareRouteWithDeps(
+    createGetRequest("?monthFrom=2024-01&monthTo=2026-12"),
+    createContext("token-1"),
+    {
+      getPublicMonthlyCategoryShare: async (token: string, monthFrom: string, monthTo: string): Promise<PublicMonthlyCategoryShare | null> => {
+        calls.push({ token, monthFrom, monthTo });
+        return SHARE;
+      },
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  assert.match(response.headers.get("cache-control") ?? "", /no-store/);
+  assert.deepEqual(calls, [{ token: "token-1", monthFrom: "2024-01", monthTo: "2025-12" }]);
+  assert.deepEqual(await response.json(), SHARE);
+});
+
+test("getPublicMonthlyShareRouteWithDeps returns equivalent 404 responses for missing shares", async (): Promise<void> => {
+  const dependencies = {
+    getPublicMonthlyCategoryShare: async (): Promise<PublicMonthlyCategoryShare | null> => null,
+  };
+
+  const first = await getPublicMonthlyShareRouteWithDeps(
+    createGetRequest("?monthFrom=2025-03&monthTo=2025-04"),
+    createContext("unknown-token"),
+    dependencies,
+  );
+  const second = await getPublicMonthlyShareRouteWithDeps(
+    createGetRequest("?monthFrom=2025-03&monthTo=2025-04"),
+    createContext("revoked-token"),
+    dependencies,
+  );
+
+  assert.equal(first.status, 404);
+  assert.equal(second.status, 404);
+  assert.equal(first.headers.get("access-control-allow-origin"), "*");
+  assert.equal(await first.text(), await second.text());
+});
+
+test("getPublicMonthlyShareRouteWithDeps rejects invalid month queries before data access", async (): Promise<void> => {
+  let callCount = 0;
+  const response = await getPublicMonthlyShareRouteWithDeps(
+    createGetRequest("?monthFrom=2025-13&monthTo=2025-04"),
+    createContext("token-1"),
+    {
+      getPublicMonthlyCategoryShare: async (): Promise<PublicMonthlyCategoryShare | null> => {
+        callCount++;
+        return SHARE;
+      },
+    },
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  assert.deepEqual(await response.json(), { error: "Invalid month format. Expected YYYY-MM" });
+  assert.equal(callCount, 0);
+});
+
+test("OPTIONS returns public CORS preflight headers with no-store policy", (): void => {
+  const response = OPTIONS();
+
+  assert.equal(response.status, 204);
+  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  assert.equal(response.headers.get("access-control-allow-methods"), "GET, OPTIONS");
+  assert.match(response.headers.get("cache-control") ?? "", /no-store/);
+});

--- a/apps/web/src/app/api/share/monthly/[token]/route.ts
+++ b/apps/web/src/app/api/share/monthly/[token]/route.ts
@@ -1,0 +1,105 @@
+import { ApiRouteError } from "@/server/api/errors";
+import { applyNoStoreHeaders, jsonNoStore } from "@/server/api/noStore";
+import { parsePublicMonthWindowQuery } from "@/server/community/months";
+import { getPublicMonthlyCategoryShare } from "@/server/community/publicMonthlyCategoryShare";
+import type { PublicMonthlyCategoryShare } from "@/server/community/publicMonthlyCategoryShareTypes";
+import { log } from "@/server/logger";
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = Readonly<{
+  params: Promise<{
+    token: string;
+  }>;
+}>;
+
+type PublicMonthlyShareRouteDependencies = Readonly<{
+  getPublicMonthlyCategoryShare: (
+    publicToken: string,
+    monthFrom: string,
+    monthTo: string,
+  ) => Promise<PublicMonthlyCategoryShare | null>;
+}>;
+
+const DEFAULT_PUBLIC_MONTHLY_SHARE_ROUTE_DEPENDENCIES: PublicMonthlyShareRouteDependencies = {
+  getPublicMonthlyCategoryShare,
+};
+
+const CORS_HEADERS: HeadersInit = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+const buildPublicHeaders = (headers: HeadersInit): Headers => {
+  const result = new Headers(CORS_HEADERS);
+  const providedHeaders = new Headers(headers);
+  providedHeaders.forEach((value: string, key: string): void => {
+    result.set(key, value);
+  });
+  return result;
+};
+
+const jsonPublicNoStore = (
+  body: unknown,
+  init: ResponseInit,
+): Response =>
+  jsonNoStore(body, {
+    ...init,
+    headers: buildPublicHeaders(init.headers ?? {}),
+  });
+
+const missingPublicShareResponse = (): Response =>
+  jsonPublicNoStore({ error: "Public monthly share not found" }, { status: 404 });
+
+const badRequestResponse = (message: string): Response =>
+  jsonPublicNoStore({ error: message }, { status: 400 });
+
+const internalErrorResponse = (): Response =>
+  jsonPublicNoStore({ error: "Public monthly share is temporarily unavailable" }, { status: 500 });
+
+export const getPublicMonthlyShareRouteWithDeps = async (
+  request: Request,
+  context: RouteContext,
+  dependencies: PublicMonthlyShareRouteDependencies,
+): Promise<Response> => {
+  try {
+    const { token } = await context.params;
+    const query = parsePublicMonthWindowQuery(new URL(request.url).searchParams);
+    const share = await dependencies.getPublicMonthlyCategoryShare(
+      token,
+      query.monthFrom,
+      query.monthTo,
+    );
+
+    if (share === null) {
+      return missingPublicShareResponse();
+    }
+
+    return jsonPublicNoStore(share, { status: 200 });
+  } catch (error) {
+    if (error instanceof ApiRouteError) {
+      return badRequestResponse(error.publicMessage);
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    log({ domain: "api", action: "error", route: "/api/share/monthly/[token]", method: "GET", error: message });
+    return internalErrorResponse();
+  }
+};
+
+export const GET = async (
+  request: Request,
+  context: RouteContext,
+): Promise<Response> =>
+  getPublicMonthlyShareRouteWithDeps(
+    request,
+    context,
+    DEFAULT_PUBLIC_MONTHLY_SHARE_ROUTE_DEPENDENCIES,
+  );
+
+export const OPTIONS = (): Response =>
+  new Response(null, {
+    status: 204,
+    headers: applyNoStoreHeaders(CORS_HEADERS),
+  });

--- a/apps/web/src/server/community/months.ts
+++ b/apps/web/src/server/community/months.ts
@@ -1,0 +1,79 @@
+import { createBadRequestError } from "@/server/api/errors";
+import { monthSchema, parseWithSchema } from "@/server/api/validation";
+
+export const PUBLIC_MONTHLY_SHARE_MAX_WINDOW_MONTHS = 24;
+
+export type MonthWindow = Readonly<{
+  monthFrom: string;
+  monthTo: string;
+}>;
+
+const parseMonthParts = (month: string): Readonly<{ year: number; month: number }> => {
+  const parsed = parseWithSchema(month, monthSchema);
+  const year = Number(parsed.slice(0, 4));
+  const monthNumber = Number(parsed.slice(5, 7));
+  return { year, month: monthNumber };
+};
+
+const toMonthIndex = (month: string): number => {
+  const parts = parseMonthParts(month);
+  return parts.year * 12 + parts.month - 1;
+};
+
+const formatMonthIndex = (monthIndex: number): string => {
+  const year = Math.floor(monthIndex / 12);
+  const month = monthIndex % 12 + 1;
+  return `${year.toString().padStart(4, "0")}-${month.toString().padStart(2, "0")}`;
+};
+
+export const clampMonthWindow = (
+  monthFrom: string,
+  monthTo: string,
+  maxMonths: number,
+): MonthWindow => {
+  if (!Number.isInteger(maxMonths) || maxMonths < 1) {
+    throw new Error(`Invalid maxMonths. Expected positive integer, received ${maxMonths}`);
+  }
+
+  const fromIndex = toMonthIndex(monthFrom);
+  const toIndex = toMonthIndex(monthTo);
+  if (fromIndex > toIndex) {
+    throw createBadRequestError("monthFrom must be <= monthTo");
+  }
+
+  const cappedToIndex = Math.min(toIndex, fromIndex + maxMonths - 1);
+  return {
+    monthFrom: formatMonthIndex(fromIndex),
+    monthTo: formatMonthIndex(cappedToIndex),
+  };
+};
+
+export const parsePublicMonthWindowQuery = (searchParams: URLSearchParams): MonthWindow => {
+  const monthFrom = searchParams.get("monthFrom");
+  const monthTo = searchParams.get("monthTo");
+
+  if (monthFrom === null || monthTo === null) {
+    throw createBadRequestError("Missing required query params: monthFrom, monthTo");
+  }
+
+  return clampMonthWindow(
+    parseWithSchema(monthFrom, monthSchema),
+    parseWithSchema(monthTo, monthSchema),
+    PUBLIC_MONTHLY_SHARE_MAX_WINDOW_MONTHS,
+  );
+};
+
+export const monthToDateString = (month: string): string => {
+  const parsed = parseWithSchema(month, monthSchema);
+  return `${parsed}-01`;
+};
+
+export const dateStringToMonth = (dateString: string | null): string | null => {
+  if (dateString === null) {
+    return null;
+  }
+  if (!/^\d{4}-(?:0[1-9]|1[0-2])-01$/.test(dateString)) {
+    throw new Error(`Invalid first-day month date from database: ${dateString}`);
+  }
+  return dateString.slice(0, 7);
+};

--- a/apps/web/src/server/community/publicMonthlyCategoryShare.test.ts
+++ b/apps/web/src/server/community/publicMonthlyCategoryShare.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import type { QueryResult } from "pg";
+
+import { clampMonthWindow } from "@/server/community/months";
+import { getPublicMonthlyCategoryShareWithQuery } from "@/server/community/publicMonthlyCategoryShare";
+
+const createQueryResult = (
+  rows: ReadonlyArray<Record<string, unknown>>,
+): QueryResult => ({
+  command: "SELECT",
+  rowCount: rows.length,
+  oid: 0,
+  fields: [],
+  rows: [...rows],
+});
+
+const readPublicShareReaderMigration = (): string =>
+  readFileSync(
+    fileURLToPath(new URL("../../../../../db/migrations/0047_community_public_monthly_share_reader.sql", import.meta.url)),
+    "utf8",
+  );
+
+const countMatches = (source: string, pattern: RegExp): number =>
+  Array.from(source.matchAll(pattern)).length;
+
+test("clampMonthWindow caps public share requests to the configured month count", (): void => {
+  assert.deepEqual(
+    clampMonthWindow("2024-01", "2026-12", 24),
+    { monthFrom: "2024-01", monthTo: "2025-12" },
+  );
+});
+
+test("getPublicMonthlyCategoryShareWithQuery maps database dates to public month strings", async (): Promise<void> => {
+  let observedParams: ReadonlyArray<unknown> = [];
+  const queryFn = async (text: string, params: ReadonlyArray<unknown>): Promise<QueryResult> => {
+    assert.match(text, /community\.read_public_monthly_category_share/);
+    observedParams = params;
+    return createQueryResult([
+      {
+        label: "Shared spend",
+        currency: "USD",
+        available_month_from: "2025-01-01",
+        available_month_to: "2025-12-01",
+        loaded_month_from: "2025-03-01",
+        loaded_month_to: "2025-04-01",
+        categories: [
+          { category: "Groceries", accessLevel: "monthly_values" },
+          { category: "Travel", accessLevel: "category_only" },
+        ],
+        cells: [
+          { month: "2025-03-01", category: "Groceries", amount: 120.5 },
+          { month: "2025-04-01", category: "Groceries", amount: 80 },
+        ],
+        year_totals: [
+          { year: 2025, category: "Groceries", amount: 200.5 },
+        ],
+      },
+    ]);
+  };
+
+  const result = await getPublicMonthlyCategoryShareWithQuery(
+    queryFn,
+    "token-1",
+    "2025-03",
+    "2025-04",
+  );
+
+  assert.deepEqual(observedParams, ["token-1", "2025-03-01", "2025-04-01"]);
+  assert.deepEqual(result, {
+    label: "Shared spend",
+    currency: "USD",
+    availableMonthFrom: "2025-01",
+    availableMonthTo: "2025-12",
+    loadedMonthFrom: "2025-03",
+    loadedMonthTo: "2025-04",
+    categories: [
+      { category: "Groceries", accessLevel: "monthly_values" },
+      { category: "Travel", accessLevel: "category_only" },
+    ],
+    cells: [
+      { month: "2025-03", category: "Groceries", amount: 120.5 },
+      { month: "2025-04", category: "Groceries", amount: 80 },
+    ],
+    yearTotals: [
+      { year: "2025", category: "Groceries", amount: 200.5 },
+    ],
+  });
+});
+
+test("getPublicMonthlyCategoryShareWithQuery returns null for every missing token equivalent", async (): Promise<void> => {
+  const queryFn = async (): Promise<QueryResult> => createQueryResult([]);
+
+  const result = await getPublicMonthlyCategoryShareWithQuery(
+    queryFn,
+    "missing-token",
+    "2025-03",
+    "2025-04",
+  );
+
+  assert.equal(result, null);
+});
+
+test("public reader migration keeps amount aggregates spend-only and monthly-values-only", (): void => {
+  const sql = readPublicShareReaderMigration();
+
+  assert.match(sql, /AND item\.direction = 'spend'/);
+  assert.equal(countMatches(sql, /AND entry\.kind = 'spend'/g), 2);
+  assert.equal(countMatches(sql, /category\.access_level = 'monthly_values'/g), 2);
+});
+
+test("public reader migration excludes unconvertible rows from every amount aggregate", (): void => {
+  const sql = readPublicShareReaderMigration();
+
+  assert.equal(countMatches(sql, /AND converted\.amount_report IS NOT NULL/g), 2);
+});
+
+test("public reader migration does not expose indexing settings in the aggregate function result", (): void => {
+  const sql = readPublicShareReaderMigration();
+
+  assert.doesNotMatch(sql, /indexing_enabled/);
+});

--- a/apps/web/src/server/community/publicMonthlyCategoryShare.ts
+++ b/apps/web/src/server/community/publicMonthlyCategoryShare.ts
@@ -1,0 +1,129 @@
+import type { QueryResult } from "pg";
+
+import { query } from "@/server/db";
+import { dateStringToMonth, monthToDateString } from "@/server/community/months";
+import type {
+  PublicMonthlyCategoryShare,
+  PublicMonthlyShareAccessLevel,
+  PublicMonthlyShareCategory,
+  PublicMonthlyShareCell,
+  PublicMonthlyShareYearTotal,
+} from "@/server/community/publicMonthlyCategoryShareTypes";
+
+type PublicMonthlyCategoryShareRow = Readonly<{
+  label: string;
+  currency: string;
+  available_month_from: string | null;
+  available_month_to: string | null;
+  loaded_month_from: string | null;
+  loaded_month_to: string | null;
+  categories: ReadonlyArray<DbPublicMonthlyShareCategory>;
+  cells: ReadonlyArray<DbPublicMonthlyShareCell>;
+  year_totals: ReadonlyArray<DbPublicMonthlyShareYearTotal>;
+}>;
+
+type DbPublicMonthlyShareCategory = Readonly<{
+  category: string;
+  accessLevel: PublicMonthlyShareAccessLevel;
+}>;
+
+type DbPublicMonthlyShareCell = Readonly<{
+  month: string;
+  category: string;
+  amount: number;
+}>;
+
+type DbPublicMonthlyShareYearTotal = Readonly<{
+  year: number;
+  category: string;
+  amount: number;
+}>;
+
+type BareQueryFn = (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>;
+
+const PUBLIC_MONTHLY_CATEGORY_SHARE_QUERY = `
+  SELECT
+    label,
+    currency,
+    available_month_from::text AS available_month_from,
+    available_month_to::text AS available_month_to,
+    loaded_month_from::text AS loaded_month_from,
+    loaded_month_to::text AS loaded_month_to,
+    categories,
+    cells,
+    year_totals
+  FROM community.read_public_monthly_category_share($1, $2::date, $3::date)
+`;
+
+const toFiniteNumber = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    throw new Error(`Invalid numeric public monthly share value from database: ${value}`);
+  }
+  return value;
+};
+
+const requiredMonthFromDateString = (dateString: string): string => {
+  const month = dateStringToMonth(dateString);
+  if (month === null) {
+    throw new Error("Invalid null public monthly share month from database");
+  }
+  return month;
+};
+
+const mapCategory = (category: DbPublicMonthlyShareCategory): PublicMonthlyShareCategory => ({
+  category: category.category,
+  accessLevel: category.accessLevel,
+});
+
+const mapCell = (cell: DbPublicMonthlyShareCell): PublicMonthlyShareCell => ({
+  month: requiredMonthFromDateString(cell.month),
+  category: cell.category,
+  amount: toFiniteNumber(cell.amount),
+});
+
+const mapYearTotal = (total: DbPublicMonthlyShareYearTotal): PublicMonthlyShareYearTotal => ({
+  year: total.year.toString(),
+  category: total.category,
+  amount: toFiniteNumber(total.amount),
+});
+
+export const mapPublicMonthlyCategoryShareRow = (
+  row: PublicMonthlyCategoryShareRow,
+): PublicMonthlyCategoryShare => ({
+  label: row.label,
+  currency: row.currency,
+  availableMonthFrom: dateStringToMonth(row.available_month_from),
+  availableMonthTo: dateStringToMonth(row.available_month_to),
+  loadedMonthFrom: dateStringToMonth(row.loaded_month_from),
+  loadedMonthTo: dateStringToMonth(row.loaded_month_to),
+  categories: row.categories.map(mapCategory),
+  cells: row.cells.map(mapCell),
+  yearTotals: row.year_totals.map(mapYearTotal),
+});
+
+export const getPublicMonthlyCategoryShareWithQuery = async (
+  queryFn: BareQueryFn,
+  publicToken: string,
+  monthFrom: string,
+  monthTo: string,
+): Promise<PublicMonthlyCategoryShare | null> => {
+  const result = await queryFn(PUBLIC_MONTHLY_CATEGORY_SHARE_QUERY, [
+    publicToken,
+    monthToDateString(monthFrom),
+    monthToDateString(monthTo),
+  ]);
+
+  const row = result.rows[0] as PublicMonthlyCategoryShareRow | undefined;
+  if (row === undefined) {
+    return null;
+  }
+
+  return mapPublicMonthlyCategoryShareRow(row);
+};
+
+export const getPublicMonthlyCategoryShare = async (
+  publicToken: string,
+  monthFrom: string,
+  monthTo: string,
+): Promise<PublicMonthlyCategoryShare | null> =>
+  getPublicMonthlyCategoryShareWithQuery(query, publicToken, monthFrom, monthTo);

--- a/apps/web/src/server/community/publicMonthlyCategoryShareTypes.ts
+++ b/apps/web/src/server/community/publicMonthlyCategoryShareTypes.ts
@@ -1,0 +1,30 @@
+export type PublicMonthlyShareAccessLevel = "category_only" | "monthly_values";
+
+export type PublicMonthlyShareCategory = Readonly<{
+  category: string;
+  accessLevel: PublicMonthlyShareAccessLevel;
+}>;
+
+export type PublicMonthlyShareCell = Readonly<{
+  month: string;
+  category: string;
+  amount: number;
+}>;
+
+export type PublicMonthlyShareYearTotal = Readonly<{
+  year: string;
+  category: string;
+  amount: number;
+}>;
+
+export type PublicMonthlyCategoryShare = Readonly<{
+  label: string;
+  currency: string;
+  availableMonthFrom: string | null;
+  availableMonthTo: string | null;
+  loadedMonthFrom: string | null;
+  loadedMonthTo: string | null;
+  categories: ReadonlyArray<PublicMonthlyShareCategory>;
+  cells: ReadonlyArray<PublicMonthlyShareCell>;
+  yearTotals: ReadonlyArray<PublicMonthlyShareYearTotal>;
+}>;

--- a/db/migrations/0047_community_public_monthly_share_reader.sql
+++ b/db/migrations/0047_community_public_monthly_share_reader.sql
@@ -1,0 +1,240 @@
+-- Narrow public reader for monthly category share JSON.
+
+CREATE FUNCTION community.read_public_monthly_category_share(
+  p_public_token TEXT,
+  p_month_from DATE,
+  p_month_to DATE
+)
+RETURNS TABLE(
+  label TEXT,
+  currency TEXT,
+  available_month_from DATE,
+  available_month_to DATE,
+  loaded_month_from DATE,
+  loaded_month_to DATE,
+  categories JSONB,
+  cells JSONB,
+  year_totals JSONB
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public, community
+AS $$
+DECLARE
+  v_share_id TEXT;
+  v_workspace_id TEXT;
+  v_label TEXT;
+  v_currency TEXT;
+  v_timezone TEXT;
+  v_config_month_from DATE;
+  v_config_month_to DATE;
+  v_request_month_from DATE;
+  v_request_month_to DATE;
+  v_capped_month_to DATE;
+  v_local_current_date DATE;
+  v_latest_eligible_month DATE;
+  v_available_month_from DATE;
+  v_available_month_to DATE;
+  v_loaded_month_from DATE;
+  v_loaded_month_to DATE;
+BEGIN
+  IF p_public_token IS NULL OR btrim(p_public_token) = '' THEN
+    RETURN;
+  END IF;
+
+  IF p_month_from IS NULL OR p_month_to IS NULL THEN
+    RAISE EXCEPTION 'read_public_monthly_category_share: p_month_from and p_month_to are required';
+  END IF;
+
+  v_request_month_from := date_trunc('month', p_month_from)::date;
+  v_request_month_to := date_trunc('month', p_month_to)::date;
+
+  IF v_request_month_from > v_request_month_to THEN
+    RAISE EXCEPTION 'read_public_monthly_category_share: p_month_from must be <= p_month_to';
+  END IF;
+
+  v_capped_month_to := LEAST(
+    v_request_month_to,
+    (v_request_month_from + (INTERVAL '1 month' * 23))::date
+  );
+
+  SELECT
+    share.share_id,
+    share.workspace_id,
+    share.display_label,
+    settings.reporting_currency,
+    settings.timezone,
+    share.month_from,
+    share.month_to
+  INTO
+    v_share_id,
+    v_workspace_id,
+    v_label,
+    v_currency,
+    v_timezone,
+    v_config_month_from,
+    v_config_month_to
+  FROM community.monthly_category_share_keys AS key
+  INNER JOIN community.monthly_category_shares AS share
+    ON share.share_id = key.share_id
+  INNER JOIN public.workspace_settings AS settings
+    ON settings.workspace_id = share.workspace_id
+  WHERE key.public_token = p_public_token
+    AND key.revoked_at IS NULL
+    AND share.enabled = true
+    AND share.blocked_at IS NULL;
+
+  IF v_share_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  v_local_current_date := (CURRENT_TIMESTAMP AT TIME ZONE v_timezone)::date;
+  v_latest_eligible_month := (
+    date_trunc('month', v_local_current_date)::date
+    - CASE
+        WHEN EXTRACT(DAY FROM v_local_current_date)::integer >= 6 THEN INTERVAL '1 month'
+        ELSE INTERVAL '2 months'
+      END
+  )::date;
+
+  v_available_month_from := v_config_month_from;
+  v_available_month_to := LEAST(
+    COALESCE(v_config_month_to, v_latest_eligible_month),
+    v_latest_eligible_month
+  );
+
+  IF v_available_month_to < v_available_month_from THEN
+    v_available_month_from := NULL;
+    v_available_month_to := NULL;
+    v_loaded_month_from := NULL;
+    v_loaded_month_to := NULL;
+  ELSE
+    v_loaded_month_from := GREATEST(v_request_month_from, v_available_month_from);
+    v_loaded_month_to := LEAST(v_capped_month_to, v_available_month_to);
+
+    IF v_loaded_month_to < v_loaded_month_from THEN
+      v_loaded_month_from := NULL;
+      v_loaded_month_to := NULL;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  WITH public_categories AS (
+    SELECT
+      item.category,
+      item.access_level
+    FROM community.monthly_category_share_items AS item
+    WHERE item.share_id = v_share_id
+      AND item.direction = 'spend'
+    ORDER BY item.category
+  ),
+  loaded_cells AS (
+    SELECT
+      date_trunc('month', local_entry.local_date)::date AS cell_month,
+      category.category,
+      SUM(-converted.amount_report)::double precision AS amount
+    FROM public_categories AS category
+    INNER JOIN public.ledger_entries AS entry
+      ON entry.workspace_id = v_workspace_id
+      AND entry.kind = 'spend'
+      AND COALESCE(entry.category, '') = category.category
+    CROSS JOIN LATERAL (
+      SELECT (entry.ts AT TIME ZONE v_timezone)::date AS local_date
+    ) AS local_entry
+    LEFT JOIN public.fx_rates_daily AS rate
+      ON rate.quote_currency = v_currency
+      AND rate.base_currency = entry.currency
+      AND rate.calendar_date = local_entry.local_date
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN entry.currency = v_currency THEN entry.amount::double precision
+          WHEN rate.rate IS NOT NULL THEN entry.amount::double precision * rate.rate::double precision
+          ELSE NULL
+        END AS amount_report
+    ) AS converted
+    WHERE category.access_level = 'monthly_values'
+      AND v_loaded_month_from IS NOT NULL
+      AND local_entry.local_date >= v_loaded_month_from
+      AND local_entry.local_date < (v_loaded_month_to + INTERVAL '1 month')::date
+      AND converted.amount_report IS NOT NULL
+    GROUP BY 1, 2
+  ),
+  configured_year_totals AS (
+    SELECT
+      EXTRACT(YEAR FROM local_entry.local_date)::integer AS total_year,
+      category.category,
+      SUM(-converted.amount_report)::double precision AS amount
+    FROM public_categories AS category
+    INNER JOIN public.ledger_entries AS entry
+      ON entry.workspace_id = v_workspace_id
+      AND entry.kind = 'spend'
+      AND COALESCE(entry.category, '') = category.category
+    CROSS JOIN LATERAL (
+      SELECT (entry.ts AT TIME ZONE v_timezone)::date AS local_date
+    ) AS local_entry
+    LEFT JOIN public.fx_rates_daily AS rate
+      ON rate.quote_currency = v_currency
+      AND rate.base_currency = entry.currency
+      AND rate.calendar_date = local_entry.local_date
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN entry.currency = v_currency THEN entry.amount::double precision
+          WHEN rate.rate IS NOT NULL THEN entry.amount::double precision * rate.rate::double precision
+          ELSE NULL
+        END AS amount_report
+    ) AS converted
+    WHERE category.access_level = 'monthly_values'
+      AND v_available_month_from IS NOT NULL
+      AND local_entry.local_date >= v_available_month_from
+      AND local_entry.local_date < (v_available_month_to + INTERVAL '1 month')::date
+      AND converted.amount_report IS NOT NULL
+    GROUP BY 1, 2
+  )
+  SELECT
+    v_label,
+    v_currency,
+    v_available_month_from,
+    v_available_month_to,
+    v_loaded_month_from,
+    v_loaded_month_to,
+    COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'category', category.category,
+          'accessLevel', category.access_level
+        )
+        ORDER BY category.category
+      )
+      FROM public_categories AS category
+    ), '[]'::jsonb),
+    COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'month', cell.cell_month,
+          'category', cell.category,
+          'amount', cell.amount
+        )
+        ORDER BY cell.cell_month, cell.category
+      )
+      FROM loaded_cells AS cell
+    ), '[]'::jsonb),
+    COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'year', total.total_year,
+          'category', total.category,
+          'amount', total.amount
+        )
+        ORDER BY total.total_year, total.category
+      )
+      FROM configured_year_totals AS total
+    ), '[]'::jsonb);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION community.read_public_monthly_category_share(TEXT, DATE, DATE) FROM PUBLIC;
+REVOKE ALL ON FUNCTION community.read_public_monthly_category_share(TEXT, DATE, DATE) FROM api_sql_executor;
+GRANT EXECUTE ON FUNCTION community.read_public_monthly_category_share(TEXT, DATE, DATE) TO app;


### PR DESCRIPTION
## Summary
- add a narrow public monthly category share reader function
- expose GET/OPTIONS at /api/share/monthly/[token]
- add focused route, mapper, month-window, and SQL guard tests

## Validation
- cd apps/web && npx tsx --test src/server/community/publicMonthlyCategoryShare.test.ts src/app/api/share-monthly-route.test.ts
- cd apps/web && npm run lint
- cd apps/web && npm run build