### PR TITLE
feat(web): parse formatted monetary input safely

### DIFF
--- a/apps/web/e2e-local/monetary-input.local-demo.spec.ts
+++ b/apps/web/e2e-local/monetary-input.local-demo.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const setDemoCookies = async (page: Page, baseURL: string): Promise<void> => {
+  const origin = new URL(baseURL);
+  await page.context().addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+};
+
+test("keeps the invalid transaction amount editor as the only active editor", async ({ page, baseURL }) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+  await setDemoCookies(page, baseURL);
+  await page.goto("/transactions", { waitUntil: "domcontentloaded" });
+
+  const amountCells = page.locator('td[data-testid^="transaction-amount-"]');
+  await expect(amountCells).not.toHaveCount(0, { timeout: 15_000 });
+  const amountCellCount = await amountCells.count();
+  expect(amountCellCount).toBeGreaterThan(1);
+
+  const firstCell = amountCells.nth(0);
+  const secondCell = amountCells.nth(1);
+  const firstCellTestId = await firstCell.getAttribute("data-testid");
+  const secondCellTestId = await secondCell.getAttribute("data-testid");
+  if (firstCellTestId === null || secondCellTestId === null) {
+    throw new Error("Transaction amount cells are missing their stable test IDs");
+  }
+  const firstEntryId = firstCellTestId.slice("transaction-amount-".length);
+  const secondEntryId = secondCellTestId.slice("transaction-amount-".length);
+
+  await firstCell.click();
+  const firstInput = page.getByTestId(`transaction-amount-input-${firstEntryId}`);
+  await expect(firstInput).toBeVisible();
+  await firstInput.fill("invalid amount");
+
+  await secondCell.click();
+
+  await expect(firstInput).toHaveAttribute("aria-invalid", "true");
+  await expect(page.getByTestId(`transaction-amount-input-${secondEntryId}`)).toHaveCount(0);
+  await expect(page.locator('[data-testid^="transaction-amount-input-"]')).toHaveCount(1);
+});
+
+test("keeps the invalid budget plan popover as the only active popover", async ({ page, baseURL }) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+  await setDemoCookies(page, baseURL);
+  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+
+  const planCells = page.locator('[data-testid^="budget-plan-cell-budget-plan:"]');
+  await expect(planCells).not.toHaveCount(0);
+  const planCellCount = await planCells.count();
+  expect(planCellCount).toBeGreaterThan(1);
+
+  const firstCell = planCells.nth(0);
+  const secondCell = planCells.nth(1);
+  const firstCellTestId = await firstCell.getAttribute("data-testid");
+  if (firstCellTestId === null) {
+    throw new Error("First budget plan cell is missing its stable test ID");
+  }
+  const firstEditorId = firstCellTestId.slice("budget-plan-cell-".length);
+
+  await firstCell.click();
+  const firstInput = page.getByTestId(`budget-plan-modifier-input-${firstEditorId}`);
+  await expect(firstInput).toBeVisible();
+  await firstInput.fill("invalid amount");
+
+  await secondCell.click();
+
+  await expect(firstInput).toHaveAttribute("aria-invalid", "true");
+  await expect(page.locator('[data-testid^="budget-plan-modifier-input-budget-plan:"]')).toHaveCount(1);
+});

--- a/apps/web/src/i18n/ar.json
+++ b/apps/web/src/i18n/ar.json
@@ -43,6 +43,7 @@
   "common.today": "اليوم",
   "common.from": "من",
   "common.to": "إلى",
+  "common.invalidNumber": "أدخل رقمًا صالحًا بالتنسيق المحدد.",
   "currency.title": "عملة التقارير",
   "apiKeys.copyWarning": "انسخ مفتاح API الآن — لن يظهر مرة أخرى.",
   "apiKeys.copy": "نسخ",

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -43,6 +43,7 @@
   "common.today": "Today",
   "common.from": "From",
   "common.to": "To",
+  "common.invalidNumber": "Enter a valid number in the selected format.",
   "currency.title": "Reporting currency",
   "apiKeys.copyWarning": "Copy the API key now — it will not be shown again.",
   "apiKeys.copy": "Copy",

--- a/apps/web/src/i18n/es.json
+++ b/apps/web/src/i18n/es.json
@@ -43,6 +43,7 @@
   "common.today": "Hoy",
   "common.from": "Desde",
   "common.to": "Hasta",
+  "common.invalidNumber": "Introduzca un número válido en el formato seleccionado.",
   "currency.title": "Moneda de reporte",
   "apiKeys.copyWarning": "Copie la clave API ahora — no se mostrará de nuevo.",
   "apiKeys.copy": "Copiar",

--- a/apps/web/src/i18n/fa.json
+++ b/apps/web/src/i18n/fa.json
@@ -43,6 +43,7 @@
   "common.today": "امروز",
   "common.from": "از",
   "common.to": "تا",
+  "common.invalidNumber": "یک عدد معتبر با قالب انتخاب‌شده وارد کنید.",
   "currency.title": "ارز گزارش",
   "apiKeys.copyWarning": "کلید API را الان کپی کنید — دوباره نمایش داده نخواهد شد.",
   "apiKeys.copy": "کپی",

--- a/apps/web/src/i18n/he.json
+++ b/apps/web/src/i18n/he.json
@@ -43,6 +43,7 @@
   "common.today": "היום",
   "common.from": "מ",
   "common.to": "עד",
+  "common.invalidNumber": "יש להזין מספר תקין בתבנית שנבחרה.",
   "currency.title": "מטבע דיווח",
   "apiKeys.copyWarning": "העתק את מפתח ה-API עכשיו — הוא לא יוצג שוב.",
   "apiKeys.copy": "העתק",

