### PR TITLE
Persist secure chat drafts per tab

### DIFF
--- a/apps/web/e2e-local/chat-draft.local-demo.spec.ts
+++ b/apps/web/e2e-local/chat-draft.local-demo.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+type NavigationHref = "/chat" | "/transactions";
+const localNavigationTimeoutMs = 20_000;
+
+const getNavigationLink = (page: Page, href: NavigationHref): Locator =>
+  page.getByRole("navigation").locator(`a[href="${href}"]`);
+
+test("keeps an unsent chat draft within one tab", async ({ page, baseURL, context }) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "chat-open", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+
+  await page.goto("/transactions", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("unsent draft");
+
+  await page.getByTestId("chat-sidebar-close").click();
+  await expect(composer).toHaveCount(0);
+  await page.getByTestId("chat-sidebar-open").click();
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue("unsent draft");
+
+  await getNavigationLink(page, "/chat").click();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat",
+    { timeout: localNavigationTimeoutMs },
+  );
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue("unsent draft");
+
+  await getNavigationLink(page, "/transactions").click();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/transactions",
+    { timeout: localNavigationTimeoutMs },
+  );
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue("unsent draft");
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue("unsent draft");
+
+  const secondTab = await context.newPage();
+  await secondTab.goto("/transactions", { waitUntil: "domcontentloaded" });
+  await expect(secondTab.getByTestId("chat-composer-input")).toHaveValue("");
+  await secondTab.close();
+
+  await page.getByTestId("chat-composer-input").fill("");
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue("");
+});

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -18,6 +18,7 @@ import { extractUserIdFromHeaders, extractWorkspaceIdFromHeaders } from "@/serve
 import { resolveWorkspaceForCurrentRequestIdentity } from "@/server/workspaceBootstrap";
 import { AccountMenu } from "@/ui/AccountMenu";
 import { ChatLayoutProvider, ChatLayoutShell } from "@/ui/chat";
+import type { ChatDraftScope } from "@/ui/chat/shell/layout/chatDraftStorage";
 import { CurrencySelector } from "@/ui/CurrencySelector";
 import { FilteredBanner } from "@/ui/FilteredBanner";
 import { FilteredModeProvider } from "@/ui/FilteredModeProvider";
