### PR TITLE
[codex] public share safety tests

### DIFF
--- a/apps/sql-api/src/machineApi/schemaService.test.ts
+++ b/apps/sql-api/src/machineApi/schemaService.test.ts
@@ -1,8 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createQueryResult } from "../handlerTestUtils.js";
-import { loadAllowedSchemaWithResolver } from "./schemaService.js";
+import { ALLOWED_RELATION_NAMES, loadAllowedSchemaWithResolver } from "./schemaService.js";
 import type { MachineApiDependencies } from "./types.js";
+
+test("machine API schema allowlist excludes community public share relations", (): void => {
+  const relationNames: ReadonlyArray<string> = ALLOWED_RELATION_NAMES;
+  assert.equal(relationNames.includes("monthly_category_shares"), false);
+  assert.equal(relationNames.includes("monthly_category_share_items"), false);
+  assert.equal(relationNames.includes("monthly_category_share_keys"), false);
+});
 
 test("loadAllowedSchema resolves a real workspace context before querying", async (): Promise<void> => {
   const identity = {

--- a/apps/sql-api/src/machineApi/sqlService.test.ts
+++ b/apps/sql-api/src/machineApi/sqlService.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import type { QueryResult } from "pg";
 import { SqlPolicyError } from "@expense-budget-tracker/agent-shared/sql-policy";
 import { createQueryResult } from "../handlerTestUtils.js";
-import { runSql } from "./sqlService.js";
+import { runSqlWithWorkspaceGetter } from "./sqlService.js";
 import type {
   AuthenticatedContext,
   MachineApiDependencies,
@@ -47,6 +47,11 @@ const createDependencies = (
       }) as QueryResult)),
 });
 
+const workspaceGetter = async (): Promise<WorkspaceSummary> => ({
+  workspaceId: "user-1",
+  name: "Personal",
+});
+
 test("runSql rejects function-only SQL before executing restricted queries", async (): Promise<void> => {
   let restrictedContextCalled = false;
   const dependencies = createDependencies({
@@ -57,7 +62,47 @@ test("runSql rejects function-only SQL before executing restricted queries", asy
   });
 
   await assert.rejects(
-    () => runSql(dependencies, createAuthenticatedContext(), "user-1", "SELECT delete_workspace_for_current_user('user-1')"),
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "SELECT delete_workspace_for_current_user('user-1')",
+      workspaceGetter,
+    ),
+    (error: unknown) => error instanceof SqlPolicyError && error.code === "function_calls_not_allowed",
+  );
+
+  assert.equal(restrictedContextCalled, false);
+});
+
+test("runSql rejects community public share relations before executing restricted queries", async (): Promise<void> => {
+  let restrictedContextCalled = false;
+  const dependencies = createDependencies({
+    withRestrictedTrustedIdentityContext: async () => {
+      restrictedContextCalled = true;
+      throw new Error("restricted context should not run");
+    },
+  });
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "SELECT * FROM community.monthly_category_shares",
+      workspaceGetter,
+    ),
+    (error: unknown) => error instanceof SqlPolicyError && error.code === "relation_not_allowed",
+  );
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "SELECT * FROM community.read_public_monthly_category_share('token', '2025-01-01', '2025-12-01')",
+      workspaceGetter,
+    ),
     (error: unknown) => error instanceof SqlPolicyError && error.code === "function_calls_not_allowed",
   );
 
@@ -85,11 +130,12 @@ test("runSql executes allowed aggregate relation queries with row metadata", asy
     },
   });
 
