### PR TITLE
feat(web): add active account suggestions

### DIFF
--- a/apps/web/src/app/api/account-suggestions/route.test.ts
+++ b/apps/web/src/app/api/account-suggestions/route.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getAccountSuggestionsRouteWithDeps } from "@/app/api/account-suggestions/route";
+
+const expectedSuggestions = [
+  { accountId: "checking-eur", currency: "EUR" },
+  { accountId: "checking-usd", currency: "USD" },
+] as const;
+
+test("account suggestions route returns the workspace-scoped response without caching", async (): Promise<void> => {
+  let receivedContext: ReadonlyArray<string> | null = null;
+  const request = new Request("http://localhost/api/account-suggestions", {
+    headers: {
+      "x-user-id": "user-1",
+      "x-workspace-id": "workspace-1",
+    },
+  });
+
+  const response = await getAccountSuggestionsRouteWithDeps(request, {
+    getAccountSuggestions: async (userId, workspaceId) => {
+      receivedContext = [userId, workspaceId];
+      return expectedSuggestions;
+    },
+    getDemoAccountSuggestions: () => {
+      throw new Error("Unexpected demo account suggestions call");
+    },
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(receivedContext, ["user-1", "workspace-1"]);
+  assert.deepEqual(await response.json(), expectedSuggestions);
+  assert.equal(response.headers.get("cache-control"), "no-store, no-cache, must-revalidate");
+  assert.equal(response.headers.get("pragma"), "no-cache");
+  assert.equal(response.headers.get("expires"), "0");
+});
+
+test("account suggestions route serves demo data without trusted identity headers", async (): Promise<void> => {
+  const request = new Request("http://localhost/api/account-suggestions", {
+    headers: { cookie: "demo=true" },
+  });
+
+  const response = await getAccountSuggestionsRouteWithDeps(request, {
+    getAccountSuggestions: async () => {
+      throw new Error("Unexpected live account suggestions call");
+    },
+    getDemoAccountSuggestions: () => expectedSuggestions,
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), expectedSuggestions);
+});

--- a/apps/web/src/app/api/account-suggestions/route.ts
+++ b/apps/web/src/app/api/account-suggestions/route.ts
@@ -1,0 +1,43 @@
+import { isDemoModeFromRequest } from "@/lib/demoMode";
+import { getAccountSuggestions } from "@/server/accounts/getAccountSuggestions";
+import { handleRoute } from "@/server/api/handleRoute";
+import { jsonNoStore } from "@/server/api/noStore";
+import { getDemoAccountSuggestions } from "@/server/demo/data";
+import { extractUserId, extractWorkspaceId } from "@/server/userId";
+
+type AccountSuggestionsRouteDependencies = Readonly<{
+  getAccountSuggestions: typeof getAccountSuggestions;
+  getDemoAccountSuggestions: typeof getDemoAccountSuggestions;
+}>;
+
+const DEFAULT_ACCOUNT_SUGGESTIONS_ROUTE_DEPENDENCIES: AccountSuggestionsRouteDependencies = {
+  getAccountSuggestions,
+  getDemoAccountSuggestions,
+};
+
+export const dynamic = "force-dynamic";
+
+export const getAccountSuggestionsRouteWithDeps = async (
+  request: Request,
+  dependencies: AccountSuggestionsRouteDependencies,
+): Promise<Response> =>
+  handleRoute(
+    {
+      route: "/api/account-suggestions",
+      method: "GET",
+      internalErrorMessage: "Database query failed",
+    },
+    async (): Promise<Response> => {
+      if (isDemoModeFromRequest(request)) {
+        return jsonNoStore(dependencies.getDemoAccountSuggestions());
+      }
+
+      const userId = extractUserId(request);
+      const workspaceId = extractWorkspaceId(request);
+      const suggestions = await dependencies.getAccountSuggestions(userId, workspaceId);
+      return jsonNoStore(suggestions);
+    },
+  );
+
+export const GET = async (request: Request): Promise<Response> =>
+  getAccountSuggestionsRouteWithDeps(request, DEFAULT_ACCOUNT_SUGGESTIONS_ROUTE_DEPENDENCIES);

--- a/apps/web/src/server/accounts/getAccountSuggestions.test.ts
+++ b/apps/web/src/server/accounts/getAccountSuggestions.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { QueryResult, QueryResultRow } from "pg";
+
+import {
+  ACCOUNT_SUGGESTIONS_QUERY,
+  getAccountSuggestionsWithQuery,
+} from "@/server/accounts/getAccountSuggestions";
+import type { QueryFn } from "@/server/db/contextRunner";
+import {
+  getDemoAccountSuggestions,
+  getDemoBalancesSummary,
+  getDemoTransactionsPage,
+} from "@/server/demo/data";
+import type { TransactionsFilter } from "@/server/transactions/getTransactions";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CURRENT_TIME_MS = Date.parse("2026-07-17T12:00:00.000Z");
+
+const createQueryResult = (rows: ReadonlyArray<QueryResultRow>): QueryResult => ({
+  command: "SELECT",
+  rowCount: rows.length,
+  oid: 0,
+  fields: [],
+  rows: [...rows],
+});
+
+test("getAccountSuggestionsWithQuery filters inactive accounts and preserves latest-operation ordering", async (): Promise<void> => {
+  const rows: ReadonlyArray<QueryResultRow> = [
+    {
+      account_id: "inactive-transfer-only",
+      currency: "USD",
+      balance: 0,
+      last_non_transfer_ms: null,
+      latest_operation_ms: CURRENT_TIME_MS,
+    },
+    {
+      account_id: "transfer-recent",
+      currency: "EUR",
+      balance: 0,
+      last_non_transfer_ms: CURRENT_TIME_MS - DAY_MS,
+      latest_operation_ms: CURRENT_TIME_MS - 1_000,
+    },
+    {
+      account_id: "account-a",
+      currency: "USD",
+      balance: 25,
+      last_non_transfer_ms: null,
+      latest_operation_ms: CURRENT_TIME_MS - 2_000,
+    },
+    {
+      account_id: "account-b",
+      currency: "GBP",
+      balance: -10,
+      last_non_transfer_ms: CURRENT_TIME_MS - 365 * DAY_MS,
+      latest_operation_ms: CURRENT_TIME_MS - 2_000,
+    },
+    {
+      account_id: "inactive-old",
+      currency: "JPY",
+      balance: 0,
+      last_non_transfer_ms: CURRENT_TIME_MS - 90 * DAY_MS - 1,
+      latest_operation_ms: CURRENT_TIME_MS - 3_000,
+    },
+  ];
+  let receivedSql = "";
+  const queryFn: QueryFn = async (sql, params): Promise<QueryResult> => {
+    receivedSql = sql;
+    assert.deepEqual(params, []);
+    return createQueryResult(rows);
+  };
+
+  const suggestions = await getAccountSuggestionsWithQuery(queryFn, CURRENT_TIME_MS);
+
+  assert.deepEqual(suggestions, [
+    { accountId: "transfer-recent", currency: "EUR" },
+    { accountId: "account-a", currency: "USD" },
+    { accountId: "account-b", currency: "GBP" },
+  ]);
+  assert.equal(receivedSql, ACCOUNT_SUGGESTIONS_QUERY);
+  assert.match(receivedSql, /MAX\(CASE WHEN le\.kind != 'transfer' THEN le\.ts END\)/);
+  assert.match(receivedSql, /MAX\(le\.ts\)/);
+  assert.match(receivedSql, /ORDER BY MAX\(le\.ts\) DESC, a\.account_id/);
+  assert.match(receivedSql, /le\.workspace_id = current_setting\('app\.workspace_id', true\)/);
+  assert.doesNotMatch(receivedSql, /COUNT\s*\(/i);
+});
+
+test("getAccountSuggestionsWithQuery rejects invalid database values", async (): Promise<void> => {
+  const queryFn: QueryFn = async (): Promise<QueryResult> =>
+    createQueryResult([
+      {
+        account_id: "checking",
+        currency: "USD",
+        balance: "10",
+        last_non_transfer_ms: CURRENT_TIME_MS,
+        latest_operation_ms: CURRENT_TIME_MS,
+      },
+    ]);
+
+  await assert.rejects(
+    getAccountSuggestionsWithQuery(queryFn, CURRENT_TIME_MS),
+    /Invalid account suggestion database row at index 0: balance:/,
+  );
+});
+
+const ALL_DEMO_TRANSACTIONS_FILTER: TransactionsFilter = {
+  dateFrom: null,
+  dateTo: null,
+  accountId: null,
+  accountIds: null,
+  kind: null,
+  kinds: null,
+  currencies: null,
+  category: null,
+  categories: null,
+  counterparties: null,
+  businessPersonalTransfers: false,
+  sortKey: "ts",
+  sortDir: "desc",
+  limit: 10_000,
+  offset: 0,
+};
+
+test("getDemoAccountSuggestions matches active demo accounts ordered by every ledger operation", (): void => {
+  const suggestions = getDemoAccountSuggestions();
+  const activeAccounts = getDemoBalancesSummary().accounts.filter((account) => account.status === "active");
+  const page = getDemoTransactionsPage(ALL_DEMO_TRANSACTIONS_FILTER);
+  assert.equal(page.entries.length, page.total);
+
+  const latestOperationTimeByAccount = new Map<string, number>();
+  for (const entry of page.entries) {
+    const operationTimeMs = Date.parse(entry.ts);
+    const previousTimeMs = latestOperationTimeByAccount.get(entry.accountId);
+    if (previousTimeMs === undefined || operationTimeMs > previousTimeMs) {
+      latestOperationTimeByAccount.set(entry.accountId, operationTimeMs);
+    }
+  }
+
+  const latestCheckingEurOperation = page.entries.find((entry) => entry.accountId === "checking-eur");
+  assert.equal(latestCheckingEurOperation?.kind, "transfer");
+
+  const expected = activeAccounts
+    .map((account) => {
+      const latestOperationTimeMs = latestOperationTimeByAccount.get(account.accountId);
+      if (latestOperationTimeMs === undefined) {
+        throw new Error(`Missing demo ledger operation for account "${account.accountId}"`);
+      }
+      return {
+        accountId: account.accountId,
+        currency: account.currency,
+        latestOperationTimeMs,
+      };
+    })
+    .sort((left, right) => {
+      const timeComparison = right.latestOperationTimeMs - left.latestOperationTimeMs;
+      if (timeComparison !== 0) return timeComparison;
+      return left.accountId < right.accountId ? -1 : left.accountId > right.accountId ? 1 : 0;
+    })
+    .map(({ accountId, currency }) => ({ accountId, currency }));
+
+  assert.deepEqual(suggestions, expected);
+  assert.deepEqual(
+    [...suggestions].map(({ accountId }) => accountId).sort(),
+    activeAccounts.map(({ accountId }) => accountId).sort(),
+  );
+});

--- a/apps/web/src/server/accounts/getAccountSuggestions.ts
+++ b/apps/web/src/server/accounts/getAccountSuggestions.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+import { computeAccountStatus } from "@/server/balances/accountStatus";
+import { withUserContext } from "@/server/db";
+import type { QueryFn } from "@/server/db/contextRunner";
+
+export type AccountSuggestion = Readonly<{
+  accountId: string;
+  currency: string;
+}>;
+
+const accountSuggestionDbRowSchema = z.object({
+  account_id: z.string().max(200),
+  currency: z.string().max(10),
+  balance: z.number().finite(),
+  last_non_transfer_ms: z.number().finite().nullable(),
+  latest_operation_ms: z.number().finite(),
+});
+
+type AccountSuggestionDbRow = z.infer<typeof accountSuggestionDbRowSchema>;
+
+export const ACCOUNT_SUGGESTIONS_QUERY = `
+  SELECT
+    a.account_id,
+    a.currency,
+    COALESCE(SUM(le.amount)::double precision, 0::double precision) AS balance,
+    (
+      EXTRACT(EPOCH FROM MAX(CASE WHEN le.kind != 'transfer' THEN le.ts END))
+      * 1000
+    )::double precision AS last_non_transfer_ms,
+    (EXTRACT(EPOCH FROM MAX(le.ts)) * 1000)::double precision AS latest_operation_ms
+  FROM accounts a
+  LEFT JOIN ledger_entries le
+    ON le.workspace_id = current_setting('app.workspace_id', true)
+   AND le.account_id = a.account_id
+  GROUP BY a.account_id, a.currency
+  ORDER BY MAX(le.ts) DESC, a.account_id
+`;
+
+const parseAccountSuggestionDbRow = (
+  row: unknown,
+  rowIndex: number,
+): AccountSuggestionDbRow => {
+  const result = accountSuggestionDbRowSchema.safeParse(row);
+  if (result.success) {
+    return result.data;
+  }
+
+  const details = result.error.issues
+    .map((issue) => `${issue.path.join(".") || "row"}: ${issue.message}`)
+    .join("; ");
+  throw new Error(`Invalid account suggestion database row at index ${rowIndex}: ${details}`);
+};
+
+export const getAccountSuggestionsWithQuery = async (
+  queryFn: QueryFn,
+  currentTimeMs: number,
+): Promise<ReadonlyArray<AccountSuggestion>> => {
+  const result = await queryFn(ACCOUNT_SUGGESTIONS_QUERY, []);
+  const suggestions: Array<AccountSuggestion> = [];
+
+  for (const [rowIndex, untrustedRow] of result.rows.entries()) {
+    const row = parseAccountSuggestionDbRow(untrustedRow, rowIndex);
+    if (computeAccountStatus(row.balance, row.last_non_transfer_ms, currentTimeMs) === "active") {
+      suggestions.push({
+        accountId: row.account_id,
+        currency: row.currency,
+      });
+    }
+  }
+
+  return suggestions;
+};
+
+export const getAccountSuggestions = async (
+  userId: string,
+  workspaceId: string,
+): Promise<ReadonlyArray<AccountSuggestion>> =>
+  withUserContext(
+    userId,
+    workspaceId,
+    async (queryFn): Promise<ReadonlyArray<AccountSuggestion>> =>
+      getAccountSuggestionsWithQuery(queryFn, Date.now()),
+  );

--- a/apps/web/src/server/balances/accountStatus.test.ts
+++ b/apps/web/src/server/balances/accountStatus.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { computeAccountStatus } from "@/server/balances/accountStatus";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CURRENT_TIME_MS = Date.parse("2026-07-17T12:00:00.000Z");
+
+test("computeAccountStatus keeps every non-zero balance active", (): void => {
+  assert.equal(computeAccountStatus(1, null, CURRENT_TIME_MS), "active");
+  assert.equal(computeAccountStatus(-1, CURRENT_TIME_MS - 365 * DAY_MS, CURRENT_TIME_MS), "active");
+});
+
+test("computeAccountStatus marks zero balances without non-transfer operations inactive", (): void => {
+  assert.equal(computeAccountStatus(0, null, CURRENT_TIME_MS), "inactive");
+});
+
+test("computeAccountStatus keeps zero balances active through exactly 90 days", (): void => {
+  assert.equal(
+    computeAccountStatus(0, CURRENT_TIME_MS - 90 * DAY_MS, CURRENT_TIME_MS),
+    "active",
+  );
+});
+
+test("computeAccountStatus marks zero balances inactive after 90 days", (): void => {
+  assert.equal(
+    computeAccountStatus(0, CURRENT_TIME_MS - 90 * DAY_MS - 1, CURRENT_TIME_MS),
+    "inactive",
+  );
+});

--- a/apps/web/src/server/balances/accountStatus.ts
+++ b/apps/web/src/server/balances/accountStatus.ts
@@ -1,0 +1,16 @@
+export type AccountStatus = "active" | "inactive";
+
+const ACCOUNT_INACTIVE_AFTER_MS = 90 * 24 * 60 * 60 * 1000;
+
+export const computeAccountStatus = (
+  balance: number,
+  lastNonTransferTimeMs: number | null,
+  currentTimeMs: number,
+): AccountStatus => {
+  if (balance !== 0) return "active";
+  if (lastNonTransferTimeMs === null) return "inactive";
+
+  return currentTimeMs - lastNonTransferTimeMs > ACCOUNT_INACTIVE_AFTER_MS
+    ? "inactive"
+    : "active";
+};

--- a/apps/web/src/server/balances/getBalancesSummary.ts
+++ b/apps/web/src/server/balances/getBalancesSummary.ts
@@ -26,6 +26,7 @@ import { withUserContext } from "@/server/db";
 import { getLatestFxCalendarDate } from "@/server/fxRates";
 import { getReportCurrency } from "@/server/reportCurrency";
 import { type StalenessInput, isAccountOverdue } from "@/server/balances/accountStaleness";
+import { computeAccountStatus, type AccountStatus } from "@/server/balances/accountStatus";
 
 export type AccountRow = Readonly<{
   accountId: string;
@@ -33,7 +34,7 @@ export type AccountRow = Readonly<{
   liquidity: AccountMetadataLiquidity;
   accountType: AccountMetadataAccountType;
   accountGroup: AccountMetadataGroup;
-  status: string;
+  status: AccountStatus;
   balance: number;
   balanceReport: number | null;
   lastTransactionTs: string | null;
@@ -59,18 +60,6 @@ export type BalancesSummaryResult = Readonly<{
   totals: ReadonlyArray<CurrencyTotal>;
   conversionWarnings: ReadonlyArray<ConversionWarning>;
 }>;
-
-const THREE_MONTHS_MS = 90 * 24 * 60 * 60 * 1000;
-
-function computeAccountStatus(
-  balance: number,
-  lastTransactionTs: string | null,
-): "active" | "inactive" {
-  if (balance !== 0) return "active";
-  if (lastTransactionTs === null) return "inactive";
-  const diffMs = Date.now() - new Date(lastTransactionTs).getTime();
-  return diffMs > THREE_MONTHS_MS ? "inactive" : "active";
-}
 
 export const ACCOUNTS_QUERY = `
   WITH latest_rates AS (
@@ -249,6 +238,8 @@ export const getBalancesSummary = async (userId: string, workspaceId: string): P
       });
     }
 
+    const currentTimeMs = Date.now();
+
     return {
       accounts: accountResult.rows.map((row: {
         account_id: string;
@@ -260,8 +251,11 @@ export const getBalancesSummary = async (userId: string, workspaceId: string): P
         const lastTransactionTs = row.last_transaction_ts !== null
           ? new Date(row.last_transaction_ts).toISOString()
           : null;
-        const daysSinceLast = lastTransactionTs !== null
-          ? Math.floor((Date.now() - new Date(lastTransactionTs).getTime()) / (1000 * 60 * 60 * 24))
+        const lastTransactionTimeMs = lastTransactionTs !== null
+          ? new Date(lastTransactionTs).getTime()
+          : null;
+        const daysSinceLast = lastTransactionTimeMs !== null
+          ? Math.floor((currentTimeMs - lastTransactionTimeMs) / (1000 * 60 * 60 * 24))
           : null;
         const staleness = stalenessMap.get(row.account_id);
         const overdue = staleness !== undefined
@@ -274,7 +268,7 @@ export const getBalancesSummary = async (userId: string, workspaceId: string): P
           liquidity: metadata?.liquidity ?? ACCOUNT_METADATA_DEFAULT_LIQUIDITY,
           accountType: metadata?.accountType ?? ACCOUNT_METADATA_DEFAULT_ACCOUNT_TYPE,
           accountGroup: metadata?.accountGroup ?? ACCOUNT_METADATA_DEFAULT_GROUP,
-          status: computeAccountStatus(Number(row.balance), lastTransactionTs),
+          status: computeAccountStatus(Number(row.balance), lastTransactionTimeMs, currentTimeMs),
           balance: Number(row.balance),
           balanceReport: row.balance_report !== null ? Number(row.balance_report) : null,
           lastTransactionTs,

--- a/apps/web/src/server/demo/data.ts
+++ b/apps/web/src/server/demo/data.ts
@@ -11,6 +11,7 @@ import {
   type AccountMetadataLiquidity,
 } from "@expense-budget-tracker/agent-shared";
 
+import type { AccountSuggestion } from "@/server/accounts/getAccountSuggestions";
 import type { AccountRow, BalancesSummaryResult, CurrencyTotal } from "@/server/balances/getBalancesSummary";
 import type { BudgetGridResult, BudgetRow } from "@/server/budget/getBudgetGrid";
 import type { CommentedCell } from "@/server/budget/getCommentedCells";
@@ -327,6 +328,42 @@ const generate = (): DemoData => {
 export const getDemoBalancesSummary = (): BalancesSummaryResult => {
   const { accounts, totals } = generate();
   return { accounts, totals, conversionWarnings: [] };
+};
+
+export const getDemoAccountSuggestions = (): ReadonlyArray<AccountSuggestion> => {
+  const { accounts, entries } = generate();
+  const latestOperationTimeByAccount = new Map<string, number>();
+
+  for (const entry of entries) {
+    const operationTimeMs = Date.parse(entry.ts);
+    if (!Number.isFinite(operationTimeMs)) {
+      throw new Error(`Invalid demo ledger timestamp "${entry.ts}" for entry "${entry.entryId}"`);
+    }
+    const latestOperationTimeMs = latestOperationTimeByAccount.get(entry.accountId);
+    if (latestOperationTimeMs === undefined || operationTimeMs > latestOperationTimeMs) {
+      latestOperationTimeByAccount.set(entry.accountId, operationTimeMs);
+    }
+  }
+
+  return accounts
+    .filter((account) => account.status === "active")
+    .map((account) => {
+      const latestOperationTimeMs = latestOperationTimeByAccount.get(account.accountId);
+      if (latestOperationTimeMs === undefined) {
+        throw new Error(`Demo account "${account.accountId}" has no ledger operations`);
+      }
+      return {
+        accountId: account.accountId,
+        currency: account.currency,
+        latestOperationTimeMs,
+      };
+    })
+    .sort((left, right) => {
+      const timeComparison = right.latestOperationTimeMs - left.latestOperationTimeMs;
+      if (timeComparison !== 0) return timeComparison;
+      return left.accountId < right.accountId ? -1 : left.accountId > right.accountId ? 1 : 0;
+    })
+    .map(({ accountId, currency }) => ({ accountId, currency }));
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a small no-store account-suggestions endpoint backed by one workspace-scoped aggregate query, shared active-account classification, transfer-aware recency ordering, demo parity, and focused tests. Validation: focused tests 9/9, npm run lint, npm run build, git diff --check, and a clean read-only review.