### PR TITLE
Build image preprocessing foundation

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@opentelemetry/sdk-node": "^0.220.0",
     "aws-jwt-verify": "^5.2.1",
     "d3": "^7.9.0",
+    "heic-to": "^1.5.2",
     "i18next": "^26.3.4",
     "mammoth": "^1.12.0",
     "next": "16.2.10",

--- a/apps/web/src/lib/chatImageFormats.test.ts
+++ b/apps/web/src/lib/chatImageFormats.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  detectHeicFtypBrand,
+  detectOpenAIImageMimeTypeFromFileName,
+  detectOpenAIImageMimeType,
+  getFileExtension,
+  isHeicFileExtension,
+  normalizeHeicImageMimeType,
+  normalizeOpenAIImageMimeType,
+} from "./chatImageFormats";
+
+const HEIC_PREFIXES: ReadonlyArray<Readonly<{
+  brand: "heic" | "heix" | "hevc" | "hevx" | "mif1" | "msf1";
+  bytes: ReadonlyArray<number>;
+}>> = [
+  { brand: "heic", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63, 0x00, 0x00, 0x00, 0x00] },
+  { brand: "heix", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x78, 0x00, 0x00, 0x00, 0x00] },
+  { brand: "hevc", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x76, 0x63, 0x00, 0x00, 0x00, 0x00] },
+  { brand: "hevx", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x76, 0x78, 0x00, 0x00, 0x00, 0x00] },
+  { brand: "mif1", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x69, 0x66, 0x31, 0x00, 0x00, 0x00, 0x00] },
+  { brand: "msf1", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x73, 0x66, 0x31, 0x00, 0x00, 0x00, 0x00] },
+];
+
+test("normalizes supported image MIME aliases", (): void => {
+  assert.equal(normalizeOpenAIImageMimeType(" IMAGE/JPG "), "image/jpeg");
+  assert.equal(normalizeOpenAIImageMimeType("image/jpeg"), "image/jpeg");
+  assert.equal(normalizeOpenAIImageMimeType("image/png"), "image/png");
+  assert.equal(normalizeOpenAIImageMimeType("image/heic"), null);
+});
+
+test("normalizes HEIC and HEIF sequence MIME types", (): void => {
+  assert.equal(normalizeHeicImageMimeType("IMAGE/HEIC"), "image/heic");
+  assert.equal(normalizeHeicImageMimeType("image/heif"), "image/heif");
+  assert.equal(normalizeHeicImageMimeType("image/heic-sequence"), "image/heic-sequence");
+  assert.equal(normalizeHeicImageMimeType("image/heif-sequence"), "image/heif-sequence");
+  assert.equal(normalizeHeicImageMimeType("image/jpeg"), null);
+});
+
+test("recognizes HEIC and HEIF extensions case-insensitively", (): void => {
+  assert.equal(getFileExtension("photo.HEIC"), ".heic");
+  assert.equal(isHeicFileExtension("photo.HEIC"), true);
+  assert.equal(isHeicFileExtension("photo.heif"), true);
+  assert.equal(isHeicFileExtension("photo.jpg"), false);
+  assert.equal(detectOpenAIImageMimeTypeFromFileName("photo.JPG"), "image/jpeg");
+  assert.equal(detectOpenAIImageMimeTypeFromFileName("photo.webp"), "image/webp");
+  assert.equal(detectOpenAIImageMimeTypeFromFileName("photo.heic"), null);
+});
+
+test("recognizes common HEIC and HEIF ftyp major brands", (): void => {
+  for (const prefix of HEIC_PREFIXES) {
+    assert.equal(detectHeicFtypBrand(Uint8Array.from(prefix.bytes)), prefix.brand);
+  }
+});
+
+test("rejects malformed and unrelated ISO-BMFF prefixes", (): void => {
+  assert.equal(detectHeicFtypBrand(Uint8Array.from([0x00, 0x00, 0x00, 0x18])), null);
+  assert.equal(
+    detectHeicFtypBrand(Uint8Array.from([
+      0x00, 0x00, 0x00, 0x0c, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63,
+    ])),
+    null,
+  );
+  assert.equal(
+    detectHeicFtypBrand(Uint8Array.from([
+      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66,
+      0x00, 0x00, 0x00, 0x00,
+    ])),
+    null,
+  );
+});
+
+test("detects supported OpenAI image formats from real magic-byte prefixes", (): void => {
+  const fixtures: ReadonlyArray<Readonly<{
+    expected: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+    bytes: ReadonlyArray<number>;
+  }>> = [
+    { expected: "image/jpeg", bytes: [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46] },
+    { expected: "image/png", bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] },
+    { expected: "image/gif", bytes: [0x47, 0x49, 0x46, 0x38, 0x37, 0x61, 0x01, 0x00] },
+    { expected: "image/gif", bytes: [0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00] },
+    { expected: "image/webp", bytes: [0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38, 0x20] },
+  ];
+
+  for (const fixture of fixtures) {
+    assert.equal(detectOpenAIImageMimeType(Uint8Array.from(fixture.bytes)), fixture.expected);
+  }
+  assert.equal(detectOpenAIImageMimeType(Uint8Array.from([0x42, 0x4d, 0x00, 0x00])), null);
+});