-  const result = await runSql(
+  const result = await runSqlWithWorkspaceGetter(
     dependencies,
     createAuthenticatedContext(),
     "user-1",
     "SELECT SUM(amount) AS balance FROM ledger_entries WHERE account_id = 'a-main-usd'",
+    workspaceGetter,
   );
   const workspace = (result?.workspace ?? null) as WorkspaceSummary | null;
   const statements = (result?.statements ?? []) as ReadonlyArray<Readonly<Record<string, unknown>>>;

--- a/apps/sql-api/src/machineApi/sqlService.ts
+++ b/apps/sql-api/src/machineApi/sqlService.ts
@@ -5,7 +5,7 @@ import {
   SqlPolicyError,
   type AllowedRelationName,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
-import type { AuthenticatedContext, EntityHints, MachineApiDependencies, PgError } from "./types.js";
+import type { AuthenticatedContext, EntityHints, MachineApiDependencies, PgError, WorkspaceSummary } from "./types.js";
 import { getWorkspace } from "./workspaceService.js";
 
 const ENTITY_METADATA: Readonly<Record<AllowedRelationName, Readonly<{
@@ -95,6 +95,12 @@ export const getUserSqlExecutionMessage = (error: unknown): string => {
 const isSchemaExplorationAttempt = (message: string): boolean =>
   /information_schema|pg_catalog|pg_/iu.test(message);
 
+type WorkspaceGetter = (
+  dependencies: MachineApiDependencies,
+  identity: AuthenticatedContext["identity"],
+  workspaceId: string,
+) => Promise<WorkspaceSummary | null>;
+
 export const getSqlPolicyInstructions = (
   error: SqlPolicyError,
   apiBaseUrl: string,
@@ -138,13 +144,14 @@ export const getSqlPolicyInstructions = (
   return "Fix the SQL statement and retry. Use only supported relations.";
 };
 
-export const runSql = async (
+export const runSqlWithWorkspaceGetter = async (
   dependencies: MachineApiDependencies,
   authenticated: AuthenticatedContext,
   workspaceId: string,
   sql: string,
+  workspaceGetter: WorkspaceGetter,
 ): Promise<Readonly<Record<string, unknown>> | null> => {
-  const workspace = await getWorkspace(dependencies, authenticated.identity, workspaceId);
+  const workspace = await workspaceGetter(dependencies, authenticated.identity, workspaceId);
   if (workspace === null) {
     return null;
   }
@@ -188,3 +195,17 @@ export const runSql = async (
     },
   };
 };
+
+export const runSql = async (
+  dependencies: MachineApiDependencies,
+  authenticated: AuthenticatedContext,
+  workspaceId: string,
+  sql: string,
+): Promise<Readonly<Record<string, unknown>> | null> =>
+  runSqlWithWorkspaceGetter(
+    dependencies,
+    authenticated,
+    workspaceId,
+    sql,
+    getWorkspace,
+  );

--- a/apps/web/e2e/public-monthly-share.spec.ts
+++ b/apps/web/e2e/public-monthly-share.spec.ts
@@ -1,0 +1,451 @@
+import { expect, test, type Browser, type Page } from "@playwright/test";
+
+import {
+  attachFailureDiagnostics,
+  createTestWorkspace,
+  createTransaction,
+  deleteTestWorkspace,
+  runIdFromClock,
+  setWorkspaceCookie,
+  setupBrowserSession,
+  signInWithDemoEmail,
+} from "./live-smoke.actions";
+
+type PublicShareSettingsResponse = Readonly<{
+  settings: Readonly<{
+    enabled: boolean;
+    indexingEnabled: boolean;
+    displayLabel: string;
+    monthFrom: string | null;
+    monthTo: string | null;
+  }>;
+  dashboardUrl: string | null;
+  jsonUrl: string | null;
+  selectedItems: ReadonlyArray<Readonly<{
+    direction: "spend";
+    category: string;
+    accessLevel: "category_only" | "monthly_values";
+  }>>;
+}>;
+
+type PublicShareBody = Readonly<{
+  categories: ReadonlyArray<Readonly<{
+    category: string;
+    accessLevel: "category_only" | "monthly_values";
+  }>>;
+  cells: ReadonlyArray<Readonly<{
+    month: string;
+    category: string;
+    amount: number;
+  }>>;
+  yearTotals: ReadonlyArray<Readonly<{
+    year: string;
+    category: string;
+    amount: number;
+  }>>;
+}>;
+
+const externalUiTimeoutMs = 30_000;
+const forbiddenPublicJsonFields: ReadonlyArray<string> = [
+  "workspaceId",
+  "userId",
+  "email",
+  "entry_id",
+  "event_id",
+  "account_id",
+  "counterparty",
+  "note",
+  "hasUnconvertible",
+];
+
+const offsetMonth = (base: string, offset: number): string => {
+  const [year, month] = base.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1 + offset, 1));
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+};
+
+const currentMonth = (): string => {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+};
+
+const monthTimestamp = (month: string): string =>
+  `${month}-15T12:00:00.000Z`;
+
+const browserFetch = async <T>(
+  page: Page,
+  baseUrl: string,
+  path: string,
+  method: "GET" | "POST" | "PUT",
+  body: unknown | null,
+): Promise<T> => {
+  const result = await page.evaluate(
+    async ({ url, requestMethod, requestBody }) => {
+      const csrfMatch = document.cookie.match(/(?:^|;\s*)__Host-csrf=([0-9a-f]+)/);
+      const csrfToken = csrfMatch !== null ? csrfMatch[1] : "";
+      const headers: Record<string, string> = {};
+      if (requestMethod !== "GET") {
+        headers["Content-Type"] = "application/json";
+        if (csrfToken !== "") {
+          headers["x-csrf-token"] = csrfToken;
+        }
+      }
+
+      const response = await fetch(url, {
+        method: requestMethod,
+        headers,
+        body: requestBody === null ? undefined : JSON.stringify(requestBody),
+        credentials: "same-origin",
+      });
+      const text = await response.text();
+      return { ok: response.ok, status: response.status, text };
+    },
+    {
+      url: `${baseUrl}${path}`,
+      requestMethod: method,
+      requestBody: body,
+    },
+  );
+
+  if (!result.ok) {
+    throw new Error(`${method} ${path} failed: status=${result.status} body=${result.text}`);
+  }
+
+  return JSON.parse(result.text) as T;
+};
+
+const setUserLocaleToEnglish = async (
+  page: Page,
+  baseUrl: string,
+): Promise<void> => {
+  await browserFetch<unknown>(
+    page,
+    baseUrl,
+    "/api/user-settings",
+    "PUT",
+    { locale: "en" },
+  );
+};
+
+const createPublicShare = async (
+  page: Page,
+  baseUrl: string,
+  params: Readonly<{
+    label: string;
+    monthFrom: string;
+    monthlyCategory: string;
+    categoryOnlyCategory: string;
+  }>,
+): Promise<PublicShareSettingsResponse> => {
+  await browserFetch<PublicShareSettingsResponse>(
+    page,
+    baseUrl,
+    "/api/community/monthly-category-share",
+    "PUT",
+    {
+      displayLabel: params.label,
+      monthFrom: params.monthFrom,
+      monthTo: null,
+    },
+  );
+  await browserFetch<PublicShareSettingsResponse>(
+    page,
+    baseUrl,
+    "/api/community/monthly-category-share/items",
+    "PUT",
+    {
+      items: [
+        { direction: "spend", category: params.monthlyCategory, accessLevel: "monthly_values" },
+        { direction: "spend", category: params.categoryOnlyCategory, accessLevel: "category_only" },
+      ],
+    },
+  );
+  return browserFetch<PublicShareSettingsResponse>(
+    page,
+    baseUrl,
+    "/api/community/monthly-category-share/enable",
+    "POST",
+    { confirmationPhrase: "make public" },
+  );
+};
+
+const disablePublicShare = async (
+  page: Page,
+  baseUrl: string,
+): Promise<PublicShareSettingsResponse> =>
+  browserFetch<PublicShareSettingsResponse>(
+    page,
+    baseUrl,
+    "/api/community/monthly-category-share/disable",
+    "POST",
+    {},
+  );
+
+const enablePublicShare = async (
+  page: Page,
+  baseUrl: string,
+): Promise<PublicShareSettingsResponse> =>
+  browserFetch<PublicShareSettingsResponse>(
+    page,
+    baseUrl,
+    "/api/community/monthly-category-share/enable",
+    "POST",
+    { confirmationPhrase: "make public" },
+  );
+
+const rotatePublicShareToken = async (
+  page: Page,
+  baseUrl: string,
+): Promise<PublicShareSettingsResponse> =>
+  browserFetch<PublicShareSettingsResponse>(
+    page,
+    baseUrl,
+    "/api/community/monthly-category-share/rotate-token",
+    "POST",
+    {},
+  );
+
+const updatePublicShareIndexing = async (
+  page: Page,
+  baseUrl: string,
+  indexingEnabled: boolean,
+): Promise<PublicShareSettingsResponse> => {
+  const body = indexingEnabled
+    ? { indexingEnabled, confirmationPhrase: "allow search" }
+    : { indexingEnabled };
+  return browserFetch<PublicShareSettingsResponse>(
+    page,
+    baseUrl,
+    "/api/community/monthly-category-share/indexing",
+    "PUT",
+    body,
+  );
+};
+
+const assertPublicShareJsonContract = (body: PublicShareBody): void => {
+  const serialized = JSON.stringify(body);
+  for (const field of forbiddenPublicJsonFields) {
+    expect(serialized).not.toContain(field);
+  }
+};
+
+const createUnauthenticatedPage = async (
+  browser: Browser,
+  baseURL: string,
+): Promise<Page> => {
+  const context = await browser.newContext({
+    baseURL,
+    ignoreHTTPSErrors: true,
+  });
+  return context.newPage();
+};
+
+test("public monthly share exposes only public aggregate data without private shell", async ({ browser, page, baseURL }, testInfo) => {
+  if (baseURL === undefined) {
+    throw new Error("Playwright baseURL is required");
+  }
+
+  const runId = runIdFromClock();
+  const workspaceName = `E2E public share ${runId}`;
+  const monthlyCategory = `E2E public groceries ${runId}`;
+  const categoryOnlyCategory = `E2E public private travel ${runId}`;
+  const privateMarker = `private-share-marker-${runId}`;
+  const unconvertibleAmount = "1357.91";
+  const incomeAmount = "2468.13";
+  const categoryOnlyAmount = "9876.54";
+  const currentMonthAmount = "4321.09";
+  const nowMonth = currentMonth();
+  const shareMonthFrom = offsetMonth(nowMonth, -15);
+  const earlierVisibleMonth = shareMonthFrom;
+  const latestSeedMonth = offsetMonth(nowMonth, -3);
+  let workspaceId: string | null = null;
+  let publicPage: Page | null = null;
+
+  try {
+    const tokens = await signInWithDemoEmail();
+    await setupBrowserSession(page, tokens);
+
+    const workspace = await createTestWorkspace(page, workspaceName);
+    workspaceId = workspace.workspaceId;
+    await setWorkspaceCookie(page, workspace.workspaceId);
+    await page.goto(baseURL, { waitUntil: "domcontentloaded" });
+    await setUserLocaleToEnglish(page, baseURL);
+
+    await createTransaction(page, {
+      ts: monthTimestamp(earlierVisibleMonth),
+      accountId: `E2E public account ${runId}`,
+      amount: -11.11,
+      currency: "USD",
+      kind: "spend",
+      category: monthlyCategory,
+      counterparty: `E2E public store ${runId}`,
+      note: `monthly public value ${runId}`,
+    });
+    await createTransaction(page, {
+      ts: monthTimestamp(latestSeedMonth),
+      accountId: `E2E public account ${runId}`,
+      amount: -22.22,
+      currency: "USD",
+      kind: "spend",
+      category: monthlyCategory,
+      counterparty: `E2E public store ${runId}`,
+      note: `latest public value ${runId}`,
+    });
+    await createTransaction(page, {
+      ts: monthTimestamp(latestSeedMonth),
+      accountId: `E2E public account ${runId}`,
+      amount: -Number(categoryOnlyAmount),
+      currency: "USD",
+      kind: "spend",
+      category: categoryOnlyCategory,
+      counterparty: privateMarker,
+      note: privateMarker,
+    });
+    await createTransaction(page, {
+      ts: monthTimestamp(latestSeedMonth),
+      accountId: `E2E public account ${runId}`,
+      amount: Number(incomeAmount),
+      currency: "USD",
+      kind: "income",
+      category: monthlyCategory,
+      counterparty: privateMarker,
+      note: privateMarker,
+    });
+    await createTransaction(page, {
+      ts: monthTimestamp(latestSeedMonth),
+      accountId: `E2E public account ${runId}`,
+      amount: -Number(unconvertibleAmount),
+      currency: "ZZZ",
+      kind: "spend",
+      category: monthlyCategory,
+      counterparty: privateMarker,
+      note: privateMarker,
+    });
+    await createTransaction(page, {
+      ts: monthTimestamp(nowMonth),
+      accountId: `E2E public account ${runId}`,
+      amount: -Number(currentMonthAmount),
+      currency: "USD",
+      kind: "spend",
+      category: monthlyCategory,
+      counterparty: privateMarker,
+      note: privateMarker,
+    });
+
+    let settings = await createPublicShare(page, baseURL, {
+      label: `E2E public share ${runId}`,
+      monthFrom: shareMonthFrom,
+      monthlyCategory,
+      categoryOnlyCategory,
+    });
+    if (settings.dashboardUrl === null || settings.jsonUrl === null) {
+      throw new Error(`Public monthly share did not return public URLs: ${JSON.stringify(settings)}`);
+    }
+
+    publicPage = await createUnauthenticatedPage(browser, baseURL);
+    const disabledSettings = await disablePublicShare(page, baseURL);
+    expect(disabledSettings.settings.enabled).toBe(false);
+    expect(disabledSettings.settings.indexingEnabled).toBe(false);
+    expect(disabledSettings.dashboardUrl).toBe(settings.dashboardUrl);
+    expect(disabledSettings.jsonUrl).toBe(settings.jsonUrl);
+    expect((await publicPage.request.get(settings.jsonUrl)).status()).toBe(404);
+
+    const reenabledSettings = await enablePublicShare(page, baseURL);
+    expect(reenabledSettings.settings.enabled).toBe(true);
+    expect(reenabledSettings.dashboardUrl).toBe(settings.dashboardUrl);
+    expect(reenabledSettings.jsonUrl).toBe(settings.jsonUrl);
+    expect((await publicPage.request.get(settings.jsonUrl)).status()).toBe(200);
+
+    const indexedSettings = await updatePublicShareIndexing(page, baseURL, true);
+    expect(indexedSettings.settings.indexingEnabled).toBe(true);
+    expect(indexedSettings.dashboardUrl).toBe(settings.dashboardUrl);
+    expect(indexedSettings.jsonUrl).toBe(settings.jsonUrl);
+    const noindexSettings = await updatePublicShareIndexing(page, baseURL, false);
+    expect(noindexSettings.settings.indexingEnabled).toBe(false);
+    expect(noindexSettings.dashboardUrl).toBe(settings.dashboardUrl);
+    expect(noindexSettings.jsonUrl).toBe(settings.jsonUrl);
+
+    const oldJsonUrl = settings.jsonUrl;
+    const oldDashboardUrl = settings.dashboardUrl;
+    settings = await rotatePublicShareToken(page, baseURL);
+    if (settings.dashboardUrl === null || settings.jsonUrl === null) {
+      throw new Error(`Public monthly share rotation did not return public URLs: ${JSON.stringify(settings)}`);
+    }
+    expect(settings.dashboardUrl).not.toBe(oldDashboardUrl);
+    expect(settings.jsonUrl).not.toBe(oldJsonUrl);
+    expect((await publicPage.request.get(oldJsonUrl)).status()).toBe(404);
+
+    const forbiddenApiRequests: Array<string> = [];
+    const publicApiResponseBodies: Array<string> = [];
+    const baseOrigin = new URL(baseURL).origin;
+    publicPage.on("request", (request) => {
+      const url = new URL(request.url());
+      if (
+        url.origin === baseOrigin
+        && url.pathname.startsWith("/api/")
+        && !url.pathname.startsWith("/api/share/monthly/")
+      ) {
+        forbiddenApiRequests.push(request.url());
+      }
+    });
+
+    const apiResponse = await publicPage.request.get(settings.jsonUrl);
+    expect(apiResponse.status()).toBe(200);
+    const apiText = await apiResponse.text();
+    publicApiResponseBodies.push(apiText);
+    const apiBody = JSON.parse(apiText) as PublicShareBody;
+    assertPublicShareJsonContract(apiBody);
+    expect(apiBody.categories).toEqual([
+      { category: monthlyCategory, accessLevel: "monthly_values" },
+      { category: categoryOnlyCategory, accessLevel: "category_only" },
+    ]);
+    expect(apiBody.cells.every((cell) => cell.category !== categoryOnlyCategory)).toBe(true);
+    expect(apiBody.yearTotals.every((total) => total.category !== categoryOnlyCategory)).toBe(true);
+
+    await publicPage.goto(settings.dashboardUrl, { waitUntil: "domcontentloaded" });
+    await expect(publicPage.locator("main table")).toBeVisible({ timeout: externalUiTimeoutMs });
+
+    const loadEarlierButton = publicPage.locator('main button[type="button"]').first();
+    await expect(loadEarlierButton).toBeVisible({ timeout: externalUiTimeoutMs });
+    const earlierResponse = await Promise.all([
+      publicPage.waitForResponse((response) => new URL(response.url()).pathname.startsWith("/api/share/monthly/")),
+      loadEarlierButton.click(),
+    ]).then(([response]) => response);
+    publicApiResponseBodies.push(await earlierResponse.text());
+
+    await expect(publicPage.locator("header.topbar")).toHaveCount(0);
+    await expect(publicPage.locator("nav.nav")).toHaveCount(0);
+    await expect(publicPage.locator(".demo-banner")).toHaveCount(0);
+    await expect(publicPage.locator('button[aria-haspopup="true"]')).toHaveCount(0);
+    await expect(publicPage.locator("textarea")).toHaveCount(0);
+    expect(forbiddenApiRequests).toEqual([]);
+
+    const publicBodies = [
+      ...publicApiResponseBodies,
+      await publicPage.content(),
+    ].join("\n");
+    expect(publicBodies).not.toContain(privateMarker);
+    expect(publicBodies).not.toContain(categoryOnlyAmount);
+    expect(publicBodies).not.toContain(incomeAmount);
+    expect(publicBodies).not.toContain(unconvertibleAmount);
+    expect(publicBodies).not.toContain(currentMonthAmount);
+    expect(publicBodies).not.toContain("hasUnconvertible");
+    await publicPage.context().close();
+    publicPage = null;
+  } catch (error) {
+    await attachFailureDiagnostics(page, testInfo, "public-monthly-share");
+    throw error;
+  } finally {
+    if (publicPage !== null) {
+      await publicPage.context().close();
+    }
+    if (workspaceId !== null) {
+      try {
+        await deleteTestWorkspace(page, workspaceId, workspaceName);
+      } catch (cleanupError) {
+        const message = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+        console.error(`[cleanup] Failed to delete workspace ${workspaceId}: ${message}`);
+      }
+    }
+  }
+});

--- a/apps/web/src/app/api/share-monthly-route.test.ts
+++ b/apps/web/src/app/api/share-monthly-route.test.ts
@@ -26,6 +26,35 @@ const SHARE: PublicMonthlyCategoryShare = {
   ],
 };
 
+const PUBLIC_SHARE_TOP_LEVEL_KEYS: ReadonlyArray<keyof PublicMonthlyCategoryShare> = [
+  "label",
+  "currency",
+  "availableMonthFrom",
+  "availableMonthTo",
+  "loadedMonthFrom",
+  "loadedMonthTo",
+  "categories",
+  "cells",
+  "yearTotals",
+];
+
+const PRIVATE_FIELD_NAMES: ReadonlyArray<string> = [
+  "workspaceId",
+  "userId",
+  "email",
+  "entry_id",
+  "event_id",
+  "account_id",
+  "counterparty",
+  "note",
+  "ts",
+  "inserted_at",
+  "budget",
+  "planned",
+  "plannedValue",
+  "hasUnconvertible",
+];
+
 const createContext = (token: string): { params: Promise<{ token: string }> } => ({
   params: Promise.resolve({ token }),
 });
@@ -36,6 +65,29 @@ const createGetRequest = (query: string): Request =>
 const assertPublicShareHeaders = (response: Response): void => {
   assert.equal(response.headers.get("access-control-allow-origin"), "*");
   assert.equal(response.headers.get("x-robots-tag"), "noindex, nofollow");
+};
+
+const collectObjectKeys = (input: unknown): ReadonlyArray<string> => {
+  const keys: Array<string> = [];
+
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item);
+      }
+      return;
+    }
+    if (typeof value !== "object" || value === null) {
+      return;
+    }
+    for (const [key, child] of Object.entries(value)) {
+      keys.push(key);
+      visit(child);
+    }
+  };
+
+  visit(input);
+  return keys;
 };
 
 test("getPublicMonthlyShareRouteWithDeps returns public JSON with CORS and no-store headers", async (): Promise<void> => {
@@ -56,6 +108,79 @@ test("getPublicMonthlyShareRouteWithDeps returns public JSON with CORS and no-st
   assert.match(response.headers.get("cache-control") ?? "", /no-store/);
   assert.deepEqual(calls, [{ token: "token-1", monthFrom: "2024-01", monthTo: "2025-12" }]);
   assert.deepEqual(await response.json(), SHARE);
+});
+
+test("getPublicMonthlyShareRouteWithDeps projects JSON to the public contract only", async (): Promise<void> => {
+  const leakyShare = {
+    ...SHARE,
+    workspaceId: "workspace-private",
+    userId: "user-private",
+    email: "user@example.com",
+    categories: [
+      { category: "Groceries", accessLevel: "monthly_values", workspaceId: "workspace-private" },
+      { category: "Travel", accessLevel: "category_only", userId: "user-private" },
+    ],
+    cells: [
+      {
+        month: "2025-03",
+        category: "Groceries",
+        amount: 120.5,
+        entry_id: "entry-private",
+        event_id: "event-private",
+        account_id: "account-private",
+        counterparty: "Private Store",
+        note: "private note",
+        ts: "2025-03-02T12:34:56.000Z",
+        hasUnconvertible: true,
+      },
+    ],
+    yearTotals: [
+      {
+        year: "2025",
+        category: "Groceries",
+        amount: 500,
+        plannedValue: 900,
+      },
+    ],
+  } as unknown as PublicMonthlyCategoryShare;
+
+  const response = await getPublicMonthlyShareRouteWithDeps(
+    createGetRequest("?monthFrom=2025-03&monthTo=2025-04"),
+    createContext("token-1"),
+    {
+      getPublicMonthlyCategoryShare: async (): Promise<PublicMonthlyCategoryShare | null> => leakyShare,
+    },
+  );
+  const body = await response.json() as PublicMonthlyCategoryShare;
+  const keys = collectObjectKeys(body);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(Object.keys(body), PUBLIC_SHARE_TOP_LEVEL_KEYS);
+  for (const privateField of PRIVATE_FIELD_NAMES) {
+    assert.equal(keys.includes(privateField), false, `Unexpected private public-share field: ${privateField}`);
+  }
+  assert.deepEqual(body.categories, SHARE.categories);
+  assert.deepEqual(body.cells, SHARE.cells);
+  assert.deepEqual(body.yearTotals, [{ year: "2025", category: "Groceries", amount: 500 }]);
+});
+
+test("getPublicMonthlyShareRouteWithDeps returns an enabled empty public share", async (): Promise<void> => {
+  const emptyShare: PublicMonthlyCategoryShare = {
+    ...SHARE,
+    categories: [],
+    cells: [],
+    yearTotals: [],
+  };
+  const response = await getPublicMonthlyShareRouteWithDeps(
+    createGetRequest("?monthFrom=2025-03&monthTo=2025-04"),
+    createContext("token-1"),
+    {
+      getPublicMonthlyCategoryShare: async (): Promise<PublicMonthlyCategoryShare | null> => emptyShare,
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), emptyShare);
 });
 
 test("getPublicMonthlyShareRouteWithDeps uses a bounded latest window when query params are omitted", async (): Promise<void> => {
@@ -79,27 +204,36 @@ test("getPublicMonthlyShareRouteWithDeps uses a bounded latest window when query
   assert.deepEqual(await response.json(), SHARE);
 });
 
-test("getPublicMonthlyShareRouteWithDeps returns equivalent 404 responses for missing shares", async (): Promise<void> => {
+test("getPublicMonthlyShareRouteWithDeps returns equivalent 404 responses for every missing-token state", async (): Promise<void> => {
   const dependencies = {
     getPublicMonthlyCategoryShare: async (): Promise<PublicMonthlyCategoryShare | null> => null,
   };
+  const tokenStates: ReadonlyArray<string> = [
+    "invalid-token",
+    "disabled-token",
+    "revoked-token",
+    "blocked-token",
+    "unknown-token",
+  ];
+  const responses: Array<Readonly<{ status: number; text: string }>> = [];
 
-  const first = await getPublicMonthlyShareRouteWithDeps(
-    createGetRequest("?monthFrom=2025-03&monthTo=2025-04"),
-    createContext("unknown-token"),
-    dependencies,
-  );
-  const second = await getPublicMonthlyShareRouteWithDeps(
-    createGetRequest("?monthFrom=2025-03&monthTo=2025-04"),
-    createContext("revoked-token"),
-    dependencies,
-  );
+  for (const token of tokenStates) {
+    const response = await getPublicMonthlyShareRouteWithDeps(
+      createGetRequest("?monthFrom=2025-03&monthTo=2025-04"),
+      createContext(token),
+      dependencies,
+    );
+    assertPublicShareHeaders(response);
+    responses.push({ status: response.status, text: await response.text() });
+  }
 
-  assert.equal(first.status, 404);
-  assert.equal(second.status, 404);
-  assertPublicShareHeaders(first);
-  assertPublicShareHeaders(second);
-  assert.equal(await first.text(), await second.text());
+  assert.deepEqual(
+    responses,
+    tokenStates.map(() => ({
+      status: 404,
+      text: "{\"error\":\"Public monthly share not found\"}",
+    })),
+  );
 });
 
 test("getPublicMonthlyShareRouteWithDeps rejects invalid month queries before data access", async (): Promise<void> => {

--- a/apps/web/src/app/api/share/monthly/[token]/route.ts
+++ b/apps/web/src/app/api/share/monthly/[token]/route.ts
@@ -67,6 +67,31 @@ const badRequestResponse = (message: string): Response =>
 const internalErrorResponse = (): Response =>
   jsonPublicNoStore({ error: "Public monthly share is temporarily unavailable" }, { status: 500 });
 
+const toPublicMonthlyShareResponseBody = (
+  share: PublicMonthlyCategoryShare,
+): PublicMonthlyCategoryShare => ({
+  label: share.label,
+  currency: share.currency,
+  availableMonthFrom: share.availableMonthFrom,
+  availableMonthTo: share.availableMonthTo,
+  loadedMonthFrom: share.loadedMonthFrom,
+  loadedMonthTo: share.loadedMonthTo,
+  categories: share.categories.map((category) => ({
+    category: category.category,
+    accessLevel: category.accessLevel,
+  })),
+  cells: share.cells.map((cell) => ({
+    month: cell.month,
+    category: cell.category,
+    amount: cell.amount,
+  })),
+  yearTotals: share.yearTotals.map((total) => ({
+    year: total.year,
+    category: total.category,
+    amount: total.amount,
+  })),
+});
+
 const maxMonth = (left: string, right: string): string =>
   left > right ? left : right;
 
@@ -146,7 +171,7 @@ export const getPublicMonthlyShareRouteWithDeps = async (
       return missingPublicShareResponse();
     }
 
-    return jsonPublicNoStore(share, { status: 200 });
+    return jsonPublicNoStore(toPublicMonthlyShareResponseBody(share), { status: 200 });
   } catch (error) {
     if (error instanceof ApiRouteError) {
       return badRequestResponse(error.publicMessage);

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,6 +1,52 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { isPublicPath, resolveWorkspaceIdFromCookie } from "./proxy";
+import { NextRequest } from "next/server";
+import { isPublicPath, proxy, resolveWorkspaceIdFromCookie } from "./proxy";
+
+type EnvSnapshot = Readonly<{
+  AUTH_MODE: string | undefined;
+  AUTH_DOMAIN: string | undefined;
+  CORS_ORIGIN: string | undefined;
+}>;
+
+const captureEnv = (): EnvSnapshot => ({
+  AUTH_MODE: process.env.AUTH_MODE,
+  AUTH_DOMAIN: process.env.AUTH_DOMAIN,
+  CORS_ORIGIN: process.env.CORS_ORIGIN,
+});
+
+const restoreEnv = (snapshot: EnvSnapshot): void => {
+  if (snapshot.AUTH_MODE === undefined) {
+    delete process.env.AUTH_MODE;
+  } else {
+    process.env.AUTH_MODE = snapshot.AUTH_MODE;
+  }
+  if (snapshot.AUTH_DOMAIN === undefined) {
+    delete process.env.AUTH_DOMAIN;
+  } else {
+    process.env.AUTH_DOMAIN = snapshot.AUTH_DOMAIN;
+  }
+  if (snapshot.CORS_ORIGIN === undefined) {
+    delete process.env.CORS_ORIGIN;
+  } else {
+    process.env.CORS_ORIGIN = snapshot.CORS_ORIGIN;
+  }
+};
+
+const withCognitoEnv = async (run: () => Promise<void>): Promise<void> => {
+  const snapshot = captureEnv();
+  process.env.AUTH_MODE = "cognito";
+  process.env.AUTH_DOMAIN = "auth.example.com";
+  process.env.CORS_ORIGIN = "https://app.example.com";
+  try {
+    await run();
+  } finally {
+    restoreEnv(snapshot);
+  }
+};
+
+const createRequest = (path: string): NextRequest =>
+  new NextRequest(`https://app.example.com${path}`, { method: "GET" });
 
 test("resolveWorkspaceIdFromCookie returns null for missing cookie values", (): void => {
   assert.equal(resolveWorkspaceIdFromCookie(undefined), null);
@@ -32,8 +78,38 @@ test("isPublicPath keeps exact public paths public", (): void => {
 test("isPublicPath allows only narrow public share prefixes", (): void => {
   assert.equal(isPublicPath("/share/monthly/token"), true);
   assert.equal(isPublicPath("/api/share/monthly/token"), true);
+  assert.equal(isPublicPath("/share/monthly"), false);
+  assert.equal(isPublicPath("/share/monthlytoken"), false);
+  assert.equal(isPublicPath("/share/monthly/token/extra"), false);
+  assert.equal(isPublicPath("/api/share/monthly"), false);
   assert.equal(isPublicPath("/share"), false);
   assert.equal(isPublicPath("/api/share/monthly-extra/token"), false);
+  assert.equal(isPublicPath("/api/share/monthlyness/token"), false);
+  assert.equal(isPublicPath("/api/share/monthly/token/extra"), false);
   assert.equal(isPublicPath("/api/share"), false);
   assert.equal(isPublicPath("/api/budget-grid"), false);
+});
+
+test("proxy allows public monthly share pages without auth cookies", async (): Promise<void> => {
+  await withCognitoEnv(async (): Promise<void> => {
+    const pageResponse = await proxy(createRequest("/share/monthly/public-token"));
+    const apiResponse = await proxy(createRequest("/api/share/monthly/public-token?monthFrom=2025-01&monthTo=2025-12"));
+
+    assert.equal(pageResponse.status, 200);
+    assert.equal(pageResponse.headers.get("location"), null);
+    assert.equal(apiResponse.status, 200);
+    assert.equal(apiResponse.headers.get("location"), null);
+  });
+});
+
+test("proxy keeps unrelated app and API routes authenticated", async (): Promise<void> => {
+  await withCognitoEnv(async (): Promise<void> => {
+    const appResponse = await proxy(createRequest("/transactions"));
+    const apiResponse = await proxy(createRequest("/api/budget-grid"));
+
+    assert.equal(appResponse.status, 307);
+    assert.match(appResponse.headers.get("location") ?? "", /^https:\/\/auth\.example\.com\/login/u);
+    assert.equal(apiResponse.status, 307);
+    assert.match(apiResponse.headers.get("location") ?? "", /^https:\/\/auth\.example\.com\/login/u);
+  });
 });

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -42,9 +42,9 @@ const PUBLIC_PATHS: ReadonlyArray<string> = [
   "/api/health",
   "/.well-known/agent.json",
 ];
-const PUBLIC_PATH_PREFIXES: ReadonlyArray<string> = [
-  "/share/monthly/",
-  "/api/share/monthly/",
+const PUBLIC_PATH_PATTERNS: ReadonlyArray<RegExp> = [
+  /^\/share\/monthly\/[^/]+$/u,
+  /^\/api\/share\/monthly\/[^/]+$/u,
 ];
 
 const getAuthDomain = (): string => {
@@ -223,7 +223,7 @@ const forwardWithIdentity = (
 
 export const isPublicPath = (pathname: string): boolean =>
   PUBLIC_PATHS.includes(pathname)
-  || PUBLIC_PATH_PREFIXES.some((prefix: string): boolean => pathname.startsWith(prefix));
+  || PUBLIC_PATH_PATTERNS.some((pattern: RegExp): boolean => pattern.test(pathname));
 
 export const resolveWorkspaceIdFromCookie = (workspaceCookie: string | undefined): string | null =>
   (workspaceCookie !== undefined && workspaceCookie !== "" && WORKSPACE_ID_RE.test(workspaceCookie))

--- a/apps/web/src/server/community/publicMonthlyCategoryShare.test.ts
+++ b/apps/web/src/server/community/publicMonthlyCategoryShare.test.ts
@@ -22,7 +22,7 @@ const createQueryResult = (
 
 const readPublicShareReaderMigration = (): string =>
   readFileSync(
-    fileURLToPath(new URL("../../../../../db/migrations/0047_community_public_monthly_share_reader.sql", import.meta.url)),
+    fileURLToPath(new URL("../../../../../db/migrations/0050_community_public_monthly_share_visible_year_totals.sql", import.meta.url)),
     "utf8",
   );
 
@@ -32,9 +32,9 @@ const readPublicShareMetadataMigration = (): string =>
     "utf8",
   );
 
-const readPublicShareLoadedYearTotalsMigration = (): string =>
+const readPublicShareSettingsMigration = (): string =>
   readFileSync(
-    fileURLToPath(new URL("../../../../../db/migrations/0049_community_public_monthly_share_loaded_year_totals.sql", import.meta.url)),
+    fileURLToPath(new URL("../../../../../db/migrations/0046_community_monthly_category_shares.sql", import.meta.url)),
     "utf8",
   );
 
@@ -78,7 +78,6 @@ test("getPublicMonthlyCategoryShareWithQuery maps database dates to public month
           { month: "2025-04-01", category: "Groceries", amount: 80 },
         ],
         year_totals: [
-          { year: 2024, category: "Groceries", amount: 999 },
           { year: 2025, category: "Groceries", amount: 999 },
         ],
       },
@@ -109,9 +108,51 @@ test("getPublicMonthlyCategoryShareWithQuery maps database dates to public month
       { month: "2025-04", category: "Groceries", amount: 80 },
     ],
     yearTotals: [
-      { year: "2025", category: "Groceries", amount: 200.5 },
+      { year: "2025", category: "Groceries", amount: 999 },
     ],
   });
+});
+
+test("getPublicMonthlyCategoryShareWithQuery keeps database year totals authoritative", async (): Promise<void> => {
+  const queryFn = async (): Promise<QueryResult> => createQueryResult([
+    {
+      label: "Shared spend",
+      currency: "USD",
+      available_month_from: "2025-01-01",
+      available_month_to: "2025-12-01",
+      loaded_month_from: "2025-03-01",
+      loaded_month_to: "2025-03-01",
+      categories: [
+        { category: "Groceries", accessLevel: "monthly_values" },
+        { category: "Travel", accessLevel: "category_only" },
+      ],
+      cells: [
+        { month: "2025-03-01", category: "Groceries", amount: 1 },
+      ],
+      year_totals: [
+        { year: 2025, category: "Groceries", amount: 365 },
+      ],
+    },
+  ]);
+
+  const result = await getPublicMonthlyCategoryShareWithQuery(
+    queryFn,
+    "token-1",
+    "2025-03",
+    "2025-03",
+  );
+
+  assert.deepEqual(result?.yearTotals, [
+    { year: "2025", category: "Groceries", amount: 365 },
+  ]);
+  assert.deepEqual(
+    result?.cells.filter((cell) => cell.category === "Travel"),
+    [],
+  );
+  assert.deepEqual(
+    result?.yearTotals.filter((total) => total.category === "Travel"),
+    [],
+  );
 });
 
 test("getPublicMonthlyCategoryShareWithQuery returns null for every missing token equivalent", async (): Promise<void> => {
@@ -149,7 +190,7 @@ test("getPublicMonthlyCategoryShareMetadataWithQuery returns null for missing to
   assert.equal(result, null);
 });
 
-test("public reader migration keeps amount aggregates spend-only and monthly-values-only", (): void => {
+test("current public reader migration keeps amount aggregates spend-only and monthly-values-only", (): void => {
   const sql = readPublicShareReaderMigration();
 
   assert.match(sql, /AND item\.direction = 'spend'/);
@@ -157,16 +198,36 @@ test("public reader migration keeps amount aggregates spend-only and monthly-val
   assert.equal(countMatches(sql, /category\.access_level = 'monthly_values'/g), 2);
 });
 
-test("public reader migration excludes unconvertible rows from every amount aggregate", (): void => {
+test("current public reader migration excludes unconvertible rows from every amount aggregate", (): void => {
   const sql = readPublicShareReaderMigration();
 
   assert.equal(countMatches(sql, /AND converted\.amount_report IS NOT NULL/g), 2);
 });
 
-test("public reader migration does not expose indexing settings in the aggregate function result", (): void => {
+test("current public reader migration does not expose indexing settings in the aggregate function result", (): void => {
   const sql = readPublicShareReaderMigration();
 
   assert.doesNotMatch(sql, /indexing_enabled/);
+});
+
+test("current public reader migration treats missing token states equivalently", (): void => {
+  const sql = readPublicShareReaderMigration();
+
+  assert.match(sql, /IF p_public_token IS NULL OR btrim\(p_public_token\) = '' THEN\s+RETURN;/);
+  assert.match(sql, /key\.public_token = p_public_token/);
+  assert.match(sql, /key\.revoked_at IS NULL/);
+  assert.match(sql, /share\.enabled = true/);
+  assert.match(sql, /share\.blocked_at IS NULL/);
+  assert.match(sql, /IF v_share_id IS NULL THEN\s+RETURN;/);
+});
+
+test("current public reader migration excludes the current month using workspace timezone and sixth-day policy", (): void => {
+  const sql = readPublicShareReaderMigration();
+
+  assert.match(sql, /CURRENT_TIMESTAMP AT TIME ZONE v_timezone/);
+  assert.match(sql, /WHEN EXTRACT\(DAY FROM v_local_current_date\)::integer >= 6 THEN INTERVAL '1 month'/);
+  assert.match(sql, /ELSE INTERVAL '2 months'/);
+  assert.match(sql, /v_available_month_to := LEAST\(\s+COALESCE\(v_config_month_to, v_latest_eligible_month\),\s+v_latest_eligible_month\s+\);/);
 });
 
 test("public metadata migration exposes only indexing through a security definer function", (): void => {
@@ -183,16 +244,34 @@ test("public metadata migration exposes only indexing through a security definer
   assert.doesNotMatch(sql, /ledger_entries/);
 });
 
-test("public loaded year totals migration bounds totals to the loaded request window", (): void => {
-  const sql = readPublicShareLoadedYearTotalsMigration();
-  const loadedYearTotalsSql = requireMatch(sql, /loaded_year_totals AS \([\s\S]*?\n  \)\n  SELECT/);
+test("current public reader migration returns full eligible year totals only for visible years", (): void => {
+  const sql = readPublicShareReaderMigration();
+  const visibleYearTotalsSql = requireMatch(sql, /visible_year_totals AS \([\s\S]*?\n  \)\n  SELECT/);
 
   assert.match(sql, /CREATE OR REPLACE FUNCTION community\.read_public_monthly_category_share/);
-  assert.equal(countMatches(sql, /AND v_loaded_month_from IS NOT NULL/g), 2);
-  assert.equal(countMatches(sql, /local_entry\.local_date >= v_loaded_month_from/g), 2);
-  assert.equal(countMatches(sql, /local_entry\.local_date < \(v_loaded_month_to \+ INTERVAL '1 month'\)::date/g), 2);
-  assert.match(loadedYearTotalsSql, /category\.access_level = 'monthly_values'/);
-  assert.match(loadedYearTotalsSql, /AND converted\.amount_report IS NOT NULL/);
-  assert.doesNotMatch(loadedYearTotalsSql, /v_available_month_/);
+  assert.match(sql, /visible_years AS/);
+  assert.match(sql, /generate_series\(\s+v_loaded_month_from::timestamp,\s+v_loaded_month_to::timestamp,/);
+  assert.match(sql, /visible_year_bounds AS/);
+  assert.match(sql, /GREATEST\(v_available_month_from, make_date\(visible_year\.total_year, 1, 1\)\)/);
+  assert.match(sql, /LEAST\(v_available_month_to, make_date\(visible_year\.total_year, 12, 1\)\)/);
+  assert.match(visibleYearTotalsSql, /category\.access_level = 'monthly_values'/);
+  assert.match(visibleYearTotalsSql, /local_entry\.local_date >= year_bound\.year_month_from/);
+  assert.match(visibleYearTotalsSql, /local_entry\.local_date < \(year_bound\.year_month_to \+ INTERVAL '1 month'\)::date/);
+  assert.match(visibleYearTotalsSql, /AND converted\.amount_report IS NOT NULL/);
+  assert.doesNotMatch(visibleYearTotalsSql, /v_loaded_month_from/);
+  assert.doesNotMatch(visibleYearTotalsSql, /v_loaded_month_to/);
   assert.doesNotMatch(sql, /configured_year_totals/);
+});
+
+test("community share objects remain unavailable to api_sql_executor", (): void => {
+  const settingsSql = readPublicShareSettingsMigration();
+  const readerSql = readPublicShareReaderMigration();
+  const metadataSql = readPublicShareMetadataMigration();
+
+  assert.match(settingsSql, /REVOKE ALL ON SCHEMA community FROM api_sql_executor/);
+  assert.match(settingsSql, /REVOKE ALL ON TABLE community\.monthly_category_shares FROM api_sql_executor/);
+  assert.match(settingsSql, /REVOKE ALL ON TABLE community\.monthly_category_share_items FROM api_sql_executor/);
+  assert.match(settingsSql, /REVOKE ALL ON TABLE community\.monthly_category_share_keys FROM api_sql_executor/);
+  assert.match(readerSql, /REVOKE ALL ON FUNCTION community\.read_public_monthly_category_share\(TEXT, DATE, DATE\) FROM api_sql_executor/);
+  assert.match(metadataSql, /REVOKE ALL ON FUNCTION community\.read_public_monthly_category_share_metadata\(TEXT\) FROM api_sql_executor/);
 });

--- a/apps/web/src/server/community/publicMonthlyCategoryShare.ts
+++ b/apps/web/src/server/community/publicMonthlyCategoryShare.ts
@@ -94,6 +94,17 @@ const mapCell = (cell: DbPublicMonthlyShareCell): PublicMonthlyShareCell => ({
   amount: toFiniteNumber(cell.amount),
 });
 
+const mapYearTotal = (total: DbPublicMonthlyShareYearTotal): PublicMonthlyShareYearTotal => {
+  if (!Number.isInteger(total.year)) {
+    throw new Error(`Invalid public monthly share year from database: ${total.year}`);
+  }
+  return {
+    year: String(total.year),
+    category: total.category,
+    amount: toFiniteNumber(total.amount),
+  };
+};
+
 const compareYearTotals = (
   left: PublicMonthlyShareYearTotal,
   right: PublicMonthlyShareYearTotal,
@@ -103,28 +114,6 @@ const compareYearTotals = (
     return yearCompare;
   }
   return left.category.localeCompare(right.category);
-};
-
-const yearTotalKey = (category: string, year: string): string =>
-  `${year}\u0000${category}`;
-
-const buildLoadedYearTotalsFromCells = (
-  cells: ReadonlyArray<PublicMonthlyShareCell>,
-): ReadonlyArray<PublicMonthlyShareYearTotal> => {
-  const totals = new Map<string, PublicMonthlyShareYearTotal>();
-
-  for (const cell of cells) {
-    const year = cell.month.slice(0, 4);
-    const key = yearTotalKey(cell.category, year);
-    const currentAmount = totals.get(key)?.amount ?? 0;
-    totals.set(key, {
-      year,
-      category: cell.category,
-      amount: toFiniteNumber(currentAmount + cell.amount),
-    });
-  }
-
-  return Array.from(totals.values()).sort(compareYearTotals);
 };
 
 export const mapPublicMonthlyCategoryShareRow = (
@@ -140,7 +129,7 @@ export const mapPublicMonthlyCategoryShareRow = (
     loadedMonthTo: dateStringToMonth(row.loaded_month_to),
     categories: row.categories.map(mapCategory),
     cells,
-    yearTotals: buildLoadedYearTotalsFromCells(cells),
+    yearTotals: row.year_totals.map(mapYearTotal).sort(compareYearTotals),
   };
 };
 

--- a/apps/web/src/ui/public-share/publicMonthlyShareModel.test.ts
+++ b/apps/web/src/ui/public-share/publicMonthlyShareModel.test.ts
@@ -26,7 +26,7 @@ const createShare = (
   yearTotals,
 });
 
-test("mergePublicMonthlyShareWindows recomputes year totals from loaded public cells", (): void => {
+test("mergePublicMonthlyShareWindows keeps server-provided year totals for visible years", (): void => {
   const currentShare = createShare(
     "2025-03",
     "2025-03",
@@ -34,7 +34,7 @@ test("mergePublicMonthlyShareWindows recomputes year totals from loaded public c
       { month: "2025-03", category: "Groceries", amount: 30 },
     ],
     [
-      { year: "2025", category: "Groceries", amount: 999 },
+      { year: "2025", category: "Groceries", amount: 300 },
     ],
   );
   const fetchedShare = createShare(
@@ -45,8 +45,8 @@ test("mergePublicMonthlyShareWindows recomputes year totals from loaded public c
       { month: "2025-01", category: "Groceries", amount: 10 },
     ],
     [
-      { year: "2024", category: "Groceries", amount: 999 },
-      { year: "2025", category: "Groceries", amount: 999 },
+      { year: "2024", category: "Groceries", amount: 50 },
+      { year: "2025", category: "Groceries", amount: 300 },
     ],
   );
 
@@ -55,10 +55,10 @@ test("mergePublicMonthlyShareWindows recomputes year totals from loaded public c
   const groceryRow = model.rows.find((row) => row.category === "Groceries");
 
   assert.deepEqual(merged.yearTotals, [
-    { year: "2024", category: "Groceries", amount: 5 },
-    { year: "2025", category: "Groceries", amount: 40 },
+    { year: "2024", category: "Groceries", amount: 50 },
+    { year: "2025", category: "Groceries", amount: 300 },
   ]);
   assert.ok(groceryRow !== undefined);
-  assert.equal(groceryRow.yearTotals.get("2024"), 5);
-  assert.equal(groceryRow.yearTotals.get("2025"), 40);
+  assert.equal(groceryRow.yearTotals.get("2024"), 50);
+  assert.equal(groceryRow.yearTotals.get("2025"), 300);
 });

--- a/apps/web/src/ui/public-share/publicMonthlyShareModel.ts
+++ b/apps/web/src/ui/public-share/publicMonthlyShareModel.ts
@@ -183,25 +183,6 @@ const buildYearTotalsByCategory = (
 const yearTotalKey = (category: string, year: string): string =>
   `${year}\u0000${category}`;
 
-const buildYearTotalsFromCells = (
-  cells: ReadonlyArray<PublicMonthlyShareCell>,
-): ReadonlyArray<PublicMonthlyShareYearTotal> => {
-  const totals = new Map<string, PublicMonthlyShareYearTotal>();
-
-  for (const cell of cells) {
-    const year = getYear(cell.month);
-    const key = yearTotalKey(cell.category, year);
-    const currentAmount = totals.get(key)?.amount ?? 0;
-    totals.set(key, {
-      year,
-      category: cell.category,
-      amount: currentAmount + cell.amount,
-    });
-  }
-
-  return Array.from(totals.values()).sort(compareYearTotals);
-};
-
 const buildVisibleYears = (months: ReadonlyArray<string>): ReadonlyArray<string> => {
   const years: Array<string> = [];
   for (const month of months) {
@@ -211,6 +192,35 @@ const buildVisibleYears = (months: ReadonlyArray<string>): ReadonlyArray<string>
     }
   }
   return years;
+};
+
+const buildVisibleYearSet = (
+  loadedMonthFrom: string | null,
+  loadedMonthTo: string | null,
+): ReadonlySet<string> => {
+  if (loadedMonthFrom === null || loadedMonthTo === null) {
+    return new Set<string>();
+  }
+  return new Set(buildVisibleYears(generateMonthRange(loadedMonthFrom, loadedMonthTo)));
+};
+
+const mergeYearTotals = (
+  currentYearTotals: ReadonlyArray<PublicMonthlyShareYearTotal>,
+  fetchedYearTotals: ReadonlyArray<PublicMonthlyShareYearTotal>,
+  mergedShare: PublicMonthlyCategoryShare,
+): ReadonlyArray<PublicMonthlyShareYearTotal> => {
+  const visibleYears = buildVisibleYearSet(mergedShare.loadedMonthFrom, mergedShare.loadedMonthTo);
+  const monthlyValueCategories = buildMonthlyValueCategorySet(mergedShare);
+  const totals = new Map<string, PublicMonthlyShareYearTotal>();
+
+  for (const total of [...currentYearTotals, ...fetchedYearTotals]) {
+    if (!visibleYears.has(total.year) || !monthlyValueCategories.has(total.category)) {
+      continue;
+    }
+    totals.set(yearTotalKey(total.category, total.year), total);
+  }
+
+  return Array.from(totals.values()).sort(compareYearTotals);
 };
 
 const sumVisibleYearTotals = (
@@ -320,7 +330,7 @@ export const mergePublicMonthlyShareWindows = (
   return {
     ...mergedShare,
     cells: mergedCells,
-    yearTotals: buildYearTotalsFromCells(mergedCells),
+    yearTotals: mergeYearTotals(currentShare.yearTotals, fetchedShare.yearTotals, mergedShare),
   };
 };
 

--- a/db/migrations/0050_community_public_monthly_share_visible_year_totals.sql
+++ b/db/migrations/0050_community_public_monthly_share_visible_year_totals.sql
@@ -1,0 +1,258 @@
+-- Return public year totals for visible table years using the full eligible share range.
+
+CREATE OR REPLACE FUNCTION community.read_public_monthly_category_share(
+  p_public_token TEXT,
+  p_month_from DATE,
+  p_month_to DATE
+)
+RETURNS TABLE(
+  label TEXT,
+  currency TEXT,
+  available_month_from DATE,
+  available_month_to DATE,
+  loaded_month_from DATE,
+  loaded_month_to DATE,
+  categories JSONB,
+  cells JSONB,
+  year_totals JSONB
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public, community
+AS $$
+DECLARE
+  v_share_id TEXT;
+  v_workspace_id TEXT;
+  v_label TEXT;
+  v_currency TEXT;
+  v_timezone TEXT;
+  v_config_month_from DATE;
+  v_config_month_to DATE;
+  v_request_month_from DATE;
+  v_request_month_to DATE;
+  v_capped_month_to DATE;
+  v_local_current_date DATE;
+  v_latest_eligible_month DATE;
+  v_available_month_from DATE;
+  v_available_month_to DATE;
+  v_loaded_month_from DATE;
+  v_loaded_month_to DATE;
+BEGIN
+  IF p_public_token IS NULL OR btrim(p_public_token) = '' THEN
+    RETURN;
+  END IF;
+
+  IF p_month_from IS NULL OR p_month_to IS NULL THEN
+    RAISE EXCEPTION 'read_public_monthly_category_share: p_month_from and p_month_to are required';
+  END IF;
+
+  v_request_month_from := date_trunc('month', p_month_from)::date;
+  v_request_month_to := date_trunc('month', p_month_to)::date;
+
+  IF v_request_month_from > v_request_month_to THEN
+    RAISE EXCEPTION 'read_public_monthly_category_share: p_month_from must be <= p_month_to';
+  END IF;
+
+  v_capped_month_to := LEAST(
+    v_request_month_to,
+    (v_request_month_from + (INTERVAL '1 month' * 23))::date
+  );
+
+  SELECT
+    share.share_id,
+    share.workspace_id,
+    share.display_label,
+    settings.reporting_currency,
+    settings.timezone,
+    share.month_from,
+    share.month_to
+  INTO
+    v_share_id,
+    v_workspace_id,
+    v_label,
+    v_currency,
+    v_timezone,
+    v_config_month_from,
+    v_config_month_to
+  FROM community.monthly_category_share_keys AS key
+  INNER JOIN community.monthly_category_shares AS share
+    ON share.share_id = key.share_id
+  INNER JOIN public.workspace_settings AS settings
+    ON settings.workspace_id = share.workspace_id
+  WHERE key.public_token = p_public_token
+    AND key.revoked_at IS NULL
+    AND share.enabled = true
+    AND share.blocked_at IS NULL;
+
+  IF v_share_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  v_local_current_date := (CURRENT_TIMESTAMP AT TIME ZONE v_timezone)::date;
+  v_latest_eligible_month := (
+    date_trunc('month', v_local_current_date)::date
+    - CASE
+        WHEN EXTRACT(DAY FROM v_local_current_date)::integer >= 6 THEN INTERVAL '1 month'
+        ELSE INTERVAL '2 months'
+      END
+  )::date;
+
+  v_available_month_from := v_config_month_from;
+  v_available_month_to := LEAST(
+    COALESCE(v_config_month_to, v_latest_eligible_month),
+    v_latest_eligible_month
+  );
+
+  IF v_available_month_to < v_available_month_from THEN
+    v_available_month_from := NULL;
+    v_available_month_to := NULL;
+    v_loaded_month_from := NULL;
+    v_loaded_month_to := NULL;
+  ELSE
+    v_loaded_month_from := GREATEST(v_request_month_from, v_available_month_from);
+    v_loaded_month_to := LEAST(v_capped_month_to, v_available_month_to);
+
+    IF v_loaded_month_to < v_loaded_month_from THEN
+      v_loaded_month_from := NULL;
+      v_loaded_month_to := NULL;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  WITH public_categories AS (
+    SELECT
+      item.category,
+      item.access_level
+    FROM community.monthly_category_share_items AS item
+    WHERE item.share_id = v_share_id
+      AND item.direction = 'spend'
+    ORDER BY item.category
+  ),
+  loaded_cells AS (
+    SELECT
+      date_trunc('month', local_entry.local_date)::date AS cell_month,
+      category.category,
+      SUM(-converted.amount_report)::double precision AS amount
+    FROM public_categories AS category
+    INNER JOIN public.ledger_entries AS entry
+      ON entry.workspace_id = v_workspace_id
+      AND entry.kind = 'spend'
+      AND COALESCE(entry.category, '') = category.category
+    CROSS JOIN LATERAL (
+      SELECT (entry.ts AT TIME ZONE v_timezone)::date AS local_date
+    ) AS local_entry
+    LEFT JOIN public.fx_rates_daily AS rate
+      ON rate.quote_currency = v_currency
+      AND rate.base_currency = entry.currency
+      AND rate.calendar_date = local_entry.local_date
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN entry.currency = v_currency THEN entry.amount::double precision
+          WHEN rate.rate IS NOT NULL THEN entry.amount::double precision * rate.rate::double precision
+          ELSE NULL
+        END AS amount_report
+    ) AS converted
+    WHERE category.access_level = 'monthly_values'
+      AND v_loaded_month_from IS NOT NULL
+      AND local_entry.local_date >= v_loaded_month_from
+      AND local_entry.local_date < (v_loaded_month_to + INTERVAL '1 month')::date
+      AND converted.amount_report IS NOT NULL
+    GROUP BY 1, 2
+  ),
+  visible_years AS (
+    SELECT DISTINCT
+      EXTRACT(YEAR FROM visible_month.month_start)::integer AS total_year
+    FROM generate_series(
+      v_loaded_month_from::timestamp,
+      v_loaded_month_to::timestamp,
+      INTERVAL '1 month'
+    ) AS visible_month(month_start)
+    WHERE v_loaded_month_from IS NOT NULL
+  ),
+  visible_year_bounds AS (
+    SELECT
+      visible_year.total_year,
+      GREATEST(v_available_month_from, make_date(visible_year.total_year, 1, 1)) AS year_month_from,
+      LEAST(v_available_month_to, make_date(visible_year.total_year, 12, 1)) AS year_month_to
+    FROM visible_years AS visible_year
+    WHERE v_available_month_from IS NOT NULL
+  ),
+  visible_year_totals AS (
+    SELECT
+      year_bound.total_year,
+      category.category,
+      SUM(-converted.amount_report)::double precision AS amount
+    FROM visible_year_bounds AS year_bound
+    INNER JOIN public_categories AS category
+      ON category.access_level = 'monthly_values'
+    INNER JOIN public.ledger_entries AS entry
+      ON entry.workspace_id = v_workspace_id
+      AND entry.kind = 'spend'
+      AND COALESCE(entry.category, '') = category.category
+    CROSS JOIN LATERAL (
+      SELECT (entry.ts AT TIME ZONE v_timezone)::date AS local_date
+    ) AS local_entry
+    LEFT JOIN public.fx_rates_daily AS rate
+      ON rate.quote_currency = v_currency
+      AND rate.base_currency = entry.currency
+      AND rate.calendar_date = local_entry.local_date
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN entry.currency = v_currency THEN entry.amount::double precision
+          WHEN rate.rate IS NOT NULL THEN entry.amount::double precision * rate.rate::double precision
+          ELSE NULL
+        END AS amount_report
+    ) AS converted
+    WHERE local_entry.local_date >= year_bound.year_month_from
+      AND local_entry.local_date < (year_bound.year_month_to + INTERVAL '1 month')::date
+      AND converted.amount_report IS NOT NULL
+    GROUP BY 1, 2
+  )
+  SELECT
+    v_label,
+    v_currency,
+    v_available_month_from,
+    v_available_month_to,
+    v_loaded_month_from,
+    v_loaded_month_to,
+    COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'category', category.category,
+          'accessLevel', category.access_level
+        )
+        ORDER BY category.category
+      )
+      FROM public_categories AS category
+    ), '[]'::jsonb),
+    COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'month', cell.cell_month,
+          'category', cell.category,
+          'amount', cell.amount
+        )
+        ORDER BY cell.cell_month, cell.category
+      )
+      FROM loaded_cells AS cell
+    ), '[]'::jsonb),
+    COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'year', total.total_year,
+          'category', total.category,
+          'amount', total.amount
+        )
+        ORDER BY total.total_year, total.category
+      )
+      FROM visible_year_totals AS total
+    ), '[]'::jsonb);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION community.read_public_monthly_category_share(TEXT, DATE, DATE) FROM PUBLIC;
+REVOKE ALL ON FUNCTION community.read_public_monthly_category_share(TEXT, DATE, DATE) FROM api_sql_executor;
+GRANT EXECUTE ON FUNCTION community.read_public_monthly_category_share(TEXT, DATE, DATE) TO app;

--- a/packages/agent-shared/src/sql-policy.test.ts
+++ b/packages/agent-shared/src/sql-policy.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { executeExpenseSql, MAX_SQL_ROWS, SqlPolicyError, validateExpenseSql } from "./sql-policy.js";
+import {
+  executeExpenseSql,
+  getAllowedRelationNames,
+  MAX_SQL_ROWS,
+  SqlPolicyError,
+  validateExpenseSql,
+} from "./sql-policy.js";
 
 const assertFunctionCallRejected = (sql: string): void => {
   assert.throws(
@@ -53,6 +59,32 @@ test("validateExpenseSql still allows direct relation queries without function c
   const validated = validateExpenseSql("SELECT account_id FROM ledger_entries ORDER BY account_id LIMIT 1");
   assert.equal(validated.statements.length, 1);
   assert.deepEqual(validated.statements[0]?.referencedRelations, ["ledger_entries"]);
+});
+
+test("restricted SQL policy does not expose community public share objects", (): void => {
+  assert.deepEqual(
+    getAllowedRelationNames().filter((relationName) => relationName.startsWith("community")),
+    [],
+  );
+
+  const rejectedRelations: ReadonlyArray<string> = [
+    "SELECT * FROM community.monthly_category_shares",
+    "SELECT * FROM monthly_category_shares",
+  ];
+
+  for (const sql of rejectedRelations) {
+    assert.throws(
+      () => validateExpenseSql(sql),
+      (error: unknown) =>
+        error instanceof SqlPolicyError && error.code === "relation_not_allowed",
+    );
+  }
+
+  assert.throws(
+    () => validateExpenseSql("SELECT * FROM community.read_public_monthly_category_share('token', '2025-01-01', '2025-12-01')"),
+    (error: unknown) =>
+      error instanceof SqlPolicyError && error.code === "function_calls_not_allowed",
+  );
 });
 
 test("executeExpenseSql reports truncation metadata without removing rowCount", async (): Promise<void> => {

--- a/scripts/publicMonthlyShareDbSmoke.ts
+++ b/scripts/publicMonthlyShareDbSmoke.ts
@@ -1,0 +1,286 @@
+import { randomUUID } from "node:crypto";
+import pg from "pg";
+
+type PgError = Error & Readonly<{
+  code?: string;
+}>;
+
+type SmokeIds = Readonly<{
+  userId: string;
+  workspaceId: string;
+  shareId: string;
+  publicToken: string;
+  rotatedToken: string;
+}>;
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+};
+
+const createPool = (connectionString: string): pg.Pool =>
+  new pg.Pool({ connectionString });
+
+const createToken = (): string =>
+  randomUUID().replaceAll("-", "") + randomUUID().replaceAll("-", "");
+
+const setupSmokeData = async (pool: pg.Pool): Promise<SmokeIds> => {
+  const suffix = randomUUID();
+  const ids: SmokeIds = {
+    userId: `public-share-smoke-user-${suffix}`,
+    workspaceId: `public-share-smoke-workspace-${suffix}`,
+    shareId: `public-share-smoke-share-${suffix}`,
+    publicToken: createToken(),
+    rotatedToken: createToken(),
+  };
+
+  await pool.query("BEGIN");
+  try {
+    await pool.query(
+      `
+        INSERT INTO public.users (
+          user_id,
+          email,
+          email_verified,
+          cognito_status,
+          cognito_enabled
+        )
+        VALUES ($1, $2, true, 'CONFIRMED', true)
+      `,
+      [ids.userId, `${ids.userId}@example.invalid`],
+    );
+    await pool.query(
+      "INSERT INTO public.workspaces (workspace_id, name) VALUES ($1, $2)",
+      [ids.workspaceId, "Public share DB smoke"],
+    );
+    await pool.query(
+      "INSERT INTO public.workspace_members (workspace_id, user_id) VALUES ($1, $2)",
+      [ids.workspaceId, ids.userId],
+    );
+    await pool.query(
+      "INSERT INTO public.workspace_settings (workspace_id, reporting_currency, timezone) VALUES ($1, 'USD', 'UTC')",
+      [ids.workspaceId],
+    );
+    await pool.query(
+      `
+        INSERT INTO public.ledger_entries (
+          event_id,
+          ts,
+          account_id,
+          amount,
+          currency,
+          kind,
+          category,
+          counterparty,
+          note,
+          workspace_id
+        )
+        VALUES
+          ($1, '2025-01-15T12:00:00.000Z', 'smoke-account', -12.34, 'USD', 'spend', 'Smoke monthly', 'private counterparty', 'private note', $2),
+          ($3, '2025-01-15T12:00:00.000Z', 'smoke-account', -56.78, 'USD', 'spend', 'Smoke category only', 'private counterparty', 'private note', $2),
+          ($4, '2025-01-15T12:00:00.000Z', 'smoke-account', 90.12, 'USD', 'income', 'Smoke monthly', 'private counterparty', 'private note', $2),
+          ($5, '2025-01-15T12:00:00.000Z', 'smoke-account', -34.56, 'ZZZ', 'spend', 'Smoke monthly', 'private counterparty', 'private note', $2)
+      `,
+      [
+        `event-spend-${suffix}`,
+        ids.workspaceId,
+        `event-category-only-${suffix}`,
+        `event-income-${suffix}`,
+        `event-unconvertible-${suffix}`,
+      ],
+    );
+    await pool.query(
+      `
+        INSERT INTO community.monthly_category_shares (
+          share_id,
+          workspace_id,
+          created_by_user_id,
+          enabled,
+          display_label,
+          month_from,
+          month_to
+        )
+        VALUES ($1, $2, $3, true, 'Smoke share', '2025-01-01', '2025-12-01')
+      `,
+      [ids.shareId, ids.workspaceId, ids.userId],
+    );
+    await pool.query(
+      `
+        INSERT INTO community.monthly_category_share_items (
+          share_id,
+          direction,
+          category,
+          access_level
+        )
+        VALUES
+          ($1, 'spend', 'Smoke monthly', 'monthly_values'),
+          ($1, 'spend', 'Smoke category only', 'category_only')
+      `,
+      [ids.shareId],
+    );
+    await pool.query(
+      "INSERT INTO community.monthly_category_share_keys (share_id, public_token) VALUES ($1, $2)",
+      [ids.shareId, ids.publicToken],
+    );
+    await pool.query("COMMIT");
+    return ids;
+  } catch (error) {
+    await pool.query("ROLLBACK");
+    throw error;
+  }
+};
+
+const cleanupSmokeData = async (pool: pg.Pool, ids: SmokeIds): Promise<void> => {
+  await pool.query("BEGIN");
+  try {
+    await pool.query("DELETE FROM community.monthly_category_shares WHERE share_id = $1", [ids.shareId]);
+    await pool.query("DELETE FROM public.ledger_entries WHERE workspace_id = $1", [ids.workspaceId]);
+    await pool.query("DELETE FROM public.workspace_settings WHERE workspace_id = $1", [ids.workspaceId]);
+    await pool.query("DELETE FROM public.workspace_members WHERE workspace_id = $1", [ids.workspaceId]);
+    await pool.query("DELETE FROM public.workspaces WHERE workspace_id = $1", [ids.workspaceId]);
+    await pool.query("DELETE FROM public.users WHERE user_id = $1", [ids.userId]);
+    await pool.query("COMMIT");
+  } catch (error) {
+    await pool.query("ROLLBACK");
+    throw error;
+  }
+};
+
+const assertAppRole = async (pool: pg.Pool): Promise<void> => {
+  const result = await pool.query("SELECT current_user AS current_user", []);
+  const currentUser = result.rows[0]?.current_user;
+  if (currentUser !== "app") {
+    throw new Error(`APP_DATABASE_URL must connect as role app; current_user=${String(currentUser)}`);
+  }
+};
+
+const readPublicShareRows = async (
+  pool: pg.Pool,
+  publicToken: string,
+): Promise<ReadonlyArray<Readonly<Record<string, unknown>>>> => {
+  const result = await pool.query(
+    `
+      SELECT categories, cells, year_totals
+      FROM community.read_public_monthly_category_share($1, '2025-01-01'::date, '2025-12-01'::date)
+    `,
+    [publicToken],
+  );
+  return result.rows as ReadonlyArray<Readonly<Record<string, unknown>>>;
+};
+
+const assertEnabledPublicReader = async (pool: pg.Pool, publicToken: string): Promise<void> => {
+  const rows = await readPublicShareRows(pool, publicToken);
+  if (rows.length !== 1) {
+    throw new Error(`Expected enabled public reader to return one row; rowCount=${rows.length}`);
+  }
+
+  const serialized = JSON.stringify(rows[0]);
+  if (!serialized.includes("Smoke monthly") || !serialized.includes("12.34")) {
+    throw new Error(`Expected public monthly aggregate is missing from reader result: ${serialized}`);
+  }
+  if (
+    serialized.includes("56.78")
+    || serialized.includes("90.12")
+    || serialized.includes("34.56")
+    || serialized.includes("private counterparty")
+    || serialized.includes("private note")
+  ) {
+    throw new Error(`Private, income, category-only, or unconvertible data leaked: ${serialized}`);
+  }
+};
+
+const assertMissingPublicReader = async (
+  pool: pg.Pool,
+  publicToken: string,
+  label: string,
+): Promise<void> => {
+  const rows = await readPublicShareRows(pool, publicToken);
+  if (rows.length !== 0) {
+    throw new Error(`Expected ${label} token to return no rows; rowCount=${rows.length}`);
+  }
+};
+
+const assertApiSqlExecutorDenied = async (
+  pool: pg.Pool,
+  sql: string,
+  params: ReadonlyArray<unknown>,
+  label: string,
+): Promise<void> => {
+  await pool.query("BEGIN");
+  try {
+    await pool.query("SET LOCAL ROLE api_sql_executor", []);
+    await pool.query(sql, params as Array<unknown>);
+    throw new Error(`api_sql_executor unexpectedly accessed ${label}`);
+  } catch (error) {
+    const pgError = error as PgError;
+    if (pgError.code !== "42501") {
+      throw error;
+    }
+  } finally {
+    await pool.query("ROLLBACK");
+  }
+};
+
+const main = async (): Promise<void> => {
+  const migrationDatabaseUrl = requireEnv("MIGRATION_DATABASE_URL");
+  const appDatabaseUrl = requireEnv("APP_DATABASE_URL");
+  const adminPool = createPool(migrationDatabaseUrl);
+  const appPool = createPool(appDatabaseUrl);
+  let ids: SmokeIds | null = null;
+
+  try {
+    ids = await setupSmokeData(adminPool);
+    await assertAppRole(appPool);
+    await assertEnabledPublicReader(appPool, ids.publicToken);
+
+    await adminPool.query("UPDATE community.monthly_category_shares SET enabled = false WHERE share_id = $1", [ids.shareId]);
+    await assertMissingPublicReader(appPool, ids.publicToken, "disabled");
+    await adminPool.query("UPDATE community.monthly_category_shares SET enabled = true WHERE share_id = $1", [ids.shareId]);
+
+    await adminPool.query(
+      "UPDATE community.monthly_category_share_keys SET revoked_at = now() WHERE share_id = $1 AND revoked_at IS NULL",
+      [ids.shareId],
+    );
+    await assertMissingPublicReader(appPool, ids.publicToken, "revoked");
+    await adminPool.query(
+      "INSERT INTO community.monthly_category_share_keys (share_id, public_token) VALUES ($1, $2)",
+      [ids.shareId, ids.rotatedToken],
+    );
+
+    await adminPool.query("UPDATE community.monthly_category_shares SET blocked_at = now() WHERE share_id = $1", [ids.shareId]);
+    await assertMissingPublicReader(appPool, ids.rotatedToken, "blocked");
+    await assertMissingPublicReader(appPool, createToken(), "unknown");
+
+    await assertApiSqlExecutorDenied(
+      appPool,
+      "SELECT 1 FROM community.monthly_category_shares LIMIT 1",
+      [],
+      "community.monthly_category_shares",
+    );
+    await assertApiSqlExecutorDenied(
+      appPool,
+      `
+        SELECT 1
+        FROM community.read_public_monthly_category_share($1, '2025-01-01'::date, '2025-12-01'::date)
+      `,
+      [ids.rotatedToken],
+      "community.read_public_monthly_category_share",
+    );
+
+    console.log(JSON.stringify({ ok: true, workspaceId: ids.workspaceId }));
+  } finally {
+    if (ids !== null) {
+      await cleanupSmokeData(adminPool, ids);
+    }
+    await adminPool.end();
+    await appPool.end();
+  }
+};
+
+void main().catch((error: unknown): void => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- Fix public monthly share year totals so visible years use the full eligible public share range, not only loaded cells.
- Add route, API contract, SQL policy, DB smoke, and E2E safety coverage for public monthly sharing.
- Keep machine SQL clients away from community share tables and public reader functions.

## Validation

- `cd apps/web && npm run lint`
- `cd apps/web && npm run build`
- focused web, sql-api, and agent-shared tests for the changed public share and SQL policy paths
- standalone TypeScript check for `scripts/publicMonthlyShareDbSmoke.ts`

Live E2E and DB smoke execution depend on external/local service prerequisites and were not run in this checkout.