### PR TITLE
Add public monthly share dashboard

### DIFF
--- a/apps/web/src/app/api/community-monthly-category-share-route.test.ts
+++ b/apps/web/src/app/api/community-monthly-category-share-route.test.ts
@@ -16,8 +16,8 @@ const createResponsePayload = (): MonthlyCategoryShareSettingsResponse => ({
     monthFrom: "2026-01",
     monthTo: null,
   },
-  dashboardUrl: "http://localhost/community/monthly-category-share/token",
-  jsonUrl: "http://localhost/api/community/monthly-category-share/public/token",
+  dashboardUrl: "http://localhost/share/monthly/token",
+  jsonUrl: "http://localhost/api/share/monthly/token",
   selectedItems: [],
   availableSpendCategories: ["Food"],
 });

--- a/apps/web/src/app/api/share-monthly-route.test.ts
+++ b/apps/web/src/app/api/share-monthly-route.test.ts
@@ -33,6 +33,11 @@ const createContext = (token: string): { params: Promise<{ token: string }> } =>
 const createGetRequest = (query: string): Request =>
   new Request(`http://localhost/api/share/monthly/token-1${query}`, { method: "GET" });
 
+const assertPublicShareHeaders = (response: Response): void => {
+  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  assert.equal(response.headers.get("x-robots-tag"), "noindex, nofollow");
+};
+
 test("getPublicMonthlyShareRouteWithDeps returns public JSON with CORS and no-store headers", async (): Promise<void> => {
   const calls: Array<Readonly<{ token: string; monthFrom: string; monthTo: string }>> = [];
   const response = await getPublicMonthlyShareRouteWithDeps(
@@ -47,9 +52,30 @@ test("getPublicMonthlyShareRouteWithDeps returns public JSON with CORS and no-st
   );
 
   assert.equal(response.status, 200);
-  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  assertPublicShareHeaders(response);
   assert.match(response.headers.get("cache-control") ?? "", /no-store/);
   assert.deepEqual(calls, [{ token: "token-1", monthFrom: "2024-01", monthTo: "2025-12" }]);
+  assert.deepEqual(await response.json(), SHARE);
+});
+
+test("getPublicMonthlyShareRouteWithDeps uses a bounded latest window when query params are omitted", async (): Promise<void> => {
+  const calls: Array<Readonly<{ token: string; monthFrom: string; monthTo: string }>> = [];
+  const response = await getPublicMonthlyShareRouteWithDeps(
+    createGetRequest(""),
+    createContext("token-1"),
+    {
+      getPublicMonthlyCategoryShare: async (token: string, monthFrom: string, monthTo: string): Promise<PublicMonthlyCategoryShare | null> => {
+        calls.push({ token, monthFrom, monthTo });
+        return SHARE;
+      },
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assertPublicShareHeaders(response);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].token, "token-1");
+  assert.deepEqual(calls[1], { token: "token-1", monthFrom: "2025-01", monthTo: "2025-12" });
   assert.deepEqual(await response.json(), SHARE);
 });
 
@@ -71,7 +97,8 @@ test("getPublicMonthlyShareRouteWithDeps returns equivalent 404 responses for mi
 
   assert.equal(first.status, 404);
   assert.equal(second.status, 404);
-  assert.equal(first.headers.get("access-control-allow-origin"), "*");
+  assertPublicShareHeaders(first);
+  assertPublicShareHeaders(second);
   assert.equal(await first.text(), await second.text());
 });
 
@@ -89,7 +116,7 @@ test("getPublicMonthlyShareRouteWithDeps rejects invalid month queries before da
   );
 
   assert.equal(response.status, 400);
-  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  assertPublicShareHeaders(response);
   assert.deepEqual(await response.json(), { error: "Invalid month format. Expected YYYY-MM" });
   assert.equal(callCount, 0);
 });
@@ -98,7 +125,7 @@ test("OPTIONS returns public CORS preflight headers with no-store policy", (): v
   const response = OPTIONS();
 
   assert.equal(response.status, 204);
-  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  assertPublicShareHeaders(response);
   assert.equal(response.headers.get("access-control-allow-methods"), "GET, OPTIONS");
   assert.match(response.headers.get("cache-control") ?? "", /no-store/);
 });

--- a/apps/web/src/app/api/share/monthly/[token]/route.ts
+++ b/apps/web/src/app/api/share/monthly/[token]/route.ts
@@ -4,6 +4,7 @@ import { parsePublicMonthWindowQuery } from "@/server/community/months";
 import { getPublicMonthlyCategoryShare } from "@/server/community/publicMonthlyCategoryShare";
 import type { PublicMonthlyCategoryShare } from "@/server/community/publicMonthlyCategoryShareTypes";
 import { log } from "@/server/logger";
+import { getCurrentMonth, offsetMonth } from "@/lib/monthUtils";
 
 export const dynamic = "force-dynamic";
 
@@ -21,18 +22,26 @@ type PublicMonthlyShareRouteDependencies = Readonly<{
   ) => Promise<PublicMonthlyCategoryShare | null>;
 }>;
 
+type PublicMonthlyShareWindow = Readonly<{
+  monthFrom: string;
+  monthTo: string;
+}>;
+
 const DEFAULT_PUBLIC_MONTHLY_SHARE_ROUTE_DEPENDENCIES: PublicMonthlyShareRouteDependencies = {
   getPublicMonthlyCategoryShare,
 };
 
