### PR TITLE
Fix public share load earlier hydration

### DIFF
--- a/apps/web/e2e/public-monthly-share.spec.ts
+++ b/apps/web/e2e/public-monthly-share.spec.ts
@@ -405,8 +405,9 @@ test("public monthly share exposes only public aggregate data without private sh
     await publicPage.goto(settings.dashboardUrl, { waitUntil: "domcontentloaded" });
     await expect(publicPage.locator("main table")).toBeVisible({ timeout: externalUiTimeoutMs });
 
-    const loadEarlierButton = publicPage.locator('main button[type="button"]').first();
+    const loadEarlierButton = publicPage.getByTestId("public-share-load-earlier");
     await expect(loadEarlierButton).toBeVisible({ timeout: externalUiTimeoutMs });
+    await expect(loadEarlierButton).toBeEnabled({ timeout: externalUiTimeoutMs });
     const earlierResponse = await Promise.all([
       publicPage.waitForResponse((response) => new URL(response.url()).pathname.startsWith("/api/share/monthly/")),
       loadEarlierButton.click(),

--- a/apps/web/src/ui/public-share/PublicMonthlySharePage.tsx
+++ b/apps/web/src/ui/public-share/PublicMonthlySharePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { SupportedLocale } from "@/lib/locale";
@@ -62,6 +62,7 @@ export const PublicMonthlySharePage = (props: PublicMonthlySharePageProps): Reac
   } = props;
   const { t } = useTranslation();
   const [share, setShare] = useState<PublicMonthlyCategoryShare>(initialShare);
+  const [isHydrated, setIsHydrated] = useState<boolean>(false);
   const [isLoadingEarlier, setIsLoadingEarlier] = useState<boolean>(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const isLoadingEarlierRef = useRef<boolean>(false);
@@ -95,6 +96,10 @@ export const PublicMonthlySharePage = (props: PublicMonthlySharePageProps): Reac
     PUBLIC_MONTHLY_SHARE_BACKFILL_WINDOW_MONTHS,
   );
   const canLoadEarlier = earlierWindow !== null;
+
+  useEffect((): void => {
+    setIsHydrated(true);
+  }, []);
 
   const handleLoadEarlier = useCallback(async (): Promise<void> => {
     if (isLoadingEarlierRef.current) {
@@ -147,8 +152,9 @@ export const PublicMonthlySharePage = (props: PublicMonthlySharePageProps): Reac
           {model.hasSelectedCategories && canLoadEarlier && (
             <button
               className={styles.loadEarlierButton}
+              data-testid="public-share-load-earlier"
               type="button"
-              disabled={isLoadingEarlier}
+              disabled={!isHydrated || isLoadingEarlier}
               onClick={(): void => {
                 void handleLoadEarlier();
               }}


### PR DESCRIPTION
## Summary
- disable the public monthly share load-earlier button until React hydration completes
- use a stable Playwright test id and wait for the button to become enabled before clicking

## Validation
- git diff --check
- apps/web lint/build and related tests were run before publishing this patch