### PR TITLE
Reject unsupported chat images before persistence

### DIFF
--- a/apps/web/src/lib/chatImageFormats.test.ts
+++ b/apps/web/src/lib/chatImageFormats.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  HEIC_FTYP_BRANDS,
+  MAX_HEIC_FTYP_BOX_BYTES,
   detectHeicFtypBrand,
   detectOpenAIImageMimeTypeFromFileName,
   detectOpenAIImageMimeType,
@@ -10,17 +12,29 @@ import {
   normalizeOpenAIImageMimeType,
 } from "./chatImageFormats";
 
-const HEIC_PREFIXES: ReadonlyArray<Readonly<{
-  brand: "heic" | "heix" | "hevc" | "hevx" | "mif1" | "msf1";
-  bytes: ReadonlyArray<number>;
-}>> = [
-  { brand: "heic", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63, 0x00, 0x00, 0x00, 0x00] },
-  { brand: "heix", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x78, 0x00, 0x00, 0x00, 0x00] },
-  { brand: "hevc", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x76, 0x63, 0x00, 0x00, 0x00, 0x00] },
-  { brand: "hevx", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x76, 0x78, 0x00, 0x00, 0x00, 0x00] },
-  { brand: "mif1", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x69, 0x66, 0x31, 0x00, 0x00, 0x00, 0x00] },
-  { brand: "msf1", bytes: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x73, 0x66, 0x31, 0x00, 0x00, 0x00, 0x00] },
+const asciiBytes = (value: string): ReadonlyArray<number> =>
+  Array.from(value, (character): number => character.charCodeAt(0));
+
+const uint32BigEndianBytes = (value: number): ReadonlyArray<number> => [
+  (value >>> 24) & 0xff,
+  (value >>> 16) & 0xff,
+  (value >>> 8) & 0xff,
+  value & 0xff,
 ];
