### PR TITLE
Attach clipboard images in AI chat

### DIFF
--- a/apps/web/src/ui/chat/shell/panel/ChatComposer.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatComposer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {
+  ClipboardEvent,
   KeyboardEvent,
   ReactElement,
   RefObject,
@@ -26,7 +27,7 @@ type Props = Readonly<{
   capabilities: ChatComposerCapabilities;
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   onInputChange: (value: string) => void;
-  onAttach: (attachment: PendingAttachment) => void;
+  onIngestFiles: (files: ReadonlyArray<File>) => Promise<number>;
   onRemoveAttachment: (index: number) => void;
   onToggleDictation: () => Promise<void>;
   onSend: () => Promise<void>;
@@ -43,7 +44,7 @@ export const ChatComposer = (props: Props): ReactElement => {
     capabilities,
     textareaRef,
     onInputChange,
-    onAttach,
+    onIngestFiles,
     onRemoveAttachment,
     onToggleDictation,
     onSend,
@@ -69,6 +70,28 @@ export const ChatComposer = (props: Props): ReactElement => {
 
     event.preventDefault();
     void onSend();
+  };
+
+  const handleTextareaPaste = (
+    event: ClipboardEvent<HTMLTextAreaElement>,
+  ): void => {
+    const imageFiles = Array.from(event.clipboardData.items)
+      .filter((item) => item.kind === "file" && item.type.startsWith("image/"))
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => file !== null)
+      .map((file) => file.name === ""
+        ? new File([file], "clipboard-image.png", {
+          type: file.type,
+          lastModified: file.lastModified,
+        })
+        : file);
+
+    if (imageFiles.length === 0 || !capabilities.isDropTargetEnabled) {
+      return;
+    }
+
+    event.preventDefault();
+    void onIngestFiles(imageFiles);
   };
 
   const handleSubmitButtonClick = (): void => {
@@ -108,6 +131,7 @@ export const ChatComposer = (props: Props): ReactElement => {
         enterKeyHint={enterKeyHint}
         onChange={(event) => onInputChange(event.target.value)}
         onKeyDown={handleTextareaKeyDown}
+        onPaste={handleTextareaPaste}
         rows={1}
       />
       {dictationStatusLabel !== null && (
@@ -138,7 +162,10 @@ export const ChatComposer = (props: Props): ReactElement => {
               )}
             </svg>
           </button>
-          <FileAttachment onAttach={onAttach} disabled={capabilities.isAttachButtonDisabled} />
+          <FileAttachment
+            onIngestFiles={onIngestFiles}
+            disabled={capabilities.isAttachButtonDisabled}
+          />
           <button
             type="button"
             className={styles.sendButton}

--- a/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
@@ -226,8 +226,22 @@ export const ChatPanel = (props: Props): ReactElement => {
     shouldRestoreTextareaFocusAfterDictationRef.current = false;
   }, [dictationState, inputText]);
 
-  const handleAttach = useCallback((attachment: PendingAttachment): void => {
-    setPendingAttachments((prev) => [...prev, attachment]);
+  const ingestFiles = useCallback(async (files: ReadonlyArray<File>): Promise<number> => {
+    let attachedFileCount = 0;
+
+    for (const file of files) {
+      const sizeError = checkFileSize(file);
+      if (sizeError !== null) {
+        alert(sizeError);
+        continue;
+      }
+
+      const attachment = await prepareAttachment(file);
+      setPendingAttachments((prev) => [...prev, attachment]);
+      attachedFileCount += 1;
+    }
+
+    return attachedFileCount;
   }, []);
 
   const removeAttachment = useCallback((index: number): void => {
@@ -288,24 +302,13 @@ export const ChatPanel = (props: Props): ReactElement => {
       return;
     }
 
-    const files = e.dataTransfer.files;
-    let hasAttachedFile = false;
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i];
-      const sizeError = checkFileSize(file);
-      if (sizeError !== null) {
-        alert(sizeError);
-        continue;
-      }
-      const attachment = await prepareAttachment(file);
-      handleAttach(attachment);
-      hasAttachedFile = true;
-    }
+    const files = Array.from(e.dataTransfer.files);
+    const attachedFileCount = await ingestFiles(files);
 
-    if (hasAttachedFile) {
+    if (attachedFileCount > 0) {
       textareaRef.current?.focus();
     }
-  }, [composerCapabilities.isDropTargetEnabled, handleAttach]);
+  }, [composerCapabilities.isDropTargetEnabled, ingestFiles]);
 
   const canSendPendingMessage = isHistoryLoaded
     && !isStopping
@@ -560,7 +563,7 @@ export const ChatPanel = (props: Props): ReactElement => {
         capabilities={composerCapabilities}
         textareaRef={textareaRef}
         onInputChange={setInputText}
-        onAttach={handleAttach}
+        onIngestFiles={ingestFiles}
         onRemoveAttachment={removeAttachment}
         onToggleDictation={handleToggleDictation}
         onSend={sendPendingMessage}

--- a/apps/web/src/ui/chat/shell/panel/FileAttachment.tsx
+++ b/apps/web/src/ui/chat/shell/panel/FileAttachment.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, type ReactElement } from "react";
+import { useRef, type ChangeEvent, type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import styles from "./ChatPanel.module.css";
 
@@ -11,7 +11,7 @@ export type PendingAttachment = Readonly<{
 }>;
 
 type Props = Readonly<{
-  onAttach: (attachment: PendingAttachment) => void;
+  onIngestFiles: (files: ReadonlyArray<File>) => Promise<number>;
   disabled?: boolean;
 }>;
 
@@ -82,29 +82,16 @@ export const prepareAttachment = async (file: File): Promise<PendingAttachment> 
 };
 
 export const FileAttachment = (props: Props): ReactElement => {
-  const { onAttach, disabled = false } = props;
+  const { onIngestFiles, disabled = false } = props;
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleChange = async (): Promise<void> => {
-    const files = inputRef.current?.files;
-    if (files === null || files === undefined) return;
-
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i];
-      const sizeError = checkFileSize(file);
-      if (sizeError !== null) {
-        alert(sizeError);
-        continue;
-      }
-      const attachment = await prepareAttachment(file);
-      onAttach(attachment);
-    }
+  const handleChange = async (event: ChangeEvent<HTMLInputElement>): Promise<void> => {
+    const files = Array.from(event.currentTarget.files ?? []);
 
     // Reset input so the same file can be attached again
-    if (inputRef.current !== null) {
-      inputRef.current.value = "";
-    }
+    event.currentTarget.value = "";
+    await onIngestFiles(files);
   };
 
   return (
@@ -116,7 +103,7 @@ export const FileAttachment = (props: Props): ReactElement => {
         multiple
         style={{ display: "none" }}
         disabled={disabled}
-        onChange={() => void handleChange()}
+        onChange={(event) => void handleChange(event)}
       />
       <button
         type="button"


### PR DESCRIPTION
## Summary
- centralize chat file ingestion for picker, drag-and-drop, and paste
- attach pasted bitmap images without inserting companion clipboard text or HTML
- preserve native text paste and existing attachment preprocessing

## Validation
- `cd apps/web && npm run lint`
- `cd apps/web && npm run build`
- `git diff --check`

## Residual risk
- Browser smoke could not run because the in-app browser could not reach the worker local server; independent review found no concrete defect from this gap.