### PR TITLE
Add space-dot number format

### DIFF
--- a/apps/web/src/lib/locale.ts
+++ b/apps/web/src/lib/locale.ts
@@ -15,9 +15,9 @@ export const LOCALE_LABELS: Readonly<Record<SupportedLocale, string>> = {
 
 export const RTL_LOCALES: ReadonlySet<SupportedLocale> = new Set(["fa", "ar", "he"]);
 
-export type NumberFormat = "1,234.56" | "1 234,56" | "1.234,56";
+export type NumberFormat = "1,234.56" | "1 234,56" | "1.234,56" | "1 234.56";
 
-export const NUMBER_FORMATS: ReadonlyArray<NumberFormat> = ["1,234.56", "1 234,56", "1.234,56"];
+export const NUMBER_FORMATS: ReadonlyArray<NumberFormat> = ["1,234.56", "1 234,56", "1.234,56", "1 234.56"];
 
 export type DateFormat = "DD.MM.YYYY" | "MM/DD/YYYY" | "YYYY-MM-DD";
 

--- a/apps/web/src/server/api/settings.test.ts
+++ b/apps/web/src/server/api/settings.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ApiRouteError } from "@/server/api/errors";
+import { parseUserSettingsBody } from "@/server/api/settings";
+
+test("parseUserSettingsBody accepts the space-dot number format", (): void => {
+  const result = parseUserSettingsBody({ numberFormat: "1 234.56" });
+
+  assert.equal(result.numberFormat, "1 234.56");
+  assert.equal(result.hasNumberFormat, true);
+});
+
+test("parseUserSettingsBody rejects an unsupported number format", (): void => {
+  assert.throws(
+    () => parseUserSettingsBody({ numberFormat: "1_234.56" }),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof ApiRouteError);
+      assert.equal(error.status, 400);
+      assert.match(error.publicMessage, /^Invalid numberFormat\./);
+      return true;
+    },
+  );
+});

--- a/apps/web/src/ui/settings/UserSettingsForm.tsx
+++ b/apps/web/src/ui/settings/UserSettingsForm.tsx
@@ -48,7 +48,7 @@ export const UserSettingsForm = (props: Props): ReactElement => {
       return;
     }
 