+
+const createFtypBox = (
+  majorBrand: string,
+  compatibleBrands: ReadonlyArray<string>,
+): Uint8Array => {
+  const boxSize = 16 + (compatibleBrands.length * 4);
+  return Uint8Array.from([
+    ...uint32BigEndianBytes(boxSize),
+    ...asciiBytes("ftyp"),
+    ...asciiBytes(majorBrand),
+    0x00, 0x00, 0x00, 0x00,
+    ...compatibleBrands.flatMap(asciiBytes),
+  ]);
+};
 
 test("normalizes supported image MIME aliases", (): void => {
   assert.equal(normalizeOpenAIImageMimeType(" IMAGE/JPG "), "image/jpeg");
@@ -47,10 +61,24 @@ test("recognizes HEIC and HEIF extensions case-insensitively", (): void => {
   assert.equal(detectOpenAIImageMimeTypeFromFileName("photo.heic"), null);
 });
 
-test("recognizes common HEIC and HEIF ftyp major brands", (): void => {
-  for (const prefix of HEIC_PREFIXES) {
-    assert.equal(detectHeicFtypBrand(Uint8Array.from(prefix.bytes)), prefix.brand);
+test("recognizes HEIC and HEIF ftyp major and compatible brands", (): void => {
+  for (const brand of HEIC_FTYP_BRANDS) {
+    assert.equal(detectHeicFtypBrand(createFtypBox(brand, [])), brand);
+    assert.equal(detectHeicFtypBrand(createFtypBox("isom", ["iso2", brand])), brand);
   }
+});
+
+test("checks compatible brands through the complete bounded ftyp box", (): void => {
+  const compatibleBrandCount = (MAX_HEIC_FTYP_BOX_BYTES - 16) / 4;
+  const compatibleBrands = Array.from(
+    { length: compatibleBrandCount },
+    (_value, index): string => index === compatibleBrandCount - 1 ? "heic" : "isom",
+  );
+
+  assert.equal(
+    detectHeicFtypBrand(createFtypBox("isom", compatibleBrands)),
+    "heic",
+  );
 });
 
 test("rejects malformed and unrelated ISO-BMFF prefixes", (): void => {
@@ -62,9 +90,20 @@ test("rejects malformed and unrelated ISO-BMFF prefixes", (): void => {
     null,
   );
   assert.equal(
+    detectHeicFtypBrand(createFtypBox("avif", [])),
+    null,
+  );
+  assert.equal(
+    detectHeicFtypBrand(createFtypBox("isom", ["heic"]).slice(0, -4)),
+    null,
+  );
+  assert.equal(
     detectHeicFtypBrand(Uint8Array.from([
-      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66,
-      0x00, 0x00, 0x00, 0x00,
+      (MAX_HEIC_FTYP_BOX_BYTES + 4) >>> 24,
+      ((MAX_HEIC_FTYP_BOX_BYTES + 4) >>> 16) & 0xff,
+      ((MAX_HEIC_FTYP_BOX_BYTES + 4) >>> 8) & 0xff,
+      (MAX_HEIC_FTYP_BOX_BYTES + 4) & 0xff,
+      0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63,
     ])),
     null,
   );

--- a/apps/web/src/lib/chatImageFormats.ts
+++ b/apps/web/src/lib/chatImageFormats.ts
@@ -31,13 +31,23 @@ export type HeicFileExtension = (typeof HEIC_FILE_EXTENSIONS)[number];
 export const HEIC_FTYP_BRANDS = [
   "heic",
   "heix",
+  "heim",
+  "heis",
   "hevc",
   "hevx",
+  "hevm",
+  "hevs",
   "mif1",
   "msf1",
 ] as const;
 
 export type HeicFtypBrand = (typeof HEIC_FTYP_BRANDS)[number];
+
+export const MAX_HEIC_FTYP_BOX_BYTES = 4 * 1024;
+
+const MINIMUM_FTYP_BOX_BYTES = 16;
+const FTYP_COMPATIBLE_BRANDS_OFFSET = 16;
+const FTYP_BRAND_BYTES = 4;
 
 const hasString = (values: ReadonlyArray<string>, value: string): boolean =>
   values.includes(value);
@@ -118,12 +128,33 @@ export const detectHeicFtypBrand = (bytes: Uint8Array): HeicFtypBrand | null => 
   }
 
   const boxSize = readUint32BigEndian(bytes, 0);
-  if (boxSize < 16) {
+  if (
+    boxSize < MINIMUM_FTYP_BOX_BYTES
+    || boxSize > MAX_HEIC_FTYP_BOX_BYTES
+    || (boxSize - MINIMUM_FTYP_BOX_BYTES) % FTYP_BRAND_BYTES !== 0
+  ) {
     return null;
   }
 
-  const brand = readAscii(bytes, 8, 4);
-  return hasString(HEIC_FTYP_BRANDS, brand) ? brand as HeicFtypBrand : null;
+  const majorBrand = readAscii(bytes, 8, FTYP_BRAND_BYTES);
+  if (hasString(HEIC_FTYP_BRANDS, majorBrand)) {
+    return majorBrand as HeicFtypBrand;
+  }
+  if (bytes.byteLength < boxSize) {
+    return null;
+  }
+
+  for (
+    let offset = FTYP_COMPATIBLE_BRANDS_OFFSET;
+    offset < boxSize;
+    offset += FTYP_BRAND_BYTES
+  ) {
+    const compatibleBrand = readAscii(bytes, offset, FTYP_BRAND_BYTES);
+    if (hasString(HEIC_FTYP_BRANDS, compatibleBrand)) {
+      return compatibleBrand as HeicFtypBrand;
+    }
+  }
+  return null;
 };
 
 export const hasHeicFileSignature = (bytes: Uint8Array): boolean =>

--- a/apps/web/src/server/chat/attachments/validation.test.ts
+++ b/apps/web/src/server/chat/attachments/validation.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  HeicFileAttachmentError,
+  ImageMimeSignatureMismatchError,
+  InvalidBase64ImageDataError,
+  UnsupportedImageMediaTypeError,
+  validateChatAttachments,
+} from "@/server/chat/attachments/validation";
+import type {
+  FileContentPart,
+  ImageContentPart,
+} from "@/server/chat/types";
+
+const JPEG_BASE64_PREFIX = "/9j/4AAQSkZJRg==";
+const PNG_BASE64_PREFIX = "iVBORw0KGgo=";
+const GIF_BASE64_PREFIX = "R0lGODlhAQA=";
+const WEBP_BASE64_PREFIX = "UklGRiQAAABXRUJQVlA4IA==";
+const HEIC_BASE64_PREFIX = "AAAAGGZ0eXBoZWljAAAAAA==";
+const HEIC_COMPATIBLE_BRAND_BASE64 = "AAAAFGZ0eXBpc29tAAAAAGhlaWM=";
+const HEIC_UNPADDED_BASE64_PREFIX = HEIC_BASE64_PREFIX.slice(0, -2);
+const HEIC_WHITESPACE_BASE64_PREFIX = "AAAA GGZ0eXBo\nZWljAAAAAA==";
+const XLSX_BASE64_PREFIX = "UEsDBBQABgA=";
+
+const createImagePart = (
+  mediaType: string,
+  base64Data: string,
+): ImageContentPart => ({
+  type: "image",
+  mediaType,
+  base64Data,
+});
+
+const createFilePart = (
+  fileName: string,
+  mediaType: string,
+  base64Data: string,
+): FileContentPart => ({
+  type: "file",
+  fileName,
+  mediaType,
+  base64Data,
+});
+
+test("validateChatAttachments accepts supported images with matching signatures", (): void => {
+  const validImages: ReadonlyArray<ImageContentPart> = [
+    createImagePart("image/jpeg", JPEG_BASE64_PREFIX),
+    createImagePart("image/png", PNG_BASE64_PREFIX),
+    createImagePart("image/gif", GIF_BASE64_PREFIX),
+    createImagePart("image/webp", WEBP_BASE64_PREFIX),
+  ];
+
+  assert.doesNotThrow((): void => validateChatAttachments(validImages));
+});
+
+test("validateChatAttachments rejects raw HEIC image parts", (): void => {
+  assert.throws(
+    (): void => validateChatAttachments([
+      { type: "text", text: "Inspect this image" },
+      createImagePart("image/heic", HEIC_BASE64_PREFIX),
+    ]),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof UnsupportedImageMediaTypeError);
+      assert.match(error.message, /Content part 1/);
+      assert.match(error.message, /claimed MIME "image\/heic"/);
+      assert.equal(error.message.includes(HEIC_BASE64_PREFIX), false);
+      return true;
+    },
+  );
+});
+
+test("validateChatAttachments rejects a HEIC signature mislabeled as JPEG", (): void => {
+  assert.throws(
+    (): void => validateChatAttachments([
+      createImagePart("image/jpeg", HEIC_BASE64_PREFIX),
+    ]),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof ImageMimeSignatureMismatchError);
+      assert.match(error.message, /Content part 0/);
+      assert.match(error.message, /image\/heic signature/);
+      assert.match(error.message, /claimed MIME "image\/jpeg"/);
+      assert.equal(error.message.includes(HEIC_BASE64_PREFIX), false);
+      return true;
+    },
+  );
+});
+
+test("validateChatAttachments rejects supported MIME types with another image signature", (): void => {
+  assert.throws(
+    (): void => validateChatAttachments([
+      createImagePart("image/jpeg", PNG_BASE64_PREFIX),
+    ]),
+    ImageMimeSignatureMismatchError,
+  );
+});
+
+test("validateChatAttachments rejects malformed base64 image data", (): void => {
+  const malformedBase64 = "%%%not-base64%%%";
+
+  assert.throws(
+    (): void => validateChatAttachments([
+      createImagePart("image/png", malformedBase64),
+    ]),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof InvalidBase64ImageDataError);
+      assert.match(error.message, /Content part 0/);
+      assert.match(error.message, /claimed MIME "image\/png"/);
+      assert.equal(error.message.includes(malformedBase64), false);
+      return true;
+    },
+  );
+});
+
+test("validateChatAttachments rejects HEIC file extensions with empty or generic MIME types", (): void => {
+  const disguisedFiles: ReadonlyArray<FileContentPart> = [
+    createFilePart("camera.HEIC", "", HEIC_BASE64_PREFIX),
+    createFilePart("camera.HEIC", "application/octet-stream", HEIC_BASE64_PREFIX),
+  ];
+
+  for (const file of disguisedFiles) {
+    assert.throws(
+      (): void => validateChatAttachments([file]),
+      (error: unknown): boolean => {
+        assert.ok(error instanceof HeicFileAttachmentError);
+        assert.match(error.message, /Content part 0/);
+        assert.match(error.message, new RegExp(`filename ${JSON.stringify(file.fileName)}`));
+        assert.match(error.message, new RegExp(`claimed MIME ${JSON.stringify(file.mediaType)}`));
+        assert.equal(error.message.includes(file.base64Data), false);
+        return true;
+      },
+    );
+  }
+});
+
+test("validateChatAttachments rejects HEIC generic files by MIME and signature", (): void => {
+  const disguisedFiles: ReadonlyArray<FileContentPart> = [
+    createFilePart("camera.bin", "image/heif", XLSX_BASE64_PREFIX),
+    createFilePart("camera.bin", "application/octet-stream", HEIC_BASE64_PREFIX),
+    createFilePart("camera.bin", "application/octet-stream", HEIC_COMPATIBLE_BRAND_BASE64),
+  ];
+
+  for (const file of disguisedFiles) {
+    assert.throws(
+      (): void => validateChatAttachments([file]),
+      HeicFileAttachmentError,
+    );
+  }
+});
+
+test("validateChatAttachments rejects unpadded and whitespace-encoded HEIC generic files", (): void => {
+  const disguisedFiles: ReadonlyArray<FileContentPart> = [
+    createFilePart("camera.bin", "application/octet-stream", HEIC_UNPADDED_BASE64_PREFIX),
+    createFilePart("camera.bin", "application/octet-stream", HEIC_WHITESPACE_BASE64_PREFIX),
+  ];
+
+  for (const file of disguisedFiles) {
+    assert.throws(
+      (): void => validateChatAttachments([file]),
+      HeicFileAttachmentError,
+    );
+  }
+});
+
+test("validateChatAttachments leaves XLSX attachments unchanged", (): void => {
+  const workbook = createFilePart(
+    "budget.xlsx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    XLSX_BASE64_PREFIX,
+  );
+
+  assert.doesNotThrow((): void => validateChatAttachments([workbook]));
+});
+
+test("validateChatAttachments accepts valid large image and generic file base64", (): void => {
+  const largeJpegBase64 = Buffer.concat([
+    Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+    Buffer.alloc(4 * 1024 * 1024),
+  ]).toString("base64");
+  const largePdf = createFilePart(
+    "report.pdf",
+    "application/pdf",
+    "A".repeat(5 * 1024 * 1024),
+  );
+
+  assert.doesNotThrow((): void => validateChatAttachments([
+    createImagePart("image/jpeg", largeJpegBase64),
+    largePdf,
+  ]));
+});