--- a/apps/web/src/lib/chatImageFormats.ts
+++ b/apps/web/src/lib/chatImageFormats.ts
@@ -1,0 +1,154 @@
+export const OPENAI_IMAGE_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+] as const;
+
+export type OpenAIImageMimeType = (typeof OPENAI_IMAGE_MIME_TYPES)[number];
+
+export const OPENAI_IMAGE_FILE_EXTENSIONS = [
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+  ".gif",
+] as const;
+
+export const HEIC_IMAGE_MIME_TYPES = [
+  "image/heic",
+  "image/heif",
+  "image/heic-sequence",
+  "image/heif-sequence",
+] as const;
+
+export type HeicImageMimeType = (typeof HEIC_IMAGE_MIME_TYPES)[number];
+
+export const HEIC_FILE_EXTENSIONS = [".heic", ".heif"] as const;
+
+export type HeicFileExtension = (typeof HEIC_FILE_EXTENSIONS)[number];
+
+export const HEIC_FTYP_BRANDS = [
+  "heic",
+  "heix",
+  "hevc",
+  "hevx",
+  "mif1",
+  "msf1",
+] as const;
+
+export type HeicFtypBrand = (typeof HEIC_FTYP_BRANDS)[number];
+
+const hasString = (values: ReadonlyArray<string>, value: string): boolean =>
+  values.includes(value);
+
+const normalizedMimeType = (value: string): string =>
+  value.trim().toLowerCase();
+
+export const normalizeOpenAIImageMimeType = (
+  value: string,
+): OpenAIImageMimeType | null => {
+  const normalized = normalizedMimeType(value);
+  if (normalized === "image/jpg") {
+    return "image/jpeg";
+  }
+  return hasString(OPENAI_IMAGE_MIME_TYPES, normalized)
+    ? normalized as OpenAIImageMimeType
+    : null;
+};
+
+export const normalizeHeicImageMimeType = (
+  value: string,
+): HeicImageMimeType | null => {
+  const normalized = normalizedMimeType(value);
+  return hasString(HEIC_IMAGE_MIME_TYPES, normalized)
+    ? normalized as HeicImageMimeType
+    : null;
+};
+
+export const getFileExtension = (fileName: string): string => {
+  const lastPathSeparator = Math.max(fileName.lastIndexOf("/"), fileName.lastIndexOf("\\"));
+  const lastDot = fileName.lastIndexOf(".");
+  return lastDot > lastPathSeparator ? fileName.slice(lastDot).toLowerCase() : "";
+};
+
+export const isHeicFileExtension = (fileName: string): boolean =>
+  hasString(HEIC_FILE_EXTENSIONS, getFileExtension(fileName));
+
+export const detectOpenAIImageMimeTypeFromFileName = (
+  fileName: string,
+): OpenAIImageMimeType | null => {
+  const extension = getFileExtension(fileName);
+  if (extension === ".png") return "image/png";
+  if (extension === ".jpg" || extension === ".jpeg") return "image/jpeg";
+  if (extension === ".webp") return "image/webp";
+  if (extension === ".gif") return "image/gif";
+  return null;
+};
+
+const hasBytesAt = (
+  bytes: Uint8Array,
+  offset: number,
+  expected: ReadonlyArray<number>,
+): boolean => {
+  if (bytes.byteLength < offset + expected.length) {
+    return false;
+  }
+  return expected.every((value: number, index: number): boolean =>
+    bytes[offset + index] === value);
+};
+
+const readAscii = (bytes: Uint8Array, offset: number, length: number): string => {
+  let value = "";
+  for (let index = offset; index < offset + length; index += 1) {
+    value += String.fromCharCode(bytes[index] ?? 0);
+  }
+  return value;
+};
+
+const readUint32BigEndian = (bytes: Uint8Array, offset: number): number =>
+  (((bytes[offset] ?? 0) * 0x1000000)
+    + ((bytes[offset + 1] ?? 0) << 16)
+    + ((bytes[offset + 2] ?? 0) << 8)
+    + (bytes[offset + 3] ?? 0)) >>> 0;
+
+export const detectHeicFtypBrand = (bytes: Uint8Array): HeicFtypBrand | null => {
+  if (bytes.byteLength < 12 || !hasBytesAt(bytes, 4, [0x66, 0x74, 0x79, 0x70])) {
+    return null;
+  }
+
+  const boxSize = readUint32BigEndian(bytes, 0);
+  if (boxSize < 16) {
+    return null;
+  }
+
+  const brand = readAscii(bytes, 8, 4);
+  return hasString(HEIC_FTYP_BRANDS, brand) ? brand as HeicFtypBrand : null;
+};
+
+export const hasHeicFileSignature = (bytes: Uint8Array): boolean =>
+  detectHeicFtypBrand(bytes) !== null;
+
+export const detectOpenAIImageMimeType = (
+  bytes: Uint8Array,
+): OpenAIImageMimeType | null => {
+  if (hasBytesAt(bytes, 0, [0xff, 0xd8, 0xff])) {
+    return "image/jpeg";
+  }
+  if (hasBytesAt(bytes, 0, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return "image/png";
+  }
+  if (
+    hasBytesAt(bytes, 0, [0x47, 0x49, 0x46, 0x38, 0x37, 0x61])
+    || hasBytesAt(bytes, 0, [0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
+  ) {
+    return "image/gif";
+  }
+  if (
+    hasBytesAt(bytes, 0, [0x52, 0x49, 0x46, 0x46])
+    && hasBytesAt(bytes, 8, [0x57, 0x45, 0x42, 0x50])
+  ) {
+    return "image/webp";
+  }
+  return null;
+};

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -7,12 +7,14 @@ type EnvSnapshot = Readonly<{
   AUTH_MODE: string | undefined;
   AUTH_DOMAIN: string | undefined;
   CORS_ORIGIN: string | undefined;
+  NODE_ENV: string | undefined;
 }>;
 
 const captureEnv = (): EnvSnapshot => ({
   AUTH_MODE: process.env.AUTH_MODE,
   AUTH_DOMAIN: process.env.AUTH_DOMAIN,
   CORS_ORIGIN: process.env.CORS_ORIGIN,
+  NODE_ENV: process.env.NODE_ENV,
 });
 
 const restoreEnv = (snapshot: EnvSnapshot): void => {
@@ -30,6 +32,11 @@ const restoreEnv = (snapshot: EnvSnapshot): void => {
     delete process.env.CORS_ORIGIN;
   } else {
     process.env.CORS_ORIGIN = snapshot.CORS_ORIGIN;
+  }
+  if (snapshot.NODE_ENV === undefined) {
+    Reflect.deleteProperty(process.env, "NODE_ENV");
+  } else {
+    Reflect.set(process.env, "NODE_ENV", snapshot.NODE_ENV);
   }
 };
 
@@ -111,5 +118,16 @@ test("proxy keeps unrelated app and API routes authenticated", async (): Promise
     assert.match(appResponse.headers.get("location") ?? "", /^https:\/\/auth\.example\.com\/login/u);
     assert.equal(apiResponse.status, 307);
     assert.match(apiResponse.headers.get("location") ?? "", /^https:\/\/auth\.example\.com\/login/u);
+  });
+});
+
+test("production CSP allows only same-origin and blob workers", async (): Promise<void> => {
+  await withCognitoEnv(async (): Promise<void> => {
+    Reflect.set(process.env, "NODE_ENV", "production");
+    const response = await proxy(createRequest("/api/health"));
+    const csp = response.headers.get("Content-Security-Policy") ?? "";
+
+    assert.match(csp, /(?:^|; )worker-src 'self' blob:(?:;|$)/u);
+    assert.doesNotMatch(csp, /script-src[^;]*'unsafe-eval'/u);
   });
 });

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -90,6 +90,7 @@ const buildCsp = (nonce: string): string => {
     "style-src-elem 'self'",
     "img-src 'self' blob: data:",
     "font-src 'self'",
+    "worker-src 'self' blob:",
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",

--- a/apps/web/src/ui/chat/attachments/imagePreprocessing.test.ts
+++ b/apps/web/src/ui/chat/attachments/imagePreprocessing.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CHAT_IMAGE_PREPROCESSING_CONSTRAINTS,
+  ImageDimensionsError,
+  ImageFormatMismatchError,
+  ImageSourceTooLargeError,
+  UnsupportedImageFormatError,
+  assertImageSourceSize,
+  buildJpegFileName,
+  calculateBoundedImageDimensions,
+  calculateNextImageEncodeSettings,
+  classifyImageFile,
+  isImageOutputWithinLimit,
+} from "./imagePreprocessing";
+
+const HEIC_PREFIX = Uint8Array.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70,
+  0x68, 0x65, 0x69, 0x63, 0x00, 0x00, 0x00, 0x00,
+]);
+const JPEG_PREFIX = Uint8Array.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const PNG_PREFIX = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+test("bounds landscape and portrait images proportionally", (): void => {
+  assert.deepEqual(calculateBoundedImageDimensions(4032, 3024, 2048), {
+    width: 2048,
+    height: 1536,
+  });
+  assert.deepEqual(calculateBoundedImageDimensions(2000, 4000, 2048), {
+    width: 1024,
+    height: 2048,
+  });
+  assert.deepEqual(calculateBoundedImageDimensions(1200, 800, 2048), {
+    width: 1200,
+    height: 800,
+  });
+  assert.throws(
+    (): void => { calculateBoundedImageDimensions(0, 800, 2048); },
+    ImageDimensionsError,
+  );
+});
+
+test("enforces source and output byte limits at their exact boundary", (): void => {
+  assert.doesNotThrow((): void => { assertImageSourceSize("photo.heic", 100, 100); });
+  assert.throws(
+    (): void => { assertImageSourceSize("photo.heic", 101, 100); },
+    ImageSourceTooLargeError,
+  );
+  assert.equal(isImageOutputWithinLimit(100, 100), true);
+  assert.equal(isImageOutputWithinLimit(101, 100), false);
+});
+
+test("creates predictable JPEG filenames", (): void => {
+  assert.equal(buildJpegFileName("holiday.photo.HEIC"), "holiday.photo.jpg");
+  assert.equal(buildJpegFileName("scan.png"), "scan.jpg");
+  assert.equal(buildJpegFileName("scan"), "scan.jpg");
+  assert.equal(buildJpegFileName(""), "image.jpg");
+});
+
+test("classifies signature-backed HEIC and native images", (): void => {
+  assert.deepEqual(classifyImageFile("photo.HEIC", "image/heic", HEIC_PREFIX), {
+    decoder: "heic",
+    detectedMediaType: "image/heic",
+  });
+  assert.deepEqual(classifyImageFile("upload", "image/jpg", JPEG_PREFIX), {
+    decoder: "native",
+    detectedMediaType: "image/jpeg",
+  });
+  assert.deepEqual(classifyImageFile("upload", "", PNG_PREFIX), {
+    decoder: "native",
+    detectedMediaType: "image/png",
+  });
+});
+
+test("rejects contradictory or malformed image classifications", (): void => {
+  assert.throws(
+    (): void => { classifyImageFile("photo.heic", "image/heic", JPEG_PREFIX); },
+    ImageFormatMismatchError,
+  );
+  assert.throws(
+    (): void => { classifyImageFile("photo.jpg", "image/jpeg", HEIC_PREFIX); },
+    ImageFormatMismatchError,
+  );
+  assert.throws(
+    (): void => { classifyImageFile("photo.jpg", "", HEIC_PREFIX); },
+    ImageFormatMismatchError,
+  );
+  assert.throws(
+    (): void => { classifyImageFile("photo.png", "image/jpeg", PNG_PREFIX); },
+    ImageFormatMismatchError,
+  );
+  assert.throws(
+    (): void => { classifyImageFile("photo.jpg", "", PNG_PREFIX); },
+    ImageFormatMismatchError,
+  );
+  assert.throws(
+    (): void => { classifyImageFile("photo.bmp", "image/bmp", Uint8Array.from([0x42, 0x4d])); },
+    UnsupportedImageFormatError,
+  );
+});
+
+test("reduces dimensions and quality after an oversized JPEG attempt", (): void => {
+  const next = calculateNextImageEncodeSettings(
+    { width: 2048, height: 1536, quality: 0.85 },
+    CHAT_IMAGE_PREPROCESSING_CONSTRAINTS.maximumOutputBytes * 2,
+    CHAT_IMAGE_PREPROCESSING_CONSTRAINTS,
+  );
+
+  assert.deepEqual(next, { width: 1375, height: 1031, quality: 0.762 });
+});