-const CORS_HEADERS: HeadersInit = {
+const DEFAULT_PUBLIC_MONTHLY_SHARE_ROUTE_WINDOW_MONTHS = 12;
+
+const PUBLIC_HEADERS: HeadersInit = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
+  "X-Robots-Tag": "noindex, nofollow",
 };
 
 const buildPublicHeaders = (headers: HeadersInit): Headers => {
-  const result = new Headers(CORS_HEADERS);
+  const result = new Headers(PUBLIC_HEADERS);
   const providedHeaders = new Headers(headers);
   providedHeaders.forEach((value: string, key: string): void => {
     result.set(key, value);
@@ -58,6 +67,60 @@ const badRequestResponse = (message: string): Response =>
 const internalErrorResponse = (): Response =>
   jsonPublicNoStore({ error: "Public monthly share is temporarily unavailable" }, { status: 500 });
 
+const maxMonth = (left: string, right: string): string =>
+  left > right ? left : right;
+
+const buildDefaultPublicMonthlyShareProbeWindow = (): PublicMonthlyShareWindow => {
+  const previousMonth = offsetMonth(getCurrentMonth(), -1);
+  return {
+    monthFrom: previousMonth,
+    monthTo: previousMonth,
+  };
+};
+
+const buildLatestPublicMonthlyShareWindow = (
+  availableMonthFrom: string | null,
+  availableMonthTo: string | null,
+): PublicMonthlyShareWindow | null => {
+  if (availableMonthFrom === null || availableMonthTo === null) {
+    return null;
+  }
+  const candidateFrom = offsetMonth(availableMonthTo, -(DEFAULT_PUBLIC_MONTHLY_SHARE_ROUTE_WINDOW_MONTHS - 1));
+  return {
+    monthFrom: maxMonth(availableMonthFrom, candidateFrom),
+    monthTo: availableMonthTo,
+  };
+};
+
+const readDefaultPublicMonthlyShare = async (
+  token: string,
+  dependencies: PublicMonthlyShareRouteDependencies,
+): Promise<PublicMonthlyCategoryShare | null> => {
+  const probeWindow = buildDefaultPublicMonthlyShareProbeWindow();
+  const probeShare = await dependencies.getPublicMonthlyCategoryShare(
+    token,
+    probeWindow.monthFrom,
+    probeWindow.monthTo,
+  );
+  if (probeShare === null) {
+    return null;
+  }
+
+  const latestWindow = buildLatestPublicMonthlyShareWindow(
+    probeShare.availableMonthFrom,
+    probeShare.availableMonthTo,
+  );
+  if (latestWindow === null) {
+    return probeShare;
+  }
+
+  return dependencies.getPublicMonthlyCategoryShare(
+    token,
+    latestWindow.monthFrom,
+    latestWindow.monthTo,
+  );
+};
+
 export const getPublicMonthlyShareRouteWithDeps = async (
   request: Request,
   context: RouteContext,
@@ -65,12 +128,19 @@ export const getPublicMonthlyShareRouteWithDeps = async (
 ): Promise<Response> => {
   try {
     const { token } = await context.params;
-    const query = parsePublicMonthWindowQuery(new URL(request.url).searchParams);
-    const share = await dependencies.getPublicMonthlyCategoryShare(
-      token,
-      query.monthFrom,
-      query.monthTo,
-    );
+    const searchParams = new URL(request.url).searchParams;
+    const monthFrom = searchParams.get("monthFrom");
+    const monthTo = searchParams.get("monthTo");
+    const explicitWindow = monthFrom === null && monthTo === null
+      ? null
+      : parsePublicMonthWindowQuery(searchParams);
+    const share = explicitWindow === null
+      ? await readDefaultPublicMonthlyShare(token, dependencies)
+      : await dependencies.getPublicMonthlyCategoryShare(
+        token,
+        explicitWindow.monthFrom,
+        explicitWindow.monthTo,
+      );
 
     if (share === null) {
       return missingPublicShareResponse();
@@ -101,5 +171,5 @@ export const GET = async (
 export const OPTIONS = (): Response =>
   new Response(null, {
     status: 204,
-    headers: applyNoStoreHeaders(CORS_HEADERS),
+    headers: applyNoStoreHeaders(PUBLIC_HEADERS),
   });

--- a/apps/web/src/app/share/monthly/[token]/not-found.tsx
+++ b/apps/web/src/app/share/monthly/[token]/not-found.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from "react";
+
+import { getLocaleCookie } from "@/lib/localeCookie";
+import { t } from "@/i18n/serverT";
+
+import styles from "@/ui/public-share/PublicMonthlyShareTable.module.css";
+
+const SITE_HREF = "https://expense-budget-tracker.com/";
+
+export default async function NotFound(): Promise<ReactElement> {
+  const locale = await getLocaleCookie();
+
+  return (
+    <main className={styles.page}>
+      <header className={styles.header}>
+        <div className={styles.headingGroup}>
+          <p className={styles.eyebrow}>{t(locale, "publicShare.title")}</p>
+          <h1 className={styles.title}>{t(locale, "publicShare.notFound")}</h1>
+        </div>
+      </header>
+      <footer className={styles.footer}>
+        <a href={SITE_HREF}>{t(locale, "publicShare.publishedWithAttribution")}</a>
+      </footer>
+    </main>
+  );
+}

--- a/apps/web/src/app/share/monthly/[token]/page.tsx
+++ b/apps/web/src/app/share/monthly/[token]/page.tsx
@@ -1,0 +1,147 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import type { ReactElement } from "react";
+
+import { getLocaleCookie } from "@/lib/localeCookie";
+import { t } from "@/i18n/serverT";
+import {
+  getPublicMonthlyCategoryShare,
+  getPublicMonthlyCategoryShareMetadata,
+} from "@/server/community/publicMonthlyCategoryShare";
+import type { PublicMonthlyCategoryShare } from "@/server/community/publicMonthlyCategoryShareTypes";
+import { PublicMonthlySharePage } from "@/ui/public-share/PublicMonthlySharePage";
+import {
+  buildLatestPublicMonthlyShareWindow,
+  buildPublicMonthlyShareProbeWindow,
+  PUBLIC_MONTHLY_SHARE_INITIAL_WINDOW_MONTHS,
+  resolvePublicMonthlyShareLabel,
+  type PublicMonthlyShareWindow,
+} from "@/ui/public-share/publicMonthlyShareModel";
+
+export const dynamic = "force-dynamic";
+
+const SITE_HREF = "https://expense-budget-tracker.com/";
+
+type PublicMonthlySharePageRouteProps = Readonly<{
+  params: Promise<{
+    token: string;
+  }>;
+}>;
+
+type InitialPublicMonthlyShare = Readonly<{
+  share: PublicMonthlyCategoryShare;
+  jsonWindow: PublicMonthlyShareWindow;
+}>;
+
+const getPublicMonthlyShareForWindow = async (
+  token: string,
+  window: PublicMonthlyShareWindow,
+): Promise<PublicMonthlyCategoryShare | null> =>
+  getPublicMonthlyCategoryShare(token, window.monthFrom, window.monthTo);
+
+const readInitialPublicMonthlyShare = async (
+  token: string,
+): Promise<InitialPublicMonthlyShare | null> => {
+  const probeWindow = buildPublicMonthlyShareProbeWindow();
+  const probeShare = await getPublicMonthlyShareForWindow(token, probeWindow);
+  if (probeShare === null) {
+    return null;
+  }
+
+  const latestWindow = buildLatestPublicMonthlyShareWindow(
+    probeShare.availableMonthFrom,
+    probeShare.availableMonthTo,
+    PUBLIC_MONTHLY_SHARE_INITIAL_WINDOW_MONTHS,
+  );
+  if (latestWindow === null) {
+    return {
+      share: probeShare,
+      jsonWindow: probeWindow,
+    };
+  }
+
+  const latestShare = await getPublicMonthlyShareForWindow(token, latestWindow);
+  if (latestShare === null) {
+    return null;
+  }
+
+  return {
+    share: latestShare,
+    jsonWindow: latestWindow,
+  };
+};
+
+const buildMetadataDescription = (
+  title: string,
+  currency: string,
+  availableMonthFrom: string | null,
+  availableMonthTo: string | null,
+): string => {
+  const range = availableMonthFrom === null || availableMonthTo === null
+    ? null
+    : `${availableMonthFrom} - ${availableMonthTo}`;
+  return [title, currency, range].filter((value): value is string => value !== null).join(" - ");
+};
+
+export const generateMetadata = async (
+  props: PublicMonthlySharePageRouteProps,
+): Promise<Metadata> => {
+  const locale = await getLocaleCookie();
+  const { token } = await props.params;
+  const fallbackTitle = t(locale, "publicShare.title");
+  const probeWindow = buildPublicMonthlyShareProbeWindow();
+  const [share, metadata] = await Promise.all([
+    getPublicMonthlyShareForWindow(token, probeWindow),
+    getPublicMonthlyCategoryShareMetadata(token),
+  ]);
+
+  if (share === null) {
+    return {
+      title: fallbackTitle,
+      description: t(locale, "publicShare.notFound"),
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+
+  const label = resolvePublicMonthlyShareLabel(share.label, t(locale, "publicShare.anonymousUser"));
+  const title = `${label} | ${fallbackTitle}`;
+  const allowIndexing = metadata?.indexingEnabled === true;
+
+  return {
+    title,
+    description: buildMetadataDescription(
+      fallbackTitle,
+      share.currency,
+      share.availableMonthFrom,
+      share.availableMonthTo,
+    ),
+    robots: {
+      index: allowIndexing,
+      follow: allowIndexing,
+    },
+  };
+};
+
+export default async function Page(
+  props: PublicMonthlySharePageRouteProps,
+): Promise<ReactElement> {
+  const locale = await getLocaleCookie();
+  const { token } = await props.params;
+  const initial = await readInitialPublicMonthlyShare(token);
+  if (initial === null) {
+    notFound();
+  }
+
+  return (
+    <PublicMonthlySharePage
+      token={token}
+      initialShare={initial.share}
+      initialJsonWindow={initial.jsonWindow}
+      locale={locale}
+      siteHref={SITE_HREF}
+    />
+  );
+}

--- a/apps/web/src/i18n/ar.json
+++ b/apps/web/src/i18n/ar.json
@@ -98,6 +98,7 @@
   "publicShare.emptyNoSelectedCategories": "لم يتم تحديد فئات عامة.",
   "publicShare.categoryOnlyMaskedValue": "القيمة مخفية",
   "publicShare.publishedWithAttribution": "نُشر باستخدام Expense Budget Tracker",
+  "publicShare.loadEarlier": "تحميل الأقدم",
   "publicShare.downloadJson": "تنزيل JSON",
   "publicShare.tableMonth": "الشهر",
   "publicShare.tableYear": "السنة",

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -98,6 +98,7 @@
   "publicShare.emptyNoSelectedCategories": "No public categories selected.",
   "publicShare.categoryOnlyMaskedValue": "Value hidden",
   "publicShare.publishedWithAttribution": "Published with Expense Budget Tracker",
+  "publicShare.loadEarlier": "Load earlier",
   "publicShare.downloadJson": "Download JSON",
   "publicShare.tableMonth": "Month",
   "publicShare.tableYear": "Year",

--- a/apps/web/src/i18n/es.json
+++ b/apps/web/src/i18n/es.json
@@ -98,6 +98,7 @@
   "publicShare.emptyNoSelectedCategories": "No hay categorías públicas seleccionadas.",
   "publicShare.categoryOnlyMaskedValue": "Valor oculto",
   "publicShare.publishedWithAttribution": "Publicado con Expense Budget Tracker",
+  "publicShare.loadEarlier": "Cargar anteriores",
   "publicShare.downloadJson": "Descargar JSON",
   "publicShare.tableMonth": "Mes",
   "publicShare.tableYear": "Año",

--- a/apps/web/src/i18n/fa.json
+++ b/apps/web/src/i18n/fa.json
@@ -98,6 +98,7 @@
   "publicShare.emptyNoSelectedCategories": "هیچ دسته عمومی انتخاب نشده است.",
   "publicShare.categoryOnlyMaskedValue": "مقدار پنهان است",
   "publicShare.publishedWithAttribution": "منتشرشده با Expense Budget Tracker",
+  "publicShare.loadEarlier": "بارگذاری ماه‌های قبل",
   "publicShare.downloadJson": "دانلود JSON",
   "publicShare.tableMonth": "ماه",
   "publicShare.tableYear": "سال",

--- a/apps/web/src/i18n/he.json
+++ b/apps/web/src/i18n/he.json
@@ -98,6 +98,7 @@
   "publicShare.emptyNoSelectedCategories": "לא נבחרו קטגוריות ציבוריות.",
   "publicShare.categoryOnlyMaskedValue": "הערך מוסתר",
   "publicShare.publishedWithAttribution": "פורסם באמצעות Expense Budget Tracker",
+  "publicShare.loadEarlier": "טען חודשים קודמים",
   "publicShare.downloadJson": "הורד JSON",
   "publicShare.tableMonth": "חודש",
   "publicShare.tableYear": "שנה",

--- a/apps/web/src/i18n/ru.json
+++ b/apps/web/src/i18n/ru.json
@@ -98,6 +98,7 @@
   "publicShare.emptyNoSelectedCategories": "Публичные категории не выбраны.",
   "publicShare.categoryOnlyMaskedValue": "Значение скрыто",
   "publicShare.publishedWithAttribution": "Опубликовано с Expense Budget Tracker",
+  "publicShare.loadEarlier": "Загрузить раньше",
   "publicShare.downloadJson": "Скачать JSON",
   "publicShare.tableMonth": "Месяц",
   "publicShare.tableYear": "Год",

--- a/apps/web/src/i18n/uk.json
+++ b/apps/web/src/i18n/uk.json
@@ -98,6 +98,7 @@
   "publicShare.emptyNoSelectedCategories": "Публічні категорії не вибрано.",
   "publicShare.categoryOnlyMaskedValue": "Значення приховано",
   "publicShare.publishedWithAttribution": "Опубліковано з Expense Budget Tracker",
+  "publicShare.loadEarlier": "Завантажити раніше",
   "publicShare.downloadJson": "Завантажити JSON",
   "publicShare.tableMonth": "Місяць",
   "publicShare.tableYear": "Рік",

--- a/apps/web/src/i18n/zh.json
+++ b/apps/web/src/i18n/zh.json
@@ -98,6 +98,7 @@
   "publicShare.emptyNoSelectedCategories": "未选择公开分类。",
   "publicShare.categoryOnlyMaskedValue": "数值已隐藏",
   "publicShare.publishedWithAttribution": "由 Expense Budget Tracker 发布",
+  "publicShare.loadEarlier": "加载更早月份",
   "publicShare.downloadJson": "下载 JSON",
   "publicShare.tableMonth": "月份",
   "publicShare.tableYear": "年份",

--- a/apps/web/src/server/community/monthlyCategoryShares.ts
+++ b/apps/web/src/server/community/monthlyCategoryShares.ts
@@ -111,10 +111,10 @@ const mapItem = (row: ShareItemRow): MonthlyCategoryShareItem => {
 };
 
 const buildDashboardUrl = (appOrigin: string, publicToken: string): string =>
-  `${appOrigin}/community/monthly-category-share/${encodeURIComponent(publicToken)}`;
+  `${appOrigin}/share/monthly/${encodeURIComponent(publicToken)}`;
 
 const buildJsonUrl = (appOrigin: string, publicToken: string): string =>
-  `${appOrigin}/api/community/monthly-category-share/public/${encodeURIComponent(publicToken)}`;
+  `${appOrigin}/api/share/monthly/${encodeURIComponent(publicToken)}`;
 
 const buildResponse = (
   share: ShareRow | null,

--- a/apps/web/src/server/community/publicMonthlyCategoryShare.test.ts
+++ b/apps/web/src/server/community/publicMonthlyCategoryShare.test.ts
@@ -5,7 +5,10 @@ import test from "node:test";
 import type { QueryResult } from "pg";
 
 import { clampMonthWindow } from "@/server/community/months";
-import { getPublicMonthlyCategoryShareWithQuery } from "@/server/community/publicMonthlyCategoryShare";
+import {
+  getPublicMonthlyCategoryShareMetadataWithQuery,
+  getPublicMonthlyCategoryShareWithQuery,
+} from "@/server/community/publicMonthlyCategoryShare";
 
 const createQueryResult = (
   rows: ReadonlyArray<Record<string, unknown>>,
@@ -23,8 +26,28 @@ const readPublicShareReaderMigration = (): string =>
     "utf8",
   );
 
+const readPublicShareMetadataMigration = (): string =>
+  readFileSync(
+    fileURLToPath(new URL("../../../../../db/migrations/0048_community_public_monthly_share_metadata.sql", import.meta.url)),
+    "utf8",
+  );
+
+const readPublicShareLoadedYearTotalsMigration = (): string =>
+  readFileSync(
+    fileURLToPath(new URL("../../../../../db/migrations/0049_community_public_monthly_share_loaded_year_totals.sql", import.meta.url)),
+    "utf8",
+  );
+
 const countMatches = (source: string, pattern: RegExp): number =>
   Array.from(source.matchAll(pattern)).length;
+
+const requireMatch = (source: string, pattern: RegExp): string => {
+  const match = source.match(pattern);
+  if (match === null) {
+    throw new Error(`Expected SQL pattern was not found: ${pattern.source}`);
+  }
+  return match[0];
+};
 
 test("clampMonthWindow caps public share requests to the configured month count", (): void => {
   assert.deepEqual(
@@ -55,7 +78,8 @@ test("getPublicMonthlyCategoryShareWithQuery maps database dates to public month
           { month: "2025-04-01", category: "Groceries", amount: 80 },
         ],
         year_totals: [
-          { year: 2025, category: "Groceries", amount: 200.5 },
+          { year: 2024, category: "Groceries", amount: 999 },
+          { year: 2025, category: "Groceries", amount: 999 },
         ],
       },
     ]);
@@ -103,6 +127,28 @@ test("getPublicMonthlyCategoryShareWithQuery returns null for every missing toke
   assert.equal(result, null);
 });
 
+test("getPublicMonthlyCategoryShareMetadataWithQuery reads through the public metadata function", async (): Promise<void> => {
+  let observedParams: ReadonlyArray<unknown> = [];
+  const queryFn = async (text: string, params: ReadonlyArray<unknown>): Promise<QueryResult> => {
+    assert.match(text, /community\.read_public_monthly_category_share_metadata/);
+    observedParams = params;
+    return createQueryResult([{ indexing_enabled: true }]);
+  };
+
+  const result = await getPublicMonthlyCategoryShareMetadataWithQuery(queryFn, "token-1");
+
+  assert.deepEqual(observedParams, ["token-1"]);
+  assert.deepEqual(result, { indexingEnabled: true });
+});
+
+test("getPublicMonthlyCategoryShareMetadataWithQuery returns null for missing tokens", async (): Promise<void> => {
+  const queryFn = async (): Promise<QueryResult> => createQueryResult([]);
+
+  const result = await getPublicMonthlyCategoryShareMetadataWithQuery(queryFn, "missing-token");
+
+  assert.equal(result, null);
+});
+
 test("public reader migration keeps amount aggregates spend-only and monthly-values-only", (): void => {
   const sql = readPublicShareReaderMigration();
 
@@ -121,4 +167,32 @@ test("public reader migration does not expose indexing settings in the aggregate
   const sql = readPublicShareReaderMigration();
 
   assert.doesNotMatch(sql, /indexing_enabled/);
+});
+
+test("public metadata migration exposes only indexing through a security definer function", (): void => {
+  const sql = readPublicShareMetadataMigration();
+
+  assert.match(sql, /CREATE FUNCTION community\.read_public_monthly_category_share_metadata/);
+  assert.match(sql, /SECURITY DEFINER/);
+  assert.match(sql, /share\.indexing_enabled/);
+  assert.match(sql, /key\.public_token = p_public_token/);
+  assert.match(sql, /key\.revoked_at IS NULL/);
+  assert.match(sql, /share\.enabled = true/);
+  assert.match(sql, /share\.blocked_at IS NULL/);
+  assert.match(sql, /GRANT EXECUTE ON FUNCTION community\.read_public_monthly_category_share_metadata\(TEXT\) TO app/);
+  assert.doesNotMatch(sql, /ledger_entries/);
+});
+
+test("public loaded year totals migration bounds totals to the loaded request window", (): void => {
+  const sql = readPublicShareLoadedYearTotalsMigration();
+  const loadedYearTotalsSql = requireMatch(sql, /loaded_year_totals AS \([\s\S]*?\n  \)\n  SELECT/);
+
+  assert.match(sql, /CREATE OR REPLACE FUNCTION community\.read_public_monthly_category_share/);
+  assert.equal(countMatches(sql, /AND v_loaded_month_from IS NOT NULL/g), 2);
+  assert.equal(countMatches(sql, /local_entry\.local_date >= v_loaded_month_from/g), 2);
+  assert.equal(countMatches(sql, /local_entry\.local_date < \(v_loaded_month_to \+ INTERVAL '1 month'\)::date/g), 2);
+  assert.match(loadedYearTotalsSql, /category\.access_level = 'monthly_values'/);
+  assert.match(loadedYearTotalsSql, /AND converted\.amount_report IS NOT NULL/);
+  assert.doesNotMatch(loadedYearTotalsSql, /v_available_month_/);
+  assert.doesNotMatch(sql, /configured_year_totals/);
 });

--- a/apps/web/src/server/community/publicMonthlyCategoryShare.ts
+++ b/apps/web/src/server/community/publicMonthlyCategoryShare.ts
@@ -39,6 +39,14 @@ type DbPublicMonthlyShareYearTotal = Readonly<{
   amount: number;
 }>;
 
+export type PublicMonthlyCategoryShareMetadata = Readonly<{
+  indexingEnabled: boolean;
+}>;
+
+type PublicMonthlyCategoryShareMetadataRow = Readonly<{
+  indexing_enabled: boolean;
+}>;
+
 type BareQueryFn = (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>;
 
 const PUBLIC_MONTHLY_CATEGORY_SHARE_QUERY = `
@@ -53,6 +61,11 @@ const PUBLIC_MONTHLY_CATEGORY_SHARE_QUERY = `
     cells,
     year_totals
   FROM community.read_public_monthly_category_share($1, $2::date, $3::date)
+`;
+
+const PUBLIC_MONTHLY_CATEGORY_SHARE_METADATA_QUERY = `
+  SELECT indexing_enabled
+  FROM community.read_public_monthly_category_share_metadata($1)
 `;
 
 const toFiniteNumber = (value: number): number => {
@@ -81,25 +94,55 @@ const mapCell = (cell: DbPublicMonthlyShareCell): PublicMonthlyShareCell => ({
   amount: toFiniteNumber(cell.amount),
 });
 
-const mapYearTotal = (total: DbPublicMonthlyShareYearTotal): PublicMonthlyShareYearTotal => ({
-  year: total.year.toString(),
-  category: total.category,
-  amount: toFiniteNumber(total.amount),
-});
+const compareYearTotals = (
+  left: PublicMonthlyShareYearTotal,
+  right: PublicMonthlyShareYearTotal,
+): number => {
+  const yearCompare = left.year.localeCompare(right.year);
+  if (yearCompare !== 0) {
+    return yearCompare;
+  }
+  return left.category.localeCompare(right.category);
+};
+
+const yearTotalKey = (category: string, year: string): string =>
+  `${year}\u0000${category}`;
+
+const buildLoadedYearTotalsFromCells = (
+  cells: ReadonlyArray<PublicMonthlyShareCell>,
+): ReadonlyArray<PublicMonthlyShareYearTotal> => {
+  const totals = new Map<string, PublicMonthlyShareYearTotal>();
+
+  for (const cell of cells) {
+    const year = cell.month.slice(0, 4);
+    const key = yearTotalKey(cell.category, year);
+    const currentAmount = totals.get(key)?.amount ?? 0;
+    totals.set(key, {
+      year,
+      category: cell.category,
+      amount: toFiniteNumber(currentAmount + cell.amount),
+    });
+  }
+
+  return Array.from(totals.values()).sort(compareYearTotals);
+};
 
 export const mapPublicMonthlyCategoryShareRow = (
   row: PublicMonthlyCategoryShareRow,
-): PublicMonthlyCategoryShare => ({
-  label: row.label,
-  currency: row.currency,
-  availableMonthFrom: dateStringToMonth(row.available_month_from),
-  availableMonthTo: dateStringToMonth(row.available_month_to),
-  loadedMonthFrom: dateStringToMonth(row.loaded_month_from),
-  loadedMonthTo: dateStringToMonth(row.loaded_month_to),
-  categories: row.categories.map(mapCategory),
-  cells: row.cells.map(mapCell),
-  yearTotals: row.year_totals.map(mapYearTotal),
-});
+): PublicMonthlyCategoryShare => {
+  const cells = row.cells.map(mapCell);
+  return {
+    label: row.label,
+    currency: row.currency,
+    availableMonthFrom: dateStringToMonth(row.available_month_from),
+    availableMonthTo: dateStringToMonth(row.available_month_to),
+    loadedMonthFrom: dateStringToMonth(row.loaded_month_from),
+    loadedMonthTo: dateStringToMonth(row.loaded_month_to),
+    categories: row.categories.map(mapCategory),
+    cells,
+    yearTotals: buildLoadedYearTotalsFromCells(cells),
+  };
+};
 
 export const getPublicMonthlyCategoryShareWithQuery = async (
   queryFn: BareQueryFn,
@@ -127,3 +170,22 @@ export const getPublicMonthlyCategoryShare = async (
   monthTo: string,
 ): Promise<PublicMonthlyCategoryShare | null> =>
   getPublicMonthlyCategoryShareWithQuery(query, publicToken, monthFrom, monthTo);
+
+export const getPublicMonthlyCategoryShareMetadataWithQuery = async (
+  queryFn: BareQueryFn,
+  publicToken: string,
+): Promise<PublicMonthlyCategoryShareMetadata | null> => {
+  const result = await queryFn(PUBLIC_MONTHLY_CATEGORY_SHARE_METADATA_QUERY, [publicToken]);
+  const row = result.rows[0] as PublicMonthlyCategoryShareMetadataRow | undefined;
+  if (row === undefined) {
+    return null;
+  }
+  return {
+    indexingEnabled: row.indexing_enabled,
+  };
+};
+
+export const getPublicMonthlyCategoryShareMetadata = async (
+  publicToken: string,
+): Promise<PublicMonthlyCategoryShareMetadata | null> =>
+  getPublicMonthlyCategoryShareMetadataWithQuery(query, publicToken);

--- a/apps/web/src/ui/public-share/PublicMonthlySharePage.tsx
+++ b/apps/web/src/ui/public-share/PublicMonthlySharePage.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState, type ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { SupportedLocale } from "@/lib/locale";
+import type { PublicMonthlyCategoryShare } from "@/server/community/publicMonthlyCategoryShareTypes";
+import { buildPublicMonthlyShareJsonHref, fetchPublicMonthlyShareWindow } from "@/ui/public-share/publicMonthlyShareClient";
+import {
+  buildEarlierPublicMonthlyShareWindow,
+  buildPublicMonthlyShareTableModel,
+  mergePublicMonthlyShareWindows,
+  PUBLIC_MONTHLY_SHARE_BACKFILL_WINDOW_MONTHS,
+  resolvePublicMonthlyShareLabel,
+  type PublicMonthlyShareWindow,
+} from "@/ui/public-share/publicMonthlyShareModel";
+import { PublicMonthlyShareTable } from "@/ui/public-share/PublicMonthlyShareTable";
+
+import styles from "./PublicMonthlyShareTable.module.css";
+
+type PublicMonthlySharePageProps = Readonly<{
+  token: string;
+  initialShare: PublicMonthlyCategoryShare;
+  initialJsonWindow: PublicMonthlyShareWindow;
+  locale: SupportedLocale;
+  siteHref: string;
+}>;
+
+const parseMonthDate = (month: string): Date =>
+  new Date(`${month}-01T00:00:00.000Z`);
+
+const formatMonth = (
+  month: string,
+  formatter: Intl.DateTimeFormat,
+): string =>
+  formatter.format(parseMonthDate(month));
+
+const buildRangeText = (
+  monthFrom: string | null,
+  monthTo: string | null,
+  formatter: Intl.DateTimeFormat,
+): string | null => {
+  if (monthFrom === null || monthTo === null) {
+    return null;
+  }
+  if (monthFrom === monthTo) {
+    return formatMonth(monthFrom, formatter);
+  }
+  return `${formatMonth(monthFrom, formatter)} - ${formatMonth(monthTo, formatter)}`;
+};
+
+const toErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+export const PublicMonthlySharePage = (props: PublicMonthlySharePageProps): ReactElement => {
+  const {
+    token,
+    initialShare,
+    initialJsonWindow,
+    locale,
+    siteHref,
+  } = props;
+  const { t } = useTranslation();
+  const [share, setShare] = useState<PublicMonthlyCategoryShare>(initialShare);
+  const [isLoadingEarlier, setIsLoadingEarlier] = useState<boolean>(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const isLoadingEarlierRef = useRef<boolean>(false);
+
+  const model = useMemo(
+    (): ReturnType<typeof buildPublicMonthlyShareTableModel> =>
+      buildPublicMonthlyShareTableModel(share),
+    [share],
+  );
+  const monthFormatter = useMemo(
+    (): Intl.DateTimeFormat =>
+      new Intl.DateTimeFormat(locale, {
+        month: "short",
+        year: "numeric",
+        timeZone: "UTC",
+      }),
+    [locale],
+  );
+  const visibleLabel = resolvePublicMonthlyShareLabel(share.label, t("publicShare.anonymousUser"));
+  const availableRangeText = buildRangeText(share.availableMonthFrom, share.availableMonthTo, monthFormatter);
+  const jsonWindow = share.loadedMonthFrom === null || share.loadedMonthTo === null
+    ? initialJsonWindow
+    : {
+      monthFrom: share.loadedMonthFrom,
+      monthTo: share.loadedMonthTo,
+    };
+  const jsonHref = buildPublicMonthlyShareJsonHref(token, jsonWindow);
+  const earlierWindow = buildEarlierPublicMonthlyShareWindow(
+    share.loadedMonthFrom,
+    share.availableMonthFrom,
+    PUBLIC_MONTHLY_SHARE_BACKFILL_WINDOW_MONTHS,
+  );
+  const canLoadEarlier = earlierWindow !== null;
+
+  const handleLoadEarlier = useCallback(async (): Promise<void> => {
+    if (isLoadingEarlierRef.current) {
+      return;
+    }
+
+    const window = buildEarlierPublicMonthlyShareWindow(
+      share.loadedMonthFrom,
+      share.availableMonthFrom,
+      PUBLIC_MONTHLY_SHARE_BACKFILL_WINDOW_MONTHS,
+    );
+    if (window === null) {
+      return;
+    }
+
+    isLoadingEarlierRef.current = true;
+    setIsLoadingEarlier(true);
+    setLoadError(null);
+
+    try {
+      const fetchedShare = await fetchPublicMonthlyShareWindow(token, window);
+      setShare((currentShare) => mergePublicMonthlyShareWindows(currentShare, fetchedShare));
+    } catch (error) {
+      setLoadError(toErrorMessage(error));
+    } finally {
+      isLoadingEarlierRef.current = false;
+      setIsLoadingEarlier(false);
+    }
+  }, [share.availableMonthFrom, share.loadedMonthFrom, token]);
+
+  return (
+    <main className={styles.page}>
+      <header className={styles.header}>
+        <div className={styles.headingGroup}>
+          <p className={styles.eyebrow}>{t("publicShare.title")}</p>
+          <h1 className={styles.title}>{visibleLabel}</h1>
+          <p className={styles.meta}>
+            {[share.currency, availableRangeText].filter((value): value is string => value !== null).join(" - ")}
+          </p>
+        </div>
+        <div className={styles.actions}>
+          <a className={styles.jsonLink} href={jsonHref} download>
+            {t("publicShare.downloadJson")}
+          </a>
+        </div>
+      </header>
+
+      <section className={styles.tableArea} aria-label={t("publicShare.title")}>
+        <div className={styles.tableStatus}>
+          {model.hasSelectedCategories && canLoadEarlier && (
+            <button
+              className={styles.loadEarlierButton}
+              type="button"
+              disabled={isLoadingEarlier}
+              onClick={(): void => {
+                void handleLoadEarlier();
+              }}
+            >
+              {isLoadingEarlier ? t("common.loading") : t("publicShare.loadEarlier")}
+            </button>
+          )}
+          {loadError !== null && <span className={styles.error}>{loadError}</span>}
+        </div>
+        {!model.hasSelectedCategories ? (
+          <p className={styles.empty}>{t("publicShare.emptyNoSelectedCategories")}</p>
+        ) : (
+          <PublicMonthlyShareTable
+            model={model}
+            currency={share.currency}
+            locale={locale}
+            canLoadEarlier={canLoadEarlier}
+            isLoadingEarlier={isLoadingEarlier}
+            onLoadEarlier={handleLoadEarlier}
+          />
+        )}
+      </section>
+
+      <footer className={styles.footer}>
+        <a href={siteHref}>{t("publicShare.publishedWithAttribution")}</a>
+      </footer>
+    </main>
+  );
+};

--- a/apps/web/src/ui/public-share/PublicMonthlyShareTable.module.css
+++ b/apps/web/src/ui/public-share/PublicMonthlyShareTable.module.css
@@ -1,0 +1,267 @@
+.page {
+  block-size: 100dvh;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding-block: 20px 16px;
+  padding-inline: 16px;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.headingGroup {
+  min-inline-size: 0;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.title {
+  margin: 0;
+  font-size: 24px;
+  line-height: 30px;
+  font-weight: 650;
+  letter-spacing: 0;
+  overflow-wrap: anywhere;
+}
+
+.meta {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.jsonLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-block-size: 32px;
+  padding-block: 6px;
+  padding-inline: 10px;
+  border: 1px solid var(--panel-border);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 12px;
+}
+
+.jsonLink:hover {
+  text-decoration: none;
+  background: var(--accent);
+  color: var(--bg);
+}
+
+.tableArea {
+  min-block-size: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.tableStatus {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-block-size: 24px;
+  padding-block: 6px 0;
+  padding-inline: 16px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.loadEarlierButton {
+  padding-block: 4px;
+  padding-inline: 10px;
+  border: 1px solid var(--panel-border);
+  border-radius: 0;
+  background: var(--bg);
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.loadEarlierButton:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--text);
+}
+
+.loadEarlierButton:disabled {
+  opacity: 0.6;
+}
+
+.error {
+  color: #b00020;
+}
+
+.empty {
+  padding-block: 24px;
+  padding-inline: 16px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.scroll {
+  overflow: auto;
+  min-block-size: 0;
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+}
+
+.scroll thead {
+  cursor: grab;
+}
+
+.dragging thead,
+.dragging {
+  cursor: grabbing;
+}
+
+.dragging {
+  user-select: none;
+}
+
+.table {
+  border-collapse: collapse;
+  inline-size: max-content;
+  min-inline-size: 100%;
+  font-size: 13px;
+  line-height: 20px;
+  white-space: nowrap;
+}
+
+.headCell {
+  padding-block: 7px;
+  padding-inline: 10px;
+  border-bottom: 1px solid var(--panel-border);
+  font-weight: 650;
+  text-align: end;
+  background: var(--panel);
+}
+
+.categoryHead {
+  min-inline-size: 180px;
+  text-align: start;
+}
+
+.stickyCol {
+  position: sticky;
+  inset-inline-start: 0;
+  z-index: 2;
+  background: var(--panel);
+}
+
+.stickyCol::after {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: -1px;
+  inline-size: 1px;
+  background: var(--panel-border);
+}
+
+.categoryCell {
+  padding-block: 6px;
+  padding-inline: 10px;
+  border-bottom: 1px solid #e5e5e5;
+  color: var(--text);
+  font-weight: 500;
+  text-align: start;
+}
+
+.cell {
+  min-inline-size: 110px;
+  padding-block: 6px;
+  padding-inline: 10px;
+  border-bottom: 1px solid #e5e5e5;
+  text-align: end;
+  font-variant-numeric: tabular-nums;
+}
+
+.yearTotal {
+  background: var(--text);
+  color: var(--bg);
+  border-inline-start: 1px solid var(--panel-border);
+  font-weight: 650;
+}
+
+.categoryOnlyRow .categoryCell {
+  color: var(--muted);
+}
+
+.maskedCell {
+  background:
+    repeating-linear-gradient(
+      135deg,
+      transparent 0,
+      transparent 5px,
+      #d0d0d0 5px,
+      #d0d0d0 6px
+    ),
+    var(--panel);
+  color: transparent;
+}
+
+.maskedText {
+  display: inline-block;
+  inline-size: 72px;
+  block-size: 10px;
+  background: var(--muted);
+  opacity: 0.35;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding-block: 10px;
+  padding-inline: 16px;
+  border-top: 1px solid var(--panel-border);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.footer a {
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .actions {
+    justify-content: flex-start;
+  }
+
+  .title {
+    font-size: 20px;
+    line-height: 26px;
+  }
+
+  .categoryHead {
+    min-inline-size: 150px;
+  }
+
+  .cell {
+    min-inline-size: 96px;
+  }
+}

--- a/apps/web/src/ui/public-share/PublicMonthlyShareTable.tsx
+++ b/apps/web/src/ui/public-share/PublicMonthlyShareTable.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, type ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { SupportedLocale } from "@/lib/locale";
+import type { PublicMonthlyShareTableModel } from "@/ui/public-share/publicMonthlyShareModel";
+
+import styles from "./PublicMonthlyShareTable.module.css";
+
+const SCROLL_LOAD_THRESHOLD_PX = 200;
+
+type PublicMonthlyShareTableProps = Readonly<{
+  model: PublicMonthlyShareTableModel;
+  currency: string;
+  locale: SupportedLocale;
+  canLoadEarlier: boolean;
+  isLoadingEarlier: boolean;
+  onLoadEarlier: () => Promise<void>;
+}>;
+
+const parseMonthDate = (month: string): Date =>
+  new Date(`${month}-01T00:00:00.000Z`);
+
+const formatMonthHeader = (
+  month: string,
+  formatter: Intl.DateTimeFormat,
+): string =>
+  formatter.format(parseMonthDate(month));
+
+export const PublicMonthlyShareTable = (props: PublicMonthlyShareTableProps): ReactElement => {
+  const {
+    model,
+    currency,
+    locale,
+    canLoadEarlier,
+    isLoadingEarlier,
+    onLoadEarlier,
+  } = props;
+  const { t } = useTranslation();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const previousScrollWidthRef = useRef<number>(0);
+  const isPrependingRef = useRef<boolean>(false);
+  const isRtl = typeof document !== "undefined" && document.documentElement.dir === "rtl";
+
+  const amountFormatter = useMemo(
+    (): Intl.NumberFormat =>
+      new Intl.NumberFormat(locale, {
+        style: "currency",
+        currency,
+      }),
+    [currency, locale],
+  );
+  const monthFormatter = useMemo(
+    (): Intl.DateTimeFormat =>
+      new Intl.DateTimeFormat(locale, {
+        month: "short",
+        year: "numeric",
+        timeZone: "UTC",
+      }),
+    [locale],
+  );
+
+  const markPrependPending = useCallback((): void => {
+    const scrollElement = scrollRef.current;
+    if (scrollElement === null || isPrependingRef.current) {
+      return;
+    }
+    previousScrollWidthRef.current = scrollElement.scrollWidth;
+    isPrependingRef.current = true;
+  }, []);
+
+  useLayoutEffect((): void => {
+    if (!isPrependingRef.current) {
+      return;
+    }
+
+    const scrollElement = scrollRef.current;
+    if (scrollElement === null) {
+      return;
+    }
+
+    const scrollDelta = scrollElement.scrollWidth - previousScrollWidthRef.current;
+    if (scrollDelta <= 0) {
+      if (!isLoadingEarlier) {
+        isPrependingRef.current = false;
+      }
+      return;
+    }
+
+    isPrependingRef.current = false;
+    scrollElement.scrollLeft += isRtl ? -scrollDelta : scrollDelta;
+  });
+
+  useEffect((): (() => void) | void => {
+    const scrollElement = scrollRef.current;
+    if (scrollElement === null) {
+      return undefined;
+    }
+
+    let rafId = 0;
+    const handleScroll = (): void => {
+      if (rafId !== 0) {
+        return;
+      }
+
+      rafId = requestAnimationFrame((): void => {
+        rafId = 0;
+        const scrollStart = isRtl ? -scrollElement.scrollLeft : scrollElement.scrollLeft;
+        if (scrollStart >= SCROLL_LOAD_THRESHOLD_PX || !canLoadEarlier || isLoadingEarlier) {
+          return;
+        }
+
+        markPrependPending();
+        void onLoadEarlier();
+      });
+    };
+
+    scrollElement.addEventListener("scroll", handleScroll, { passive: true });
+    return (): void => {
+      scrollElement.removeEventListener("scroll", handleScroll);
+      if (rafId !== 0) {
+        cancelAnimationFrame(rafId);
+      }
+    };
+  }, [canLoadEarlier, isLoadingEarlier, isRtl, markPrependPending, onLoadEarlier]);
+
+  useEffect((): (() => void) | void => {
+    const scrollElement = scrollRef.current;
+    if (scrollElement === null) {
+      return undefined;
+    }
+
+    const tableHead = scrollElement.querySelector<HTMLElement>("thead");
+    if (tableHead === null) {
+      return undefined;
+    }
+
+    let startX = 0;
+    let startScrollLeft = 0;
+
+    const onMouseMove = (event: MouseEvent): void => {
+      scrollElement.scrollLeft = startScrollLeft - (event.pageX - startX);
+    };
+
+    const onMouseUp = (): void => {
+      scrollElement.classList.remove(styles.dragging);
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
+
+    const onMouseDown = (event: MouseEvent): void => {
+      event.preventDefault();
+      startX = event.pageX;
+      startScrollLeft = scrollElement.scrollLeft;
+      scrollElement.classList.add(styles.dragging);
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    };
+
+    tableHead.addEventListener("mousedown", onMouseDown);
+    return (): void => {
+      tableHead.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
+  }, []);
+
+  return (
+    <div className={styles.scroll} ref={scrollRef}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th className={`${styles.headCell} ${styles.stickyCol} ${styles.categoryHead}`} scope="col">
+              {t("publicShare.tableCategory")}
+            </th>
+            {model.columns.map((column): ReactElement => {
+              if (column.kind === "month") {
+                return (
+                  <th key={`month-${column.month}`} className={styles.headCell} scope="col" data-month={column.month}>
+                    {formatMonthHeader(column.month, monthFormatter)}
+                  </th>
+                );
+              }
+              return (
+                <th key={`year-${column.year}`} className={`${styles.headCell} ${styles.yearTotal}`} scope="col">
+                  {column.year} {t("publicShare.tableTotal")}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {model.rows.map((row): ReactElement => (
+            <tr
+              key={`${row.accessLevel}-${row.category}`}
+              className={row.accessLevel === "category_only" ? styles.categoryOnlyRow : undefined}
+            >
+              <th className={`${styles.categoryCell} ${styles.stickyCol}`} scope="row">
+                {row.category}
+              </th>
+              {model.columns.map((column): ReactElement => {
+                const key = column.kind === "month"
+                  ? `${row.category}-${column.month}`
+                  : `${row.category}-${column.year}`;
+
+                if (row.accessLevel === "category_only") {
+                  return (
+                    <td
+                      key={key}
+                      className={`${styles.cell} ${column.kind === "year-total" ? styles.yearTotal : ""} ${styles.maskedCell}`}
+                      aria-label={t("publicShare.categoryOnlyMaskedValue")}
+                    >
+                      <span className={styles.maskedText}>{t("publicShare.categoryOnlyMaskedValue")}</span>
+                    </td>
+                  );
+                }
+
+                if (column.kind === "month") {
+                  return (
+                    <td key={key} className={styles.cell} data-month={column.month}>
+                      {amountFormatter.format(row.monthAmounts.get(column.month) ?? 0)}
+                    </td>
+                  );
+                }
+
+                return (
+                  <td key={key} className={`${styles.cell} ${styles.yearTotal}`}>
+                    {amountFormatter.format(row.yearTotals.get(column.year) ?? 0)}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/apps/web/src/ui/public-share/publicMonthlyShareClient.ts
+++ b/apps/web/src/ui/public-share/publicMonthlyShareClient.ts
@@ -1,0 +1,30 @@
+import type { PublicMonthlyCategoryShare } from "@/server/community/publicMonthlyCategoryShareTypes";
+import type { PublicMonthlyShareWindow } from "@/ui/public-share/publicMonthlyShareModel";
+
+export const buildPublicMonthlyShareJsonHref = (
+  token: string,
+  window: PublicMonthlyShareWindow,
+): string => {
+  const params = new URLSearchParams({
+    monthFrom: window.monthFrom,
+    monthTo: window.monthTo,
+  });
+  return `/api/share/monthly/${encodeURIComponent(token)}?${params.toString()}`;
+};
+
+export const fetchPublicMonthlyShareWindow = async (
+  token: string,
+  window: PublicMonthlyShareWindow,
+): Promise<PublicMonthlyCategoryShare> => {
+  const url = buildPublicMonthlyShareJsonHref(token, window);
+  const response = await fetch(url, {
+    method: "GET",
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Public monthly share fetch failed: status=${response.status} body=${await response.text()} monthFrom=${window.monthFrom} monthTo=${window.monthTo} tokenLength=${token.length}`,
+    );
+  }
+  return response.json() as Promise<PublicMonthlyCategoryShare>;
+};

--- a/apps/web/src/ui/public-share/publicMonthlyShareModel.test.ts
+++ b/apps/web/src/ui/public-share/publicMonthlyShareModel.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { PublicMonthlyCategoryShare } from "@/server/community/publicMonthlyCategoryShareTypes";
+import {
+  buildPublicMonthlyShareTableModel,
+  mergePublicMonthlyShareWindows,
+} from "@/ui/public-share/publicMonthlyShareModel";
+
+const createShare = (
+  loadedMonthFrom: string,
+  loadedMonthTo: string,
+  cells: PublicMonthlyCategoryShare["cells"],
+  yearTotals: PublicMonthlyCategoryShare["yearTotals"],
+): PublicMonthlyCategoryShare => ({
+  label: "Shared spend",
+  currency: "USD",
+  availableMonthFrom: "2024-12",
+  availableMonthTo: "2025-03",
+  loadedMonthFrom,
+  loadedMonthTo,
+  categories: [
+    { category: "Groceries", accessLevel: "monthly_values" },
+  ],
+  cells,
+  yearTotals,
+});
+
+test("mergePublicMonthlyShareWindows recomputes year totals from loaded public cells", (): void => {
+  const currentShare = createShare(
+    "2025-03",
+    "2025-03",
+    [
+      { month: "2025-03", category: "Groceries", amount: 30 },
+    ],
+    [
+      { year: "2025", category: "Groceries", amount: 999 },
+    ],
+  );
+  const fetchedShare = createShare(
+    "2024-12",
+    "2025-02",
+    [
+      { month: "2024-12", category: "Groceries", amount: 5 },
+      { month: "2025-01", category: "Groceries", amount: 10 },
+    ],
+    [
+      { year: "2024", category: "Groceries", amount: 999 },
+      { year: "2025", category: "Groceries", amount: 999 },
+    ],
+  );
+
+  const merged = mergePublicMonthlyShareWindows(currentShare, fetchedShare);
+  const model = buildPublicMonthlyShareTableModel(merged);
+  const groceryRow = model.rows.find((row) => row.category === "Groceries");
+
+  assert.deepEqual(merged.yearTotals, [
+    { year: "2024", category: "Groceries", amount: 5 },
+    { year: "2025", category: "Groceries", amount: 40 },
+  ]);
+  assert.ok(groceryRow !== undefined);
+  assert.equal(groceryRow.yearTotals.get("2024"), 5);
+  assert.equal(groceryRow.yearTotals.get("2025"), 40);
+});

--- a/apps/web/src/ui/public-share/publicMonthlyShareModel.ts
+++ b/apps/web/src/ui/public-share/publicMonthlyShareModel.ts
@@ -1,0 +1,374 @@
+import { generateMonthRange, getCurrentMonth, getYear, offsetMonth } from "@/lib/monthUtils";
+import type {
+  PublicMonthlyCategoryShare,
+  PublicMonthlyShareAccessLevel,
+  PublicMonthlyShareCell,
+  PublicMonthlyShareYearTotal,
+} from "@/server/community/publicMonthlyCategoryShareTypes";
+
+export const PUBLIC_MONTHLY_SHARE_INITIAL_WINDOW_MONTHS = 12;
+export const PUBLIC_MONTHLY_SHARE_BACKFILL_WINDOW_MONTHS = 12;
+
+export type PublicMonthlyShareWindow = Readonly<{
+  monthFrom: string;
+  monthTo: string;
+}>;
+
+export type PublicMonthlyShareColumn = Readonly<
+  | { kind: "month"; month: string }
+  | { kind: "year-total"; year: string }
+>;
+
+export type PublicMonthlyShareTableRow = Readonly<{
+  category: string;
+  accessLevel: PublicMonthlyShareAccessLevel;
+  monthAmounts: ReadonlyMap<string, number>;
+  yearTotals: ReadonlyMap<string, number>;
+  visibleYearTotal: number;
+}>;
+
+export type PublicMonthlyShareTableModel = Readonly<{
+  months: ReadonlyArray<string>;
+  columns: ReadonlyArray<PublicMonthlyShareColumn>;
+  rows: ReadonlyArray<PublicMonthlyShareTableRow>;
+  hasSelectedCategories: boolean;
+}>;
+
+const cellKey = (cell: PublicMonthlyShareCell): string =>
+  `${cell.month}\u0000${cell.category}`;
+
+const compareCells = (
+  left: PublicMonthlyShareCell,
+  right: PublicMonthlyShareCell,
+): number => {
+  const monthCompare = left.month.localeCompare(right.month);
+  if (monthCompare !== 0) {
+    return monthCompare;
+  }
+  return left.category.localeCompare(right.category);
+};
+
+const compareYearTotals = (
+  left: PublicMonthlyShareYearTotal,
+  right: PublicMonthlyShareYearTotal,
+): number => {
+  const yearCompare = left.year.localeCompare(right.year);
+  if (yearCompare !== 0) {
+    return yearCompare;
+  }
+  return left.category.localeCompare(right.category);
+};
+
+const minMonthOrNull = (left: string | null, right: string | null): string | null => {
+  if (left === null) {
+    return right;
+  }
+  if (right === null) {
+    return left;
+  }
+  return left < right ? left : right;
+};
+
+const maxMonthOrNull = (left: string | null, right: string | null): string | null => {
+  if (left === null) {
+    return right;
+  }
+  if (right === null) {
+    return left;
+  }
+  return left > right ? left : right;
+};
+
+const maxMonth = (left: string, right: string): string =>
+  left > right ? left : right;
+
+const minMonth = (left: string, right: string): string =>
+  left < right ? left : right;
+
+const clampLoadedMonthFrom = (
+  loadedMonthFrom: string | null,
+  availableMonthFrom: string | null,
+  availableMonthTo: string | null,
+): string | null => {
+  if (loadedMonthFrom === null || availableMonthFrom === null || availableMonthTo === null) {
+    return null;
+  }
+  const clamped = maxMonth(loadedMonthFrom, availableMonthFrom);
+  return clamped > availableMonthTo ? null : clamped;
+};
+
+const clampLoadedMonthTo = (
+  loadedMonthTo: string | null,
+  availableMonthFrom: string | null,
+  availableMonthTo: string | null,
+): string | null => {
+  if (loadedMonthTo === null || availableMonthFrom === null || availableMonthTo === null) {
+    return null;
+  }
+  const clamped = minMonth(loadedMonthTo, availableMonthTo);
+  return clamped < availableMonthFrom ? null : clamped;
+};
+
+const mergeCells = (
+  currentCells: ReadonlyArray<PublicMonthlyShareCell>,
+  fetchedCells: ReadonlyArray<PublicMonthlyShareCell>,
+): ReadonlyArray<PublicMonthlyShareCell> => {
+  const merged = new Map<string, PublicMonthlyShareCell>();
+  for (const cell of currentCells) {
+    merged.set(cellKey(cell), cell);
+  }
+  for (const cell of fetchedCells) {
+    merged.set(cellKey(cell), cell);
+  }
+  return Array.from(merged.values()).sort(compareCells);
+};
+
+const buildMonthlyValueCategorySet = (
+  share: PublicMonthlyCategoryShare,
+): ReadonlySet<string> => {
+  const monthlyValueCategories = new Set<string>();
+  for (const category of share.categories) {
+    if (category.accessLevel === "monthly_values") {
+      monthlyValueCategories.add(category.category);
+    }
+  }
+  return monthlyValueCategories;
+};
+
+const filterCellsForShare = (
+  cells: ReadonlyArray<PublicMonthlyShareCell>,
+  share: PublicMonthlyCategoryShare,
+): ReadonlyArray<PublicMonthlyShareCell> => {
+  const loadedMonthFrom = share.loadedMonthFrom;
+  const loadedMonthTo = share.loadedMonthTo;
+  if (loadedMonthFrom === null || loadedMonthTo === null) {
+    return [];
+  }
+
+  const monthlyValueCategories = buildMonthlyValueCategorySet(share);
+  return cells.filter((cell: PublicMonthlyShareCell): boolean =>
+    monthlyValueCategories.has(cell.category)
+    && cell.month >= loadedMonthFrom
+    && cell.month <= loadedMonthTo);
+};
+
+const buildMonthAmountsByCategory = (
+  cells: ReadonlyArray<PublicMonthlyShareCell>,
+): ReadonlyMap<string, ReadonlyMap<string, number>> => {
+  const byCategory = new Map<string, Map<string, number>>();
+
+  for (const cell of cells) {
+    const categoryAmounts = byCategory.get(cell.category) ?? new Map<string, number>();
+    categoryAmounts.set(cell.month, cell.amount);
+    byCategory.set(cell.category, categoryAmounts);
+  }
+
+  return byCategory;
+};
+
+const buildYearTotalsByCategory = (
+  yearTotals: ReadonlyArray<PublicMonthlyShareYearTotal>,
+): ReadonlyMap<string, ReadonlyMap<string, number>> => {
+  const byCategory = new Map<string, Map<string, number>>();
+
+  for (const total of yearTotals) {
+    const categoryTotals = byCategory.get(total.category) ?? new Map<string, number>();
+    categoryTotals.set(total.year, total.amount);
+    byCategory.set(total.category, categoryTotals);
+  }
+
+  return byCategory;
+};
+
+const yearTotalKey = (category: string, year: string): string =>
+  `${year}\u0000${category}`;
+
+const buildYearTotalsFromCells = (
+  cells: ReadonlyArray<PublicMonthlyShareCell>,
+): ReadonlyArray<PublicMonthlyShareYearTotal> => {
+  const totals = new Map<string, PublicMonthlyShareYearTotal>();
+
+  for (const cell of cells) {
+    const year = getYear(cell.month);
+    const key = yearTotalKey(cell.category, year);
+    const currentAmount = totals.get(key)?.amount ?? 0;
+    totals.set(key, {
+      year,
+      category: cell.category,
+      amount: currentAmount + cell.amount,
+    });
+  }
+
+  return Array.from(totals.values()).sort(compareYearTotals);
+};
+
+const buildVisibleYears = (months: ReadonlyArray<string>): ReadonlyArray<string> => {
+  const years: Array<string> = [];
+  for (const month of months) {
+    const year = getYear(month);
+    if (!years.includes(year)) {
+      years.push(year);
+    }
+  }
+  return years;
+};
+
+const sumVisibleYearTotals = (
+  totals: ReadonlyMap<string, number>,
+  visibleYears: ReadonlyArray<string>,
+): number => {
+  let result = 0;
+  for (const year of visibleYears) {
+    result += totals.get(year) ?? 0;
+  }
+  return result;
+};
+
+export const buildPublicMonthlyShareProbeWindow = (): PublicMonthlyShareWindow => {
+  const previousMonth = offsetMonth(getCurrentMonth(), -1);
+  return {
+    monthFrom: previousMonth,
+    monthTo: previousMonth,
+  };
+};
+
+export const buildLatestPublicMonthlyShareWindow = (
+  availableMonthFrom: string | null,
+  availableMonthTo: string | null,
+  windowMonths: number,
+): PublicMonthlyShareWindow | null => {
+  if (!Number.isInteger(windowMonths) || windowMonths < 1) {
+    throw new Error(`Invalid public monthly share window size: ${windowMonths}`);
+  }
+  if (availableMonthFrom === null || availableMonthTo === null) {
+    return null;
+  }
+
+  const candidateFrom = offsetMonth(availableMonthTo, -(windowMonths - 1));
+  return {
+    monthFrom: maxMonth(availableMonthFrom, candidateFrom),
+    monthTo: availableMonthTo,
+  };
+};
+
+export const buildEarlierPublicMonthlyShareWindow = (
+  loadedMonthFrom: string | null,
+  availableMonthFrom: string | null,
+  windowMonths: number,
+): PublicMonthlyShareWindow | null => {
+  if (!Number.isInteger(windowMonths) || windowMonths < 1) {
+    throw new Error(`Invalid public monthly share backfill window size: ${windowMonths}`);
+  }
+  if (loadedMonthFrom === null || availableMonthFrom === null || loadedMonthFrom <= availableMonthFrom) {
+    return null;
+  }
+
+  return {
+    monthFrom: maxMonth(availableMonthFrom, offsetMonth(loadedMonthFrom, -windowMonths)),
+    monthTo: offsetMonth(loadedMonthFrom, -1),
+  };
+};
+
+export const buildPublicMonthlyShareColumnSequence = (
+  months: ReadonlyArray<string>,
+): ReadonlyArray<PublicMonthlyShareColumn> => {
+  const columns: Array<PublicMonthlyShareColumn> = [];
+
+  for (let index = 0; index < months.length; index++) {
+    const month = months[index];
+    const nextMonth = months[index + 1];
+    columns.push({ kind: "month", month });
+    if (nextMonth === undefined || getYear(nextMonth) !== getYear(month)) {
+      columns.push({ kind: "year-total", year: getYear(month) });
+    }
+  }
+
+  return columns;
+};
+
+export const mergePublicMonthlyShareWindows = (
+  currentShare: PublicMonthlyCategoryShare,
+  fetchedShare: PublicMonthlyCategoryShare,
+): PublicMonthlyCategoryShare => {
+  const loadedMonthFrom = clampLoadedMonthFrom(
+    minMonthOrNull(currentShare.loadedMonthFrom, fetchedShare.loadedMonthFrom),
+    fetchedShare.availableMonthFrom,
+    fetchedShare.availableMonthTo,
+  );
+  const loadedMonthTo = clampLoadedMonthTo(
+    maxMonthOrNull(currentShare.loadedMonthTo, fetchedShare.loadedMonthTo),
+    fetchedShare.availableMonthFrom,
+    fetchedShare.availableMonthTo,
+  );
+  const mergedShare: PublicMonthlyCategoryShare = {
+    label: fetchedShare.label,
+    currency: fetchedShare.currency,
+    availableMonthFrom: fetchedShare.availableMonthFrom,
+    availableMonthTo: fetchedShare.availableMonthTo,
+    loadedMonthFrom: loadedMonthFrom !== null && loadedMonthTo !== null && loadedMonthFrom <= loadedMonthTo
+      ? loadedMonthFrom
+      : null,
+    loadedMonthTo: loadedMonthFrom !== null && loadedMonthTo !== null && loadedMonthFrom <= loadedMonthTo
+      ? loadedMonthTo
+      : null,
+    categories: fetchedShare.categories,
+    cells: [],
+    yearTotals: [],
+  };
+  const mergedCells = filterCellsForShare(mergeCells(currentShare.cells, fetchedShare.cells), mergedShare);
+
+  return {
+    ...mergedShare,
+    cells: mergedCells,
+    yearTotals: buildYearTotalsFromCells(mergedCells),
+  };
+};
+
+export const buildPublicMonthlyShareTableModel = (
+  share: PublicMonthlyCategoryShare,
+): PublicMonthlyShareTableModel => {
+  const months = share.loadedMonthFrom === null || share.loadedMonthTo === null
+    ? []
+    : generateMonthRange(share.loadedMonthFrom, share.loadedMonthTo);
+  const columns = buildPublicMonthlyShareColumnSequence(months);
+  const visibleYears = buildVisibleYears(months);
+  const monthAmountsByCategory = buildMonthAmountsByCategory(share.cells);
+  const yearTotalsByCategory = buildYearTotalsByCategory(share.yearTotals);
+
+  const monthlyValueRows: Array<PublicMonthlyShareTableRow> = [];
+  const categoryOnlyRows: Array<PublicMonthlyShareTableRow> = [];
+
+  for (const category of share.categories) {
+    const yearTotals = yearTotalsByCategory.get(category.category) ?? new Map<string, number>();
+    const row: PublicMonthlyShareTableRow = {
+      category: category.category,
+      accessLevel: category.accessLevel,
+      monthAmounts: monthAmountsByCategory.get(category.category) ?? new Map<string, number>(),
+      yearTotals,
+      visibleYearTotal: sumVisibleYearTotals(yearTotals, visibleYears),
+    };
+
+    if (category.accessLevel === "monthly_values") {
+      monthlyValueRows.push(row);
+    } else {
+      categoryOnlyRows.push(row);
+    }
+  }
+
+  return {
+    months,
+    columns,
+    rows: [
+      ...monthlyValueRows.sort((left, right) =>
+        right.visibleYearTotal - left.visibleYearTotal || left.category.localeCompare(right.category)),
+      ...categoryOnlyRows,
+    ],
+    hasSelectedCategories: share.categories.length > 0,
+  };
+};
+
+export const resolvePublicMonthlyShareLabel = (
+  label: string,
+  anonymousLabel: string,
+): string =>
+  label.trim() === "" ? anonymousLabel : label;

--- a/db/migrations/0048_community_public_monthly_share_metadata.sql
+++ b/db/migrations/0048_community_public_monthly_share_metadata.sql
@@ -1,0 +1,33 @@
+-- Narrow public metadata reader for monthly category share pages.
+
+CREATE FUNCTION community.read_public_monthly_category_share_metadata(
+  p_public_token TEXT
+)
+RETURNS TABLE(
+  indexing_enabled BOOLEAN
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public, community
+AS $$
+BEGIN
+  IF p_public_token IS NULL OR btrim(p_public_token) = '' THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT share.indexing_enabled
+  FROM community.monthly_category_share_keys AS key
+  INNER JOIN community.monthly_category_shares AS share
+    ON share.share_id = key.share_id
+  WHERE key.public_token = p_public_token
+    AND key.revoked_at IS NULL
+    AND share.enabled = true
+    AND share.blocked_at IS NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION community.read_public_monthly_category_share_metadata(TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION community.read_public_monthly_category_share_metadata(TEXT) FROM api_sql_executor;
+GRANT EXECUTE ON FUNCTION community.read_public_monthly_category_share_metadata(TEXT) TO app;

--- a/db/migrations/0049_community_public_monthly_share_loaded_year_totals.sql
+++ b/db/migrations/0049_community_public_monthly_share_loaded_year_totals.sql
@@ -1,0 +1,240 @@
+-- Keep public year totals bounded to the loaded month window.
+
+CREATE OR REPLACE FUNCTION community.read_public_monthly_category_share(
+  p_public_token TEXT,
+  p_month_from DATE,
+  p_month_to DATE
+)
+RETURNS TABLE(
+  label TEXT,
+  currency TEXT,
+  available_month_from DATE,
+  available_month_to DATE,
+  loaded_month_from DATE,
+  loaded_month_to DATE,
+  categories JSONB,
+  cells JSONB,
+  year_totals JSONB
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public, community
+AS $$
+DECLARE
+  v_share_id TEXT;
+  v_workspace_id TEXT;
+  v_label TEXT;
+  v_currency TEXT;
+  v_timezone TEXT;
+  v_config_month_from DATE;
+  v_config_month_to DATE;
+  v_request_month_from DATE;
+  v_request_month_to DATE;
+  v_capped_month_to DATE;
+  v_local_current_date DATE;
+  v_latest_eligible_month DATE;
+  v_available_month_from DATE;
+  v_available_month_to DATE;
+  v_loaded_month_from DATE;
+  v_loaded_month_to DATE;
+BEGIN
+  IF p_public_token IS NULL OR btrim(p_public_token) = '' THEN
+    RETURN;
+  END IF;
+
+  IF p_month_from IS NULL OR p_month_to IS NULL THEN
+    RAISE EXCEPTION 'read_public_monthly_category_share: p_month_from and p_month_to are required';
+  END IF;
+
+  v_request_month_from := date_trunc('month', p_month_from)::date;
+  v_request_month_to := date_trunc('month', p_month_to)::date;
+
+  IF v_request_month_from > v_request_month_to THEN
+    RAISE EXCEPTION 'read_public_monthly_category_share: p_month_from must be <= p_month_to';
+  END IF;
+
+  v_capped_month_to := LEAST(
+    v_request_month_to,
+    (v_request_month_from + (INTERVAL '1 month' * 23))::date
+  );
+
+  SELECT
+    share.share_id,
+    share.workspace_id,
+    share.display_label,
+    settings.reporting_currency,
+    settings.timezone,
+    share.month_from,
+    share.month_to
+  INTO
+    v_share_id,
+    v_workspace_id,
+    v_label,
+    v_currency,
+    v_timezone,
+    v_config_month_from,
+    v_config_month_to
+  FROM community.monthly_category_share_keys AS key
+  INNER JOIN community.monthly_category_shares AS share
+    ON share.share_id = key.share_id
+  INNER JOIN public.workspace_settings AS settings
+    ON settings.workspace_id = share.workspace_id
+  WHERE key.public_token = p_public_token
+    AND key.revoked_at IS NULL
+    AND share.enabled = true
+    AND share.blocked_at IS NULL;
+
+  IF v_share_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  v_local_current_date := (CURRENT_TIMESTAMP AT TIME ZONE v_timezone)::date;
+  v_latest_eligible_month := (
+    date_trunc('month', v_local_current_date)::date
+    - CASE
+        WHEN EXTRACT(DAY FROM v_local_current_date)::integer >= 6 THEN INTERVAL '1 month'
+        ELSE INTERVAL '2 months'
+      END
+  )::date;
+
+  v_available_month_from := v_config_month_from;
+  v_available_month_to := LEAST(
+    COALESCE(v_config_month_to, v_latest_eligible_month),
+    v_latest_eligible_month
+  );
+
+  IF v_available_month_to < v_available_month_from THEN
+    v_available_month_from := NULL;
+    v_available_month_to := NULL;
+    v_loaded_month_from := NULL;
+    v_loaded_month_to := NULL;
+  ELSE
+    v_loaded_month_from := GREATEST(v_request_month_from, v_available_month_from);
+    v_loaded_month_to := LEAST(v_capped_month_to, v_available_month_to);
+
+    IF v_loaded_month_to < v_loaded_month_from THEN
+      v_loaded_month_from := NULL;
+      v_loaded_month_to := NULL;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  WITH public_categories AS (
+    SELECT
+      item.category,
+      item.access_level
+    FROM community.monthly_category_share_items AS item
+    WHERE item.share_id = v_share_id
+      AND item.direction = 'spend'
+    ORDER BY item.category
+  ),
+  loaded_cells AS (
+    SELECT
+      date_trunc('month', local_entry.local_date)::date AS cell_month,
+      category.category,
+      SUM(-converted.amount_report)::double precision AS amount
+    FROM public_categories AS category
+    INNER JOIN public.ledger_entries AS entry
+      ON entry.workspace_id = v_workspace_id
+      AND entry.kind = 'spend'
+      AND COALESCE(entry.category, '') = category.category
+    CROSS JOIN LATERAL (
+      SELECT (entry.ts AT TIME ZONE v_timezone)::date AS local_date
+    ) AS local_entry
+    LEFT JOIN public.fx_rates_daily AS rate
+      ON rate.quote_currency = v_currency
+      AND rate.base_currency = entry.currency
+      AND rate.calendar_date = local_entry.local_date
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN entry.currency = v_currency THEN entry.amount::double precision
+          WHEN rate.rate IS NOT NULL THEN entry.amount::double precision * rate.rate::double precision
+          ELSE NULL
+        END AS amount_report
+    ) AS converted
+    WHERE category.access_level = 'monthly_values'
+      AND v_loaded_month_from IS NOT NULL
+      AND local_entry.local_date >= v_loaded_month_from
+      AND local_entry.local_date < (v_loaded_month_to + INTERVAL '1 month')::date
+      AND converted.amount_report IS NOT NULL
+    GROUP BY 1, 2
+  ),
+  loaded_year_totals AS (
+    SELECT
+      EXTRACT(YEAR FROM local_entry.local_date)::integer AS total_year,
+      category.category,
+      SUM(-converted.amount_report)::double precision AS amount
+    FROM public_categories AS category
+    INNER JOIN public.ledger_entries AS entry
+      ON entry.workspace_id = v_workspace_id
+      AND entry.kind = 'spend'
+      AND COALESCE(entry.category, '') = category.category
+    CROSS JOIN LATERAL (
+      SELECT (entry.ts AT TIME ZONE v_timezone)::date AS local_date
+    ) AS local_entry
+    LEFT JOIN public.fx_rates_daily AS rate
+      ON rate.quote_currency = v_currency
+      AND rate.base_currency = entry.currency
+      AND rate.calendar_date = local_entry.local_date
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN entry.currency = v_currency THEN entry.amount::double precision
+          WHEN rate.rate IS NOT NULL THEN entry.amount::double precision * rate.rate::double precision
+          ELSE NULL
+        END AS amount_report
+    ) AS converted
+    WHERE category.access_level = 'monthly_values'
+      AND v_loaded_month_from IS NOT NULL
+      AND local_entry.local_date >= v_loaded_month_from
+      AND local_entry.local_date < (v_loaded_month_to + INTERVAL '1 month')::date
+      AND converted.amount_report IS NOT NULL
+    GROUP BY 1, 2
+  )
+  SELECT
+    v_label,
+    v_currency,
+    v_available_month_from,
+    v_available_month_to,
+    v_loaded_month_from,
+    v_loaded_month_to,
+    COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'category', category.category,
+          'accessLevel', category.access_level
+        )
+        ORDER BY category.category
+      )
+      FROM public_categories AS category
+    ), '[]'::jsonb),
+    COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'month', cell.cell_month,
+          'category', cell.category,
+          'amount', cell.amount
+        )
+        ORDER BY cell.cell_month, cell.category
+      )
+      FROM loaded_cells AS cell
+    ), '[]'::jsonb),
+    COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'year', total.total_year,
+          'category', total.category,
+          'amount', total.amount
+        )
+        ORDER BY total.total_year, total.category
+      )
+      FROM loaded_year_totals AS total
+    ), '[]'::jsonb);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION community.read_public_monthly_category_share(TEXT, DATE, DATE) FROM PUBLIC;
+REVOKE ALL ON FUNCTION community.read_public_monthly_category_share(TEXT, DATE, DATE) FROM api_sql_executor;
+GRANT EXECUTE ON FUNCTION community.read_public_monthly_category_share(TEXT, DATE, DATE) TO app;


### PR DESCRIPTION
## Summary
- add the public monthly share page and spend-only table UI
- route public JSON through /api/share/monthly/<token> with no-store/noindex public headers
- add public metadata and loaded-window year-total database readers

## Validation
- cd apps/web && node --import tsx --test src/app/api/share-monthly-route.test.ts src/app/api/community-monthly-category-share-route.test.ts src/server/community/publicMonthlyCategoryShare.test.ts src/ui/public-share/publicMonthlyShareModel.test.ts
- cd apps/web && npm run lint
- cd apps/web && npm run build