--- a/apps/web/src/server/chat/attachments/validation.ts
+++ b/apps/web/src/server/chat/attachments/validation.ts
@@ -1,0 +1,194 @@
+import {
+  MAX_HEIC_FTYP_BOX_BYTES,
+  OPENAI_IMAGE_MIME_TYPES,
+  detectOpenAIImageMimeType,
+  hasHeicFileSignature,
+  isHeicFileExtension,
+  normalizeHeicImageMimeType,
+  normalizeOpenAIImageMimeType,
+} from "@/lib/chatImageFormats";
+import type { OpenAIImageMimeType } from "@/lib/chatImageFormats";
+import type {
+  ContentPart,
+  FileContentPart,
+  ImageContentPart,
+} from "@/server/chat/types";
+
+const IMAGE_SIGNATURE_BYTE_COUNT = MAX_HEIC_FTYP_BOX_BYTES;
+const BASE64_PREFIX_CHARACTER_COUNT = Math.ceil(IMAGE_SIGNATURE_BYTE_COUNT / 3) * 4;
+
+type DetectedImageMimeType = OpenAIImageMimeType | "image/heic";
+type HeicDetectionMethod = "claimed MIME" | "filename extension" | "file signature";
+
+const formatContentPartContext = (
+  partIndex: number,
+  mediaType: string,
+  fileName: string | null,
+): string => {
+  const fileNameContext = fileName === null ? "" : `, filename ${JSON.stringify(fileName)}`;
+  return `Content part ${partIndex} (claimed MIME ${JSON.stringify(mediaType)}${fileNameContext})`;
+};
+
+export class InvalidBase64ImageDataError extends Error {
+  public constructor(partIndex: number, mediaType: string) {
+    super(
+      `${formatContentPartContext(partIndex, mediaType, null)} contains invalid base64 image data.`,
+    );
+    this.name = "InvalidBase64ImageDataError";
+  }
+}
+
+export class UnsupportedImageMediaTypeError extends Error {
+  public constructor(partIndex: number, mediaType: string) {
+    super(
+      `${formatContentPartContext(partIndex, mediaType, null)} uses an unsupported image media type. `
+      + `Supported media types: ${OPENAI_IMAGE_MIME_TYPES.join(", ")}. Convert HEIC/HEIF images before upload.`,
+    );
+    this.name = "UnsupportedImageMediaTypeError";
+  }
+}
+
+export class ImageMimeSignatureMismatchError extends Error {
+  public constructor(
+    partIndex: number,
+    mediaType: string,
+    detectedMediaType: DetectedImageMimeType | null,
+  ) {
+    const mismatch = detectedMediaType === null
+      ? "does not have a recognized supported image signature"
+      : `has a ${detectedMediaType} signature that does not match the claimed MIME`;
+    super(`${formatContentPartContext(partIndex, mediaType, null)} ${mismatch}.`);
+    this.name = "ImageMimeSignatureMismatchError";
+  }
+}
+
+export class HeicFileAttachmentError extends Error {
+  public constructor(
+    partIndex: number,
+    mediaType: string,
+    fileName: string,
+    detectionMethod: HeicDetectionMethod,
+  ) {
+    super(
+      `${formatContentPartContext(partIndex, mediaType, fileName)} is an unsupported HEIC/HEIF image `
+      + `submitted as a generic file (${detectionMethod}). Convert it to JPEG, PNG, WebP, or GIF before upload.`,
+    );
+    this.name = "HeicFileAttachmentError";
+  }
+}
+
+const isBase64DataCharacter = (characterCode: number): boolean =>
+  (characterCode >= 0x41 && characterCode <= 0x5a)
+  || (characterCode >= 0x61 && characterCode <= 0x7a)
+  || (characterCode >= 0x30 && characterCode <= 0x39)
+  || characterCode === 0x2b
+  || characterCode === 0x2f;
+
+const hasValidBase64Shape = (value: string): boolean => {
+  if (value.length === 0 || value.length % 4 !== 0) {
+    return false;
+  }
+
+  const paddingLength = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+  const dataLength = value.length - paddingLength;
+  for (let index = 0; index < dataLength; index += 1) {
+    if (!isBase64DataCharacter(value.charCodeAt(index))) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const decodeBase64Prefix = (value: string): Uint8Array =>
+  Uint8Array.from(
+    Buffer.from(value.slice(0, BASE64_PREFIX_CHARACTER_COUNT), "base64")
+      .subarray(0, IMAGE_SIGNATURE_BYTE_COUNT),
+  );
+
+const decodeTolerantBase64Prefix = (value: string): Uint8Array => {
+  let encodedPrefix = "";
+  for (
+    let index = 0;
+    index < value.length && encodedPrefix.length < BASE64_PREFIX_CHARACTER_COUNT;
+    index += 1
+  ) {
+    const characterCode = value.charCodeAt(index);
+    if (characterCode === 0x3d) {
+      break;
+    }
+    if (isBase64DataCharacter(characterCode)) {
+      encodedPrefix += value[index];
+    }
+  }
+  return Uint8Array.from(
+    Buffer.from(encodedPrefix, "base64").subarray(0, IMAGE_SIGNATURE_BYTE_COUNT),
+  );
+};
+
+const validateImagePart = (
+  part: ImageContentPart,
+  partIndex: number,
+): void => {
+  const normalizedMediaType = normalizeOpenAIImageMimeType(part.mediaType);
+  if (normalizedMediaType === null) {
+    throw new UnsupportedImageMediaTypeError(partIndex, part.mediaType);
+  }
+
+  if (!hasValidBase64Shape(part.base64Data)) {
+    throw new InvalidBase64ImageDataError(partIndex, part.mediaType);
+  }
+
+  const prefix = decodeBase64Prefix(part.base64Data);
+  if (hasHeicFileSignature(prefix)) {
+    throw new ImageMimeSignatureMismatchError(partIndex, part.mediaType, "image/heic");
+  }
+
+  const detectedMediaType = detectOpenAIImageMimeType(prefix);
+  if (detectedMediaType !== normalizedMediaType) {
+    throw new ImageMimeSignatureMismatchError(partIndex, part.mediaType, detectedMediaType);
+  }
+};
+
+const validateFilePart = (
+  part: FileContentPart,
+  partIndex: number,
+): void => {
+  if (normalizeHeicImageMimeType(part.mediaType) !== null) {
+    throw new HeicFileAttachmentError(
+      partIndex,
+      part.mediaType,
+      part.fileName,
+      "claimed MIME",
+    );
+  }
+
+  if (isHeicFileExtension(part.fileName)) {
+    throw new HeicFileAttachmentError(
+      partIndex,
+      part.mediaType,
+      part.fileName,
+      "filename extension",
+    );
+  }
+
+  if (hasHeicFileSignature(decodeTolerantBase64Prefix(part.base64Data))) {
+    throw new HeicFileAttachmentError(
+      partIndex,
+      part.mediaType,
+      part.fileName,
+      "file signature",
+    );
+  }
+};
+
+export const validateChatAttachments = (
+  content: ReadonlyArray<ContentPart>,
+): void => {
+  content.forEach((part, partIndex): void => {
+    if (part.type === "image") {
+      validateImagePart(part, partIndex);
+    } else if (part.type === "file") {
+      validateFilePart(part, partIndex);
+    }
+  });
+};

--- a/apps/web/src/server/chat/http/request.ts
+++ b/apps/web/src/server/chat/http/request.ts
@@ -2,6 +2,7 @@ import type {
   ChatSessionRunState,
   ChatSessionSnapshot,
 } from "@/server/chat/store";
+import { validateChatAttachments } from "@/server/chat/attachments/validation";
 import type { ContentPart } from "@/server/chat/types";
 import { extractUserId, extractWorkspaceId } from "@/server/userId";
 
@@ -129,6 +130,8 @@ export const parseChatRequestBody = (body: unknown): ChatRequestBody => {
   if (typeof candidate.sessionId !== "string" || candidate.sessionId.trim().length === 0) {
     throw new Error("sessionId must be a non-empty string");
   }
+
+  validateChatAttachments(candidate.content);
 
   return {
     sessionId: candidate.sessionId,

--- a/apps/web/src/server/chat/http/routeHandlers.test.ts
+++ b/apps/web/src/server/chat/http/routeHandlers.test.ts
@@ -16,6 +16,10 @@ import type { ChatRunStartReservation } from "@/server/chat/runtime/runtime";
 import type { ChatStreamEvent, ContentPart } from "@/server/chat/types";
 
 const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
+const HEIC_BASE64_PREFIX = "AAAAGGZ0eXBoZWljAAAAAA==";
+const HEIC_COMPATIBLE_BRAND_BASE64 = "AAAAFGZ0eXBpc29tAAAAAGhlaWM=";
+const HEIC_UNPADDED_BASE64_PREFIX = HEIC_BASE64_PREFIX.slice(0, -2);
+const HEIC_WHITESPACE_BASE64_PREFIX = "AAAA GGZ0eXBo\nZWljAAAAAA==";
 
 const createHeaders = (): Headers =>
   new Headers({
@@ -125,6 +129,114 @@ test("postChatRouteWithDeps returns 400 for invalid request bodies", async (): P
 
     assert.equal(response.status, 400);
     assert.equal(await response.text(), "content array is empty");
+  });
+});
+
+test("postChatRouteWithDeps rejects unsupported images before reserving or persisting a run", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    let snapshotCallCount = 0;
+    let reservationCallCount = 0;
+    let prepareCallCount = 0;
+    let modelStartCallCount = 0;
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        content: [{
+          type: "image",
+          mediaType: "image/jpeg",
+          base64Data: HEIC_BASE64_PREFIX,
+        }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies({
+        resolveSnapshotWithRunRecovery: async () => {
+          snapshotCallCount += 1;
+          return createSnapshot();
+        },
+        reserveChatRunStart: (sessionId) => {
+          reservationCallCount += 1;
+          return createReservation(sessionId);
+        },
+        prepareChatRun: async () => {
+          prepareCallCount += 1;
+          return createPreparedRun("session-1");
+        },
+        startPersistedChatRun: () => {
+          modelStartCallCount += 1;
+          return (async function* (): AsyncGenerator<ChatStreamEvent> {
+            yield { type: "done" };
+          })();
+        },
+      }),
+    );
+
+    assert.equal(response.status, 400);
+    assert.match(await response.text(), /image\/heic signature/);
+    assert.equal(response.headers.get("content-type"), "text/plain;charset=UTF-8");
+    assert.equal(snapshotCallCount, 0);
+    assert.equal(reservationCallCount, 0);
+    assert.equal(prepareCallCount, 0);
+    assert.equal(modelStartCallCount, 0);
+  });
+});
+
+test("postChatRouteWithDeps rejects generic HEIC signatures before persistence", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    let snapshotCallCount = 0;
+    let reservationCallCount = 0;
+    let prepareCallCount = 0;
+    let modelStartCallCount = 0;
+    const disguisedHeicData: ReadonlyArray<string> = [
+      HEIC_UNPADDED_BASE64_PREFIX,
+      HEIC_WHITESPACE_BASE64_PREFIX,
+      HEIC_COMPATIBLE_BRAND_BASE64,
+    ];
+
+    for (const base64Data of disguisedHeicData) {
+      const response = await postChatRouteWithDeps(
+        createChatRequest({
+          sessionId: "session-1",
+          content: [{
+            type: "file",
+            fileName: "camera.bin",
+            mediaType: "application/octet-stream",
+            base64Data,
+          }],
+          model: CHAT_MODEL_ID,
+          timezone: "Europe/Madrid",
+        }),
+        createPostDependencies({
+          resolveSnapshotWithRunRecovery: async () => {
+            snapshotCallCount += 1;
+            return createSnapshot();
+          },
+          reserveChatRunStart: (sessionId) => {
+            reservationCallCount += 1;
+            return createReservation(sessionId);
+          },
+          prepareChatRun: async () => {
+            prepareCallCount += 1;
+            return createPreparedRun("session-1");
+          },
+          startPersistedChatRun: () => {
+            modelStartCallCount += 1;
+            return (async function* (): AsyncGenerator<ChatStreamEvent> {
+              yield { type: "done" };
+            })();
+          },
+        }),
+      );
+
+      assert.equal(response.status, 400);
+      assert.match(await response.text(), /file signature/);
+      assert.equal(response.headers.get("content-type"), "text/plain;charset=UTF-8");
+    }
+
+    assert.equal(snapshotCallCount, 0);
+    assert.equal(reservationCallCount, 0);
+    assert.equal(prepareCallCount, 0);
+    assert.equal(modelStartCallCount, 0);
   });
 });
 


### PR DESCRIPTION
## Summary
- validate browser-chat image attachments before run persistence
- reject HEIC/HEIF MIME, extension, major-brand, and compatible-brand bypasses
- preserve existing document attachment behavior with bounded prefix inspection

## Validation
- 39 shared/server/browser-consumer tests passed
- npm run lint
- npm run build
- git diff --check