--- a/apps/web/src/i18n/ru.json
+++ b/apps/web/src/i18n/ru.json
@@ -43,6 +43,7 @@
   "common.today": "Сегодня",
   "common.from": "С",
   "common.to": "По",
+  "common.invalidNumber": "Введите корректное число в выбранном формате.",
   "currency.title": "Валюта отчётности",
   "apiKeys.copyWarning": "Скопируйте API-ключ сейчас — он больше не будет показан.",
   "apiKeys.copy": "Копировать",

--- a/apps/web/src/i18n/uk.json
+++ b/apps/web/src/i18n/uk.json
@@ -43,6 +43,7 @@
   "common.today": "Сьогодні",
   "common.from": "З",
   "common.to": "По",
+  "common.invalidNumber": "Введіть коректне число у вибраному форматі.",
   "currency.title": "Валюта звітності",
   "apiKeys.copyWarning": "Скопіюйте API-ключ зараз — він більше не буде показаний.",
   "apiKeys.copy": "Копіювати",

--- a/apps/web/src/i18n/zh.json
+++ b/apps/web/src/i18n/zh.json
@@ -43,6 +43,7 @@
   "common.today": "今天",
   "common.from": "从",
   "common.to": "到",
+  "common.invalidNumber": "请按所选格式输入有效数字。",
   "currency.title": "报告货币",
   "apiKeys.copyWarning": "请立即复制 API 密钥 — 之后将不再显示。",
   "apiKeys.copy": "复制",

--- a/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
@@ -4,10 +4,13 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
+import type { NumberFormat } from "@/lib/locale";
 import { useFormat } from "@/ui/FormatProvider";
 import { postBudgetPlan, postBudgetPlanFill, fetchComment, postComment } from "@/ui/tables/budget/budgetTableApi";
 import { formatAmount, isDecember } from "@/ui/tables/budget/budgetTableLogic";
 import styles from "@/ui/tables/budget/BudgetTable.module.css";
+import { parseMonetaryNumberEdit } from "@/ui/tables/shared/format";
+import { useTableEditorActivation } from "@/ui/tables/shared/TableEditorActivationProvider";
 import tableStateStyles from "@/ui/tables/shared/TableStates.module.css";
 
 const POPOVER_WIDTH = 240;
@@ -25,6 +28,33 @@ type PopoverSize = Readonly<{
 }>;
 
 type TextDirection = "ltr" | "rtl";
+
+type RoundedBudgetInputsResult =
+  | Readonly<{ ok: true; base: number; modifier: number }>
+  | Readonly<{ ok: false; baseInvalid: boolean; modifierInvalid: boolean }>;
+
+const parseRoundedBudgetInputs = (
+  baseInput: string,
+  modifierInput: string,
+  originalBase: number,
+  originalModifier: number,
+  numberFormat: NumberFormat,
+): RoundedBudgetInputsResult => {
+  const base = parseMonetaryNumberEdit(baseInput, originalBase, numberFormat);
+  const modifier = parseMonetaryNumberEdit(modifierInput, originalModifier, numberFormat);
+  if (!base.ok || !modifier.ok) {
+    return {
+      ok: false,
+      baseInvalid: !base.ok,
+      modifierInvalid: !modifier.ok,
+    };
+  }
+  return {
+    ok: true,
+    base: Math.round(base.value),
+    modifier: Math.round(modifier.value),
+  };
+};
 
 const getClampedCoordinate = (preferred: number, min: number, max: number): number => {
   const normalizedMax = Math.max(min, max);
@@ -99,9 +129,13 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
 
   const { numberFormat } = useFormat();
   const { t } = useTranslation();
+  const editorId = `budget-plan:${month}:${direction}:${category}`;
+  const { requestActivation, releaseActivation } = useTableEditorActivation(editorId);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [baseInput, setBaseInput] = useState<string>("");
   const [modifierInput, setModifierInput] = useState<string>("");
+  const [baseValidationError, setBaseValidationError] = useState<string | null>(null);
+  const [modifierValidationError, setModifierValidationError] = useState<string | null>(null);
   const [commentInput, setCommentInput] = useState<string>("");
   const [isLoadingComment, setIsLoadingComment] = useState<boolean>(false);
   const [popoverPos, setPopoverPos] = useState<PopoverPosition>({ top: 0, left: 0 });
@@ -109,6 +143,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
   const cellRef = useRef<HTMLTableCellElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const adjustInputRef = useRef<HTMLInputElement>(null);
+  const baseInputRef = useRef<HTMLInputElement>(null);
 
   const originalBase = useRef<number>(0);
   const originalModifier = useRef<number>(0);
@@ -116,10 +151,13 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
 
   const openPopover = (): void => {
     if (!showData) return;
+    if (!requestActivation()) return;
     const roundedBase = Math.round(plannedBase);
     const roundedModifier = Math.round(plannedModifier);
     setBaseInput(String(roundedBase));
     setModifierInput(String(roundedModifier));
+    setBaseValidationError(null);
+    setModifierValidationError(null);
     originalBase.current = roundedBase;
     originalModifier.current = roundedModifier;
 
@@ -204,17 +242,39 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     }
   }, [isOpen]);
 