-    if (locale !== props.locale) {
+    if (locale !== props.locale || numberFormat !== props.numberFormat || dateFormat !== props.dateFormat) {
       window.location.reload();
       return;
     }

--- a/apps/web/src/ui/tables/budget/model/cells.test.ts
+++ b/apps/web/src/ui/tables/budget/model/cells.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { formatSignedAmount } from "@/ui/tables/budget/model/cells";
+import { formatFxAmount } from "@/ui/tables/fx/format";
 
 test("formatSignedAmount formats signed rounded integers", (): void => {
   assert.equal(formatSignedAmount(42.4, "1,234.56"), "+42");
@@ -13,4 +14,15 @@ test("formatSignedAmount formats signed rounded integers", (): void => {
 
 test("formatSignedAmount uses the selected thousands separator", (): void => {
   assert.equal(formatSignedAmount(12_345.4, "1.234,56"), "+12.345");
+});
+
+test("formatSignedAmount supports ordinary-space grouping", (): void => {
+  assert.equal(formatSignedAmount(12_345.4, "1 234.56"), "+12 345");
+  assert.equal(formatSignedAmount(-12_345.4, "1 234.56"), "-12 345");
+});
+
+test("formatFxAmount preserves its inverted sign with ordinary-space grouping", (): void => {
+  assert.equal(formatFxAmount(-12_345.4, "1 234.56"), "+12 345");
+  assert.equal(formatFxAmount(12_345.4, "1 234.56"), "-12 345");
+  assert.equal(formatFxAmount(0.4, "1 234.56"), "0");
 });

--- a/apps/web/src/ui/tables/budget/model/cells.ts
+++ b/apps/web/src/ui/tables/budget/model/cells.ts
@@ -1,5 +1,5 @@
 import type { NumberFormat } from "@/lib/locale";
-import { NUMBER_FORMAT_LOCALE } from "@/ui/tables/shared/format";
+import { formatNumber } from "@/ui/tables/shared/format";
 
 export type CellValue = Readonly<{
   plannedBase: number;
@@ -19,13 +19,13 @@ export const lookupCell = (cells: ReadonlyMap<string, CellValue>, month: string,
 export const formatAmount = (value: number, numberFormat: NumberFormat): string => {
   const rounded = Math.round(value);
   if (rounded === 0) return "0";
-  return rounded.toLocaleString(NUMBER_FORMAT_LOCALE[numberFormat]);
+  return formatNumber(rounded, numberFormat, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 };
 
 export const formatSignedAmount = (value: number, numberFormat: NumberFormat): string => {
   const rounded = Math.round(value);
   if (rounded === 0) return "0";
-  const formatted = rounded.toLocaleString(NUMBER_FORMAT_LOCALE[numberFormat]);
+  const formatted = formatNumber(rounded, numberFormat, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
   return rounded > 0 ? `+${formatted}` : formatted;
 };
 

--- a/apps/web/src/ui/tables/fx/format.ts
+++ b/apps/web/src/ui/tables/fx/format.ts
@@ -1,6 +1,6 @@
 import type { NumberFormat } from "@/lib/locale";
 
-import { NUMBER_FORMAT_LOCALE } from "@/ui/tables/shared/format";
+import { formatNumber } from "@/ui/tables/shared/format";
 
 /**
  * Formats an FX adjustment for display.
@@ -13,5 +13,5 @@ export const formatFxAmount = (value: number, numberFormat: NumberFormat): strin
   const display = Math.round(-value);
   if (display === 0) return "0";
   const prefix = display > 0 ? "+" : "";
-  return prefix + display.toLocaleString(NUMBER_FORMAT_LOCALE[numberFormat]);
+  return prefix + formatNumber(display, numberFormat, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 };

--- a/apps/web/src/ui/tables/shared/format.test.ts
+++ b/apps/web/src/ui/tables/shared/format.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { NumberFormat } from "@/lib/locale";
+import { formatAmount } from "@/ui/tables/shared/format";
+
+type FormatExpectations = Readonly<{
+  positive: string;
+  negative: string;
+  rounded: string;
+}>;
+
+const EXPECTATIONS: Readonly<Record<NumberFormat, FormatExpectations>> = {
+  "1,234.56": {
+    positive: "1,234.56",
+    negative: "-1,234.56",
+    rounded: "1,234.57",
+  },
+  "1 234,56": {
+    positive: "1\u00a0234,56",
+    negative: "-1\u00a0234,56",
+    rounded: "1\u00a0234,57",
+  },
+  "1.234,56": {
+    positive: "1.234,56",
+    negative: "-1.234,56",
+    rounded: "1.234,57",
+  },
+  "1 234.56": {
+    positive: "1 234.56",
+    negative: "-1 234.56",
+    rounded: "1 234.57",
+  },
+};
+
+for (const [numberFormat, expected] of Object.entries(EXPECTATIONS) as ReadonlyArray<[NumberFormat, FormatExpectations]>) {
+  test(`formatAmount preserves sign, zero, and rounding for ${numberFormat}`, (): void => {
+    assert.equal(formatAmount(1234.56, numberFormat), expected.positive);
+    assert.equal(formatAmount(-1234.56, numberFormat), expected.negative);
+    assert.equal(formatAmount(0, numberFormat), "0");
+    assert.equal(formatAmount(1234.567, numberFormat), expected.rounded);
+  });
+}
+
+test("formatAmount uses an ordinary space for the space-dot format", (): void => {
+  const formatted = formatAmount(1234.56, "1 234.56");
+
+  assert.equal(formatted, "1\u0020234.56");
+  assert.deepEqual(
+    Array.from(formatted, (character): number => character.charCodeAt(0)),
+    [0x31, 0x20, 0x32, 0x33, 0x34, 0x2e, 0x35, 0x36],
+  );
+  assert.equal(formatted.includes("\u00a0"), false);
+  assert.equal(formatted.includes("\u202f"), false);
+});

--- a/apps/web/src/ui/tables/shared/format.ts
+++ b/apps/web/src/ui/tables/shared/format.ts
@@ -1,15 +1,42 @@
 import type { NumberFormat, DateFormat } from "@/lib/locale";
 
-export const NUMBER_FORMAT_LOCALE: Readonly<Record<NumberFormat, string>> = {
-  "1,234.56": "en-US",
-  "1 234,56": "ru-RU",
-  "1.234,56": "de-DE",
+type NumberFormatSeparators = Readonly<{
+  group: string;
+  decimal: string;
+}>;
+
+export type FormatNumberOptions = Readonly<{
+  minimumFractionDigits: number;
+  maximumFractionDigits: number;
+}>;
+
+const NUMBER_FORMAT_SEPARATORS: Readonly<Record<NumberFormat, NumberFormatSeparators>> = {
+  "1,234.56": { group: ",", decimal: "." },
+  "1 234,56": { group: "\u00a0", decimal: "," },
+  "1.234,56": { group: ".", decimal: "," },
+  "1 234.56": { group: " ", decimal: "." },
+};
+
+export const formatNumber = (
+  value: number,
+  numberFormat: NumberFormat,
+  options: FormatNumberOptions,
+): string => {
+  const separators = NUMBER_FORMAT_SEPARATORS[numberFormat];
+  const formatter = new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: options.minimumFractionDigits,
+    maximumFractionDigits: options.maximumFractionDigits,
+  });
+  return formatter.formatToParts(value).map((part): string => {
+    if (part.type === "group") return separators.group;
+    if (part.type === "decimal") return separators.decimal;
+    return part.value;
+  }).join("");
 };
 
 export const formatAmount = (value: number, numberFormat: NumberFormat): string => {
   if (value === 0) return "0";
-  const locale = NUMBER_FORMAT_LOCALE[numberFormat];
-  return value.toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return formatNumber(value, numberFormat, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 };
 
 export const formatDateTime = (isoString: string, dateFormat: DateFormat): string => {

--- a/db/migrations/0051_add_space_dot_number_format.sql
+++ b/db/migrations/0051_add_space_dot_number_format.sql
@@ -1,0 +1,6 @@
+ALTER TABLE user_settings
+  DROP CONSTRAINT user_settings_number_format_check;
+
+ALTER TABLE user_settings
+  ADD CONSTRAINT user_settings_number_format_check
+  CHECK (number_format IN ('1,234.56', '1 234,56', '1.234,56', '1 234.56'));


### PR DESCRIPTION
## Summary
- persist the new `1 234.56` number-format preference
- render supported separators deterministically through one shared formatter
- refresh formatting context after settings updates and cover compatibility behavior

## Validation
- `npx tsx --test src/ui/tables/shared/format.test.ts src/ui/tables/budget/model/cells.test.ts src/server/api/settings.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`

## Residual risk
- The migration SQL was not executed against a live PostgreSQL instance because this repository has no applicable migration-test harness.