--- a/apps/web/src/ui/chat/attachments/imagePreprocessing.ts
+++ b/apps/web/src/ui/chat/attachments/imagePreprocessing.ts
@@ -1,0 +1,473 @@
+"use client";
+
+import {
+  detectOpenAIImageMimeTypeFromFileName,
+  detectOpenAIImageMimeType,
+  hasHeicFileSignature,
+  isHeicFileExtension,
+  normalizeHeicImageMimeType,
+  normalizeOpenAIImageMimeType,
+  type OpenAIImageMimeType,
+} from "@/lib/chatImageFormats";
+
+const IMAGE_SIGNATURE_PREFIX_BYTES = 32;
+const JPEG_MEDIA_TYPE = "image/jpeg";
+const RESIZE_SAFETY_FACTOR = 0.95;
+const MAX_RESIZE_STEP = 0.9;
+
+export type ImagePreprocessingConstraints = Readonly<{
+  maximumSourceBytes: number;
+  maximumLongEdge: number;
+  initialJpegQuality: number;
+  minimumJpegQuality: number;
+  maximumOutputBytes: number;
+  maximumEncodeAttempts: number;
+}>;
+
+export const CHAT_IMAGE_PREPROCESSING_CONSTRAINTS: ImagePreprocessingConstraints = {
+  maximumSourceBytes: 20 * 1024 * 1024,
+  maximumLongEdge: 2048,
+  initialJpegQuality: 0.85,
+  minimumJpegQuality: 0.5,
+  maximumOutputBytes: 2.5 * 1024 * 1024,
+  maximumEncodeAttempts: 5,
+};
+
+export type PreparedImageAttachment = Readonly<{
+  fileName: string;
+  mediaType: "image/jpeg";
+  base64Data: string;
+}>;
+
+export type ImageDimensions = Readonly<{
+  width: number;
+  height: number;
+}>;
+
+export type ImageEncodeSettings = ImageDimensions & Readonly<{
+  quality: number;
+}>;
+
+export type ImageFileClassification = Readonly<{
+  decoder: "heic" | "native";
+  detectedMediaType: OpenAIImageMimeType | "image/heic";
+}>;
+
+export class ImagePreprocessingConfigurationError extends Error {
+  public constructor(message: string) {
+    super(`Invalid image preprocessing constraints: ${message}`);
+    this.name = "ImagePreprocessingConfigurationError";
+  }
+}
+
+export class ImageSourceTooLargeError extends Error {
+  public constructor(fileName: string, sourceBytes: number, maximumSourceBytes: number) {
+    super(
+      `Image "${fileName}" is too large to process: ${sourceBytes} bytes exceeds the ${maximumSourceBytes}-byte source limit.`,
+    );
+    this.name = "ImageSourceTooLargeError";
+  }
+}
+
+export class ImageReadError extends Error {
+  public constructor(fileName: string, reason: string) {
+    super(`Failed to read image "${fileName}": ${reason}`);
+    this.name = "ImageReadError";
+  }
+}
+
+export class ImageFormatMismatchError extends Error {
+  public constructor(fileName: string, reason: string) {
+    super(`Image "${fileName}" has contradictory format metadata: ${reason}`);
+    this.name = "ImageFormatMismatchError";
+  }
+}
+
+export class UnsupportedImageFormatError extends Error {
+  public constructor(fileName: string, mediaType: string) {
+    const declaredType = mediaType.trim() === "" ? "no declared MIME type" : `declared MIME type ${mediaType}`;
+    super(`Image "${fileName}" has an unsupported or malformed file signature (${declaredType}).`);
+    this.name = "UnsupportedImageFormatError";
+  }
+}
+
+export class ImageDimensionsError extends Error {
+  public constructor(width: number, height: number) {
+    super(`Image dimensions must be positive integers; received ${width}x${height}.`);
+    this.name = "ImageDimensionsError";
+  }
+}
+
+export class ImageDecodeError extends Error {
+  public constructor(fileName: string, reason: string) {
+    super(`Failed to decode image "${fileName}": ${reason}`);
+    this.name = "ImageDecodeError";
+  }
+}
+
+export class ImageEncodeError extends Error {
+  public constructor(fileName: string, reason: string) {
+    super(`Failed to encode image "${fileName}" as JPEG: ${reason}`);
+    this.name = "ImageEncodeError";
+  }
+}
+
+export class ImageOutputTooLargeError extends Error {
+  public constructor(
+    fileName: string,
+    outputBytes: number,
+    maximumOutputBytes: number,
+    maximumEncodeAttempts: number,
+  ) {
+    super(
+      `Image "${fileName}" is still ${outputBytes} bytes after ${maximumEncodeAttempts} JPEG encode attempts; maximum output is ${maximumOutputBytes} bytes.`,
+    );
+    this.name = "ImageOutputTooLargeError";
+  }
+}
+
+const assertPositiveInteger = (name: string, value: number): void => {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new ImagePreprocessingConfigurationError(`${name} must be a positive integer; received ${value}`);
+  }
+};
+
+export const validateImagePreprocessingConstraints = (
+  constraints: ImagePreprocessingConstraints,
+): void => {
+  assertPositiveInteger("maximumSourceBytes", constraints.maximumSourceBytes);
+  assertPositiveInteger("maximumLongEdge", constraints.maximumLongEdge);
+  assertPositiveInteger("maximumOutputBytes", constraints.maximumOutputBytes);
+  assertPositiveInteger("maximumEncodeAttempts", constraints.maximumEncodeAttempts);
+
+  if (
+    !Number.isFinite(constraints.initialJpegQuality)
+    || constraints.initialJpegQuality <= 0
+    || constraints.initialJpegQuality > 1
+  ) {
+    throw new ImagePreprocessingConfigurationError(
+      `initialJpegQuality must be greater than 0 and at most 1; received ${constraints.initialJpegQuality}`,
+    );
+  }
+  if (
+    !Number.isFinite(constraints.minimumJpegQuality)
+    || constraints.minimumJpegQuality <= 0
+    || constraints.minimumJpegQuality > constraints.initialJpegQuality
+  ) {
+    throw new ImagePreprocessingConfigurationError(
+      `minimumJpegQuality must be greater than 0 and at most initialJpegQuality; received ${constraints.minimumJpegQuality}`,
+    );
+  }
+};
+
+export const assertImageSourceSize = (
+  fileName: string,
+  sourceBytes: number,
+  maximumSourceBytes: number,
+): void => {
+  if (sourceBytes > maximumSourceBytes) {
+    throw new ImageSourceTooLargeError(fileName, sourceBytes, maximumSourceBytes);
+  }
+};
+
+export const isImageOutputWithinLimit = (
+  outputBytes: number,
+  maximumOutputBytes: number,
+): boolean => outputBytes <= maximumOutputBytes;
+
+export const buildJpegFileName = (fileName: string): string => {
+  const lastDot = fileName.lastIndexOf(".");
+  const stem = lastDot > 0 ? fileName.slice(0, lastDot) : fileName;
+  return `${stem === "" ? "image" : stem}.jpg`;
+};
+
+export const calculateBoundedImageDimensions = (
+  sourceWidth: number,
+  sourceHeight: number,
+  maximumLongEdge: number,
+): ImageDimensions => {
+  if (
+    !Number.isInteger(sourceWidth)
+    || sourceWidth <= 0
+    || !Number.isInteger(sourceHeight)
+    || sourceHeight <= 0
+  ) {
+    throw new ImageDimensionsError(sourceWidth, sourceHeight);
+  }
+  assertPositiveInteger("maximumLongEdge", maximumLongEdge);
+
+  const longEdge = Math.max(sourceWidth, sourceHeight);
+  if (longEdge <= maximumLongEdge) {
+    return { width: sourceWidth, height: sourceHeight };
+  }
+
+  const scale = maximumLongEdge / longEdge;
+  return {
+    width: Math.max(1, Math.round(sourceWidth * scale)),
+    height: Math.max(1, Math.round(sourceHeight * scale)),
+  };
+};
+
+export const classifyImageFile = (
+  fileName: string,
+  declaredMediaType: string,
+  prefix: Uint8Array,
+): ImageFileClassification => {
+  const declaredOpenAIType = normalizeOpenAIImageMimeType(declaredMediaType);
+  const declaredOpenAIExtensionType = detectOpenAIImageMimeTypeFromFileName(fileName);
+  const declaredHeicType = normalizeHeicImageMimeType(declaredMediaType);
+  const hasDeclaredHeicType = declaredHeicType !== null;
+  const hasDeclaredHeicExtension = isHeicFileExtension(fileName);
+  const hasHeicSignature = hasHeicFileSignature(prefix);
+  const hasOtherDeclaredImageType = declaredMediaType.trim().toLowerCase().startsWith("image/")
+    && declaredOpenAIType === null
+    && declaredHeicType === null;
+
+  if (hasHeicSignature) {
+    if (
+      declaredOpenAIType !== null
+      || declaredOpenAIExtensionType !== null
+      || hasOtherDeclaredImageType
+    ) {
+      throw new ImageFormatMismatchError(
+        fileName,
+        "the declared MIME type or extension does not match the HEIC/HEIF ftyp signature",
+      );
+    }
+    return { decoder: "heic", detectedMediaType: "image/heic" };
+  }
+
+  if (hasDeclaredHeicType || hasDeclaredHeicExtension) {
+    throw new ImageFormatMismatchError(
+      fileName,
+      "the HEIC/HEIF MIME type or extension is not backed by a recognized ftyp signature",
+    );
+  }
+
+  const detectedMediaType = detectOpenAIImageMimeType(prefix);
+  if (detectedMediaType === null) {
+    throw new UnsupportedImageFormatError(fileName, declaredMediaType);
+  }
+  if (declaredOpenAIType !== null && declaredOpenAIType !== detectedMediaType) {
+    throw new ImageFormatMismatchError(
+      fileName,
+      `${declaredMediaType} does not match the detected ${detectedMediaType} signature`,
+    );
+  }
+  if (
+    declaredOpenAIExtensionType !== null
+    && declaredOpenAIExtensionType !== detectedMediaType
+  ) {
+    throw new ImageFormatMismatchError(
+      fileName,
+      `the filename extension does not match the detected ${detectedMediaType} signature`,
+    );
+  }
+  if (hasOtherDeclaredImageType) {
+    throw new ImageFormatMismatchError(
+      fileName,
+      `${declaredMediaType} does not match the detected ${detectedMediaType} signature`,
+    );
+  }
+
+  return { decoder: "native", detectedMediaType };
+};
+
+export const calculateNextImageEncodeSettings = (
+  current: ImageEncodeSettings,
+  outputBytes: number,
+  constraints: ImagePreprocessingConstraints,
+): ImageEncodeSettings => {
+  const qualityStep = (constraints.initialJpegQuality - constraints.minimumJpegQuality)
+    / Math.max(1, constraints.maximumEncodeAttempts - 1);
+  const quality = Math.max(
+    constraints.minimumJpegQuality,
+    Number((current.quality - qualityStep).toFixed(3)),
+  );
+  const targetScale = Math.sqrt(constraints.maximumOutputBytes / outputBytes)
+    * RESIZE_SAFETY_FACTOR;
+  const scale = Math.min(MAX_RESIZE_STEP, targetScale);
+
+  return {
+    width: Math.max(1, Math.floor(current.width * scale)),
+    height: Math.max(1, Math.floor(current.height * scale)),
+    quality,
+  };
+};
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const decodeNativeImage = async (file: File): Promise<ImageBitmap> => {
+  try {
+    return await createImageBitmap(file, { imageOrientation: "from-image" });
+  } catch (error) {
+    throw new ImageDecodeError(file.name, errorMessage(error));
+  }
+};
+
+const decodeHeicImage = async (file: File): Promise<ImageBitmap> => {
+  try {
+    const { heicTo } = await import("heic-to/csp");
+    return await heicTo({
+      blob: file,
+      type: "bitmap",
+      options: { imageOrientation: "from-image" },
+    });
+  } catch (error) {
+    throw new ImageDecodeError(file.name, errorMessage(error));
+  }
+};
+
+const decodeImage = async (
+  file: File,
+  classification: ImageFileClassification,
+): Promise<ImageBitmap> =>
+  classification.decoder === "heic"
+    ? decodeHeicImage(file)
+    : decodeNativeImage(file);
+
+const encodeCanvasAsJpeg = (
+  canvas: HTMLCanvasElement,
+  quality: number,
+  fileName: string,
+): Promise<Blob> =>
+  new Promise<Blob>((resolve, reject): void => {
+    try {
+      canvas.toBlob((blob: Blob | null): void => {
+        if (blob === null || blob.size === 0) {
+          reject(new ImageEncodeError(fileName, "canvas.toBlob returned no data"));
+          return;
+        }
+        if (blob.type !== JPEG_MEDIA_TYPE) {
+          reject(new ImageEncodeError(fileName, `canvas.toBlob returned ${blob.type}`));
+          return;
+        }
+        resolve(blob);
+      }, JPEG_MEDIA_TYPE, quality);
+    } catch (error) {
+      reject(new ImageEncodeError(fileName, errorMessage(error)));
+    }
+  });
+
+const releaseCanvas = (canvas: HTMLCanvasElement): void => {
+  canvas.width = 1;
+  canvas.height = 1;
+  const context = canvas.getContext("2d");
+  context?.clearRect(0, 0, 1, 1);
+};
+
+const encodeBoundedJpeg = async (
+  bitmap: ImageBitmap,
+  fileName: string,
+  constraints: ImagePreprocessingConstraints,
+): Promise<Blob> => {
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+  if (context === null) {
+    releaseCanvas(canvas);
+    throw new ImageEncodeError(fileName, "Canvas 2D context is unavailable");
+  }
+
+  const initialDimensions = calculateBoundedImageDimensions(
+    bitmap.width,
+    bitmap.height,
+    constraints.maximumLongEdge,
+  );
+  let settings: ImageEncodeSettings = {
+    ...initialDimensions,
+    quality: constraints.initialJpegQuality,
+  };
+  let lastOutputBytes = 0;
+
+  try {
+    for (let attempt = 0; attempt < constraints.maximumEncodeAttempts; attempt += 1) {
+      canvas.width = settings.width;
+      canvas.height = settings.height;
+      context.clearRect(0, 0, settings.width, settings.height);
+      try {
+        context.drawImage(bitmap, 0, 0, settings.width, settings.height);
+      } catch (error) {
+        throw new ImageEncodeError(fileName, errorMessage(error));
+      }
+
+      const output = await encodeCanvasAsJpeg(canvas, settings.quality, fileName);
+      lastOutputBytes = output.size;
+      if (isImageOutputWithinLimit(output.size, constraints.maximumOutputBytes)) {
+        return output;
+      }
+      if (attempt + 1 < constraints.maximumEncodeAttempts) {
+        settings = calculateNextImageEncodeSettings(settings, output.size, constraints);
+      }
+    }
+  } finally {
+    releaseCanvas(canvas);
+  }
+
+  throw new ImageOutputTooLargeError(
+    fileName,
+    lastOutputBytes,
+    constraints.maximumOutputBytes,
+    constraints.maximumEncodeAttempts,
+  );
+};
+
+const blobToBase64 = (blob: Blob, fileName: string): Promise<string> =>
+  new Promise<string>((resolve, reject): void => {
+    const reader = new FileReader();
+    reader.onload = (): void => {
+      if (typeof reader.result !== "string") {
+        reject(new ImageEncodeError(fileName, "FileReader returned a non-string result"));
+        return;
+      }
+      const commaIndex = reader.result.indexOf(",");
+      if (commaIndex < 0) {
+        reject(new ImageEncodeError(fileName, "FileReader returned an invalid data URL"));
+        return;
+      }
+      resolve(reader.result.slice(commaIndex + 1));
+    };
+    reader.onerror = (): void => {
+      reject(new ImageEncodeError(fileName, errorMessage(reader.error)));
+    };
+    try {
+      reader.readAsDataURL(blob);
+    } catch (error) {
+      reject(new ImageEncodeError(fileName, errorMessage(error)));
+    }
+  });
+
+const readImagePrefix = async (file: File): Promise<Uint8Array> => {
+  try {
+    return new Uint8Array(
+      await file.slice(0, IMAGE_SIGNATURE_PREFIX_BYTES).arrayBuffer(),
+    );
+  } catch (error) {
+    throw new ImageReadError(file.name, errorMessage(error));
+  }
+};
+
+export const preprocessImageAttachment = async (
+  file: File,
+  constraints: ImagePreprocessingConstraints,
+): Promise<PreparedImageAttachment> => {
+  validateImagePreprocessingConstraints(constraints);
+  assertImageSourceSize(file.name, file.size, constraints.maximumSourceBytes);
+
+  const prefix = await readImagePrefix(file);
+  const classification = classifyImageFile(file.name, file.type, prefix);
+  let bitmap: ImageBitmap | null = null;
+
+  try {
+    bitmap = await decodeImage(file, classification);
+    const output = await encodeBoundedJpeg(bitmap, file.name, constraints);
+    const base64Data = await blobToBase64(output, file.name);
+    return {
+      fileName: buildJpegFileName(file.name),
+      mediaType: JPEG_MEDIA_TYPE,
+      base64Data,
+    };
+  } finally {
+    bitmap?.close();
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@opentelemetry/sdk-node": "^0.220.0",
         "aws-jwt-verify": "^5.2.1",
         "d3": "^7.9.0",
+        "heic-to": "^1.5.2",
         "i18next": "^26.3.4",
         "mammoth": "^1.12.0",
         "next": "16.2.10",
@@ -4557,6 +4558,12 @@
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
+    },
+    "node_modules/heic-to": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
+      "integrity": "sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==",
+      "license": "LGPL-3.0"
     },
     "node_modules/hono": {
       "version": "4.12.28",


### PR DESCRIPTION
## Summary
- add shared image MIME, extension, and signature policy
- add browser-only HEIC/HEIF preprocessing with bounded JPEG output
- allow CSP-safe blob workers and cover the policy with focused tests

## Validation
- `npx tsx --test src/lib/chatImageFormats.test.ts src/ui/chat/attachments/imagePreprocessing.test.ts src/proxy.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`