### PR TITLE
Add stable transaction clipboard JSON contract

### DIFF
--- a/apps/web/src/ui/tables/transactions/transactionClipboard.test.ts
+++ b/apps/web/src/ui/tables/transactions/transactionClipboard.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { LedgerEntry } from "@/server/transactions/getTransactions";
+
+import {
+  serializeTransactionClipboard,
+  toTransactionClipboardPayload,
+} from "./transactionClipboard";
+
+test("toTransactionClipboardPayload maps every ledger value to stable snake_case keys", (): void => {
+  const entry: LedgerEntry = {
+    note: "Monthly subscription",
+    currency: "EUR",
+    eventId: "event-456",
+    amountReport: -21.75,
+    accountId: "account-789",
+    category: "Software",
+    entryId: "entry-123",
+    counterparty: "Example Cloud",
+    ts: "2026-07-12T09:30:00.000Z",
+    kind: "spend",
+    amount: -24.5,
+  };
+
+  const payload = toTransactionClipboardPayload(entry);
+
+  assert.deepEqual(Object.keys(payload), [
+    "entry_id",
+    "event_id",
+    "ts",
+    "account_id",
+    "amount",
+    "amount_report",
+    "currency",
+    "kind",
+    "category",
+    "counterparty",
+    "note",
+  ]);
+  assert.deepEqual(payload, {
+    entry_id: "entry-123",
+    event_id: "event-456",
+    ts: "2026-07-12T09:30:00.000Z",
+    account_id: "account-789",
+    amount: -24.5,
+    amount_report: -21.75,
+    currency: "EUR",
+    kind: "spend",
+    category: "Software",
+    counterparty: "Example Cloud",
+    note: "Monthly subscription",
+  });
+});
+
+test("serializeTransactionClipboard preserves nulls and returns deterministic readable JSON", (): void => {
+  const entry: LedgerEntry = {
+    entryId: "entry-nullable",
+    eventId: "event-nullable",
+    ts: "2026-01-02T03:04:05.000Z",
+    accountId: "account-main",
+    amount: -10,
+    amountReport: null,
+    currency: "USD",
+    kind: "spend",
+    category: null,
+    counterparty: null,
+    note: null,
+  };
+
+  assert.equal(
+    serializeTransactionClipboard(entry),
+    `{
+  "entry_id": "entry-nullable",
+  "event_id": "event-nullable",
+  "ts": "2026-01-02T03:04:05.000Z",
+  "account_id": "account-main",
+  "amount": -10,
+  "amount_report": null,
+  "currency": "USD",
+  "kind": "spend",
+  "category": null,
+  "counterparty": null,
+  "note": null
+}`,
+  );
+});

--- a/apps/web/src/ui/tables/transactions/transactionClipboard.ts
+++ b/apps/web/src/ui/tables/transactions/transactionClipboard.ts
@@ -1,0 +1,34 @@
+import type { LedgerEntry } from "@/server/transactions/getTransactions";
+
+export type TransactionClipboardPayload = Readonly<{
+  entry_id: string;
+  event_id: string;
+  ts: string;
+  account_id: string;
+  amount: number;
+  amount_report: number | null;
+  currency: string;
+  kind: string;
+  category: string | null;
+  counterparty: string | null;
+  note: string | null;
+}>;
+
+export const toTransactionClipboardPayload = (
+  entry: LedgerEntry,
+): TransactionClipboardPayload => ({
+  entry_id: entry.entryId,
+  event_id: entry.eventId,
+  ts: entry.ts,
+  account_id: entry.accountId,
+  amount: entry.amount,
+  amount_report: entry.amountReport,
+  currency: entry.currency,
+  kind: entry.kind,
+  category: entry.category,
+  counterparty: entry.counterparty,
+  note: entry.note,
+});
+
+export const serializeTransactionClipboard = (entry: LedgerEntry): string =>
+  JSON.stringify(toTransactionClipboardPayload(entry), null, 2);


### PR DESCRIPTION
## Summary
- add an explicit readonly snake_case clipboard payload for transaction rows
- map every current LedgerEntry field without display formatting
- serialize deterministic readable JSON while preserving numbers and nulls

## Validation
- npx tsx --test src/ui/tables/transactions/transactionClipboard.test.ts
- npm run lint
- npm run build
- git diff --check