@@ -53,6 +54,7 @@ export default async function RootLayout(props: Readonly<{ children: React.React
 
   const demo = await isDemoMode();
   const { chatOpen, chatWidth } = await readChatCookies();
+  const currentUserId = extractUserIdFromHeaders(headersList);
 
   const authEnabled = process.env.AUTH_MODE === "cognito";
   let reportingCurrency = "USD";
@@ -66,8 +68,8 @@ export default async function RootLayout(props: Readonly<{ children: React.React
     locale = await getLocaleCookie();
   } else {
     try {
-      const userId = extractUserIdFromHeaders(headersList);
       const workspaceId = extractWorkspaceIdFromHeaders(headersList);
+      currentWorkspaceId = workspaceId;
       if (authEnabled) {
         const resolvedWorkspace = await resolveWorkspaceForCurrentRequestIdentity(
           buildRequestIdentity(headersList),
@@ -78,13 +80,12 @@ export default async function RootLayout(props: Readonly<{ children: React.React
           redirect(`/api/workspaces/bootstrap?returnTo=${encodeURIComponent(returnTo)}`);
         }
       }
-      reportingCurrency = await getReportCurrency(userId, workspaceId);
-      currentWorkspaceId = workspaceId;
+      reportingCurrency = await getReportCurrency(currentUserId, workspaceId);
       if (authEnabled) {
-        workspaces = await listWorkspaces(userId, workspaceId);
+        workspaces = await listWorkspaces(currentUserId, workspaceId);
       }
       const initialLocale = await getLocaleCookie();
-      const userSettings = await getUserSettings(userId, workspaceId, initialLocale);
+      const userSettings = await getUserSettings(currentUserId, workspaceId, initialLocale);
       locale = userSettings.locale;
       numberFormat = userSettings.numberFormat;
       dateFormat = userSettings.dateFormat;
@@ -94,6 +95,10 @@ export default async function RootLayout(props: Readonly<{ children: React.React
       locale = await getLocaleCookie();
     }
   }
+
+  const chatDraftScope: ChatDraftScope = demo
+    ? { mode: "demo", userId: currentUserId }
+    : { mode: "workspace", userId: currentUserId, workspaceId: currentWorkspaceId };
 
   return (
     <html lang={locale} dir={RTL_LOCALES.has(locale) ? "rtl" : "ltr"}>
@@ -129,7 +134,11 @@ export default async function RootLayout(props: Readonly<{ children: React.React
                   <CurrencySelector initialCurrency={reportingCurrency} titleText={t(locale, "currency.title")} />
                 </nav>
               </div>
-              <ChatLayoutProvider initialChatOpen={chatOpen} initialChatWidth={chatWidth}>
+              <ChatLayoutProvider
+                initialChatOpen={chatOpen}
+                initialChatWidth={chatWidth}
+                draftScope={chatDraftScope}
+              >
                 <ChatLayoutShell workspaceId={currentWorkspaceId}>
                   {children}
                 </ChatLayoutShell>

--- a/apps/web/src/ui/AccountMenu.tsx
+++ b/apps/web/src/ui/AccountMenu.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { fetchWithCsrf } from "@/lib/csrf";
 import { cn } from "@/lib/cn";
 import { resolveBrowserTimezone } from "@/lib/timezone";
+import { clearChatDrafts } from "@/ui/chat/shell/layout/chatDraftStorage";
 
 import styles from "./AccountMenu.module.css";
 
@@ -89,6 +90,7 @@ export const AccountMenu = (props: Props): ReactElement | null => {
   }, []);
 
   const handleLogout = useCallback((): void => {
+    clearChatDrafts(window.sessionStorage);
     fetchWithCsrf("/api/auth/logout", { method: "POST" }).finally(() => {
       window.location.href = "/";
     });

--- a/apps/web/src/ui/chat/shell/layout/ChatLayoutProvider.tsx
+++ b/apps/web/src/ui/chat/shell/layout/ChatLayoutProvider.tsx
@@ -1,12 +1,32 @@
 "use client";
 
-import { createContext, useContext, useState, type ReactElement, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type ReactElement,
+  type ReactNode,
+  type SetStateAction,
+} from "react";
+
+import {
+  getChatDraftStorageKey,
+  readChatDraft,
+  writeChatDraft,
+  type ChatDraftScope,
+} from "./chatDraftStorage";
 
 type ChatLayoutContextValue = Readonly<{
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
   chatWidth: number;
   setChatWidth: (width: number) => void;
+  chatDraftText: string;
+  setChatDraftText: Dispatch<SetStateAction<string>>;
 }>;
 
 const ChatLayoutContext = createContext<ChatLayoutContextValue | null>(null);
@@ -21,12 +41,39 @@ type Props = Readonly<{
   children: ReactNode;
   initialChatOpen: boolean;
   initialChatWidth: number;
+  draftScope: ChatDraftScope;
+}>;
+
+type ChatDraftState = Readonly<{
+  storageKey: string;
+  text: string;
 }>;
 
 export const ChatLayoutProvider = (props: Props): ReactElement => {
-  const { children, initialChatOpen, initialChatWidth } = props;
+  const {
+    children,
+    initialChatOpen,
+    initialChatWidth,
+    draftScope,
+  } = props;
   const [isOpen, setIsOpenState] = useState<boolean>(initialChatOpen);
   const [chatWidth, setChatWidthState] = useState<number>(initialChatWidth);
+  const draftStorageKey = getChatDraftStorageKey(draftScope);
+  const initialChatDraftState: ChatDraftState = {
+    storageKey: draftStorageKey,
+    text: "",
+  };
+  const [chatDraftState, setChatDraftState] = useState<ChatDraftState>(initialChatDraftState);
+  const chatDraftStateRef = useRef<ChatDraftState>(initialChatDraftState);
+
+  useEffect(() => {
+    const nextState: ChatDraftState = {
+      storageKey: draftStorageKey,
+      text: readChatDraft(window.sessionStorage, draftScope),
+    };
+    chatDraftStateRef.current = nextState;
+    setChatDraftState(nextState);
+  }, [draftScope, draftStorageKey]);
 
   const setIsOpen = (open: boolean): void => {
     setIsOpenState(open);
@@ -38,8 +85,34 @@ export const ChatLayoutProvider = (props: Props): ReactElement => {
     writeCookie("chat-width", String(Math.round(width)));
   };
 
+  const setChatDraftText = useCallback((update: SetStateAction<string>): void => {
+    const currentText = chatDraftStateRef.current.storageKey === draftStorageKey
+      ? chatDraftStateRef.current.text
+      : readChatDraft(window.sessionStorage, draftScope);
+    const nextText = typeof update === "function" ? update(currentText) : update;
+    const nextState: ChatDraftState = {
+      storageKey: draftStorageKey,
+      text: nextText,
+    };
+
+    writeChatDraft(window.sessionStorage, draftScope, nextText);
+    chatDraftStateRef.current = nextState;
+    setChatDraftState(nextState);
+  }, [draftScope, draftStorageKey]);
+
+  const chatDraftText = chatDraftState.storageKey === draftStorageKey
+    ? chatDraftState.text
+    : "";
+
   return (
-    <ChatLayoutContext.Provider value={{ isOpen, setIsOpen, chatWidth, setChatWidth }}>
+    <ChatLayoutContext.Provider value={{
+      isOpen,
+      setIsOpen,
+      chatWidth,
+      setChatWidth,
+      chatDraftText,
+      setChatDraftText,
+    }}>
       {children}
     </ChatLayoutContext.Provider>
   );

--- a/apps/web/src/ui/chat/shell/layout/ChatToggle.tsx
+++ b/apps/web/src/ui/chat/shell/layout/ChatToggle.tsx
@@ -12,6 +12,7 @@ export const ChatToggle = (): ReactElement => {
   return (
     <button
       type="button"
+      data-testid="chat-sidebar-open"
       className={styles.toggleFloating}
       onClick={() => setIsOpen(true)}
     >

--- a/apps/web/src/ui/chat/shell/layout/chatDraftStorage.test.ts
+++ b/apps/web/src/ui/chat/shell/layout/chatDraftStorage.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clearChatDrafts,
+  getChatDraftStorageKey,
+  readChatDraft,
+  writeChatDraft,
+  type ChatDraftScope,
+} from "./chatDraftStorage";
+
+const createStorage = (): Storage => {
+  const values = new Map<string, string>();
+
+  return {
+    get length(): number {
+      return values.size;
+    },
+    clear: (): void => values.clear(),
+    getItem: (key: string): string | null => values.get(key) ?? null,
+    key: (index: number): string | null => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string): void => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string): void => {
+      values.set(key, value);
+    },
+  };
+};
+
+test("draft keys isolate authenticated users, workspaces, and demo mode", (): void => {
+  const userOneWorkspaceOne: ChatDraftScope = {
+    mode: "workspace",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  };
+  const keys = [
+    getChatDraftStorageKey(userOneWorkspaceOne),
+    getChatDraftStorageKey({
+      mode: "workspace",
+      userId: "user-2",
+      workspaceId: "workspace-1",
+    }),
+    getChatDraftStorageKey({
+      mode: "workspace",
+      userId: "user-1",
+      workspaceId: "workspace-2",
+    }),
+    getChatDraftStorageKey({
+      mode: "demo",
+      userId: "user-1",
+    }),
+  ];
+
+  assert.equal(new Set(keys).size, keys.length);
+});
+
+test("draft text is restored and empty text removes the stored draft", (): void => {
+  const storage = createStorage();
+  const scope: ChatDraftScope = {
+    mode: "workspace",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  };
+
+  writeChatDraft(storage, scope, "unsent text");
+  assert.equal(readChatDraft(storage, scope), "unsent text");
+
+  writeChatDraft(storage, scope, "");
+  assert.equal(readChatDraft(storage, scope), "");
+  assert.equal(storage.length, 0);
+});
+
+test("separate tab storage does not share a draft", (): void => {
+  const firstTabStorage = createStorage();
+  const secondTabStorage = createStorage();
+  const scope: ChatDraftScope = {
+    mode: "demo",
+    userId: "user-1",
+  };
+
+  writeChatDraft(firstTabStorage, scope, "first tab draft");
+
+  assert.equal(readChatDraft(firstTabStorage, scope), "first tab draft");
+  assert.equal(readChatDraft(secondTabStorage, scope), "");
+});
+
+test("logout clearing removes chat drafts and preserves unrelated session data", (): void => {
+  const storage = createStorage();
+  writeChatDraft(storage, { mode: "demo", userId: "user-1" }, "demo draft");
+  writeChatDraft(storage, {
+    mode: "workspace",
+    userId: "user-2",
+    workspaceId: "workspace-1",
+  }, "workspace draft");
+  storage.setItem("unrelated-session-state", "keep me");
+
+  clearChatDrafts(storage);
+
+  assert.equal(storage.length, 1);
+  assert.equal(storage.getItem("unrelated-session-state"), "keep me");
+});
+
+test("invalid draft scopes fail with an actionable error", (): void => {
+  assert.throws(
+    () => getChatDraftStorageKey({
+      mode: "workspace",
+      userId: "user-1",
+      workspaceId: "",
+    }),
+    /empty workspaceId/u,
+  );
+});

--- a/apps/web/src/ui/chat/shell/layout/chatDraftStorage.ts
+++ b/apps/web/src/ui/chat/shell/layout/chatDraftStorage.ts
@@ -1,0 +1,61 @@
+const CHAT_DRAFT_STORAGE_PREFIX = "expense-tracker-chat-draft:v1:";
+
+export type ChatDraftScope =
+  | Readonly<{
+      mode: "demo";
+      userId: string;
+    }>
+  | Readonly<{
+      mode: "workspace";
+      userId: string;
+      workspaceId: string;
+    }>;
+
+const requireStorageKeyPart = (name: string, value: string): string => {
+  if (value.trim() === "") {
+    throw new Error(`Cannot persist a chat draft with an empty ${name}`);
+  }
+
+  return encodeURIComponent(value);
+};
+
+export const getChatDraftStorageKey = (scope: ChatDraftScope): string => {
+  const userId = requireStorageKeyPart("userId", scope.userId);
+  if (scope.mode === "demo") {
+    return `${CHAT_DRAFT_STORAGE_PREFIX}demo:${userId}`;
+  }
+
+  const workspaceId = requireStorageKeyPart("workspaceId", scope.workspaceId);
+  return `${CHAT_DRAFT_STORAGE_PREFIX}workspace:${userId}:${workspaceId}`;
+};
+
+export const readChatDraft = (
+  storage: Storage,
+  scope: ChatDraftScope,
+): string => storage.getItem(getChatDraftStorageKey(scope)) ?? "";
+
+export const writeChatDraft = (
+  storage: Storage,
+  scope: ChatDraftScope,
+  text: string,
+): void => {
+  const storageKey = getChatDraftStorageKey(scope);
+  if (text === "") {
+    storage.removeItem(storageKey);
+    return;
+  }
+
+  storage.setItem(storageKey, text);
+};
+
+export const clearChatDrafts = (storage: Storage): void => {
+  const draftStorageKeys = Array.from(
+    { length: storage.length },
+    (_value: undefined, index: number): string | null => storage.key(index),
+  ).filter((storageKey: string | null): storageKey is string =>
+    storageKey !== null && storageKey.startsWith(CHAT_DRAFT_STORAGE_PREFIX));
+
+  for (const storageKey of draftStorageKeys) {
+    storage.removeItem(storageKey);
+  }
+};

--- a/apps/web/src/ui/chat/shell/panel/ChatComposer.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatComposer.tsx
@@ -124,6 +124,7 @@ export const ChatComposer = (props: Props): ReactElement => {
       )}
       <textarea
         ref={textareaRef}
+        data-testid="chat-composer-input"
         className={styles.textarea}
         placeholder={t("chat.placeholder")}
         value={inputText}

--- a/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
@@ -125,7 +125,13 @@ const getMicrophoneErrorMessage = (
 export const ChatPanel = (props: Props): ReactElement => {
   const { mode, workspaceId } = props;
   const { t } = useTranslation();
-  const { setIsOpen, chatWidth, setChatWidth } = useChatLayout();
+  const {
+    setIsOpen,
+    chatWidth,
+    setChatWidth,
+    chatDraftText: inputText,
+    setChatDraftText: setInputText,
+  } = useChatLayout();
   const {
     messages,
     runState,
@@ -143,7 +149,6 @@ export const ChatPanel = (props: Props): ReactElement => {
 
   const [localWidth, setLocalWidth] = useState<number>(chatWidth);
   const [isDragging, setIsDragging] = useState<boolean>(false);
-  const [inputText, setInputText] = useState<string>("");
   const [pendingAttachments, setPendingAttachments] = useState<ReadonlyArray<PendingAttachment>>([]);
   const [isDragOver, setIsDragOver] = useState<boolean>(false);
   const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle");

--- a/apps/web/src/ui/chat/shell/panel/ChatPanelHeader.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatPanelHeader.tsx
@@ -62,6 +62,7 @@ export const ChatPanelHeader = (props: Props): ReactElement => {
         {mode === "sidebar" && (
           <button
             type="button"
+            data-testid="chat-sidebar-close"
             className={styles.closeButton}
             onClick={onCloseSidebar}
           >


### PR DESCRIPTION
## Summary
- preserve unsent chat text across close/reopen, route navigation, and same-tab reloads
- isolate drafts by authenticated user, workspace, demo mode, and browser tab
- clear chat draft storage on send, input clearing, and logout
- add focused storage and local Playwright coverage

## Validation
- focused storage and dictation tests: 9 passed
- npm run lint
- npm run build
- targeted local Playwright scenario: 3 consecutive passes
- git diff --check
- independent review: no P0-P4 findings