### PR TITLE
Persist auto filter delay setting

### DIFF
--- a/apps/web/src/app/api/community-monthly-category-share-route.test.ts
+++ b/apps/web/src/app/api/community-monthly-category-share-route.test.ts
@@ -84,6 +84,7 @@ test("postEnableMonthlyCategoryShareRouteWithDeps rejects a phrase from the wron
         locale: "ru",
         numberFormat: "1,234.56",
         dateFormat: "YYYY-MM-DD",
+        autoFilterDelayMinutes: 2,
       }),
       enableMonthlyCategoryShare: async () => {
         enableCalled = true;
@@ -114,6 +115,7 @@ test("postEnableMonthlyCategoryShareRouteWithDeps accepts the localized public-l
           locale: "en",
           numberFormat: "1,234.56",
           dateFormat: "YYYY-MM-DD",
+          autoFilterDelayMinutes: 2,
         }),
         enableMonthlyCategoryShare: async (userId, workspaceId, appOrigin) => {
           receivedContext = [userId, workspaceId, appOrigin];

--- a/apps/web/src/app/api/user-settings/route.ts
+++ b/apps/web/src/app/api/user-settings/route.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { isDemoModeFromRequest } from "@/lib/demoMode";
-import { DEFAULT_USER_SETTINGS, SUPPORTED_LOCALES, NUMBER_FORMATS, DATE_FORMATS, type SupportedLocale, type NumberFormat, type DateFormat } from "@/lib/locale";
+import { DEFAULT_USER_SETTINGS, type AutoFilterDelayMinutes, type SupportedLocale, type NumberFormat, type DateFormat } from "@/lib/locale";
 import { getLocaleFromRequest } from "@/lib/localeCookie";
 import { handleRoute } from "@/server/api/handleRoute";
 import { parseUserSettingsBody } from "@/server/api/settings";
@@ -35,6 +35,7 @@ export const PUT = async (request: Request): Promise<Response> =>
         if (body.hasLocale) result.locale = body.locale;
         if (body.hasNumberFormat) result.numberFormat = body.numberFormat;
         if (body.hasDateFormat) result.dateFormat = body.dateFormat;
+        if (body.hasAutoFilterDelayMinutes) result.autoFilterDelayMinutes = body.autoFilterDelayMinutes;
         const responseHeaders = new Headers({ "Content-Type": "application/json" });
         if (body.hasLocale) {
           responseHeaders.set("Set-Cookie", `locale=${body.locale as string}; Path=/; Max-Age=31536000; SameSite=Lax; Secure`);
@@ -49,10 +50,12 @@ export const PUT = async (request: Request): Promise<Response> =>
         locale?: SupportedLocale;
         numberFormat?: NumberFormat;
         dateFormat?: DateFormat;
+        autoFilterDelayMinutes?: AutoFilterDelayMinutes;
       } = {};
       if (body.hasLocale) updates.locale = body.locale as SupportedLocale;
       if (body.hasNumberFormat) updates.numberFormat = body.numberFormat as NumberFormat;
       if (body.hasDateFormat) updates.dateFormat = body.dateFormat as DateFormat;
+      if (body.hasAutoFilterDelayMinutes) updates.autoFilterDelayMinutes = body.autoFilterDelayMinutes as AutoFilterDelayMinutes;
 
       const result = await updateUserSettings(userId, workspaceId, updates, initialLocale);
       const responseHeaders = new Headers({ "Content-Type": "application/json" });

--- a/apps/web/src/lib/locale.ts
+++ b/apps/web/src/lib/locale.ts
@@ -23,16 +23,24 @@ export type DateFormat = "DD.MM.YYYY" | "MM/DD/YYYY" | "YYYY-MM-DD";
 
 export const DATE_FORMATS: ReadonlyArray<DateFormat> = ["DD.MM.YYYY", "MM/DD/YYYY", "YYYY-MM-DD"];
 
+export type EnabledAutoFilterDelayMinutes = 1 | 2 | 5 | 10 | 30;
+
+export type AutoFilterDelayMinutes = EnabledAutoFilterDelayMinutes | null;
+
+export const AUTO_FILTER_DELAY_MINUTES: ReadonlyArray<EnabledAutoFilterDelayMinutes> = [1, 2, 5, 10, 30];
+
 export type UserSettings = Readonly<{
   locale: SupportedLocale;
   numberFormat: NumberFormat;
   dateFormat: DateFormat;
+  autoFilterDelayMinutes: AutoFilterDelayMinutes;
 }>;
 
 export const DEFAULT_USER_SETTINGS: UserSettings = {
   locale: "en",
   numberFormat: "1,234.56",
   dateFormat: "YYYY-MM-DD",
+  autoFilterDelayMinutes: 2,
 };
 
 export const resolveLocale = (raw: string): SupportedLocale => {

--- a/apps/web/src/server/api/settings.test.ts
+++ b/apps/web/src/server/api/settings.test.ts
@@ -9,6 +9,7 @@ test("parseUserSettingsBody accepts the space-dot number format", (): void => {
 
   assert.equal(result.numberFormat, "1 234.56");
   assert.equal(result.hasNumberFormat, true);
+  assert.equal(result.hasAutoFilterDelayMinutes, false);
 });
 
 test("parseUserSettingsBody rejects an unsupported number format", (): void => {
@@ -21,4 +22,45 @@ test("parseUserSettingsBody rejects an unsupported number format", (): void => {
       return true;
     },
   );
+});
+
+test("parseUserSettingsBody accepts supported auto filter delay values", (): void => {
+  const supportedValues: ReadonlyArray<number> = [1, 2, 5, 10, 30];
+
+  for (const value of supportedValues) {
+    const result = parseUserSettingsBody({ autoFilterDelayMinutes: value });
+
+    assert.equal(result.autoFilterDelayMinutes, value);
+    assert.equal(result.hasAutoFilterDelayMinutes, true);
+  }
+});
+
+test("parseUserSettingsBody accepts null auto filter delay", (): void => {
+  const result = parseUserSettingsBody({ autoFilterDelayMinutes: null });
+
+  assert.equal(result.autoFilterDelayMinutes, null);
+  assert.equal(result.hasAutoFilterDelayMinutes, true);
+});
+
+test("parseUserSettingsBody preserves absent auto filter delay", (): void => {
+  const result = parseUserSettingsBody({ dateFormat: "YYYY-MM-DD" });
+
+  assert.equal(result.autoFilterDelayMinutes, undefined);
+  assert.equal(result.hasAutoFilterDelayMinutes, false);
+});
+
+test("parseUserSettingsBody rejects unsupported auto filter delay values", (): void => {
+  const invalidValues: ReadonlyArray<unknown> = [0, -1, 3, "2", true, { value: 2 }];
+
+  for (const value of invalidValues) {
+    assert.throws(
+      () => parseUserSettingsBody({ autoFilterDelayMinutes: value }),
+      (error: unknown): boolean => {
+        assert.ok(error instanceof ApiRouteError);
+        assert.equal(error.status, 400);
+        assert.match(error.publicMessage, /^Invalid autoFilterDelayMinutes\./);
+        return true;
+      },
+    );
+  }
 });

--- a/apps/web/src/server/api/settings.ts
+++ b/apps/web/src/server/api/settings.ts
@@ -1,6 +1,15 @@
 import { z } from "zod";
 
-import { DATE_FORMATS, NUMBER_FORMATS, SUPPORTED_LOCALES, type DateFormat, type NumberFormat, type SupportedLocale } from "@/lib/locale";
+import {
+  AUTO_FILTER_DELAY_MINUTES,
+  DATE_FORMATS,
+  NUMBER_FORMATS,
+  SUPPORTED_LOCALES,
+  type AutoFilterDelayMinutes,
+  type DateFormat,
+  type NumberFormat,
+  type SupportedLocale,
+} from "@/lib/locale";
 import { INVALID_TIMEZONE_MESSAGE, parseTimezone } from "@/lib/timezone";
 import { createBadRequestError } from "@/server/api/errors";
 import { integerRangeSchema, parseWithSchema } from "@/server/api/validation";
@@ -9,9 +18,11 @@ type ParsedUserSettingsBody = Readonly<{
   locale?: SupportedLocale;
   numberFormat?: NumberFormat;
   dateFormat?: DateFormat;
+  autoFilterDelayMinutes?: AutoFilterDelayMinutes;
   hasLocale: boolean;
   hasNumberFormat: boolean;
   hasDateFormat: boolean;
+  hasAutoFilterDelayMinutes: boolean;
 }>;
 
 type ParsedWorkspaceSettingsBody = Readonly<{
@@ -47,6 +58,15 @@ const dateFormatSchema = z.unknown().superRefine((value, ctx) => {
     ctx.addIssue({ code: "custom", message: `Invalid dateFormat. Expected one of: ${DATE_FORMATS.join(", ")}` });
   }
 }).transform((value): DateFormat => value as DateFormat);
+
+const autoFilterDelayMinutesSchema = z.unknown().superRefine((value, ctx) => {
+  if (value === null) {
+    return;
+  }
+  if (typeof value !== "number" || !(AUTO_FILTER_DELAY_MINUTES as ReadonlyArray<number>).includes(value)) {
+    ctx.addIssue({ code: "custom", message: `Invalid autoFilterDelayMinutes. Expected one of: ${AUTO_FILTER_DELAY_MINUTES.join(", ")} or null` });
+  }
+}).transform((value): AutoFilterDelayMinutes => value as AutoFilterDelayMinutes);
 
 const reportingCurrencySchema = z.unknown().superRefine((value, ctx) => {
   if (typeof value !== "string" || !/^[A-Z]{3}$/.test(value)) {
@@ -87,13 +107,15 @@ export const parseUserSettingsBody = (input: unknown): ParsedUserSettingsBody =>
     locale: localeSchema.optional(),
     numberFormat: numberFormatSchema.optional(),
     dateFormat: dateFormatSchema.optional(),
+    autoFilterDelayMinutes: autoFilterDelayMinutesSchema.optional(),
   }));
 
   const hasLocale = parsed.locale !== undefined;
   const hasNumberFormat = parsed.numberFormat !== undefined;
   const hasDateFormat = parsed.dateFormat !== undefined;
+  const hasAutoFilterDelayMinutes = parsed.autoFilterDelayMinutes !== undefined;
 
-  if (!hasLocale && !hasNumberFormat && !hasDateFormat) {
+  if (!hasLocale && !hasNumberFormat && !hasDateFormat && !hasAutoFilterDelayMinutes) {
     throw createBadRequestError("No fields to update");
   }
 
@@ -101,9 +123,11 @@ export const parseUserSettingsBody = (input: unknown): ParsedUserSettingsBody =>
     locale: parsed.locale,
     numberFormat: parsed.numberFormat,
     dateFormat: parsed.dateFormat,
+    autoFilterDelayMinutes: parsed.autoFilterDelayMinutes,
     hasLocale,
     hasNumberFormat,
     hasDateFormat,
+    hasAutoFilterDelayMinutes,
   };
 };
 

--- a/apps/web/src/server/userSettings.ts
+++ b/apps/web/src/server/userSettings.ts
@@ -1,10 +1,23 @@
-import { type SupportedLocale, type NumberFormat, type DateFormat, type UserSettings, DEFAULT_USER_SETTINGS, resolveLocale, NUMBER_FORMATS, DATE_FORMATS } from "@/lib/locale";
+import {
+  type SupportedLocale,
+  type NumberFormat,
+  type DateFormat,
+  type UserSettings,
+  type AutoFilterDelayMinutes,
+  type EnabledAutoFilterDelayMinutes,
+  DEFAULT_USER_SETTINGS,
+  resolveLocale,
+  NUMBER_FORMATS,
+  DATE_FORMATS,
+  AUTO_FILTER_DELAY_MINUTES,
+} from "@/lib/locale";
 import { queryAs } from "@/server/db";
 
 type UserSettingsRow = Readonly<{
   locale: string;
   number_format: string;
   date_format: string;
+  auto_filter_delay_minutes: unknown;
 }>;
 
 const parseNumberFormat = (raw: string): NumberFormat => {
@@ -21,11 +34,21 @@ const parseDateFormat = (raw: string): DateFormat => {
   return DEFAULT_USER_SETTINGS.dateFormat;
 };
 
+const parseAutoFilterDelayMinutes = (raw: unknown): AutoFilterDelayMinutes => {
+  if (raw === null) {
+    return null;
+  }
+  if (typeof raw === "number" && (AUTO_FILTER_DELAY_MINUTES as ReadonlyArray<number>).includes(raw)) {
+    return raw as EnabledAutoFilterDelayMinutes;
+  }
+  throw new Error(`Unexpected user_settings.auto_filter_delay_minutes value ${String(raw)}. Expected one of: ${AUTO_FILTER_DELAY_MINUTES.join(", ")} or null`);
+};
+
 export const getUserSettings = async (userId: string, workspaceId: string, initialLocale: SupportedLocale): Promise<UserSettings> => {
   const result = await queryAs(
     userId,
     workspaceId,
-    "SELECT locale, number_format, date_format FROM user_settings WHERE user_id = $1",
+    "SELECT locale, number_format, date_format, auto_filter_delay_minutes FROM user_settings WHERE user_id = $1",
     [userId],
   );
   if (result.rows.length === 0) {
@@ -36,13 +59,14 @@ export const getUserSettings = async (userId: string, workspaceId: string, initi
     locale: resolveLocale(row.locale),
     numberFormat: parseNumberFormat(row.number_format),
     dateFormat: parseDateFormat(row.date_format),
+    autoFilterDelayMinutes: parseAutoFilterDelayMinutes(row.auto_filter_delay_minutes),
   };
 };
 
 export const updateUserSettings = async (
   userId: string,
   workspaceId: string,
-  settings: Partial<Pick<UserSettings, "locale" | "numberFormat" | "dateFormat">>,
+  settings: Partial<Pick<UserSettings, "locale" | "numberFormat" | "dateFormat" | "autoFilterDelayMinutes">>,
   initialLocale: SupportedLocale,
 ): Promise<UserSettings> => {
   const setClauses: Array<string> = [];
@@ -64,6 +88,11 @@ export const updateUserSettings = async (
     params.push(settings.dateFormat);
     idx++;
   }
+  if (settings.autoFilterDelayMinutes !== undefined) {
+    setClauses.push(`auto_filter_delay_minutes = $${idx}`);
+    params.push(settings.autoFilterDelayMinutes);
+    idx++;
+  }
 
   if (setClauses.length === 0) {
     return getUserSettings(userId, workspaceId, initialLocale);
@@ -72,7 +101,7 @@ export const updateUserSettings = async (
   const result = await queryAs(
     userId,
     workspaceId,
-    `UPDATE user_settings SET ${setClauses.join(", ")} WHERE user_id = $1 RETURNING locale, number_format, date_format`,
+    `UPDATE user_settings SET ${setClauses.join(", ")} WHERE user_id = $1 RETURNING locale, number_format, date_format, auto_filter_delay_minutes`,
     params,
   );
 
@@ -85,5 +114,6 @@ export const updateUserSettings = async (
     locale: resolveLocale(row.locale),
     numberFormat: parseNumberFormat(row.number_format),
     dateFormat: parseDateFormat(row.date_format),
+    autoFilterDelayMinutes: parseAutoFilterDelayMinutes(row.auto_filter_delay_minutes),
   };
 };

--- a/db/migrations/0052_add_auto_filter_delay.sql
+++ b/db/migrations/0052_add_auto_filter_delay.sql
@@ -1,0 +1,4 @@
+ALTER TABLE user_settings
+  ADD COLUMN auto_filter_delay_minutes SMALLINT DEFAULT 2,
+  ADD CONSTRAINT user_settings_auto_filter_delay_minutes_check
+  CHECK (auto_filter_delay_minutes IS NULL OR auto_filter_delay_minutes IN (1, 2, 5, 10, 30));


### PR DESCRIPTION
## Summary
- add per-user autoFilterDelayMinutes contract and default
- persist auto_filter_delay_minutes with nullable disabled state and DB constraint
- validate authenticated user-settings updates for supported values and explicit null

## Validation
- npx tsx --test src/server/api/settings.test.ts: 6/6 passed
- npx tsx --test src/app/api/community-monthly-category-share-route.test.ts: 4/4 passed
- npm run lint: passed
- npm run build: passed
- git --no-pager diff --check: passed
- worker-owned review gate: no split recommendation, no P0-P4 findings