### PR TITLE
Return authoritative transaction updates

### DIFF
--- a/apps/web/src/app/api/transactions/create/route.ts
+++ b/apps/web/src/app/api/transactions/create/route.ts
@@ -6,17 +6,9 @@ import { isDemoModeFromRequest } from "@/lib/demoMode";
 import { handleRoute } from "@/server/api/handleRoute";
 import { parseTransactionsCreateBody } from "@/server/api/transactions";
 import { parseJsonBody } from "@/server/api/validation";
+import { getDemoAmountReport } from "@/server/demo/transactions";
 import { createLedgerEntry } from "@/server/transactions/createLedgerEntry";
 import { extractUserId, extractWorkspaceId } from "@/server/userId";
-
-const DEMO_FX_RATES: Readonly<Record<string, number>> = { USD: 1, EUR: 1.029, GBP: 1.24 };
-
-const getDemoAmountReport = (amount: number, currency: string): number | null => {
-  if (currency.length === 0) return null;
-  const rate = DEMO_FX_RATES[currency];
-  if (rate === undefined) return null;
-  return Math.round(amount * rate * 100) / 100;
-};
 
 export const POST = async (request: Request): Promise<Response> =>
   handleRoute(

--- a/apps/web/src/app/api/transactions/update/route.test.ts
+++ b/apps/web/src/app/api/transactions/update/route.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { POST } from "@/app/api/transactions/update/route";
+
+const updateBody = {
+  entryId: "entry-123",
+  category: "Software",
+  note: "Monthly subscription",
+  counterparty: "Example Cloud",
+  kind: "spend",
+  ts: "2026-07-12T09:30:00.000Z",
+  accountId: "account-789",
+  amount: -24.5,
+  currency: "EUR",
+} as const;
+
+const createDemoUpdateRequest = (body: object): Request =>
+  new Request("http://localhost/api/transactions/update", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: "demo=true",
+    },
+    body: JSON.stringify(body),
+  });
+
+test("Demo update accepts the legacy body without eventId", async (): Promise<void> => {
+  const response = await POST(createDemoUpdateRequest(updateBody));
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true });
+});
+
+test("Demo update accepts eventId and returns the complete updated ledger entry", async (): Promise<void> => {
+  const response = await POST(createDemoUpdateRequest({
+    ...updateBody,
+    eventId: "event-456",
+  }));
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    entryId: "entry-123",
+    eventId: "event-456",
+    ts: "2026-07-12T09:30:00.000Z",
+    accountId: "account-789",
+    amount: -24.5,
+    amountReport: -25.21,
+    currency: "EUR",
+    kind: "spend",
+    category: "Software",
+    counterparty: "Example Cloud",
+    note: "Monthly subscription",
+  });
+});

--- a/apps/web/src/app/api/transactions/update/route.ts
+++ b/apps/web/src/app/api/transactions/update/route.ts
@@ -4,6 +4,7 @@ import { isDemoModeFromRequest } from "@/lib/demoMode";
 import { handleRoute } from "@/server/api/handleRoute";
 import { parseTransactionsUpdateBody } from "@/server/api/transactions";
 import { parseJsonBody } from "@/server/api/validation";
+import { getDemoAmountReport } from "@/server/demo/transactions";
 import { updateLedgerEntry } from "@/server/transactions/updateLedgerEntry";
 import { extractUserId, extractWorkspaceId } from "@/server/userId";
 
@@ -14,12 +15,27 @@ export const POST = async (request: Request): Promise<Response> =>
       const body = parseTransactionsUpdateBody(await parseJsonBody(request, z.unknown()));
 
       if (isDemoModeFromRequest(request)) {
+        if (body.eventId !== undefined) {
+          return Response.json({
+            entryId: body.entryId,
+            eventId: body.eventId,
+            ts: new Date(body.ts).toISOString(),
+            accountId: body.accountId,
+            amount: body.amount,
+            amountReport: getDemoAmountReport(body.amount, body.currency),
+            currency: body.currency,
+            kind: body.kind,
+            category: body.category,
+            counterparty: body.counterparty,
+            note: body.note,
+          });
+        }
         return Response.json({ ok: true });
       }
 
       const userId = extractUserId(request);
       const workspaceId = extractWorkspaceId(request);
