### PR TITLE
Improve budget summary row presentation

### DIFF
--- a/apps/web/src/ui/tables/budget/BudgetTable.module.css
+++ b/apps/web/src/ui/tables/budget/BudgetTable.module.css
@@ -112,6 +112,10 @@
   border-top: 1px solid var(--panel-border);
 }
 
+.businessPersonalDivider {
+  border-block-start: 1px solid var(--panel-border);
+}
+
 .directionLabel {
   padding: 4px 10px;
   font-weight: 650;
@@ -135,6 +139,14 @@
 
 .cellSubtotal {
   font-weight: 650;
+}
+
+.remainderPositive:not(:global(.data-masked)) {
+  color: #2e7d32;
+}
+
+.remainderNegative:not(:global(.data-masked)) {
+  color: #c0392b;
 }
 
 .currentMonth {
@@ -185,6 +197,14 @@ tbody tr:last-child .currentMonthActual {
 .yearTotalDanger {
   --budget-table-year-total-color: #e74c3c;
   --table-state-danger-color: #e74c3c;
+}
+
+.yearTotal.remainderNegative:not(:global(.data-masked)) {
+  color: #e74c3c;
+}
+
+.yearTotal.remainderPositive:not(:global(.data-masked)) {
+  color: #4caf50;
 }
 
 .yearTotal:has(+ .yearTotal) {

--- a/apps/web/src/ui/tables/budget/model/cells.test.ts
+++ b/apps/web/src/ui/tables/budget/model/cells.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatSignedAmount } from "@/ui/tables/budget/model/cells";
+
+test("formatSignedAmount formats signed rounded integers", (): void => {
+  assert.equal(formatSignedAmount(42.4, "1,234.56"), "+42");
+  assert.equal(formatSignedAmount(-42.4, "1,234.56"), "-42");
+  assert.equal(formatSignedAmount(0, "1,234.56"), "0");
+  assert.equal(formatSignedAmount(0.4, "1,234.56"), "0");
+  assert.equal(formatSignedAmount(-0.4, "1,234.56"), "0");
+});
+
+test("formatSignedAmount uses the selected thousands separator", (): void => {
+  assert.equal(formatSignedAmount(12_345.4, "1.234,56"), "+12.345");
+});

--- a/apps/web/src/ui/tables/budget/model/cells.ts
+++ b/apps/web/src/ui/tables/budget/model/cells.ts
@@ -22,6 +22,13 @@ export const formatAmount = (value: number, numberFormat: NumberFormat): string 
   return rounded.toLocaleString(NUMBER_FORMAT_LOCALE[numberFormat]);
 };
 
+export const formatSignedAmount = (value: number, numberFormat: NumberFormat): string => {
+  const rounded = Math.round(value);
+  if (rounded === 0) return "0";
+  const formatted = rounded.toLocaleString(NUMBER_FORMAT_LOCALE[numberFormat]);
+  return rounded > 0 ? `+${formatted}` : formatted;
+};
+
 /**
  * Sums CellValues produced by a lookup function over a list of months.
  * Used for both per-category totals and direction subtotals.

--- a/apps/web/src/ui/tables/budget/table/sections/BudgetDerivedSection.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/BudgetDerivedSection.tsx
@@ -8,6 +8,7 @@ import type { NumberFormat } from "@/lib/locale";
 import type { BusinessPersonalTransferCell } from "@/server/budget/getBudgetGrid";
 import {
   formatAmount,
+  formatSignedAmount,
   zeroCellValue,
   type CellValue,
   type ColumnEntry,
@@ -30,6 +31,11 @@ import type { DrillDownFilter } from "@/ui/tables/shared/drillDownFilter";
 const ZERO_BUSINESS_PERSONAL_TRANSFER: BusinessPersonalTransferCell = {
   actual: 0,
   hasUnconvertible: false,
+};
+
+const getRemainderValueClass = (value: number, isTainted: boolean): string => {
+  if (isTainted) return "";
+  return Math.round(value) < 0 ? styles.remainderNegative : styles.remainderPositive;
 };
 
 export type BudgetDerivedSectionProps = Readonly<{
@@ -86,128 +92,25 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
   return (
     <>
       <MetricRow
-        label={t("budget.remainder")}
-        columnSequence={columnSequence}
-        currentMonth={currentMonth}
-        currentYear={currentYear}
-        yearComputed={yearComputed}
-        loadingKind="subtotal"
-        rowClassName={styles.directionRow}
-        renderPastYear={(year, yearData) => {
-          const yearTotalStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.actual));
-          return (
-            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalStateClass}`}>
-              {formatAmount(yearData.remainder.actual, numberFormat)}
-            </td>
-          );
-        }}
-        renderFutureYear={(year, yearData) => {
-          const yearTotalStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.planned));
-          return (
-            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalStateClass}`}>
-              {formatAmount(yearData.remainder.planned, numberFormat)}
-            </td>
-          );
-        }}
-        renderCurrentYear={(year, yearData) => {
-          const yearTotalPlanStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.planned));
-          const yearTotalActualStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.actual));
-          return (
-            <Fragment key={`total-${year}`}>
-              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalPlanStateClass}`}>
-                {formatAmount(yearData.remainder.planned, numberFormat)}
-              </td>
-              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalActualStateClass}`}>
-                {formatAmount(yearData.remainder.actual, numberFormat)}
-              </td>
-            </Fragment>
-          );
-        }}
-        renderPastMonth={(month) => {
-          const income = incomeSubtotals?.get(month) ?? zeroCellValue;
-          const spend = spendSubtotals?.get(month) ?? zeroCellValue;
-          const transfer = transferSubtotals?.get(month) ?? zeroCellValue;
-          return renderValueCells({
-            key: month,
-            month,
-            currentMonth,
-            planned: income.planned - spend.planned + transfer.planned,
-            actual: income.actual - spend.actual + transfer.actual,
-            isTainted: taintedMonths.has(month),
-            isPlanOver: false,
-            isActualOver: false,
-            isSubtotal: true,
-            maskClass: derivedMaskClass,
-            numberFormat,
-            formatter: formatAmount,
-            onActualClick: null,
-          });
-        }}
-        renderFutureMonth={(month) => {
-          const income = incomeSubtotals?.get(month) ?? zeroCellValue;
-          const spend = spendSubtotals?.get(month) ?? zeroCellValue;
-          const transfer = transferSubtotals?.get(month) ?? zeroCellValue;
-          const remainderPlan = income.planned - spend.planned + transfer.planned;
-          return renderValueCells({
-            key: month,
-            month,
-            currentMonth,
-            planned: remainderPlan,
-            actual: income.actual - spend.actual + transfer.actual,
-            isTainted: taintedMonths.has(month),
-            isPlanOver: isNegativeValueOver(remainderPlan),
-            isActualOver: false,
-            isSubtotal: true,
-            maskClass: derivedMaskClass,
-            numberFormat,
-            formatter: formatAmount,
-            onActualClick: null,
-          });
-        }}
-        renderCurrentMonth={(month) => {
-          const income = incomeSubtotals?.get(month) ?? zeroCellValue;
-          const spend = spendSubtotals?.get(month) ?? zeroCellValue;
-          const transfer = transferSubtotals?.get(month) ?? zeroCellValue;
-          const remainderPlan = income.planned - spend.planned + transfer.planned;
-          const remainderActual = income.actual - spend.actual + transfer.actual;
-          return renderValueCells({
-            key: month,
-            month,
-            currentMonth,
-            planned: remainderPlan,
-            actual: remainderActual,
-            isTainted: taintedMonths.has(month),
-            isPlanOver: isNegativeValueOver(remainderPlan),
-            isActualOver: isNegativeValueOver(remainderActual),
-            isSubtotal: true,
-            maskClass: derivedMaskClass,
-            numberFormat,
-            formatter: formatAmount,
-            onActualClick: null,
-          });
-        }}
-      />
-
-      <MetricRow
         label={t("budget.fxAdjust")}
         columnSequence={columnSequence}
         currentMonth={currentMonth}
         currentYear={currentYear}
         yearComputed={yearComputed}
-        loadingKind="subtotal"
+        loadingKind="derived"
         rowClassName={styles.categoryRow}
         renderPastYear={(year, yearData) => (
-          <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}`}>
+          <td key={`total-${year}`} className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
             {formatFxAmount(yearData.yearFxAdjust, numberFormat)}
           </td>
         )}
         renderFutureYear={(year) => (
-          <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}`} />
+          <td key={`total-${year}`} className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`} />
         )}
         renderCurrentYear={(year, yearData) => (
           <Fragment key={`total-${year}`}>
-            <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}`} />
-            <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}`}>
+            <td className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`} />
+            <td className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
               {formatFxAmount(yearData.yearFxAdjust, numberFormat)}
             </td>
           </Fragment>
@@ -224,8 +127,10 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
             isTainted: false,
             isPlanOver: false,
             isActualOver: false,
-            isSubtotal: true,
+            isSubtotal: false,
             maskClass: `${derivedMaskClass}${fxClickable ? ` ${styles.cellClickable}` : ""}`,
+            plannedValueClass: "",
+            actualValueClass: "",
             numberFormat,
             formatter: formatFxAmount,
             onActualClick: fxClickable ? () => openFxBreakdown(month) : null,
@@ -240,8 +145,10 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           isTainted: false,
           isPlanOver: false,
           isActualOver: false,
-          isSubtotal: true,
+          isSubtotal: false,
           maskClass: derivedMaskClass,
+          plannedValueClass: "",
+          actualValueClass: "",
           numberFormat,
           formatter: formatFxAmount,
           onActualClick: null,
@@ -258,11 +165,128 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
             isTainted: false,
             isPlanOver: false,
             isActualOver: false,
-            isSubtotal: true,
+            isSubtotal: false,
             maskClass: derivedMaskClass,
+            plannedValueClass: "",
+            actualValueClass: "",
             numberFormat,
             formatter: formatFxAmount,
             onActualClick: fxClickable ? () => openFxBreakdown(month) : null,
+          });
+        }}
+      />
+
+      <MetricRow
+        label={t("budget.remainder")}
+        columnSequence={columnSequence}
+        currentMonth={currentMonth}
+        currentYear={currentYear}
+        yearComputed={yearComputed}
+        loadingKind="subtotal"
+        rowClassName={styles.directionRow}
+        renderPastYear={(year, yearData) => {
+          const yearTotalStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.actual));
+          return (
+            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalStateClass} ${getRemainderValueClass(yearData.remainder.actual, yearData.anyTainted)}`}>
+              {formatSignedAmount(yearData.remainder.actual, numberFormat)}
+            </td>
+          );
+        }}
+        renderFutureYear={(year, yearData) => {
+          const yearTotalStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.planned));
+          return (
+            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalStateClass} ${getRemainderValueClass(yearData.remainder.planned, yearData.anyTainted)}`}>
+              {formatSignedAmount(yearData.remainder.planned, numberFormat)}
+            </td>
+          );
+        }}
+        renderCurrentYear={(year, yearData) => {
+          const yearTotalPlanStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.planned));
+          const yearTotalActualStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.actual));
+          return (
+            <Fragment key={`total-${year}`}>
+              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalPlanStateClass} ${getRemainderValueClass(yearData.remainder.planned, yearData.anyTainted)}`}>
+                {formatSignedAmount(yearData.remainder.planned, numberFormat)}
+              </td>
+              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalActualStateClass} ${getRemainderValueClass(yearData.remainder.actual, yearData.anyTainted)}`}>
+                {formatSignedAmount(yearData.remainder.actual, numberFormat)}
+              </td>
+            </Fragment>
+          );
+        }}
+        renderPastMonth={(month) => {
+          const income = incomeSubtotals?.get(month) ?? zeroCellValue;
+          const spend = spendSubtotals?.get(month) ?? zeroCellValue;
+          const transfer = transferSubtotals?.get(month) ?? zeroCellValue;
+          const remainderPlan = income.planned - spend.planned + transfer.planned;
+          const remainderActual = income.actual - spend.actual + transfer.actual;
+          const isTainted = taintedMonths.has(month);
+          return renderValueCells({
+            key: month,
+            month,
+            currentMonth,
+            planned: remainderPlan,
+            actual: remainderActual,
+            isTainted,
+            isPlanOver: false,
+            isActualOver: false,
+            isSubtotal: true,
+            maskClass: derivedMaskClass,
+            plannedValueClass: getRemainderValueClass(remainderPlan, isTainted),
+            actualValueClass: getRemainderValueClass(remainderActual, isTainted),
+            numberFormat,
+            formatter: formatSignedAmount,
+            onActualClick: null,
+          });
+        }}
+        renderFutureMonth={(month) => {
+          const income = incomeSubtotals?.get(month) ?? zeroCellValue;
+          const spend = spendSubtotals?.get(month) ?? zeroCellValue;
+          const transfer = transferSubtotals?.get(month) ?? zeroCellValue;
+          const remainderPlan = income.planned - spend.planned + transfer.planned;
+          const remainderActual = income.actual - spend.actual + transfer.actual;
+          const isTainted = taintedMonths.has(month);
+          return renderValueCells({
+            key: month,
+            month,
+            currentMonth,
+            planned: remainderPlan,
+            actual: remainderActual,
+            isTainted,
+            isPlanOver: isNegativeValueOver(remainderPlan),
+            isActualOver: false,
+            isSubtotal: true,
+            maskClass: derivedMaskClass,
+            plannedValueClass: getRemainderValueClass(remainderPlan, isTainted),
+            actualValueClass: getRemainderValueClass(remainderActual, isTainted),
+            numberFormat,
+            formatter: formatSignedAmount,
+            onActualClick: null,
+          });
+        }}
+        renderCurrentMonth={(month) => {
+          const income = incomeSubtotals?.get(month) ?? zeroCellValue;
+          const spend = spendSubtotals?.get(month) ?? zeroCellValue;
+          const transfer = transferSubtotals?.get(month) ?? zeroCellValue;
+          const remainderPlan = income.planned - spend.planned + transfer.planned;
+          const remainderActual = income.actual - spend.actual + transfer.actual;
+          const isTainted = taintedMonths.has(month);
+          return renderValueCells({
+            key: month,
+            month,
+            currentMonth,
+            planned: remainderPlan,
+            actual: remainderActual,
+            isTainted,
+            isPlanOver: isNegativeValueOver(remainderPlan),
+            isActualOver: isNegativeValueOver(remainderActual),
+            isSubtotal: true,
+            maskClass: derivedMaskClass,
+            plannedValueClass: getRemainderValueClass(remainderPlan, isTainted),
+            actualValueClass: getRemainderValueClass(remainderActual, isTainted),
+            numberFormat,
+            formatter: formatSignedAmount,
+            onActualClick: null,
           });
         }}
       />
@@ -318,6 +342,8 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
             isActualOver: false,
             isSubtotal: true,
             maskClass: derivedMaskClass,
+            plannedValueClass: "",
+            actualValueClass: "",
             numberFormat,
             formatter: formatAmount,
             onActualClick: null,
@@ -336,6 +362,8 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
             isActualOver: false,
             isSubtotal: true,
             maskClass: derivedMaskClass,
+            plannedValueClass: "",
+            actualValueClass: "",
             numberFormat,
             formatter: formatAmount,
             onActualClick: null,
@@ -354,6 +382,8 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
             isActualOver: isNegativeValueOver(balance.actual),
             isSubtotal: true,
             maskClass: derivedMaskClass,
+            plannedValueClass: "",
+            actualValueClass: "",
             numberFormat,
             formatter: formatAmount,
             onActualClick: null,
@@ -383,15 +413,15 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           currentMonth={currentMonth}
           currentYear={currentYear}
           yearComputed={yearComputed}
-          loadingKind="subtotal"
-          rowClassName={styles.categoryRow}
+          loadingKind="derived"
+          rowClassName={`${styles.categoryRow} ${styles.businessPersonalDivider}`}
           renderPastYear={(year, yearData) => {
             const cell = yearData.businessPersonalTransfer;
             const stateClass = buildYearTotalStateClass(cell.hasUnconvertible, false);
             return (
               <td
                 key={`total-${year}`}
-                className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${stateClass}${canOpenDerivedDrillDown ? ` ${styles.cellClickable}` : ""}`}
+                className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}${stateClass}${canOpenDerivedDrillDown ? ` ${styles.cellClickable}` : ""}`}
                 onClick={canOpenDerivedDrillDown ? () => openDrillDown(buildBusinessPersonalTransferYearDrillDownFilter(year)) : undefined}
               >
                 {formatAmount(cell.actual, numberFormat)}
@@ -399,16 +429,16 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
             );
           }}
           renderFutureYear={(year) => (
-            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}`} />
+            <td key={`total-${year}`} className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`} />
           )}
           renderCurrentYear={(year, yearData) => {
             const cell = yearData.businessPersonalTransfer;
             const stateClass = buildYearTotalStateClass(cell.hasUnconvertible, false);
             return (
               <Fragment key={`total-${year}`}>
-                <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}`} />
+                <td className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`} />
                 <td
-                  className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${stateClass}${canOpenDerivedDrillDown ? ` ${styles.cellClickable}` : ""}`}
+                  className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}${stateClass}${canOpenDerivedDrillDown ? ` ${styles.cellClickable}` : ""}`}
                   onClick={canOpenDerivedDrillDown ? () => openDrillDown(buildBusinessPersonalTransferYearDrillDownFilter(year)) : undefined}
                 >
                   {formatAmount(cell.actual, numberFormat)}
@@ -427,8 +457,10 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
               isTainted: cell.hasUnconvertible,
               isPlanOver: false,
               isActualOver: false,
-              isSubtotal: true,
+              isSubtotal: false,
               maskClass: derivedMaskClass,
+              plannedValueClass: "",
+              actualValueClass: "",
               numberFormat,
               formatter: formatAmount,
               onActualClick: canOpenDerivedDrillDown ? () => openDrillDown(buildBusinessPersonalTransferMonthDrillDownFilter(month)) : null,
@@ -443,8 +475,10 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
             isTainted: false,
             isPlanOver: false,
             isActualOver: false,
-            isSubtotal: true,
+            isSubtotal: false,
             maskClass: derivedMaskClass,
+            plannedValueClass: "",
+            actualValueClass: "",
             numberFormat,
             formatter: formatAmount,
             onActualClick: null,
@@ -460,8 +494,10 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
               isTainted: cell.hasUnconvertible,
               isPlanOver: false,
               isActualOver: false,
-              isSubtotal: true,
+              isSubtotal: false,
               maskClass: derivedMaskClass,
+              plannedValueClass: "",
+              actualValueClass: "",
               numberFormat,
               formatter: formatAmount,
               onActualClick: canOpenDerivedDrillDown ? () => openDrillDown(buildBusinessPersonalTransferMonthDrillDownFilter(month)) : null,

--- a/apps/web/src/ui/tables/budget/table/sections/direction/DirectionSubtotalRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/direction/DirectionSubtotalRow.tsx
@@ -21,6 +21,7 @@ import {
   buildYearTotalStateClass,
   isDirectionActualOverPlanned,
   renderColumnCells,
+  renderDerivedYearLoadingCells,
   renderSubtotalYearLoadingCells,
   renderValueCells,
 } from "../shared";
@@ -55,10 +56,14 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
   } = props;
   const { t } = useTranslation();
   const dirVis: CellVisibility = { showData: true, maskClass: "" };
+  const isTransfer = block.direction === "transfer";
+  const labelClass = isTransfer ? styles.categoryLabel : styles.directionLabel;
+  const subtotalClass = isTransfer ? "" : ` ${styles.cellSubtotal}`;
+  const renderYearLoading = isTransfer ? renderDerivedYearLoadingCells : renderSubtotalYearLoadingCells;
 
   return (
     <tr className={styles.directionRow}>
-      <td className={`${styles.directionLabel} ${styles.stickyCol}`}>
+      <td className={`${labelClass} ${styles.stickyCol}`}>
         {t(`budget.direction${block.direction.charAt(0).toUpperCase()}${block.direction.slice(1)}`)}
       </td>
       <td className={styles.leftSpacer} />
@@ -70,10 +75,10 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
           currentYear,
           isYearLoading: column.kind === "year-total" && yearData === undefined,
           renderYearLoading: (isCurrentYearValue) =>
-            renderSubtotalYearLoadingCells(column.kind === "year-total" ? column.year : "", isCurrentYearValue),
+            renderYearLoading(column.kind === "year-total" ? column.year : "", isCurrentYearValue),
           renderPastYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
-              return renderSubtotalYearLoadingCells(column.kind === "year-total" ? column.year : "", false);
+              return renderYearLoading(column.kind === "year-total" ? column.year : "", false);
             }
             const yearSubtotal = useFilteredSubtotals
               ? (yearData.filteredSubtotals.get(block.direction) ?? zeroCellValue)
@@ -82,7 +87,7 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
             return (
               <td
                 key={`total-${column.year}`}
-                className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${dirVis.maskClass}${yearTotalStateClass}${dirVis.showData ? ` ${styles.cellClickable}` : ""}`}
+                className={`${styles.cell}${subtotalClass} ${styles.yearTotal}${dirVis.maskClass}${yearTotalStateClass}${dirVis.showData ? ` ${styles.cellClickable}` : ""}`}
                 onClick={dirVis.showData
                   ? () => openDrillDown(buildDirectionYearDrillDownFilter(column.year, block.direction, allowedCategoriesArray))
                   : undefined}
@@ -93,21 +98,21 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
           },
           renderFutureYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
-              return renderSubtotalYearLoadingCells(column.kind === "year-total" ? column.year : "", false);
+              return renderYearLoading(column.kind === "year-total" ? column.year : "", false);
             }
             const yearSubtotal = useFilteredSubtotals
               ? (yearData.filteredSubtotals.get(block.direction) ?? zeroCellValue)
               : (yearData.directionSubtotals.get(block.direction) ?? zeroCellValue);
             const yearTotalStateClass = buildYearTotalStateClass(yearData.taintedDirections.has(block.direction), false);
             return (
-              <td key={`total-${column.year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${dirVis.maskClass}${yearTotalStateClass}`}>
+              <td key={`total-${column.year}`} className={`${styles.cell}${subtotalClass} ${styles.yearTotal}${dirVis.maskClass}${yearTotalStateClass}`}>
                 {formatAmount(yearSubtotal.planned, numberFormat)}
               </td>
             );
           },
           renderCurrentYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
-              return renderSubtotalYearLoadingCells(column.kind === "year-total" ? column.year : "", true);
+              return renderYearLoading(column.kind === "year-total" ? column.year : "", true);
             }
             const yearSubtotal = useFilteredSubtotals
               ? (yearData.filteredSubtotals.get(block.direction) ?? zeroCellValue)
@@ -117,11 +122,11 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
             const yearTotalActualStateClass = buildYearTotalStateClass(yearData.taintedDirections.has(block.direction), isActualOver);
             return (
               <Fragment key={`total-${column.year}`}>
-                <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${dirVis.maskClass}${yearTotalPlanStateClass}`}>
+                <td className={`${styles.cell}${subtotalClass} ${styles.yearTotal}${dirVis.maskClass}${yearTotalPlanStateClass}`}>
                   {formatAmount(yearSubtotal.planned, numberFormat)}
                 </td>
                 <td
-                  className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${dirVis.maskClass}${yearTotalActualStateClass}${dirVis.showData ? ` ${styles.cellClickable}` : ""}`}
+                  className={`${styles.cell}${subtotalClass} ${styles.yearTotal}${dirVis.maskClass}${yearTotalActualStateClass}${dirVis.showData ? ` ${styles.cellClickable}` : ""}`}
                   onClick={dirVis.showData
                     ? () => openDrillDown(buildDirectionYearDrillDownFilter(column.year, block.direction, allowedCategoriesArray))
                     : undefined}
@@ -133,7 +138,7 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
           },
           renderPastMonth: () => {
             if (column.kind !== "month") {
-              return renderSubtotalYearLoadingCells("invalid", false);
+              return renderYearLoading("invalid", false);
             }
             const subtotal = (useFilteredSubtotals
               ? filteredSubtotalsMap.get(block.direction)?.get(column.month)
@@ -148,8 +153,10 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
               isTainted,
               isPlanOver: false,
               isActualOver: false,
-              isSubtotal: true,
+              isSubtotal: !isTransfer,
               maskClass: dirVis.maskClass,
+              plannedValueClass: "",
+              actualValueClass: "",
               numberFormat,
               formatter: formatAmount,
               onActualClick: dirVis.showData
@@ -159,7 +166,7 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
           },
           renderFutureMonth: () => {
             if (column.kind !== "month") {
-              return renderSubtotalYearLoadingCells("invalid", false);
+              return renderYearLoading("invalid", false);
             }
             const subtotal = (useFilteredSubtotals
               ? filteredSubtotalsMap.get(block.direction)?.get(column.month)
@@ -174,8 +181,10 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
               isTainted,
               isPlanOver: false,
               isActualOver: false,
-              isSubtotal: true,
+              isSubtotal: !isTransfer,
               maskClass: dirVis.maskClass,
+              plannedValueClass: "",
+              actualValueClass: "",
               numberFormat,
               formatter: formatAmount,
               onActualClick: null,
@@ -183,7 +192,7 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
           },
           renderCurrentMonth: () => {
             if (column.kind !== "month") {
-              return renderSubtotalYearLoadingCells("invalid", false);
+              return renderYearLoading("invalid", false);
             }
             const subtotal = (useFilteredSubtotals
               ? filteredSubtotalsMap.get(block.direction)?.get(column.month)
@@ -198,8 +207,10 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
               isTainted,
               isPlanOver: false,
               isActualOver: isDirectionActualOverPlanned(block.direction, subtotal.planned, subtotal.actual),
-              isSubtotal: true,
+              isSubtotal: !isTransfer,
               maskClass: dirVis.maskClass,
+              plannedValueClass: "",
+              actualValueClass: "",
               numberFormat,
               formatter: formatAmount,
               onActualClick: dirVis.showData

--- a/apps/web/src/ui/tables/budget/table/sections/shared.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/shared.tsx
@@ -30,6 +30,8 @@ export type RenderValueCellsParams = Readonly<{
   isActualOver: boolean;
   isSubtotal: boolean;
   maskClass: string;
+  plannedValueClass: string;
+  actualValueClass: string;
   numberFormat: NumberFormat;
   formatter: (value: number, numberFormat: NumberFormat) => string;
   onActualClick: (() => void) | null;
@@ -79,6 +81,8 @@ export const renderValueCells = (params: RenderValueCellsParams): ReactElement =
     isActualOver,
     isSubtotal,
     maskClass,
+    plannedValueClass,
+    actualValueClass,
     numberFormat,
     formatter,
     onActualClick,
@@ -91,7 +95,7 @@ export const renderValueCells = (params: RenderValueCellsParams): ReactElement =
     return (
       <td
         key={key}
-        className={`${styles.cell}${subtotalClass}${maskClass}${taintedClass}${clickableClass}`}
+        className={`${styles.cell}${subtotalClass}${maskClass}${taintedClass}${clickableClass} ${actualValueClass}`}
         onClick={onActualClick ?? undefined}
       >
         {formatter(actual, numberFormat)}
@@ -103,7 +107,7 @@ export const renderValueCells = (params: RenderValueCellsParams): ReactElement =
     return (
       <td
         key={key}
-        className={`${styles.cell}${subtotalClass}${maskClass}${taintedClass}${isPlanOver ? ` ${tableStateStyles.over}` : ""}`}
+        className={`${styles.cell}${subtotalClass}${maskClass}${taintedClass}${isPlanOver ? ` ${tableStateStyles.over}` : ""} ${plannedValueClass}`}
       >
         {formatter(planned, numberFormat)}
       </td>
@@ -114,12 +118,12 @@ export const renderValueCells = (params: RenderValueCellsParams): ReactElement =
   return (
     <Fragment key={key}>
       <td
-        className={`${styles.cell} ${styles.currentMonthPlan}${subtotalClass}${maskClass}${taintedClass}${isPlanOver ? ` ${tableStateStyles.over}` : ""}`}
+        className={`${styles.cell} ${styles.currentMonthPlan}${subtotalClass}${maskClass}${taintedClass}${isPlanOver ? ` ${tableStateStyles.over}` : ""} ${plannedValueClass}`}
       >
         {formatter(planned, numberFormat)}
       </td>
       <td
-        className={`${styles.cell} ${styles.currentMonthActual}${subtotalClass}${maskClass}${taintedClass}${isActualOver ? ` ${tableStateStyles.over}` : ""}${clickableClass}`}
+        className={`${styles.cell} ${styles.currentMonthActual}${subtotalClass}${maskClass}${taintedClass}${isActualOver ? ` ${tableStateStyles.over}` : ""}${clickableClass} ${actualValueClass}`}
         onClick={onActualClick ?? undefined}
       >
         {formatter(actual, numberFormat)}


### PR DESCRIPTION
## Summary
- reorder and restyle budget summary rows across monthly and yearly columns
- add signed, taint-aware Remainder formatting and accessible value colors
- keep Transfer, FX adjust, and Business to personal at regular weight

## Validation
- `npx tsx --test src/ui/tables/budget/model/cells.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`

Browser navigation timed out during the optional visual smoke check.