-  const saveChanges = useCallback((): void => {
-    const newBase = Math.round(Number(baseInput));
-    const newMod = Math.round(Number(modifierInput));
+  const reportInvalidInputs = useCallback((result: Extract<RoundedBudgetInputsResult, { ok: false }>): void => {
+    const message = t("common.invalidNumber");
+    const baseError = result.baseInvalid ? message : null;
+    const modifierError = result.modifierInvalid ? message : null;
+    setBaseValidationError(baseError);
+    setModifierValidationError(modifierError);
+    baseInputRef.current?.setCustomValidity(baseError ?? "");
+    adjustInputRef.current?.setCustomValidity(modifierError ?? "");
 
-    const baseChanged = Number.isFinite(newBase) && newBase !== originalBase.current;
-    const modChanged = Number.isFinite(newMod) && newMod !== originalModifier.current;
+    const firstInvalidInput = result.modifierInvalid ? adjustInputRef.current : baseInputRef.current;
+    firstInvalidInput?.reportValidity();
+  }, [t]);
+
+  const saveChanges = useCallback((): boolean => {
+    const parsedInputs = parseRoundedBudgetInputs(
+      baseInput,
+      modifierInput,
+      originalBase.current,
+      originalModifier.current,
+      numberFormat,
+    );
+    if (!parsedInputs.ok) {
+      reportInvalidInputs(parsedInputs);
+      return false;
+    }
+
+    const baseChanged = parsedInputs.base !== originalBase.current;
+    const modChanged = parsedInputs.modifier !== originalModifier.current;
 
     if (baseChanged) {
       onSyncStart();
-      onPlanSave(month, direction, category, "base", newBase);
-      postBudgetPlan({ month, direction, category, kind: "base", plannedValue: newBase })
+      onPlanSave(month, direction, category, "base", parsedInputs.base);
+      postBudgetPlan({ month, direction, category, kind: "base", plannedValue: parsedInputs.base })
         .catch((error) => {
           onPlanSave(month, direction, category, "base", originalBase.current);
           console.error(error);
@@ -224,8 +284,8 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
 
     if (modChanged) {
       onSyncStart();
-      onPlanSave(month, direction, category, "modifier", newMod);
-      postBudgetPlan({ month, direction, category, kind: "modifier", plannedValue: newMod })
+      onPlanSave(month, direction, category, "modifier", parsedInputs.modifier);
+      postBudgetPlan({ month, direction, category, kind: "modifier", plannedValue: parsedInputs.modifier })
         .catch((error) => {
           onPlanSave(month, direction, category, "modifier", originalModifier.current);
           console.error(error);
@@ -240,23 +300,34 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
         .catch((error) => console.error(error))
         .finally(onSyncEnd);
     }
-  }, [baseInput, modifierInput, commentInput, month, direction, category, onPlanSave, onCommentPresenceChange, onSyncStart, onSyncEnd]);
+    return true;
+  }, [baseInput, modifierInput, commentInput, month, direction, category, numberFormat, onPlanSave, onCommentPresenceChange, onSyncStart, onSyncEnd, reportInvalidInputs]);
 
   const closePopover = useCallback((): void => {
     if (!isOpen) return;
-    saveChanges();
+    if (!saveChanges()) return;
     setIsOpen(false);
-  }, [isOpen, saveChanges]);
+    releaseActivation();
+  }, [isOpen, releaseActivation, saveChanges]);
 
   const handleFill = useCallback((): void => {
-    const newBase = Math.round(Number(baseInput));
-    if (!Number.isFinite(newBase)) return;
+    const parsedInputs = parseRoundedBudgetInputs(
+      baseInput,
+      modifierInput,
+      originalBase.current,
+      originalModifier.current,
+      numberFormat,
+    );
+    if (!parsedInputs.ok) {
+      reportInvalidInputs(parsedInputs);
+      return;
+    }
 
     // Save base for current month if changed
-    if (newBase !== originalBase.current) {
+    if (parsedInputs.base !== originalBase.current) {
       onSyncStart();
-      onPlanSave(month, direction, category, "base", newBase);
-      postBudgetPlan({ month, direction, category, kind: "base", plannedValue: newBase })
+      onPlanSave(month, direction, category, "base", parsedInputs.base);
+      postBudgetPlan({ month, direction, category, kind: "base", plannedValue: parsedInputs.base })
         .catch((error) => {
           onPlanSave(month, direction, category, "base", originalBase.current);
           console.error(error);
@@ -265,11 +336,10 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     }
 
     // Save modifier for current month if changed
-    const newMod = Math.round(Number(modifierInput));
-    if (Number.isFinite(newMod) && newMod !== originalModifier.current) {
+    if (parsedInputs.modifier !== originalModifier.current) {
       onSyncStart();
-      onPlanSave(month, direction, category, "modifier", newMod);
-      postBudgetPlan({ month, direction, category, kind: "modifier", plannedValue: newMod })
+      onPlanSave(month, direction, category, "modifier", parsedInputs.modifier);
+      postBudgetPlan({ month, direction, category, kind: "modifier", plannedValue: parsedInputs.modifier })
         .catch((error) => {
           onPlanSave(month, direction, category, "modifier", originalModifier.current);
           console.error(error);
@@ -279,15 +349,16 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
 
     // Fill base to following months
     onSyncStart();
-    onFillMonths(month, direction, category, newBase);
-    postBudgetPlanFill({ fromMonth: month, direction, category, baseValue: newBase })
+    onFillMonths(month, direction, category, parsedInputs.base);
+    postBudgetPlanFill({ fromMonth: month, direction, category, baseValue: parsedInputs.base })
       .catch((error) => {
         console.error(error);
       })
       .finally(onSyncEnd);
 
     setIsOpen(false);
-  }, [baseInput, modifierInput, month, direction, category, onPlanSave, onFillMonths, onSyncStart, onSyncEnd]);
+    releaseActivation();
+  }, [baseInput, modifierInput, month, direction, category, numberFormat, onPlanSave, onFillMonths, onSyncStart, onSyncEnd, releaseActivation, reportInvalidInputs]);
 
   // Click outside → close
   useEffect(() => {
@@ -311,11 +382,12 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     const handleKeyDown = (e: KeyboardEvent): void => {
       if (e.key === "Escape") {
         setIsOpen(false); // close without saving
+        releaseActivation();
       }
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen]);
+  }, [isOpen, releaseActivation]);
 
   const handleBaseKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === "Enter") closePopover();
@@ -325,7 +397,14 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     if (e.key === "Enter") closePopover();
   };
 
-  const computedTotal = Math.round(Number(baseInput) || 0) + Math.round(Number(modifierInput) || 0);
+  const parsedInputs = parseRoundedBudgetInputs(
+    baseInput,
+    modifierInput,
+    originalBase.current,
+    originalModifier.current,
+    numberFormat,
+  );
+  const computedTotal = parsedInputs.ok ? parsedInputs.base + parsedInputs.modifier : 0;
   const canFill = !isDecember(month);
 
   const modifierIconClass = direction === "income"
@@ -336,6 +415,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     <td
       ref={cellRef}
       className={cn(styles.cell, styles.cellEditable, cmClass, maskClass, taintedClass, isPlanOver ? tableStateStyles.over : "")}
+      data-testid={`budget-plan-cell-${editorId}`}
       onClick={isOpen ? undefined : openPopover}
     >
       {showData && plannedModifier !== 0 && (
@@ -352,20 +432,35 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
             <span className={styles.popoverLabel}>{t("budget.popoverAdjust")}</span>
             <input
               ref={adjustInputRef}
-              type="number"
+              type="text"
+              inputMode="decimal"
               className={styles.popoverInput}
+              data-testid={`budget-plan-modifier-input-${editorId}`}
               value={modifierInput}
-              onChange={(e) => setModifierInput(e.target.value)}
+              aria-invalid={modifierValidationError !== null}
+              onChange={(e) => {
+                setModifierInput(e.target.value);
+                setModifierValidationError(null);
+                e.currentTarget.setCustomValidity("");
+              }}
               onKeyDown={handleModifierKeyDown}
             />
           </label>
           <label className={styles.popoverField}>
             <span className={styles.popoverLabel}>{t("budget.popoverBase")}</span>
             <input
-              type="number"
+              ref={baseInputRef}
+              type="text"
+              inputMode="decimal"
               className={styles.popoverInput}
+              data-testid={`budget-plan-base-input-${editorId}`}
               value={baseInput}
-              onChange={(e) => setBaseInput(e.target.value)}
+              aria-invalid={baseValidationError !== null}
+              onChange={(e) => {
+                setBaseInput(e.target.value);
+                setBaseValidationError(null);
+                e.currentTarget.setCustomValidity("");
+              }}
               onKeyDown={handleBaseKeyDown}
             />
           </label>

--- a/apps/web/src/ui/tables/budget/BudgetTable.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetTable.tsx
@@ -16,6 +16,7 @@ import {
   type BudgetTableProps,
   useBudgetTableController,
 } from "@/ui/tables/budget/controller/useBudgetTableController";
+import { TableEditorActivationProvider } from "@/ui/tables/shared/TableEditorActivationProvider";
 import tableStateStyles from "@/ui/tables/shared/TableStates.module.css";
 import styles from "@/ui/tables/budget/BudgetTable.module.css";
 
@@ -53,62 +54,64 @@ export const BudgetTable = (props: BudgetTableProps): ReactElement => {
         {controller.pendingSaves > 0 && <span className={styles.syncStatus}>{t("common.syncing")}</span>}
       </div>
       <div className={styles.scroll} ref={controller.scrollRef}>
-        <table className={styles.table}>
-          <BudgetTableHeader
-            columnSequence={controller.columnSequence}
-            currentMonth={controller.currentMonth}
-            currentYear={controller.currentYear}
-            isLoadingLeft={controller.isLoadingLeft}
-          />
-          <tbody>
-            {controller.blocks.map((block) => (
-              <Fragment key={block.direction}>
-                <BudgetDirectionSection
-                  block={block}
-                  effectiveAllowlist={controller.effectiveAllowlist}
-                  columnSequence={controller.columnSequence}
-                  currentMonth={controller.currentMonth}
-                  currentYear={controller.currentYear}
-                  yearComputed={controller.yearComputed}
-                  filteredSubtotalsMap={controller.filteredSubtotalsMap}
-                  taintedDirectionMonths={controller.taintedDirectionMonths}
-                  taintedCells={controller.taintedCells}
-                  commentedCells={controller.commentedCells}
-                  numberFormat={numberFormat}
-                  copyToClipboard={copyToClipboard}
-                  openDrillDown={controller.openDrillDown}
-                  onPlanSave={controller.handlePlanSave}
-                  onFillMonths={controller.handleFillMonths}
-                  onCommentPresenceChange={controller.updateCommentCell}
-                  onSyncStart={controller.onSyncStart}
-                  onSyncEnd={controller.onSyncEnd}
-                />
-              </Fragment>
-            ))}
-            <BudgetDerivedSection
-              effectiveAllowlist={controller.effectiveAllowlist}
+        <TableEditorActivationProvider>
+          <table className={styles.table}>
+            <BudgetTableHeader
               columnSequence={controller.columnSequence}
               currentMonth={controller.currentMonth}
               currentYear={controller.currentYear}
-              yearComputed={controller.yearComputed}
-              incomeSubtotals={controller.incomeSubtotals}
-              spendSubtotals={controller.spendSubtotals}
-              transferSubtotals={controller.transferSubtotals}
-              taintedMonths={controller.taintedMonths}
-              fxAdjustments={controller.fxAdjustments}
-              businessPersonalTransfers={controller.businessPersonalTransfers}
-              hasBusinessAccount={controller.hasBusinessAccount}
-              cumulativeBalances={controller.cumulativeBalances}
-              hasLiquidityBreakdown={controller.hasLiquidityBreakdown}
-              liquidityTiers={controller.liquidityTiers}
-              mebByLiq={controller.mebByLiq}
-              projectedLiqBalances={controller.projectedLiqBalances}
-              numberFormat={numberFormat}
-              openDrillDown={controller.openDrillDown}
-              openFxBreakdown={controller.openFxBreakdown}
+              isLoadingLeft={controller.isLoadingLeft}
             />
-          </tbody>
-        </table>
+            <tbody>
+              {controller.blocks.map((block) => (
+                <Fragment key={block.direction}>
+                  <BudgetDirectionSection
+                    block={block}
+                    effectiveAllowlist={controller.effectiveAllowlist}
+                    columnSequence={controller.columnSequence}
+                    currentMonth={controller.currentMonth}
+                    currentYear={controller.currentYear}
+                    yearComputed={controller.yearComputed}
+                    filteredSubtotalsMap={controller.filteredSubtotalsMap}
+                    taintedDirectionMonths={controller.taintedDirectionMonths}
+                    taintedCells={controller.taintedCells}
+                    commentedCells={controller.commentedCells}
+                    numberFormat={numberFormat}
+                    copyToClipboard={copyToClipboard}
+                    openDrillDown={controller.openDrillDown}
+                    onPlanSave={controller.handlePlanSave}
+                    onFillMonths={controller.handleFillMonths}
+                    onCommentPresenceChange={controller.updateCommentCell}
+                    onSyncStart={controller.onSyncStart}
+                    onSyncEnd={controller.onSyncEnd}
+                  />
+                </Fragment>
+              ))}
+              <BudgetDerivedSection
+                effectiveAllowlist={controller.effectiveAllowlist}
+                columnSequence={controller.columnSequence}
+                currentMonth={controller.currentMonth}
+                currentYear={controller.currentYear}
+                yearComputed={controller.yearComputed}
+                incomeSubtotals={controller.incomeSubtotals}
+                spendSubtotals={controller.spendSubtotals}
+                transferSubtotals={controller.transferSubtotals}
+                taintedMonths={controller.taintedMonths}
+                fxAdjustments={controller.fxAdjustments}
+                businessPersonalTransfers={controller.businessPersonalTransfers}
+                hasBusinessAccount={controller.hasBusinessAccount}
+                cumulativeBalances={controller.cumulativeBalances}
+                hasLiquidityBreakdown={controller.hasLiquidityBreakdown}
+                liquidityTiers={controller.liquidityTiers}
+                mebByLiq={controller.mebByLiq}
+                projectedLiqBalances={controller.projectedLiqBalances}
+                numberFormat={numberFormat}
+                openDrillDown={controller.openDrillDown}
+                openFxBreakdown={controller.openFxBreakdown}
+              />
+            </tbody>
+          </table>
+        </TableEditorActivationProvider>
         <div className={tableStateStyles.loadingEdge}>{controller.isLoadingRight ? t("common.loading") : ""}</div>
       </div>
       {toastMessage !== null && <div className="copy-toast">{toastMessage}</div>}

--- a/apps/web/src/ui/tables/editable/EditableAmount.tsx
+++ b/apps/web/src/ui/tables/editable/EditableAmount.tsx
@@ -1,11 +1,13 @@
 import { type ReactElement } from "react";
 import { createPortal } from "react-dom";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
 import { useFormat } from "@/ui/FormatProvider";
 
-import { formatAmount } from "@/ui/tables/shared/format";
+import { formatAmount, parseMonetaryNumberEdit } from "@/ui/tables/shared/format";
+import { useTableEditorActivation } from "@/ui/tables/shared/TableEditorActivationProvider";
 import styles from "@/ui/tables/shared/TableUi.module.css";
 
 type Rect = Readonly<{ top: number; left: number; width: number; height: number }>;
@@ -20,9 +22,13 @@ type Props = Readonly<{
 export const EditableAmount = (props: Props): ReactElement => {
   const { entryId, currentValue, maskClass, onAmountCommit } = props;
   const { numberFormat } = useFormat();
+  const { t } = useTranslation();
+  const editorId = `transaction-amount:${entryId}`;
+  const { requestActivation, releaseActivation } = useTableEditorActivation(editorId);
 
   const [editing, setEditing] = useState<boolean>(false);
   const [editValue, setEditValue] = useState<string>("");
+  const [validationError, setValidationError] = useState<string | null>(null);
   const [rect, setRect] = useState<Rect | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const cellRef = useRef<HTMLTableCellElement | null>(null);
@@ -36,19 +42,31 @@ export const EditableAmount = (props: Props): ReactElement => {
 
   const startEditing = (): void => {
     if (cellRef.current === null) return;
+    if (!requestActivation()) return;
     const r = cellRef.current.getBoundingClientRect();
     setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
     setEditValue(String(currentValue));
+    setValidationError(null);
     setEditing(true);
   };
 
   const commitEdit = (): void => {
+    const parsed = parseMonetaryNumberEdit(editValue, currentValue, numberFormat);
+    if (!parsed.ok) {
+      const message = t("common.invalidNumber");
+      setValidationError(message);
+      if (inputRef.current !== null) {
+        inputRef.current.setCustomValidity(message);
+        inputRef.current.reportValidity();
+      }
+      return;
+    }
+
     setEditing(false);
     setRect(null);
-    const parsed = parseFloat(editValue.trim());
-    if (!Number.isFinite(parsed)) return;
-    if (parsed === currentValue) return;
-    onAmountCommit(entryId, parsed, currentValue);
+    releaseActivation();
+    if (parsed.value === currentValue) return;
+    onAmountCommit(entryId, parsed.value, currentValue);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
@@ -61,6 +79,7 @@ export const EditableAmount = (props: Props): ReactElement => {
       e.stopPropagation();
       setEditing(false);
       setRect(null);
+      releaseActivation();
     }
   };
 
@@ -81,9 +100,15 @@ export const EditableAmount = (props: Props): ReactElement => {
           type="text"
           inputMode="decimal"
           data-testid={`transaction-amount-input-${entryId}`}
+          aria-invalid={validationError !== null}
+          aria-label={t("table.amount")}
           value={editValue}
           style={{ top: rect.top, left: rect.left, width: rect.width, height: rect.height, textAlign: "right" }}
-          onChange={(e) => setEditValue(e.target.value)}
+          onChange={(e) => {
+            setEditValue(e.target.value);
+            setValidationError(null);
+            e.currentTarget.setCustomValidity("");
+          }}
           onBlur={commitEdit}
           onKeyDown={handleKeyDown}
         />,

--- a/apps/web/src/ui/tables/shared/TableEditorActivationProvider.tsx
+++ b/apps/web/src/ui/tables/shared/TableEditorActivationProvider.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  createContext,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+
+type TableEditorActivationContextValue = Readonly<{
+  requestActivation: (editorId: string) => boolean;
+  releaseActivation: (editorId: string) => void;
+}>;
+
+const TableEditorActivationContext = createContext<TableEditorActivationContextValue | null>(null);
+
+type ProviderProps = Readonly<{
+  children: ReactNode;
+}>;
+
+export const TableEditorActivationProvider = (props: ProviderProps): ReactElement => {
+  const activeEditorIdRef = useRef<string | null>(null);
+
+  const requestActivation = useCallback((editorId: string): boolean => {
+    const activeEditorId = activeEditorIdRef.current;
+    if (activeEditorId !== null && activeEditorId !== editorId) return false;
+    activeEditorIdRef.current = editorId;
+    return true;
+  }, []);
+
+  const releaseActivation = useCallback((editorId: string): void => {
+    if (activeEditorIdRef.current === editorId) {
+      activeEditorIdRef.current = null;
+    }
+  }, []);
+
+  const value = useMemo<TableEditorActivationContextValue>(
+    () => ({ requestActivation, releaseActivation }),
+    [releaseActivation, requestActivation],
+  );
+
+  return (
+    <TableEditorActivationContext value={value}>
+      {props.children}
+    </TableEditorActivationContext>
+  );
+};
+
+type TableEditorActivation = Readonly<{
+  requestActivation: () => boolean;
+  releaseActivation: () => void;
+}>;
+
+export const useTableEditorActivation = (editorId: string): TableEditorActivation => {
+  const context = useContext(TableEditorActivationContext);
+  if (context === null) {
+    throw new Error("useTableEditorActivation must be used within TableEditorActivationProvider");
+  }
+
+  const requestActivation = useCallback(
+    (): boolean => context.requestActivation(editorId),
+    [context, editorId],
+  );
+  const releaseActivation = useCallback(
+    (): void => context.releaseActivation(editorId),
+    [context, editorId],
+  );
+
+  useEffect(() => releaseActivation, [releaseActivation]);
+
+  return { requestActivation, releaseActivation };
+};

--- a/apps/web/src/ui/tables/shared/format.test.ts
+++ b/apps/web/src/ui/tables/shared/format.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { NumberFormat } from "@/lib/locale";
-import { formatAmount } from "@/ui/tables/shared/format";
+import {
+  formatAmount,
+  parseMonetaryNumber,
+  parseMonetaryNumberEdit,
+} from "@/ui/tables/shared/format";
 
 type FormatExpectations = Readonly<{
   positive: string;
@@ -52,4 +56,135 @@ test("formatAmount uses an ordinary space for the space-dot format", (): void =>
   );
   assert.equal(formatted.includes("\u00a0"), false);
   assert.equal(formatted.includes("\u202f"), false);
+});
+
+type ParseExpectation = Readonly<{
+  selected: string;
+  selectedNegative: string;
+  selectedUngrouped: string;
+}>;
+
+const PARSE_EXPECTATIONS: Readonly<Record<NumberFormat, ParseExpectation>> = {
+  "1,234.56": {
+    selected: "1,234.56",
+    selectedNegative: "-1,234.56",
+    selectedUngrouped: "1234.56",
+  },
+  "1 234,56": {
+    selected: "1 234,56",
+    selectedNegative: "-1 234,56",
+    selectedUngrouped: "1234,56",
+  },
+  "1.234,56": {
+    selected: "1.234,56",
+    selectedNegative: "-1.234,56",
+    selectedUngrouped: "1234,56",
+  },
+  "1 234.56": {
+    selected: "1 234.56",
+    selectedNegative: "-1 234.56",
+    selectedUngrouped: "1234.56",
+  },
+};
+
+for (const [numberFormat, input] of Object.entries(PARSE_EXPECTATIONS) as ReadonlyArray<[NumberFormat, ParseExpectation]>) {
+  test(`parseMonetaryNumber accepts canonical and selected syntax for ${numberFormat}`, (): void => {
+    assert.deepEqual(parseMonetaryNumber("1234.56", numberFormat), { ok: true, value: 1234.56 });
+    assert.deepEqual(parseMonetaryNumber("  +1234.56  ", numberFormat), { ok: true, value: 1234.56 });
+    assert.deepEqual(parseMonetaryNumber(input.selected, numberFormat), { ok: true, value: 1234.56 });
+    assert.deepEqual(parseMonetaryNumber(input.selectedNegative, numberFormat), { ok: true, value: -1234.56 });
+    assert.deepEqual(parseMonetaryNumber(input.selectedUngrouped, numberFormat), { ok: true, value: 1234.56 });
+  });
+}
+
+for (const numberFormat of ["1 234,56", "1 234.56"] as const) {
+  const decimal = numberFormat === "1 234,56" ? "," : ".";
+
+  test(`parseMonetaryNumber accepts clipboard space variants for ${numberFormat}`, (): void => {
+    for (const group of ["\u0020", "\u00a0", "\u202f"]) {
+      assert.deepEqual(
+        parseMonetaryNumber(`1${group}234${decimal}56`, numberFormat),
+        { ok: true, value: 1234.56 },
+      );
+    }
+    assert.deepEqual(
+      parseMonetaryNumber(`1\u0020234\u00a0567${decimal}89`, numberFormat),
+      { ok: true, value: 1234567.89 },
+    );
+  });
+}
+
+test("parseMonetaryNumber gives canonical dot-decimal syntax precedence over dot grouping", (): void => {
+  assert.deepEqual(parseMonetaryNumber("1.234", "1.234,56"), { ok: true, value: 1.234 });
+  assert.deepEqual(parseMonetaryNumber("1234", "1.234,56"), { ok: true, value: 1234 });
+  assert.deepEqual(parseMonetaryNumber("1.234,0", "1.234,56"), { ok: true, value: 1234 });
+  assert.deepEqual(parseMonetaryNumber("1.234.567", "1.234,56"), { ok: true, value: 1234567 });
+});
+
+test("parseMonetaryNumber parses the complete space-grouped input instead of truncating it", (): void => {
+  assert.deepEqual(parseMonetaryNumber("1 234.56", "1 234.56"), { ok: true, value: 1234.56 });
+});
+
+test("parseMonetaryNumberEdit preserves exact exponent-form initial values without accepting changed exponents", (): void => {
+  for (const originalValue of [1e-7, -1e-7, 1e21, -1e21]) {
+    const initialInput = String(originalValue);
+    assert.match(initialInput, /e/);
+    assert.deepEqual(
+      parseMonetaryNumber(initialInput, "1,234.56"),
+      { ok: false, reason: "invalid-format" },
+    );
+    assert.deepEqual(
+      parseMonetaryNumberEdit(initialInput, originalValue, "1,234.56"),
+      { ok: true, value: originalValue },
+    );
+  }
+
+  assert.deepEqual(
+    parseMonetaryNumberEdit("2e-7", 1e-7, "1,234.56"),
+    { ok: false, reason: "invalid-format" },
+  );
+  assert.deepEqual(
+    parseMonetaryNumberEdit("Infinity", Number.POSITIVE_INFINITY, "1,234.56"),
+    { ok: false, reason: "invalid-format" },
+  );
+});
+
+test("parseMonetaryNumber rejects malformed or unsupported syntax", (): void => {
+  const invalidInputs: ReadonlyArray<Readonly<{ value: string; numberFormat: NumberFormat }>> = [
+    { value: "12,34.56", numberFormat: "1,234.56" },
+    { value: "1,23,456.78", numberFormat: "1,234.56" },
+    { value: "1,234 567.89", numberFormat: "1,234.56" },
+    { value: "12 34,56", numberFormat: "1 234,56" },
+    { value: "1.23,45", numberFormat: "1.234,56" },
+    { value: "1.234 567,89", numberFormat: "1.234,56" },
+    { value: "12 34.56", numberFormat: "1 234.56" },
+    { value: "1234.5.6", numberFormat: "1,234.56" },
+    { value: "1234,5,6", numberFormat: "1.234,56" },
+    { value: "1,234.56usd", numberFormat: "1,234.56" },
+    { value: "NaN", numberFormat: "1,234.56" },
+    { value: "Infinity", numberFormat: "1,234.56" },
+    { value: "-Infinity", numberFormat: "1,234.56" },
+    { value: "1e3", numberFormat: "1,234.56" },
+    { value: "(1234.56)", numberFormat: "1,234.56" },
+    { value: "$1234.56", numberFormat: "1,234.56" },
+    { value: "+", numberFormat: "1,234.56" },
+    { value: "-", numberFormat: "1,234.56" },
+  ];
+
+  for (const input of invalidInputs) {
+    assert.deepEqual(
+      parseMonetaryNumber(input.value, input.numberFormat),
+      { ok: false, reason: "invalid-format" },
+      input.value,
+    );
+  }
+
+  assert.deepEqual(
+    parseMonetaryNumber(" \t ", "1,234.56"),
+    { ok: false, reason: "empty-input" },
+  );
+  assert.deepEqual(
+    parseMonetaryNumber("9".repeat(400), "1,234.56"),
+    { ok: false, reason: "non-finite" },
+  );
 });

--- a/apps/web/src/ui/tables/shared/format.ts
+++ b/apps/web/src/ui/tables/shared/format.ts
@@ -5,6 +5,10 @@ type NumberFormatSeparators = Readonly<{
   decimal: string;
 }>;
 
+export type ParseMonetaryNumberResult =
+  | Readonly<{ ok: true; value: number }>
+  | Readonly<{ ok: false; reason: "empty-input" | "invalid-format" | "non-finite" }>;
+
 export type FormatNumberOptions = Readonly<{
   minimumFractionDigits: number;
   maximumFractionDigits: number;
@@ -15,6 +19,72 @@ const NUMBER_FORMAT_SEPARATORS: Readonly<Record<NumberFormat, NumberFormatSepara
   "1 234,56": { group: "\u00a0", decimal: "," },
   "1.234,56": { group: ".", decimal: "," },
   "1 234.56": { group: " ", decimal: "." },
+};
+
+const CANONICAL_NUMBER_PATTERN = /^[+-]?\d+(?:\.\d+)?$/;
+const SPACE_GROUP_PATTERN = "[\\u0020\\u00a0\\u202f]";
+const SPACE_GROUP_CHARACTERS_PATTERN = /[\u0020\u00a0\u202f]/g;
+
+const escapeRegularExpression = (value: string): string => (
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+);
+
+const isSpaceGroup = (separator: string): boolean => (
+  separator === "\u0020" || separator === "\u00a0" || separator === "\u202f"
+);
+
+const getSelectedNumberPattern = (separators: NumberFormatSeparators): RegExp => {
+  const groupPattern = isSpaceGroup(separators.group)
+    ? SPACE_GROUP_PATTERN
+    : escapeRegularExpression(separators.group);
+  const decimalPattern = escapeRegularExpression(separators.decimal);
+  return new RegExp(
+    `^[+-]?(?:\\d+|\\d{1,3}(?:${groupPattern}\\d{3})+)(?:${decimalPattern}\\d+)?$`,
+  );
+};
+
+const parseNormalizedNumber = (value: string): ParseMonetaryNumberResult => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return { ok: false, reason: "non-finite" };
+  }
+  return { ok: true, value: parsed };
+};
+
+export const parseMonetaryNumber = (
+  input: string,
+  numberFormat: NumberFormat,
+): ParseMonetaryNumberResult => {
+  const value = input.trim();
+  if (value.length === 0) {
+    return { ok: false, reason: "empty-input" };
+  }
+
+  if (CANONICAL_NUMBER_PATTERN.test(value)) {
+    return parseNormalizedNumber(value);
+  }
+
+  const separators = NUMBER_FORMAT_SEPARATORS[numberFormat];
+  if (!getSelectedNumberPattern(separators).test(value)) {
+    return { ok: false, reason: "invalid-format" };
+  }
+
+  const ungrouped = isSpaceGroup(separators.group)
+    ? value.replace(SPACE_GROUP_CHARACTERS_PATTERN, "")
+    : value.replaceAll(separators.group, "");
+  const normalized = ungrouped.replace(separators.decimal, ".");
+  return parseNormalizedNumber(normalized);
+};
+
+export const parseMonetaryNumberEdit = (
+  input: string,
+  originalValue: number,
+  numberFormat: NumberFormat,
+): ParseMonetaryNumberResult => {
+  if (Number.isFinite(originalValue) && input === String(originalValue)) {
+    return { ok: true, value: originalValue };
+  }
+  return parseMonetaryNumber(input, numberFormat);
 };
 
 export const formatNumber = (

--- a/apps/web/src/ui/tables/transactions/DrillDownPanel.tsx
+++ b/apps/web/src/ui/tables/transactions/DrillDownPanel.tsx
@@ -17,6 +17,7 @@ import type { ColumnDef, PageResult } from "@/ui/tables/shared/data-table/types"
 import type { DrillDownFilter } from "@/ui/tables/shared/drillDownFilter";
 import panelStyles from "@/ui/tables/shared/TablePanel.module.css";
 import { useTableSort } from "@/ui/tables/shared/data-table/useTableSort";
+import { TableEditorActivationProvider } from "@/ui/tables/shared/TableEditorActivationProvider";
 import {
   buildDrillDownCreateEntryRequest,
   buildDrillDownPageUrl,
@@ -278,17 +279,19 @@ export const DrillDownPanel = (props: Props): ReactElement => {
         <TransactionCopyFeedback feedback={copyFeedback} />
 
         <div className={panelStyles.panelBody}>
-          <DataTable<LedgerEntry>
-            columns={columns}
-            rows={rows}
-            rowKey={(row) => row.entryId}
-            sort={sort}
-            onSort={onSort}
-            emptyMessage={t("txn.noMatch")}
-            loading={loading}
-            loadingMore={loadingMore}
-            sentinelRef={sentinelRef}
-          />
+          <TableEditorActivationProvider>
+            <DataTable<LedgerEntry>
+              columns={columns}
+              rows={rows}
+              rowKey={(row) => row.entryId}
+              sort={sort}
+              onSort={onSort}
+              emptyMessage={t("txn.noMatch")}
+              loading={loading}
+              loadingMore={loadingMore}
+              sentinelRef={sentinelRef}
+            />
+          </TableEditorActivationProvider>
         </div>
       </div>
     </>

--- a/apps/web/src/ui/tables/transactions/TransactionsRawTable.tsx
+++ b/apps/web/src/ui/tables/transactions/TransactionsRawTable.tsx
@@ -14,6 +14,7 @@ import filterStyles from "@/ui/FilterControls.module.css";
 import { DataTable } from "@/ui/tables/shared/data-table/DataTable";
 import type { ColumnDef, PageResult } from "@/ui/tables/shared/data-table/types";
 import { useTableSort } from "@/ui/tables/shared/data-table/useTableSort";
+import { TableEditorActivationProvider } from "@/ui/tables/shared/TableEditorActivationProvider";
 import tableStyles from "@/ui/tables/shared/TableUi.module.css";
 import transactionStyles from "./TransactionsTable.module.css";
 import { TransactionCopyFeedback } from "./TransactionCopyFeedback";
@@ -337,17 +338,19 @@ export const TransactionsRawTable = (props: Props): ReactElement => {
       <TransactionCopyFeedback feedback={copyFeedback} />
 
       <div className={tableStyles.scroll}>
-        <DataTable<LedgerEntry>
-          columns={columns}
-          rows={rows}
-          rowKey={(row) => row.entryId}
-          sort={sort}
-          onSort={onSort}
-          emptyMessage={t("txn.noMatch")}
-          loading={loading}
-          loadingMore={loadingMore}
-          sentinelRef={sentinelRef}
-        />
+        <TableEditorActivationProvider>
+          <DataTable<LedgerEntry>
+            columns={columns}
+            rows={rows}
+            rowKey={(row) => row.entryId}
+            sort={sort}
+            onSort={onSort}
+            emptyMessage={t("txn.noMatch")}
+            loading={loading}
+            loadingMore={loadingMore}
+            sentinelRef={sentinelRef}
+          />
+        </TableEditorActivationProvider>
       </div>
     </>
   );


### PR DESCRIPTION
Adds strict locale-aware monetary input parsing, preserves unchanged numeric precision, and enforces one active invalid editor per table. Includes synchronized validation translations, focused parser coverage, and stable-ID local Demo interaction tests. Validation: parser/formatter 15/15, Playwright 2/2, TypeScript lint, production build, locale JSON validation, and diff checks.