-      await updateLedgerEntry(userId, workspaceId, body);
-      return Response.json({ ok: true });
+      const entry = await updateLedgerEntry(userId, workspaceId, body);
+      return Response.json(entry);
     },
   );

--- a/apps/web/src/server/api/transactions.ts
+++ b/apps/web/src/server/api/transactions.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import type { TransactionsFilter } from "@/server/transactions/getTransactions";
-import { accountIdSchema, counterpartySchema, currencySchema, entryIdSchema, finiteNumberSchema, isoDateTimeSchema, noteSchema, nullableCategorySchema, parseOptionalQueryParam, parseRepeatedQueryParam, parseWithSchema, transactionKindSchema } from "@/server/api/validation";
+import { accountIdSchema, counterpartySchema, currencySchema, entryIdSchema, eventIdSchema, finiteNumberSchema, isoDateTimeSchema, noteSchema, nullableCategorySchema, parseOptionalQueryParam, parseRepeatedQueryParam, parseWithSchema, transactionKindSchema } from "@/server/api/validation";
 
 type CreateTransactionBody = Readonly<{
   ts: string;
@@ -16,6 +16,7 @@ type CreateTransactionBody = Readonly<{
 
 type UpdateTransactionBody = Readonly<{
   entryId: string;
+  eventId?: string;
   category: string | null;
   note: string | null;
   counterparty: string | null;
@@ -107,7 +108,10 @@ export const parseTransactionsCreateBody = (input: unknown): CreateTransactionBo
  * Validate the POST /api/transactions/update request body.
  */
 export const parseTransactionsUpdateBody = (input: unknown): UpdateTransactionBody =>
-  parseWithSchema(input, transactionBodySchema.extend({ entryId: entryIdSchema }));
+  parseWithSchema(input, transactionBodySchema.extend({
+    entryId: entryIdSchema,
+    eventId: eventIdSchema.optional(),
+  }));
 
 /**
  * Validate the POST /api/transactions/delete request body.

--- a/apps/web/src/server/api/validation.ts
+++ b/apps/web/src/server/api/validation.ts
@@ -140,6 +140,14 @@ export const entryIdSchema: ZodType<string> = createStringSchema(
 );
 
 /**
+ * Accept an event identifier string up to 200 characters.
+ */
+export const eventIdSchema: ZodType<string> = createStringSchema(
+  (value: string): boolean => value.length > 0 && value.length <= 200,
+  "Invalid eventId. Expected non-empty string (max 200 chars)",
+);
+
+/**
  * Accept a finite number for the named field.
  */
 export const finiteNumberSchema = (fieldName: string): ZodType<number> =>

--- a/apps/web/src/server/demo/transactions.ts
+++ b/apps/web/src/server/demo/transactions.ts
@@ -1,0 +1,9 @@
+const DEMO_FX_RATES: Readonly<Record<string, number>> = { USD: 1, EUR: 1.029, GBP: 1.24 };
+
+export const getDemoAmountReport = (amount: number, currency: string): number | null => {
+  const rate = DEMO_FX_RATES[currency];
+  if (rate === undefined) {
+    return null;
+  }
+  return Math.round(amount * rate * 100) / 100;
+};

--- a/apps/web/src/server/transactions/createLedgerEntry.ts
+++ b/apps/web/src/server/transactions/createLedgerEntry.ts
@@ -6,6 +6,7 @@
  */
 import { queryAs } from "@/server/db";
 import { getReportCurrency } from "@/server/reportCurrency";
+import { mapLedgerEntryRow, type LedgerEntry, type LedgerEntryRow } from "@/server/transactions/getTransactions";
 
 type CreateLedgerEntryParams = Readonly<{
   ts: string;
@@ -20,37 +21,11 @@ type CreateLedgerEntryParams = Readonly<{
 
 export type { CreateLedgerEntryParams };
 
-type LedgerEntryRow = Readonly<{
-  entry_id: string;
-  event_id: string;
-  ts: string;
-  account_id: string;
-  amount: number;
-  amount_report: number | null;
-  currency: string;
-  kind: string;
-  category: string | null;
-  counterparty: string | null;
-  note: string | null;
-}>;
-
 export const createLedgerEntry = async (
   userId: string,
   workspaceId: string,
   params: CreateLedgerEntryParams,
-): Promise<Readonly<{
-  entryId: string;
-  eventId: string;
-  ts: string;
-  accountId: string;
-  amount: number;
-  amountReport: number | null;
-  currency: string;
-  kind: string;
-  category: string | null;
-  counterparty: string | null;
-  note: string | null;
-}>> => {
+): Promise<LedgerEntry> => {
   const reportCurrency = await getReportCurrency(userId, workspaceId);
   const result = await queryAs(
     userId,
@@ -124,17 +99,5 @@ export const createLedgerEntry = async (
     throw new Error("Failed to create ledger entry: insert returned no row");
   }
 
-  return {
-    entryId: row.entry_id,
-    eventId: row.event_id,
-    ts: new Date(row.ts).toISOString(),
-    accountId: row.account_id,
-    amount: Number(row.amount),
-    amountReport: row.amount_report !== null ? Number(row.amount_report) : null,
-    currency: row.currency,
-    kind: row.kind,
-    category: row.category,
-    counterparty: row.counterparty,
-    note: row.note,
-  };
+  return mapLedgerEntryRow(row);
 };

--- a/apps/web/src/server/transactions/getTransactions.test.ts
+++ b/apps/web/src/server/transactions/getTransactions.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mapLedgerEntryRow, type LedgerEntryRow } from "@/server/transactions/getTransactions";
+
+test("mapLedgerEntryRow maps the authoritative database event and recalculated report amount", (): void => {
+  const row: LedgerEntryRow = {
+    entry_id: "entry-database",
+    event_id: "event-database",
+    ts: "2026-07-12 09:30:00+00",
+    account_id: "account-database",
+    amount: -24.5,
+    amount_report: -25.2105,
+    currency: "EUR",
+    kind: "spend",
+    category: "Software",
+    counterparty: "Example Cloud",
+    note: "Monthly subscription",
+  };
+
+  assert.deepEqual(mapLedgerEntryRow(row), {
+    entryId: "entry-database",
+    eventId: "event-database",
+    ts: "2026-07-12T09:30:00.000Z",
+    accountId: "account-database",
+    amount: -24.5,
+    amountReport: -25.2105,
+    currency: "EUR",
+    kind: "spend",
+    category: "Software",
+    counterparty: "Example Cloud",
+    note: "Monthly subscription",
+  });
+});

--- a/apps/web/src/server/transactions/getTransactions.ts
+++ b/apps/web/src/server/transactions/getTransactions.ts
@@ -23,6 +23,34 @@ export type LedgerEntry = Readonly<{
   note: string | null;
 }>;
 
+export type LedgerEntryRow = Readonly<{
+  entry_id: string;
+  event_id: string;
+  ts: string;
+  account_id: string;
+  amount: number;
+  amount_report: number | null;
+  currency: string;
+  kind: string;
+  category: string | null;
+  counterparty: string | null;
+  note: string | null;
+}>;
+
+export const mapLedgerEntryRow = (row: LedgerEntryRow): LedgerEntry => ({
+  entryId: row.entry_id,
+  eventId: row.event_id,
+  ts: new Date(row.ts).toISOString(),
+  accountId: row.account_id,
+  amount: Number(row.amount),
+  amountReport: row.amount_report !== null ? Number(row.amount_report) : null,
+  currency: row.currency,
+  kind: row.kind,
+  category: row.category,
+  counterparty: row.counterparty,
+  note: row.note,
+});
+
 export type AccountOption = Readonly<{
   accountId: string;
 }>;
@@ -253,31 +281,7 @@ export const getTransactionsPage = async (
     ]);
 
     return {
-      entries: entriesResult.rows.map((row: {
-        entry_id: string;
-        event_id: string;
-        ts: string;
-        account_id: string;
-        amount: number;
-        amount_report: number | null;
-        currency: string;
-        kind: string;
-        category: string | null;
-        counterparty: string | null;
-        note: string | null;
-      }) => ({
-        entryId: row.entry_id,
-        eventId: row.event_id,
-        ts: new Date(row.ts).toISOString(),
-        accountId: row.account_id,
-        amount: Number(row.amount),
-        amountReport: row.amount_report !== null ? Number(row.amount_report) : null,
-        currency: row.currency,
-        kind: row.kind,
-        category: row.category,
-        counterparty: row.counterparty,
-        note: row.note,
-      })),
+      entries: entriesResult.rows.map((row: LedgerEntryRow): LedgerEntry => mapLedgerEntryRow(row)),
       total: Number((countResult.rows[0] as { total: string }).total),
     };
   });

--- a/apps/web/src/server/transactions/updateLedgerEntry.ts
+++ b/apps/web/src/server/transactions/updateLedgerEntry.ts
@@ -5,6 +5,8 @@
  * RLS ensures the update only affects entries owned by the given user.
  */
 import { queryAs } from "@/server/db";
+import { getReportCurrency } from "@/server/reportCurrency";
+import { mapLedgerEntryRow, type LedgerEntry, type LedgerEntryRow } from "@/server/transactions/getTransactions";
 
 type UpdateLedgerEntryParams = Readonly<{
   entryId: string;
@@ -20,11 +22,72 @@ type UpdateLedgerEntryParams = Readonly<{
 
 export type { UpdateLedgerEntryParams };
 
-export const updateLedgerEntry = async (userId: string, workspaceId: string, params: UpdateLedgerEntryParams): Promise<void> => {
-  await queryAs(
+export const updateLedgerEntry = async (
+  userId: string,
+  workspaceId: string,
+  params: UpdateLedgerEntryParams,
+): Promise<LedgerEntry> => {
+  const reportCurrency = await getReportCurrency(userId, workspaceId);
+  const result = await queryAs(
     userId,
     workspaceId,
-    "UPDATE ledger_entries SET category = $1, note = $2, counterparty = $3, kind = $4, ts = $5, account_id = $6, amount = $7, currency = $8 WHERE entry_id = $9",
-    [params.category, params.note, params.counterparty, params.kind, params.ts, params.accountId, params.amount, params.currency, params.entryId],
+    `
+      WITH updated AS (
+        UPDATE ledger_entries
+        SET
+          category = $2,
+          note = $3,
+          counterparty = $4,
+          kind = $5,
+          ts = $6,
+          account_id = $7,
+          amount = $8,
+          currency = $9
+        WHERE entry_id = $10
+        RETURNING entry_id, event_id, ts, account_id, amount, currency, kind, category, counterparty, note
+      )
+      SELECT
+        u.entry_id,
+        u.event_id,
+        u.ts,
+        u.account_id,
+        u.amount::double precision AS amount,
+        CASE
+          WHEN u.currency = $1 THEN u.amount::double precision
+          WHEN r.rate IS NOT NULL THEN u.amount::double precision * r.rate::double precision
+          ELSE NULL
+        END AS amount_report,
+        u.currency,
+        u.kind,
+        u.category,
+        u.counterparty,
+        u.note
+      FROM updated u
+      LEFT JOIN fx_rates_daily r
+        ON r.quote_currency = $1
+        AND r.base_currency = u.currency
+        AND r.calendar_date = u.ts::date
+    `,
+    [
+      reportCurrency,
+      params.category,
+      params.note,
+      params.counterparty,
+      params.kind,
+      params.ts,
+      params.accountId,
+      params.amount,
+      params.currency,
+      params.entryId,
+    ],
   );
+
+  const row = result.rows[0] as LedgerEntryRow | undefined;
+  if (row === undefined) {
+    throw new Error(
+      `No ledger entry was updated for entryId "${params.entryId}": the entry does not exist in workspace "${workspaceId}" or is not accessible to the current user`,
+    );
+  }
+
+  return mapLedgerEntryRow(row);
 };


### PR DESCRIPTION
## Summary
- keep transaction update requests compatible when eventId is omitted
- return the authoritative database LedgerEntry with exact-date report-currency conversion
- preserve Demo compatibility and cover old/new request contracts

## Validation
- focused tests: 3 passed, 0 failed
- npm run lint
- npm run build
- git diff --check