### PR TITLE
Apply selected number format to charts and FX breakdowns

### DIFF
--- a/apps/web/src/ui/charts/BudgetStreamChart.tsx
+++ b/apps/web/src/ui/charts/BudgetStreamChart.tsx
@@ -7,8 +7,11 @@ import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
 import { isCategoryVisible } from "@/lib/dataMask";
+import type { NumberFormat } from "@/lib/locale";
 import type { BudgetRow } from "@/server/budget/getBudgetGrid";
+import { useFormat } from "@/ui/FormatProvider";
 import styles from "@/ui/charts/BudgetStreamChart.module.css";
+import { formatNumber } from "@/ui/tables/shared/format";
 
 type Props = Readonly<{
   rows: ReadonlyArray<BudgetRow>;
@@ -94,16 +97,16 @@ const pivotByMonth = (
   }));
 };
 
-const formatAmount = (value: number): string => {
+const formatAmount = (value: number, numberFormat: NumberFormat): string => {
   const abs = Math.abs(value);
   if (abs >= 1000) {
-    return `${(value / 1000).toFixed(1)}k`;
+    return `${formatNumber(value / 1000, numberFormat, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}k`;
   }
-  return Math.round(value).toLocaleString("en-US");
+  return formatNumber(Math.round(value), numberFormat, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 };
 
-const formatAmountFull = (value: number): string =>
-  Math.round(value).toLocaleString("en-US");
+const formatAmountFull = (value: number, numberFormat: NumberFormat): string =>
+  formatNumber(Math.round(value), numberFormat, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 
 const formatMonthToYYYYMM = (date: Date): string => {
   const y = date.getUTCFullYear();
@@ -142,6 +145,7 @@ const findClosestDateIndex = (
 export const BudgetStreamChart = (props: Props): ReactElement => {
   const { rows, allowlist, reportingCurrency, onMonthClick } = props;
   const { t } = useTranslation();
+  const { numberFormat } = useFormat();
   const masked = allowlist !== null && allowlist.size === 0;
   const svgRef = useRef<SVGSVGElement>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -404,7 +408,7 @@ export const BudgetStreamChart = (props: Props): ReactElement => {
                     fill="#898989"
                     fontSize={11}
                   >
-                    {formatAmount(tick)}
+                    {formatAmount(tick, numberFormat)}
                   </text>
                 </g>
               );
@@ -507,13 +511,13 @@ export const BudgetStreamChart = (props: Props): ReactElement => {
           {hover.incomeItems.length > 0 && (
             <>
               <div className={styles.tooltipSection}>
-                {t("chart.income")}: {formatAmountFull(hover.incomeTotal)}
+                {t("chart.income")}: {formatAmountFull(hover.incomeTotal, numberFormat)}
               </div>
               {hover.incomeItems.map((item) => (
                 <div key={`tip-i-${item.category}`} className={styles.tooltipRow}>
                   <span className={styles.legendSwatch} style={{ background: item.color }} />
                   <span>{item.category}</span>
-                  <span className={styles.tooltipValue}>{formatAmountFull(item.value)}</span>
+                  <span className={styles.tooltipValue}>{formatAmountFull(item.value, numberFormat)}</span>
                 </div>
               ))}
             </>
@@ -521,13 +525,13 @@ export const BudgetStreamChart = (props: Props): ReactElement => {
           {hover.spendItems.length > 0 && (
             <>
               <div className={styles.tooltipSection}>
-                {t("chart.spend")}: {formatAmountFull(hover.spendTotal)}
+                {t("chart.spend")}: {formatAmountFull(hover.spendTotal, numberFormat)}
               </div>
               {hover.spendItems.map((item) => (
                 <div key={`tip-s-${item.category}`} className={styles.tooltipRow}>
                   <span className={styles.legendSwatch} style={{ background: item.color }} />
                   <span>{item.category}</span>
-                  <span className={styles.tooltipValue}>{formatAmountFull(item.value)}</span>
+                  <span className={styles.tooltipValue}>{formatAmountFull(item.value, numberFormat)}</span>
                 </div>
               ))}
             </>

--- a/apps/web/src/ui/charts/ExpenseTreemapChart.tsx
+++ b/apps/web/src/ui/charts/ExpenseTreemapChart.tsx
@@ -8,8 +8,11 @@ import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
 import { isCategoryVisible } from "@/lib/dataMask";
+import type { NumberFormat } from "@/lib/locale";
 import type { LedgerEntry } from "@/server/transactions/getTransactions";
+import { useFormat } from "@/ui/FormatProvider";
 import styles from "@/ui/charts/ExpenseTreemapChart.module.css";
+import { formatNumber } from "@/ui/tables/shared/format";
 
 type Props = Readonly<{
   entries: ReadonlyArray<LedgerEntry>;
@@ -42,14 +45,14 @@ const HEIGHT = 600;
 const HEADER_H = 18;
 const PAD_TOP = HEADER_H + 3;
 
-const fmtTotal = (value: number, currency: string): string =>
-  `${Math.round(value).toLocaleString("en-US")} ${currency}`;
+const fmtTotal = (value: number, currency: string, numberFormat: NumberFormat): string =>
+  `${formatNumber(Math.round(value), numberFormat, { minimumFractionDigits: 0, maximumFractionDigits: 0 })} ${currency}`;
 
-const fmtAmount = (value: number): string =>
-  Math.round(value).toLocaleString("en-US");
+const fmtAmount = (value: number, numberFormat: NumberFormat): string =>
+  formatNumber(Math.round(value), numberFormat, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
 
-const fmtCurrency = (amount: number, currency: string): string =>
-  `${amount.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`;
+const fmtCurrency = (amount: number, currency: string, numberFormat: NumberFormat): string =>
+  `${formatNumber(amount, numberFormat, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`;
 
 const fmtDate = (ts: string): string => {
   const d = new Date(ts);
@@ -112,6 +115,7 @@ const buildHierarchy = (
 export const ExpenseTreemapChart = (props: Props): ReactElement => {
   const { entries, allowlist, reportingCurrency, onCellClick } = props;
   const { t } = useTranslation();
+  const { numberFormat } = useFormat();
   const masked = allowlist !== null && allowlist.size === 0;
   const wrapRef = useRef<HTMLDivElement>(null);
   const [hover, setHover] = useState<HoverInfo | null>(null);
@@ -181,7 +185,7 @@ export const ExpenseTreemapChart = (props: Props): ReactElement => {
     <>
       {!masked && (
         <div className={styles.total}>
-          {fmtTotal(grandTotal, reportingCurrency)}
+          {fmtTotal(grandTotal, reportingCurrency, numberFormat)}
         </div>
       )}
 
@@ -196,7 +200,7 @@ export const ExpenseTreemapChart = (props: Props): ReactElement => {
             const clipId = `tm-clip-${ci}`;
             const showHeader = cw > 40 && ch > PAD_TOP;
 
-            const headerText = `${catName} — ${fmtTotal(catTotal, reportingCurrency)}`;
+            const headerText = `${catName} — ${fmtTotal(catTotal, reportingCurrency, numberFormat)}`;
             const headerLabel = estTextW(headerText, 11) < cw - 8 ? headerText : catName;
 
             return (
@@ -227,7 +231,7 @@ export const ExpenseTreemapChart = (props: Props): ReactElement => {
                     const lh = leaf.y1 - leaf.y0;
                     const val = leaf.value ?? 0;
                     const fs = cellFontSize(lw, lh);
-                    const amt = fmtAmount(val);
+                    const amt = fmtAmount(val, numberFormat);
                     const amtFits = estTextW(amt, fs) < lw - 6 && fs + 4 < lh;
                     const cp = leaf.data.counterparty;
                     const cpFits = amtFits && lh > fs + 18 && lw > 40
@@ -307,11 +311,11 @@ export const ExpenseTreemapChart = (props: Props): ReactElement => {
             }}
           >
             <div className={styles.tooltipAmount}>
-              {fmtCurrency(Math.abs(hover.entry.amount), hover.entry.currency)}
+              {fmtCurrency(Math.abs(hover.entry.amount), hover.entry.currency, numberFormat)}
             </div>
             {hover.entry.amountReport !== null && hover.entry.currency !== reportingCurrency && (
               <div className={styles.tooltipConverted}>
-                ≈ {fmtCurrency(Math.abs(hover.entry.amountReport), reportingCurrency)}
+                ≈ {fmtCurrency(Math.abs(hover.entry.amountReport), reportingCurrency, numberFormat)}
               </div>
             )}
             {hover.entry.counterparty !== null && (

--- a/apps/web/src/ui/tables/fx-breakdown/FxBreakdownPanel.tsx
+++ b/apps/web/src/ui/tables/fx-breakdown/FxBreakdownPanel.tsx
@@ -5,13 +5,14 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/cn";
 import { buildLiveDataUrl, fetchLiveData } from "@/lib/liveDataFetch";
+import type { NumberFormat } from "@/lib/locale";
 import { getMonthEndDate } from "@/lib/monthUtils";
 import type { FxBreakdownRow, FxBreakdownResult } from "@/server/budget/getFxBreakdown";
 import { useFormat } from "@/ui/FormatProvider";
 import alertStyles from "@/ui/Alert.module.css";
 
 import { formatFxAmount } from "@/ui/tables/fx/format";
-import { formatAmount } from "@/ui/tables/shared/format";
+import { formatAmount, formatNumber } from "@/ui/tables/shared/format";
 import panelStyles from "@/ui/tables/shared/TablePanel.module.css";
 import tableStateStyles from "@/ui/tables/shared/TableStates.module.css";
 import tableStyles from "@/ui/tables/shared/TableUi.module.css";
@@ -24,15 +25,15 @@ type Props = Readonly<{
   onClose: () => void;
 }>;
 
-const formatRate = (value: number): string => {
+const formatRate = (value: number, numberFormat: NumberFormat): string => {
   if (value === 0) return "—";
   if (value === 1) return "1";
-  return value.toLocaleString("en-US", { minimumFractionDigits: 4, maximumFractionDigits: 6 });
+  return formatNumber(value, numberFormat, { minimumFractionDigits: 4, maximumFractionDigits: 6 });
 };
 
-const formatNative = (value: number): string => {
+const formatNative = (value: number, numberFormat: NumberFormat): string => {
   if (value === 0) return "0";
-  return value.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return formatNumber(value, numberFormat, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 };
 
 export const FxBreakdownPanel = (props: Props): ReactElement => {
@@ -158,12 +159,12 @@ export const FxBreakdownPanel = (props: Props): ReactElement => {
               {rows.map((row) => (
                 <tr key={row.currency} className={tableStyles.row}>
                   <td className={cn(tableStyles.cell, tableStyles.cellMono)}>{row.currency}</td>
-                  <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatNative(row.openNative)}</td>
-                  <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatRate(row.openRate)}</td>
+                  <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatNative(row.openNative, numberFormat)}</td>
+                  <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatRate(row.openRate, numberFormat)}</td>
                   <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatAmount(row.openReport, numberFormat)}</td>
                   <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatAmount(row.flowReport, numberFormat)}</td>
-                  <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatNative(row.closeNative)}</td>
-                  <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatRate(row.closeRate)}</td>
+                  <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatNative(row.closeNative, numberFormat)}</td>
+                  <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatRate(row.closeRate, numberFormat)}</td>
                   <td className={cn(tableStyles.cell, tableStyles.cellRight)}>{formatAmount(row.closeReport, numberFormat)}</td>
                   <td className={cn(tableStyles.cell, tableStyles.cellRight, row.fxAdjustReport < 0 ? tableStateStyles.over : "")}>{formatFxAmount(row.fxAdjustReport, numberFormat)}</td>
                 </tr>


### PR DESCRIPTION
## Summary
- apply the selected number format to budget chart axes and tooltips
- apply it to expense treemap totals, labels, and tooltip amounts
- apply it to FX breakdown native amounts and rates through the shared formatter

## Validation
- npx tsx --test src/ui/tables/shared/format.test.ts
- npm run lint
- npm run build
- git diff --check