### PR TITLE
Add dormant restricted SQL lexer foundation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Build shared package
         run: npm --workspace @expense-budget-tracker/agent-shared run build
 
+      - name: Test shared package
+        run: npm --workspace @expense-budget-tracker/agent-shared run test
+
       # Refresh Cloudflare edge IP ranges so the ALB security group stays current.
       # Best-effort: if the API is unreachable, the committed cloudflare-ips.json is used.
       - name: Update Cloudflare IPs

--- a/packages/agent-shared/package.json
+++ b/packages/agent-shared/package.json
@@ -30,7 +30,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "tsc --noEmit -p tsconfig.test.json && node --import tsx --test src/*.test.ts"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",

--- a/packages/agent-shared/src/sql-policy-lexer.test.ts
+++ b/packages/agent-shared/src/sql-policy-lexer.test.ts
@@ -1,0 +1,873 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  lexSqlPolicyInfrastructure,
+  SqlPolicyLexerError,
+  type SqlIdentifierToken,
+  type SqlNumericToken,
+  type SqlPolicyToken,
+  type SqlStringToken,
+} from "./sql-policy-lexer.js";
+import {
+  executeExpenseSql,
+  validateExpenseSql,
+} from "./sql-policy.js";
+
+const withoutTrivia = (
+  tokens: ReadonlyArray<SqlPolicyToken>,
+): ReadonlyArray<SqlPolicyToken> =>
+  tokens.filter((token) =>
+    token.kind !== "comment" && token.kind !== "whitespace",
+  );
+
+const numericToken = (sql: string): SqlNumericToken => {
+  const tokens = withoutTrivia(lexSqlPolicyInfrastructure(sql).tokens);
+  assert.equal(tokens.length, 1, sql);
+  const token = tokens[0];
+  assert.equal(token?.kind, "numeric", sql);
+  return token as SqlNumericToken;
+};
+
+const identifierTokens = (
+  sql: string,
+): ReadonlyArray<SqlIdentifierToken> =>
+  lexSqlPolicyInfrastructure(sql).tokens.filter(
+    (token): token is SqlIdentifierToken => token.kind === "identifier",
+  );
+
+const stringTokens = (sql: string): ReadonlyArray<SqlStringToken> =>
+  lexSqlPolicyInfrastructure(sql).tokens.filter(
+    (token): token is SqlStringToken => token.kind === "string",
+  );
+
+const expectLexerError = (
+  sql: string,
+  code: SqlPolicyLexerError["code"],
+): void => {
+  assert.throws(
+    () => lexSqlPolicyInfrastructure(sql),
+    (error: unknown) =>
+      error instanceof SqlPolicyLexerError
+      && error.code === code
+      && error.range.start >= 0
+      && error.range.end > error.range.start
+      && error.range.end <= sql.length,
+    sql,
+  );
+};
+
+test("lexer preserves every lexical state and statement boundary", (): void => {
+  const sql = String.raw`
+    SELECT 'ordinary''quote',
+      E'a\\\'; still one statement',
+      U&'!0061bc' UESCAPE '!',
+      N'national',
+      B'1010',
+      X'CAFE',
+      $$dollar ; ' " text$$,
+      $tag$nested /* not comment */ -- not comment$tag$,
+      "quoted""name",
+      U&"d!0061ta" UESCAPE '!'
+    /* outer ; /* nested */ complete */
+    FROM ledger_entries;
+    -- second statement
+    SELECT 2`;
+  const lexed = lexSqlPolicyInfrastructure(sql);
+
+  assert.equal(lexed.statements.length, 2);
+  assert.deepEqual(
+    lexed.tokens
+      .filter((token) => token.kind === "string")
+      .map((token) => token.style),
+    [
+      "ordinary",
+      "escape",
+      "unicode",
+      "national",
+      "bit",
+      "hex",
+      "dollar",
+      "dollar",
+    ],
+  );
+  assert.deepEqual(
+    lexed.tokens
+      .filter((token) => token.kind === "comment")
+      .map((token) => token.style),
+    ["block", "line"],
+  );
+  assert.equal(
+    identifierTokens(sql).find((token) => token.unicodeEscaped)?.normalized,
+    "data",
+  );
+  assert.equal(lexed.statements[0]?.terminatorRange !== null, true);
+  assert.equal(lexed.statements[1]?.terminatorRange, null);
+});
+
+test("newline-separated PostgreSQL strings continue losslessly in every supported state", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    sql: string;
+    style: SqlStringToken["style"];
+    value: string;
+  }>> = [
+    { sql: "'a'\n'b'", style: "ordinary", value: "ab" },
+    { sql: "E'\\u0061'\n'\\x62'", style: "escape", value: "ab" },
+    { sql: "U&'\\D83D'\n'\\DE00'", style: "unicode", value: "😀" },
+    { sql: "N'a'\n'b'", style: "national", value: "ab" },
+    { sql: "B'10'\n'01'", style: "bit", value: "1001" },
+    { sql: "X'CA'\n'FE'", style: "hex", value: "CAFE" },
+    { sql: "'a' -- continuation\n'b'", style: "ordinary", value: "ab" },
+    { sql: "E'\\xC3'\n'\\xA9'", style: "escape", value: "é" },
+  ];
+
+  for (const expected of cases) {
+    const strings = stringTokens(expected.sql);
+    assert.equal(strings.length, 1, expected.sql);
+    assert.equal(strings[0]?.style, expected.style, expected.sql);
+    assert.equal(strings[0]?.semanticValue, expected.value, expected.sql);
+    assert.equal(strings[0]?.semanticSegments.length, 2, expected.sql);
+    assert.equal(strings[0]?.semanticSegments.map((segment) => segment.value).join(""), expected.value);
+    assert.equal(strings[0]?.text, expected.sql, expected.sql);
+  }
+
+  for (const sql of ["'a' 'b'", "'a' /* newline\\ninside */ 'b'"]) {
+    assert.equal(stringTokens(sql).length, 2, sql);
+  }
+
+  const semicolonControl = String.raw`E'a\\\'; FOR UPDATE'
+'; still data'`;
+  assert.equal(stringTokens(semicolonControl)[0]?.semanticValue.includes("; FOR UPDATE"), true);
+  assert.equal(lexSqlPolicyInfrastructure(semicolonControl).statements.length, 1);
+});
+
+test("escape strings preserve a leading UTF-8 byte-order mark", (): void => {
+  const byteOrderMark = "\uFEFF";
+  const cases: ReadonlyArray<Readonly<{
+    segmentValues: ReadonlyArray<string>;
+    sql: string;
+    value: string;
+  }>> = [
+    {
+      segmentValues: [`${byteOrderMark}raw`],
+      sql: `E'${byteOrderMark}raw'`,
+      value: `${byteOrderMark}raw`,
+    },
+    {
+      segmentValues: [`${byteOrderMark}escaped`],
+      sql: String.raw`E'\xEF\xBB\xBFescaped'`,
+      value: `${byteOrderMark}escaped`,
+    },
+    {
+      segmentValues: ["", `${byteOrderMark}continued`],
+      sql: String.raw`E'\xEF'
+'\xBB\xBFcontinued'`,
+      value: `${byteOrderMark}continued`,
+    },
+  ];
+
+  for (const expected of cases) {
+    const token = stringTokens(expected.sql)[0];
+    assert.equal(token?.style, "escape", expected.sql);
+    assert.equal(token?.semanticValue, expected.value, expected.sql);
+    assert.deepEqual(
+      token?.semanticSegments.map((segment) => segment.value),
+      expected.segmentValues,
+      expected.sql,
+    );
+  }
+});
+
+test("literal prefixes are recognized only at scanner token boundaries", (): void => {
+  const boundaryCases: ReadonlyArray<Readonly<{
+    sql: string;
+    styles: ReadonlyArray<SqlStringToken["style"]>;
+    texts: ReadonlyArray<string>;
+    values: ReadonlyArray<string>;
+  }>> = [
+    {
+      sql: String.raw`$E'\x61'`,
+      styles: ["escape"],
+      texts: ["$", String.raw`E'\x61'`],
+      values: ["a"],
+    },
+    {
+      sql: "$$x$$E'y'",
+      styles: ["dollar", "escape"],
+      texts: ["$$x$$", "E'y'"],
+      values: ["x", "y"],
+    },
+    {
+      sql: String.raw`$tag$x$tag$U&'\0079'`,
+      styles: ["dollar", "unicode"],
+      texts: ["$tag$x$tag$", String.raw`U&'\0079'`],
+      values: ["x", "y"],
+    },
+    {
+      sql: "$B'10'$N'n'$X'CA'",
+      styles: ["bit", "national", "hex"],
+      texts: ["$", "B'10'", "$", "N'n'", "$", "X'CA'"],
+      values: ["10", "n", "CA"],
+    },
+  ];
+
+  for (const expected of boundaryCases) {
+    const tokens = withoutTrivia(
+      lexSqlPolicyInfrastructure(expected.sql).tokens,
+    );
+    assert.deepEqual(
+      tokens.map((token) => token.text),
+      expected.texts,
+      expected.sql,
+    );
+    const strings = tokens.filter(
+      (token): token is SqlStringToken => token.kind === "string",
+    );
+    assert.deepEqual(
+      strings.map((token) => token.style),
+      expected.styles,
+      expected.sql,
+    );
+    assert.deepEqual(
+      strings.map((token) => token.semanticValue),
+      expected.values,
+      expected.sql,
+    );
+  }
+
+  const identifierCases: ReadonlyArray<Readonly<{
+    identifier: string;
+    sql: string;
+    stringStyle: SqlStringToken["style"];
+  }>> = [
+    { identifier: "foo$E", sql: "foo$E'x'", stringStyle: "ordinary" },
+    {
+      identifier: "foo$U",
+      sql: String.raw`foo$U&'\0061'`,
+      stringStyle: "ordinary",
+    },
+    {
+      identifier: "δ$E",
+      sql: "δ$E'x'",
+      stringStyle: "ordinary",
+    },
+    {
+      identifier: "foo$E",
+      sql: "$$x$$foo$E'y'",
+      stringStyle: "ordinary",
+    },
+  ];
+  for (const expected of identifierCases) {
+    const tokens = withoutTrivia(
+      lexSqlPolicyInfrastructure(expected.sql).tokens,
+    );
+    const identifier = tokens.find(
+      (token): token is SqlIdentifierToken => token.kind === "identifier",
+    );
+    const string = tokens.filter(
+      (token): token is SqlStringToken => token.kind === "string",
+    ).at(-1);
+    assert.equal(identifier?.text, expected.identifier, expected.sql);
+    assert.equal(string?.style, expected.stringStyle, expected.sql);
+  }
+
+  assert.throws(
+    () => lexSqlPolicyInfrastructure("$1E'x'"),
+    (error: unknown) =>
+      error instanceof SqlPolicyLexerError
+      && error.code === "invalid_parameter"
+      && error.range.start === 0
+      && error.range.end === 3,
+  );
+  const numericPrefix = withoutTrivia(
+    lexSqlPolicyInfrastructure("1E'x'").tokens,
+  );
+  assert.equal(numericPrefix[0]?.kind, "numeric");
+  assert.equal(
+    numericPrefix[0]?.kind === "numeric" && numericPrefix[0].valid,
+    false,
+  );
+  assert.equal(numericPrefix[1]?.kind, "string");
+  assert.equal(
+    numericPrefix[1]?.kind === "string" && numericPrefix[1].style,
+    "ordinary",
+  );
+});
+
+test("UESCAPE lookahead skips tokens and validates one decoded byte", (): void => {
+  const cases: ReadonlyArray<Readonly<{ sql: string; value: string }>> = [
+    { sql: "U&'!0061' UESCAPE '!'", value: "a" },
+    { sql: "U&'#0061'/* outer /* nested */ */UESCAPE/* gap */'#'", value: "a" },
+    { sql: String.raw`U&'!0061' -- gap
+UESCAPE E'\x21'`, value: "a" },
+    { sql: String.raw`U&'\0061' UESCAPE E'\\'`, value: "a" },
+    { sql: String.raw`U&'!0061' UESCAPE E'\441'`, value: "a" },
+    {
+      sql: "U&'!0061' /* before */ UESCAPE /* after */ $escape$!$escape$",
+      value: "a",
+    },
+    { sql: String.raw`U&'\0061' UESCAPE $q$\$q$`, value: "a" },
+  ];
+  for (const expected of cases) {
+    const token = stringTokens(expected.sql)[0];
+    assert.equal(token?.semanticValue, expected.value, expected.sql);
+    assert.equal(token?.unicodeEscapeCharacter, expected.sql.includes("!0061")
+      ? "!"
+      : expected.sql.includes("#0061")
+        ? "#"
+        : "\\");
+    assert.equal(token?.text, expected.sql);
+  }
+
+  const identifier = identifierTokens(
+    "U&\"d!0061ta\" /* gap */ UESCAPE E'\\x21'",
+  )[0];
+  assert.equal(identifier?.normalized, "data");
+  assert.equal(identifier?.unicodeEscapeCharacter, "!");
+  const dollarIdentifier = identifierTokens(
+    "U&\"d!0061ta\" UESCAPE $escape$!$escape$",
+  )[0];
+  assert.equal(dollarIdentifier?.normalized, "data");
+  assert.equal(dollarIdentifier?.unicodeEscapeCharacter, "!");
+
+  const invalid: ReadonlyArray<Readonly<{
+    code: SqlPolicyLexerError["code"];
+    sql: string;
+  }>> = [
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE 'é'" },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE 'ab'" },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE '0'" },
+    { code: "invalid_unicode_escape_character", sql: String.raw`U&'data' UESCAPE E'\t'` },
+    { code: "invalid_unicode_escape_character", sql: String.raw`U&'data' UESCAPE E'\440'` },
+    { code: "invalid_string_encoding", sql: String.raw`U&'data' UESCAPE E'\400'` },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE B'1'" },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE" },
+  ];
+  for (const expected of invalid) {
+    expectLexerError(expected.sql, expected.code);
+  }
+
+  const invalidDollar: ReadonlyArray<Readonly<{
+    code: SqlPolicyLexerError["code"];
+    sql: string;
+  }>> = [
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE $$$$" },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE $q$!!$q$" },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE $q$é$q$" },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE $q$0$q$" },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE $q$+$q$" },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE $q$'$q$" },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE $q$\"$q$" },
+    { code: "invalid_unicode_escape_character", sql: "U&'data' UESCAPE $q$ $q$" },
+    { code: "unterminated_dollar_string", sql: "U&'data' UESCAPE $q$!" },
+  ];
+  for (const expected of invalidDollar) {
+    const literalStart = expected.sql.indexOf("$");
+    assert.throws(
+      () => lexSqlPolicyInfrastructure(expected.sql),
+      (error: unknown) =>
+        error instanceof SqlPolicyLexerError
+        && error.code === expected.code
+        && error.range.start === literalStart
+        && error.range.end === expected.sql.length,
+      expected.sql,
+    );
+  }
+});
+
+test("identifier tokens expose complete PostgreSQL names and qualification boundaries", (): void => {
+  const sql = String.raw`
+    public.evil$count,
+    "Mi""xed".U&"d!0061ta" UESCAPE '!',
+    δημόσιο.κλήση$,
+    foo$tag$,
+    U&"\D83D\DE00",
+    U&"\+00D83D\+00DE00",
+    U&"\+01F600"
+  `;
+  const lexed = lexSqlPolicyInfrastructure(sql);
+  const identifiers = lexed.tokens.filter(
+    (token): token is SqlIdentifierToken => token.kind === "identifier",
+  );
+
+  assert.deepEqual(
+    identifiers.map((identifier) => identifier.normalized),
+    [
+      "public",
+      "evil$count",
+      "Mi\"xed",
+      "data",
+      "δημόσιο",
+      "κλήση$",
+      "foo$tag$",
+      "😀",
+      "😀",
+      "😀",
+    ],
+  );
+  assert.deepEqual(
+    lexed.tokens
+      .filter((token) => token.kind === "punctuation")
+      .map((token) => token.text),
+    [".", ",", ".", ",", ".", ",", ",", ",", ","],
+  );
+  assert.equal(identifiers[2]?.quoted, true);
+  assert.equal(identifiers[3]?.unicodeEscapeCharacter, "!");
+  assert.equal(identifiers[6]?.unicodeEscaped, false);
+});
+
+test("identifier normalization matches PostgreSQL ASCII folding and 63-byte names", (): void => {
+  const exact = "A".repeat(63);
+  const longAscii = "B".repeat(64);
+  const longUtf8 = `${"c".repeat(62)}étail`;
+  const quotedUtf8 = `${"Q".repeat(61)}😀tail`;
+  const sql = `${exact} ${longAscii} ${longUtf8} "${quotedUtf8}" ÄBC`;
+  const identifiers = identifierTokens(sql);
+
+  assert.deepEqual(
+    identifiers.map((token) => ({
+      normalized: token.normalized,
+      truncated: token.truncated,
+      untruncatedNormalized: token.untruncatedNormalized,
+    })),
+    [
+      {
+        normalized: "a".repeat(63),
+        truncated: false,
+        untruncatedNormalized: "a".repeat(63),
+      },
+      {
+        normalized: "b".repeat(63),
+        truncated: true,
+        untruncatedNormalized: "b".repeat(64),
+      },
+      {
+        normalized: "c".repeat(62),
+        truncated: true,
+        untruncatedNormalized: longUtf8,
+      },
+      {
+        normalized: "Q".repeat(61),
+        truncated: true,
+        untruncatedNormalized: quotedUtf8,
+      },
+      {
+        normalized: "Äbc",
+        truncated: false,
+        untruncatedNormalized: "Äbc",
+      },
+    ],
+  );
+  assert.equal(identifiers[1]?.text, longAscii);
+  assert.deepEqual(identifiers[1]?.range, {
+    start: exact.length + 1,
+    end: exact.length + 1 + longAscii.length,
+  });
+
+  const unicodeQuoted = identifierTokens(
+    `U&"${"d".repeat(62)}\\00E9tail"`,
+  )[0];
+  assert.equal(unicodeQuoted?.normalized, "d".repeat(62));
+  assert.equal(unicodeQuoted?.truncated, true);
+});
+
+test("parameters, operators, and punctuation use unambiguous tokens", (): void => {
+  const sql = "$1::numeric[], value->>'key', x*-y, a@-b, left:=right, x=>y, $42, item[1:2];";
+  const tokens = withoutTrivia(lexSqlPolicyInfrastructure(sql).tokens);
+
+  assert.deepEqual(
+    tokens.filter((token) => token.kind === "parameter").map((token) => ({
+      positionText: token.positionText,
+      text: token.text,
+    })),
+    [
+      { positionText: "1", text: "$1" },
+      { positionText: "42", text: "$42" },
+    ],
+  );
+  assert.deepEqual(
+    tokens.filter((token) => token.kind === "operator").map((token) => token.text),
+    ["::", "->>", "*", "-", "@-", ":=", "=>"],
+  );
+  assert.deepEqual(
+    tokens.filter((token) => token.kind === "punctuation").map((token) => token.text),
+    ["[", "]", ",", ",", ",", ",", ",", ",", ",", "[", ":", "]", ";"],
+  );
+});
+
+test("longest-match boundaries follow PostgreSQL for numbers, parameters, and dollar tags", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    kinds: ReadonlyArray<SqlPolicyToken["kind"]>;
+    sql: string;
+    texts: ReadonlyArray<string>;
+  }>> = [
+    {
+      kinds: ["numeric", "parameter"],
+      sql: "1$2",
+      texts: ["1", "$2"],
+    },
+    {
+      kinds: ["parameter", "parameter"],
+      sql: "$1$2",
+      texts: ["$1", "$2"],
+    },
+    {
+      kinds: ["numeric", "string"],
+      sql: "123$tag$body$tag$",
+      texts: ["123", "$tag$body$tag$"],
+    },
+    {
+      kinds: ["numeric", "string"],
+      sql: "123$$body$$",
+      texts: ["123", "$$body$$"],
+    },
+    {
+      kinds: ["numeric", "parameter"],
+      sql: "1_2$3",
+      texts: ["1_2", "$3"],
+    },
+    {
+      kinds: ["numeric", "parameter"],
+      sql: "1.2$3",
+      texts: ["1.2", "$3"],
+    },
+    {
+      kinds: ["numeric", "parameter"],
+      sql: "1e+2$3",
+      texts: ["1e+2", "$3"],
+    },
+    {
+      kinds: ["numeric", "string"],
+      sql: "1_2$tag$body$tag$",
+      texts: ["1_2", "$tag$body$tag$"],
+    },
+  ];
+  for (const expected of cases) {
+    const tokens = withoutTrivia(
+      lexSqlPolicyInfrastructure(expected.sql).tokens,
+    );
+    assert.deepEqual(tokens.map((token) => token.kind), expected.kinds, expected.sql);
+    assert.deepEqual(tokens.map((token) => token.text), expected.texts, expected.sql);
+    let rangeStart = 0;
+    for (const token of tokens) {
+      assert.deepEqual(token.range, {
+        start: rangeStart,
+        end: rangeStart + token.text.length,
+      }, expected.sql);
+      rangeStart = token.range.end;
+    }
+  }
+
+  for (const sql of [
+    "0xFFé",
+    "0xFF$2",
+    "0xFF$tag$body$tag$",
+    "0b10tail",
+    "0b10$2",
+    "1_foo",
+    "1e2$3",
+    ".1e2$3",
+    "1_$2",
+    "1e$2",
+    "1e2_$3",
+    "1__$$x$$",
+    "1.2_$3",
+    "1e+2_$3",
+  ]) {
+    const token = numericToken(sql);
+    assert.equal(token.valid, false, sql);
+    assert.deepEqual(token.range, { start: 0, end: sql.length }, sql);
+    if (!token.valid) {
+      assert.equal(token.diagnostic.message.includes("PostgreSQL numeric"), true);
+    }
+  }
+  for (const sql of ["$1evil", "$1é", "$1e$2"]) {
+    assert.throws(
+      () => lexSqlPolicyInfrastructure(sql),
+      (error: unknown) =>
+        error instanceof SqlPolicyLexerError
+        && error.code === "invalid_parameter"
+        && error.range.start === 0
+        && error.range.end === sql.length,
+      sql,
+    );
+  }
+
+  const partialJunk = withoutTrivia(
+    lexSqlPolicyInfrastructure("1_.0 1e+$2").tokens,
+  );
+  assert.deepEqual(
+    partialJunk.map((token) => ({
+      range: token.range,
+      text: token.text,
+    })),
+    [
+      { range: { start: 0, end: 2 }, text: "1_" },
+      { range: { start: 2, end: 4 }, text: ".0" },
+      { range: { start: 5, end: 8 }, text: "1e+" },
+      { range: { start: 8, end: 10 }, text: "$2" },
+    ],
+  );
+});
+
+test("parameter and operator limits report exact PostgreSQL ranges", (): void => {
+  const validSql = "$0 $0001 $2147483647";
+  const parameters = lexSqlPolicyInfrastructure(validSql).tokens.filter(
+    (token) => token.kind === "parameter",
+  );
+  assert.deepEqual(
+    parameters.map((token) => ({
+      position: token.position,
+      positionText: token.positionText,
+    })),
+    [
+      { position: 0, positionText: "0" },
+      { position: 1, positionText: "0001" },
+      { position: 2_147_483_647, positionText: "2147483647" },
+    ],
+  );
+  assert.deepEqual(
+    withoutTrivia(lexSqlPolicyInfrastructure("$-1").tokens).map((token) => token.text),
+    ["$", "-", "1"],
+  );
+
+  for (const sql of ["$2147483648", "$0002147483648", "$999999999999999999999"]) {
+    assert.throws(
+      () => lexSqlPolicyInfrastructure(sql),
+      (error: unknown) =>
+        error instanceof SqlPolicyLexerError
+        && error.code === "parameter_number_too_large"
+        && error.range.start === 0
+        && error.range.end === sql.length,
+      sql,
+    );
+  }
+
+  const validOperator = "?".repeat(63);
+  assert.equal(
+    withoutTrivia(lexSqlPolicyInfrastructure(validOperator).tokens)[0]?.text,
+    validOperator,
+  );
+  const longOperator = "?".repeat(64);
+  assert.throws(
+    () => lexSqlPolicyInfrastructure(longOperator),
+    (error: unknown) =>
+      error instanceof SqlPolicyLexerError
+      && error.code === "operator_too_long"
+      && error.range.start === 0
+      && error.range.end === longOperator.length,
+  );
+});
+
+test("PostgreSQL 18 valid numeric forms remain single normalized tokens", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    form: "binary" | "decimal" | "hexadecimal" | "octal";
+    normalized: string;
+    sql: string;
+  }>> = [
+    { form: "decimal", normalized: "42", sql: "42" },
+    { form: "decimal", normalized: "3.5", sql: "3.5" },
+    { form: "decimal", normalized: "4.", sql: "4." },
+    { form: "decimal", normalized: ".001", sql: ".001" },
+    { form: "decimal", normalized: "5e2", sql: "5e2" },
+    { form: "decimal", normalized: "1.925e-3", sql: "1.925e-3" },
+    { form: "decimal", normalized: "1500000000", sql: "1_500_000_000" },
+    { form: "decimal", normalized: "1.618034", sql: "1.618_034" },
+    { form: "decimal", normalized: ".12", sql: ".1_2" },
+    { form: "binary", normalized: "0b1000100000000000", sql: "0b10001000_00000000" },
+    { form: "binary", normalized: "0b101", sql: "0b_1_01" },
+    { form: "octal", normalized: "0o1755", sql: "0o_1_755" },
+    { form: "hexadecimal", normalized: "0xffffffff", sql: "0xFFFF_FFFF" },
+    { form: "hexadecimal", normalized: "0xcafe", sql: "0XCAFE" },
+  ];
+
+  for (const expected of cases) {
+    const token = numericToken(expected.sql);
+    assert.equal(token.valid, true, expected.sql);
+    if (token.valid) {
+      assert.equal(token.form, expected.form, expected.sql);
+      assert.equal(token.normalized, expected.normalized, expected.sql);
+    }
+  }
+});
+
+test("invalid numeric candidates stay single diagnostic tokens", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    code:
+      | "invalid_digit"
+      | "invalid_exponent"
+      | "invalid_separator"
+      | "missing_digits"
+      | "trailing_junk";
+    sql: string;
+  }>> = [
+    { code: "invalid_separator", sql: "1__0" },
+    { code: "invalid_separator", sql: "1_" },
+    { code: "invalid_separator", sql: "1._0" },
+    { code: "invalid_separator", sql: "1e_2" },
+    { code: "invalid_separator", sql: "1e2_" },
+    { code: "missing_digits", sql: "0x" },
+    { code: "invalid_separator", sql: "0b_" },
+    { code: "invalid_digit", sql: "0b102" },
+    { code: "invalid_digit", sql: "0o89" },
+    { code: "invalid_digit", sql: "0xCAFEG" },
+    { code: "invalid_exponent", sql: "1e+" },
+    { code: "trailing_junk", sql: "123evil" },
+    { code: "trailing_junk", sql: "0z12" },
+  ];
+
+  for (const expected of cases) {
+    const token = numericToken(expected.sql);
+    assert.equal(token.valid, false, expected.sql);
+    if (!token.valid) {
+      assert.equal(token.diagnostic.code, expected.code, expected.sql);
+      assert.match(token.diagnostic.message, /Invalid PostgreSQL numeric literal/u);
+    }
+  }
+
+  const noFakeCall = withoutTrivia(
+    lexSqlPolicyInfrastructure("123evil(1)").tokens,
+  );
+  assert.deepEqual(
+    noFakeCall.map((token) => token.kind),
+    ["numeric", "punctuation", "numeric", "punctuation"],
+  );
+});
+
+test("escape strings validate Unicode, surrogate, and UTF-8 semantics", (): void => {
+  const valid: ReadonlyArray<Readonly<{ sql: string; value: string }>> = [
+    { sql: String.raw`E'\u0061'`, value: "a" },
+    { sql: String.raw`E'\U0001F600'`, value: "😀" },
+    { sql: String.raw`E'\uD83D\uDE00'`, value: "😀" },
+    { sql: String.raw`E'\U0000D83D\U0000DE00'`, value: "😀" },
+    { sql: String.raw`E'\101\x42\n'`, value: "AB\n" },
+    { sql: String.raw`E'\401'`, value: "\u0001" },
+    { sql: String.raw`E'\477'`, value: "?" },
+    { sql: String.raw`E'\1000'`, value: "@0" },
+    { sql: "E'\\703'\n'\\251'", value: "é" },
+  ];
+  for (const expected of valid) {
+    assert.equal(stringTokens(expected.sql)[0]?.semanticValue, expected.value, expected.sql);
+  }
+
+  const invalid: ReadonlyArray<Readonly<{
+    code: SqlPolicyLexerError["code"];
+    sql: string;
+  }>> = [
+    { code: "invalid_unicode_escape", sql: String.raw`E'\u12'` },
+    { code: "invalid_unicode_escape", sql: String.raw`E'\u12ZZ'` },
+    { code: "invalid_unicode_escape", sql: String.raw`E'\U00110000'` },
+    { code: "invalid_unicode_escape", sql: String.raw`E'\u0000'` },
+    { code: "invalid_unicode_surrogate", sql: String.raw`E'\uD83D'` },
+    { code: "invalid_unicode_surrogate", sql: String.raw`E'\uDE00'` },
+    { code: "invalid_unicode_surrogate", sql: String.raw`E'\uD83D\u0061'` },
+    { code: "invalid_string_encoding", sql: String.raw`E'\x00'` },
+    { code: "invalid_string_encoding", sql: String.raw`E'\000'` },
+    { code: "invalid_string_encoding", sql: String.raw`E'\400'` },
+    { code: "invalid_string_encoding", sql: String.raw`E'\600'` },
+    { code: "invalid_string_encoding", sql: String.raw`E'\777'` },
+    { code: "invalid_string_encoding", sql: String.raw`E'\x80'` },
+    { code: "invalid_string_encoding", sql: String.raw`E'\xC3x'` },
+    { code: "invalid_string_encoding", sql: "E'\\xC3'\n''" },
+  ];
+  for (const expected of invalid) {
+    expectLexerError(expected.sql, expected.code);
+  }
+});
+
+test("token ranges form an exact lossless partition of the input", (): void => {
+  const sql = String.raw`SELECT E'x\';;' AS value /* nested /* block */ */; ;
+-- comment-only segment
+SELECT U&"d!0061ta" UESCAPE '!' FROM foo$bar$`;
+  const lexed = lexSqlPolicyInfrastructure(sql);
+
+  assert.equal(lexed.tokens.map((token) => token.text).join(""), sql);
+  let nextStart = 0;
+  for (const token of lexed.tokens) {
+    assert.equal(token.range.start, nextStart);
+    assert.equal(token.text, sql.slice(token.range.start, token.range.end));
+    nextStart = token.range.end;
+  }
+  assert.equal(nextStart, sql.length);
+  assert.equal(lexed.statements.length, 2);
+  for (const statement of lexed.statements) {
+    assert.equal(
+      statement.tokens.map((token) => token.text).join(""),
+      sql.slice(statement.range.start, statement.range.end),
+    );
+  }
+});
+
+test("lexer raises actionable errors for invalid lexical constructs", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    code:
+      | "invalid_character"
+      | "invalid_parameter"
+      | "invalid_quoted_identifier"
+      | "invalid_unicode_escape"
+      | "invalid_unicode_escape_character"
+      | "invalid_unicode_surrogate"
+      | "unterminated_block_comment"
+      | "unterminated_dollar_string"
+      | "unterminated_quoted_identifier"
+      | "unterminated_string";
+    sql: string;
+  }>> = [
+    { code: "unterminated_string", sql: "SELECT 'open" },
+    { code: "unterminated_string", sql: "SELECT E'open\\" },
+    { code: "unterminated_quoted_identifier", sql: "SELECT \"open" },
+    { code: "invalid_quoted_identifier", sql: "SELECT \"\"" },
+    { code: "unterminated_dollar_string", sql: "SELECT $tag$open" },
+    { code: "unterminated_block_comment", sql: "SELECT /* open" },
+    { code: "invalid_unicode_escape", sql: String.raw`SELECT U&"\ZZZZ"` },
+    { code: "invalid_unicode_escape", sql: String.raw`SELECT U&"\12"` },
+    { code: "invalid_unicode_surrogate", sql: String.raw`SELECT U&"\D800"` },
+    { code: "invalid_unicode_escape_character", sql: "SELECT U&\"data\" UESCAPE '0'" },
+    { code: "invalid_parameter", sql: "SELECT $1evil(1)" },
+    { code: "invalid_character", sql: "SELECT \0" },
+    { code: "invalid_character", sql: `SELECT E'${String.fromCharCode(0xD800)}'` },
+  ];
+
+  for (const expected of cases) {
+    assert.throws(
+      () => lexSqlPolicyInfrastructure(expected.sql),
+      (error: unknown) =>
+        error instanceof SqlPolicyLexerError
+        && error.code === expected.code
+        && error.range.end > error.range.start
+        && error.message.includes("offset"),
+      expected.sql,
+    );
+  }
+
+  assert.throws(
+    () => lexSqlPolicyInfrastructure(String.raw`SELECT U&"\12"`),
+    (error: unknown) =>
+      error instanceof SqlPolicyLexerError
+      && error.range.end <= String.raw`SELECT U&"\12"`.length,
+  );
+
+  assert.deepEqual(
+    stringTokens("B'102' X'CAFG'").map((token) => token.semanticValue),
+    ["102", "CAFG"],
+  );
+});
+
+test("the lexer remains dormant and current policy execution is unchanged", async (): Promise<void> => {
+  const sql = "SELECT * FROM ledger_entries FOR SHARE";
+  const validated = validateExpenseSql(sql);
+  assert.equal(validated.statements.length, 1);
+
+  let callbackCount = 0;
+  const executed = await executeExpenseSql(sql, async (statementSql) => {
+    callbackCount++;
+    assert.equal(statementSql, sql);
+    return {
+      command: "SELECT",
+      rowCount: 0,
+      rows: [],
+    };
+  });
+
+  assert.equal(callbackCount, 1);
+  assert.equal(executed.statements.length, 1);
+});

--- a/packages/agent-shared/src/sql-policy-lexer.ts
+++ b/packages/agent-shared/src/sql-policy-lexer.ts
@@ -1,0 +1,1614 @@
+export type SqlSourceRange = Readonly<{
+  start: number;
+  end: number;
+}>;
+
+type SqlTokenBase = Readonly<{
+  range: SqlSourceRange;
+  text: string;
+}>;
+
+export type SqlWhitespaceToken = SqlTokenBase & Readonly<{
+  kind: "whitespace";
+}>;
+
+export type SqlCommentToken = SqlTokenBase & Readonly<{
+  kind: "comment";
+  style: "block" | "line";
+}>;
+
+export type SqlIdentifierToken = SqlTokenBase & Readonly<{
+  kind: "identifier";
+  normalized: string;
+  quoted: boolean;
+  truncated: boolean;
+  untruncatedNormalized: string;
+  unicodeEscaped: boolean;
+  unicodeEscapeCharacter: string | null;
+}>;
+
+export type SqlStringSegment = Readonly<{
+  range: SqlSourceRange;
+  value: string;
+}>;
+
+export type SqlStringToken = SqlTokenBase & Readonly<{
+  kind: "string";
+  style:
+    | "bit"
+    | "dollar"
+    | "escape"
+    | "hex"
+    | "national"
+    | "ordinary"
+    | "unicode";
+  dollarTag: string | null;
+  semanticSegments: ReadonlyArray<SqlStringSegment>;
+  semanticValue: string;
+  unicodeEscapeCharacter: string | null;
+}>;
+
+export type SqlParameterToken = SqlTokenBase & Readonly<{
+  kind: "parameter";
+  position: number;
+  positionText: string;
+}>;
+
+export type SqlValidNumericToken = SqlTokenBase & Readonly<{
+  kind: "numeric";
+  form: "binary" | "decimal" | "hexadecimal" | "octal";
+  normalized: string;
+  valid: true;
+}>;
+
+export type SqlInvalidNumericCode =
+  | "invalid_digit"
+  | "invalid_exponent"
+  | "invalid_separator"
+  | "missing_digits"
+  | "trailing_junk";
+
+export type SqlInvalidNumericToken = SqlTokenBase & Readonly<{
+  kind: "numeric";
+  diagnostic: Readonly<{
+    code: SqlInvalidNumericCode;
+    message: string;
+  }>;
+  valid: false;
+}>;
+
+export type SqlNumericToken = SqlValidNumericToken | SqlInvalidNumericToken;
+
+export type SqlOperatorToken = SqlTokenBase & Readonly<{
+  kind: "operator";
+}>;
+
+export type SqlPunctuationToken = SqlTokenBase & Readonly<{
+  kind: "punctuation";
+}>;
+
+export type SqlPolicyToken =
+  | SqlCommentToken
+  | SqlIdentifierToken
+  | SqlNumericToken
+  | SqlOperatorToken
+  | SqlParameterToken
+  | SqlPunctuationToken
+  | SqlStringToken
+  | SqlWhitespaceToken;
+
+export type SqlLexedStatement = Readonly<{
+  range: SqlSourceRange;
+  terminatorRange: SqlSourceRange | null;
+  tokens: ReadonlyArray<SqlPolicyToken>;
+}>;
+
+export type SqlLexedScript = Readonly<{
+  sql: string;
+  statements: ReadonlyArray<SqlLexedStatement>;
+  tokens: ReadonlyArray<SqlPolicyToken>;
+}>;
+
+export type SqlPolicyLexerErrorCode =
+  | "internal_invariant"
+  | "invalid_character"
+  | "invalid_escape_string"
+  | "invalid_parameter"
+  | "invalid_quoted_identifier"
+  | "invalid_string_encoding"
+  | "invalid_unicode_escape"
+  | "invalid_unicode_escape_character"
+  | "invalid_unicode_surrogate"
+  | "operator_too_long"
+  | "parameter_number_too_large"
+  | "unterminated_block_comment"
+  | "unterminated_dollar_string"
+  | "unterminated_quoted_identifier"
+  | "unterminated_string";
+
+export class SqlPolicyLexerError extends Error {
+  readonly code: SqlPolicyLexerErrorCode;
+  readonly range: SqlSourceRange;
+
+  constructor(
+    code: SqlPolicyLexerErrorCode,
+    message: string,
+    range: SqlSourceRange,
+  ) {
+    super(message);
+    this.code = code;
+    this.range = range;
+  }
+}
+
+type UnicodeEscapeClause = Readonly<{
+  end: number;
+  escapeCharacter: string;
+}>;
+
+type QuotedSegment = Readonly<{
+  bodyRange: SqlSourceRange;
+  range: SqlSourceRange;
+}>;
+
+type QuotedSequence = Readonly<{
+  end: number;
+  segments: ReadonlyArray<QuotedSegment>;
+}>;
+
+type NumericScan = Readonly<{
+  end: number;
+  token: SqlNumericToken;
+}>;
+
+const MAX_IDENTIFIER_BYTES = 63;
+const MAX_PARAMETER_NUMBER = 2_147_483_647n;
+
+const OPERATOR_CHARACTERS = new Set(
+  Array.from("+-*/<>=~!@#%^&|`?"),
+);
+
+const PUNCTUATION_CHARACTERS = new Set(
+  Array.from("()[],;{}"),
+);
+
+const readCodePoint = (
+  value: string,
+  index: number,
+): Readonly<{ character: string; width: number }> | null => {
+  const codePoint = value.codePointAt(index);
+  if (codePoint === undefined) {
+    return null;
+  }
+  const character = String.fromCodePoint(codePoint);
+  return { character, width: character.length };
+};
+
+const isIdentifierStart = (value: string): boolean => {
+  const codePoint = value.codePointAt(0);
+  return codePoint !== undefined
+    && (/[A-Za-z_]/u.test(value) || codePoint >= 0x80);
+};
+
+const isIdentifierPart = (value: string): boolean =>
+  isIdentifierStart(value) || /[0-9$]/u.test(value);
+
+const isSqlWhitespace = (value: string): boolean =>
+  /[\t\n\v\f\r ]/u.test(value);
+
+const invalidUtf16Index = (value: string): number => {
+  for (let index = 0; index < value.length; index++) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xD800 && codeUnit <= 0xDBFF) {
+      const next = value.charCodeAt(index + 1);
+      if (!Number.isFinite(next) || next < 0xDC00 || next > 0xDFFF) {
+        return index;
+      }
+      index++;
+    } else if (codeUnit >= 0xDC00 && codeUnit <= 0xDFFF) {
+      return index;
+    }
+  }
+  return -1;
+};
+
+const lexerError = (
+  code: SqlPolicyLexerErrorCode,
+  message: string,
+  start: number,
+  end: number,
+): never => {
+  throw new SqlPolicyLexerError(code, message, { start, end });
+};
+
+const readIdentifierEnd = (sql: string, start: number): number => {
+  const first = readCodePoint(sql, start);
+  if (first === null || !isIdentifierStart(first.character)) {
+    return start;
+  }
+  let index = start + first.width;
+  while (index < sql.length) {
+    const current = readCodePoint(sql, index);
+    if (current === null || !isIdentifierPart(current.character)) {
+      break;
+    }
+    index += current.width;
+  }
+  return index;
+};
+
+const foldUnquotedIdentifier = (value: string): string =>
+  value.replace(/[A-Z]/gu, (character) =>
+    String.fromCharCode(character.charCodeAt(0) + 32),
+  );
+
+const truncateUtf8 = (
+  value: string,
+  maximumBytes: number,
+): Readonly<{ truncated: boolean; value: string }> => {
+  let bytes = 0;
+  let result = "";
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character, "utf8");
+    if (bytes + characterBytes > maximumBytes) {
+      return { truncated: true, value: result };
+    }
+    result += character;
+    bytes += characterBytes;
+  }
+  return { truncated: false, value: result };
+};
+
+const identifierNormalization = (
+  value: string,
+  quoted: boolean,
+): Readonly<{
+  normalized: string;
+  truncated: boolean;
+  untruncatedNormalized: string;
+}> => {
+  const untruncatedNormalized = quoted
+    ? value
+    : foldUnquotedIdentifier(value);
+  const truncated = truncateUtf8(
+    untruncatedNormalized,
+    MAX_IDENTIFIER_BYTES,
+  );
+  return {
+    normalized: truncated.value,
+    truncated: truncated.truncated,
+    untruncatedNormalized,
+  };
+};
+
+const readQuotedSegment = (
+  sql: string,
+  quoteIndex: number,
+  quote: "'" | "\"",
+  doubledQuotes: boolean,
+  backslashEscapes: boolean,
+  errorCode: "unterminated_quoted_identifier" | "unterminated_string",
+): QuotedSegment => {
+  let index = quoteIndex + 1;
+  while (index < sql.length) {
+    const current = sql[index];
+    const next = sql[index + 1];
+    if (backslashEscapes && current === "\\" && next !== undefined) {
+      index += 2;
+    } else if (doubledQuotes && current === quote && next === quote) {
+      index += 2;
+    } else if (current === quote) {
+      return {
+        bodyRange: { start: quoteIndex + 1, end: index },
+        range: { start: quoteIndex, end: index + 1 },
+      };
+    } else {
+      index += readCodePoint(sql, index)?.width ?? 1;
+    }
+  }
+  return lexerError(
+    errorCode,
+    `Unterminated ${quote === "'" ? "string" : "quoted identifier"} starting at offset ${String(quoteIndex)}`,
+    quoteIndex,
+    sql.length,
+  );
+};
+
+const readQuoteContinuation = (
+  sql: string,
+  start: number,
+): number | null => {
+  let hasNewline = false;
+  let index = start;
+  while (index < sql.length) {
+    if (isSqlWhitespace(sql[index] ?? "")) {
+      hasNewline ||= sql[index] === "\n" || sql[index] === "\r";
+      index++;
+      continue;
+    }
+    if (sql.startsWith("--", index)) {
+      index += 2;
+      while (
+        index < sql.length
+        && sql[index] !== "\n"
+        && sql[index] !== "\r"
+      ) {
+        index += readCodePoint(sql, index)?.width ?? 1;
+      }
+      continue;
+    }
+    break;
+  }
+  return hasNewline && sql[index] === "'" ? index : null;
+};
+
+const readQuotedSequence = (
+  sql: string,
+  tokenStart: number,
+  firstQuoteIndex: number,
+  doubledQuotes: boolean,
+  backslashEscapes: boolean,
+): QuotedSequence => {
+  const segments: Array<QuotedSegment> = [];
+  let quoteIndex = firstQuoteIndex;
+  while (true) {
+    const segment = readQuotedSegment(
+      sql,
+      quoteIndex,
+      "'",
+      doubledQuotes,
+      backslashEscapes,
+      "unterminated_string",
+    );
+    segments.push({
+      bodyRange: segment.bodyRange,
+      range: {
+        start: segments.length === 0 ? tokenStart : segment.range.start,
+        end: segment.range.end,
+      },
+    });
+    const continuation = readQuoteContinuation(sql, segment.range.end);
+    if (continuation === null) {
+      return { end: segment.range.end, segments };
+    }
+    quoteIndex = continuation;
+  }
+};
+
+const readBlockCommentEnd = (sql: string, start: number): number => {
+  let depth = 1;
+  let index = start + 2;
+  while (index < sql.length && depth > 0) {
+    if (sql.startsWith("/*", index)) {
+      depth++;
+      index += 2;
+    } else if (sql.startsWith("*/", index)) {
+      depth--;
+      index += 2;
+    } else {
+      index += readCodePoint(sql, index)?.width ?? 1;
+    }
+  }
+  if (depth !== 0) {
+    return lexerError(
+      "unterminated_block_comment",
+      `Unterminated block comment starting at offset ${String(start)}`,
+      start,
+      sql.length,
+    );
+  }
+  return index;
+};
+
+const readTriviaEnd = (sql: string, start: number): number => {
+  let index = start;
+  while (index < sql.length) {
+    if (isSqlWhitespace(sql[index] ?? "")) {
+      index++;
+    } else if (sql.startsWith("--", index)) {
+      index += 2;
+      while (
+        index < sql.length
+        && sql[index] !== "\n"
+        && sql[index] !== "\r"
+      ) {
+        index += readCodePoint(sql, index)?.width ?? 1;
+      }
+    } else if (sql.startsWith("/*", index)) {
+      index = readBlockCommentEnd(sql, index);
+    } else {
+      break;
+    }
+  }
+  return index;
+};
+
+const decodeDoubledQuotes = (
+  sql: string,
+  range: SqlSourceRange,
+  quote: "'" | "\"",
+): string => sql.slice(range.start, range.end).replaceAll(quote + quote, quote);
+
+const appendUtf8 = (bytes: Array<number>, value: string): void => {
+  bytes.push(...Buffer.from(value, "utf8"));
+};
+
+const escapeUnicodeValue = (
+  sql: string,
+  escapeIndex: number,
+  prefix: "U" | "u",
+  bodyEnd: number,
+): Readonly<{ end: number; value: number }> => {
+  const digitsLength = prefix === "u" ? 4 : 8;
+  const end = escapeIndex + 2 + digitsLength;
+  const digits = sql.slice(escapeIndex + 2, end);
+  if (end > bodyEnd || !/^[0-9A-Fa-f]+$/u.test(digits)) {
+    return lexerError(
+      "invalid_unicode_escape",
+      `Invalid ${prefix === "u" ? "\\uXXXX" : "\\UXXXXXXXX"} escape at offset ${String(escapeIndex)}`,
+      escapeIndex,
+      Math.min(end, bodyEnd),
+    );
+  }
+  const value = Number.parseInt(digits, 16);
+  if (value === 0 || value > 0x10FFFF) {
+    return lexerError(
+      "invalid_unicode_escape",
+      `Unicode escape at offset ${String(escapeIndex)} is outside PostgreSQL's valid code-point range`,
+      escapeIndex,
+      end,
+    );
+  }
+  return { end, value };
+};
+
+const decodeEscapeSegmentBytes = (
+  sql: string,
+  range: SqlSourceRange,
+): ReadonlyArray<number> => {
+  const bytes: Array<number> = [];
+  for (let index = range.start; index < range.end;) {
+    if (sql[index] === "'" && sql[index + 1] === "'") {
+      bytes.push(0x27);
+      index += 2;
+      continue;
+    }
+    if (sql[index] !== "\\") {
+      const current = readCodePoint(sql, index);
+      if (current === null) {
+        break;
+      }
+      appendUtf8(bytes, current.character);
+      index += current.width;
+      continue;
+    }
+
+    const escaped = readCodePoint(sql, index + 1);
+    if (escaped === null) {
+      return lexerError(
+        "invalid_escape_string",
+        `Incomplete escape sequence at offset ${String(index)}`,
+        index,
+        range.end,
+      );
+    }
+    if (escaped.character === "u" || escaped.character === "U") {
+      const escapeStart = index;
+      const first = escapeUnicodeValue(
+        sql,
+        index,
+        escaped.character,
+        range.end,
+      );
+      let value = first.value;
+      index = first.end;
+      if (value >= 0xD800 && value <= 0xDBFF) {
+        if (
+          sql[index] !== "\\"
+          || (sql[index + 1] !== "u" && sql[index + 1] !== "U")
+        ) {
+          return lexerError(
+            "invalid_unicode_surrogate",
+            `High surrogate at offset ${String(escapeStart)} is not followed by a Unicode low surrogate`,
+            escapeStart,
+            Math.min(first.end, range.end),
+          );
+        }
+        const secondPrefix = sql[index + 1] as "U" | "u";
+        const second = escapeUnicodeValue(
+          sql,
+          index,
+          secondPrefix,
+          range.end,
+        );
+        if (second.value < 0xDC00 || second.value > 0xDFFF) {
+          return lexerError(
+            "invalid_unicode_surrogate",
+            `Invalid Unicode surrogate pair at offset ${String(index)}`,
+            index,
+            second.end,
+          );
+        }
+        value = 0x10000
+          + ((value - 0xD800) << 10)
+          + second.value
+          - 0xDC00;
+        index = second.end;
+      } else if (value >= 0xDC00 && value <= 0xDFFF) {
+        return lexerError(
+          "invalid_unicode_surrogate",
+          `Unexpected Unicode low surrogate at offset ${String(escapeStart)}`,
+          escapeStart,
+          index,
+        );
+      }
+      appendUtf8(bytes, String.fromCodePoint(value));
+      continue;
+    }
+    if (/[0-7]/u.test(escaped.character)) {
+      let end = index + 2;
+      while (end < range.end && end < index + 4 && /[0-7]/u.test(sql[end] ?? "")) {
+        end++;
+      }
+      bytes.push(Number.parseInt(sql.slice(index + 1, end), 8) & 0xFF);
+      index = end;
+      continue;
+    }
+    if (escaped.character === "x" && /[0-9A-Fa-f]/u.test(sql[index + 2] ?? "")) {
+      let end = index + 3;
+      if (/[0-9A-Fa-f]/u.test(sql[end] ?? "")) {
+        end++;
+      }
+      bytes.push(Number.parseInt(sql.slice(index + 2, end), 16));
+      index = end;
+      continue;
+    }
+    const escapedValues: Readonly<Record<string, number>> = {
+      b: 0x08,
+      f: 0x0C,
+      n: 0x0A,
+      r: 0x0D,
+      t: 0x09,
+      v: 0x0B,
+    };
+    const mapped = escapedValues[escaped.character];
+    if (mapped === undefined) {
+      appendUtf8(bytes, escaped.character);
+    } else {
+      bytes.push(mapped);
+    }
+    index += 1 + escaped.width;
+  }
+  return bytes;
+};
+
+const decodeEscapeSegments = (
+  sql: string,
+  segments: ReadonlyArray<QuotedSegment>,
+): ReadonlyArray<string> => {
+  const decoder = new TextDecoder("utf-8", {
+    fatal: true,
+    ignoreBOM: true,
+  });
+  const values: Array<string> = [];
+  for (const [segmentIndex, segment] of segments.entries()) {
+    const bytes = decodeEscapeSegmentBytes(sql, segment.bodyRange);
+    const nulIndex = bytes.indexOf(0);
+    if (nulIndex !== -1) {
+      return lexerError(
+        "invalid_string_encoding",
+        `NUL produced by escape string segment at offset ${String(segment.bodyRange.start)}`,
+        segment.bodyRange.start,
+        segment.bodyRange.end,
+      );
+    }
+    try {
+      values.push(decoder.decode(
+        Uint8Array.from(bytes),
+        { stream: segmentIndex < segments.length - 1 },
+      ));
+    } catch {
+      const tokenRange = {
+        start: segments[0]?.range.start ?? segment.bodyRange.start,
+        end: segments.at(-1)?.range.end ?? segment.bodyRange.end,
+      };
+      return lexerError(
+        "invalid_string_encoding",
+        `Escape string is not valid UTF-8 near offset ${String(segment.bodyRange.start)}`,
+        tokenRange.start,
+        tokenRange.end,
+      );
+    }
+  }
+  return values;
+};
+
+const readUnicodeEscapeClause = (
+  sql: string,
+  quotedEnd: number,
+): UnicodeEscapeClause => {
+  const keywordStart = readTriviaEnd(sql, quotedEnd);
+  const keywordEnd = readIdentifierEnd(sql, keywordStart);
+  if (
+    foldUnquotedIdentifier(sql.slice(keywordStart, keywordEnd)) !== "uescape"
+  ) {
+    return { end: quotedEnd, escapeCharacter: "\\" };
+  }
+  const literalStart = readTriviaEnd(sql, keywordEnd);
+  const quotedStyle = (
+    (sql[literalStart] === "e" || sql[literalStart] === "E")
+    && sql[literalStart + 1] === "'"
+  )
+    ? "escape"
+    : sql[literalStart] === "'"
+      ? "ordinary"
+      : null;
+  const dollarTag = readDollarTag(sql, literalStart);
+  if (quotedStyle === null && dollarTag === null) {
+    const errorStart = literalStart < sql.length ? literalStart : keywordStart;
+    return lexerError(
+      "invalid_unicode_escape_character",
+      `UESCAPE at offset ${String(keywordStart)} must be followed by one simple string literal`,
+      errorStart,
+      literalStart < sql.length ? literalStart + 1 : keywordEnd,
+    );
+  }
+  let literalEnd: number;
+  let escapeCharacter: string;
+  if (dollarTag !== null) {
+    const closingStart = sql.indexOf(
+      dollarTag,
+      literalStart + dollarTag.length,
+    );
+    if (closingStart === -1) {
+      return lexerError(
+        "unterminated_dollar_string",
+        `Unterminated dollar-quoted string ${dollarTag} starting at offset ${String(literalStart)}`,
+        literalStart,
+        sql.length,
+      );
+    }
+    literalEnd = closingStart + dollarTag.length;
+    escapeCharacter = sql.slice(
+      literalStart + dollarTag.length,
+      closingStart,
+    );
+  } else {
+    const sequence = readQuotedSequence(
+      sql,
+      literalStart,
+      literalStart + (quotedStyle === "escape" ? 1 : 0),
+      true,
+      quotedStyle === "escape",
+    );
+    const values = quotedStyle === "escape"
+      ? decodeEscapeSegments(sql, sequence.segments)
+      : sequence.segments.map((segment) =>
+        decodeDoubledQuotes(sql, segment.bodyRange, "'"),
+      );
+    literalEnd = sequence.end;
+    escapeCharacter = values.join("");
+  }
+  if (
+    Buffer.byteLength(escapeCharacter, "utf8") !== 1
+    || /[0-9A-Fa-f+'"\t\n\v\f\r ]/u.test(escapeCharacter)
+  ) {
+    return lexerError(
+      "invalid_unicode_escape_character",
+      `Invalid Unicode escape character at offset ${String(literalStart)}`,
+      literalStart,
+      literalEnd,
+    );
+  }
+  return { end: literalEnd, escapeCharacter };
+};
+
+const unicodeCodePoint = (
+  digits: string,
+  start: number,
+  end: number,
+): number => {
+  if (!/^[0-9A-Fa-f]+$/u.test(digits)) {
+    return lexerError(
+      "invalid_unicode_escape",
+      `Invalid Unicode escape at offset ${String(start)}`,
+      start,
+      end,
+    );
+  }
+  const value = Number.parseInt(digits, 16);
+  if (value === 0 || value > 0x10FFFF) {
+    return lexerError(
+      "invalid_unicode_escape",
+      `Unicode escape at offset ${String(start)} is outside the supported code-point range`,
+      start,
+      end,
+    );
+  }
+  return value;
+};
+
+const readUnicodeEscapedCodePoint = (
+  sql: string,
+  escapeIndex: number,
+  bodyEnd: number,
+): Readonly<{ next: number; value: number }> => {
+  const extended = sql[escapeIndex + 1] === "+";
+  const digitsStart = escapeIndex + (extended ? 2 : 1);
+  const digitsLength = extended ? 6 : 4;
+  const digitsEnd = digitsStart + digitsLength;
+  const rangeEnd = Math.min(digitsEnd, bodyEnd);
+  return {
+    next: digitsEnd,
+    value: unicodeCodePoint(
+      sql.slice(digitsStart, digitsEnd),
+      escapeIndex,
+      rangeEnd,
+    ),
+  };
+};
+
+const decodeUnicodeSegments = (
+  sql: string,
+  bodyRanges: ReadonlyArray<SqlSourceRange>,
+  escapeCharacter: string,
+  quote: "'" | "\"",
+): ReadonlyArray<string> => {
+  const values = bodyRanges.map(() => "");
+  let pendingHigh: Readonly<{ range: SqlSourceRange; value: number }> | null = null;
+  for (const [rangeIndex, bodyRange] of bodyRanges.entries()) {
+    for (let index = bodyRange.start; index < bodyRange.end;) {
+      if (sql[index] === quote && sql[index + 1] === quote) {
+        if (pendingHigh !== null) {
+          return lexerError(
+            "invalid_unicode_surrogate",
+            `High surrogate at offset ${String(pendingHigh.range.start)} is not followed by a low surrogate`,
+            pendingHigh.range.start,
+            pendingHigh.range.end,
+          );
+        }
+        values[rangeIndex] += quote;
+        index += 2;
+        continue;
+      }
+      if (sql[index] !== escapeCharacter) {
+        if (pendingHigh !== null) {
+          return lexerError(
+            "invalid_unicode_surrogate",
+            `High surrogate at offset ${String(pendingHigh.range.start)} is not followed by a low surrogate`,
+            pendingHigh.range.start,
+            pendingHigh.range.end,
+          );
+        }
+        const codePoint = readCodePoint(sql, index);
+        if (codePoint === null) {
+          break;
+        }
+        values[rangeIndex] += codePoint.character;
+        index += codePoint.width;
+        continue;
+      }
+      if (sql[index + 1] === escapeCharacter) {
+        if (pendingHigh !== null) {
+          return lexerError(
+            "invalid_unicode_surrogate",
+            `High surrogate at offset ${String(pendingHigh.range.start)} is not followed by a low surrogate`,
+            pendingHigh.range.start,
+            pendingHigh.range.end,
+          );
+        }
+        values[rangeIndex] += escapeCharacter;
+        index += 2;
+        continue;
+      }
+      const first = readUnicodeEscapedCodePoint(
+        sql,
+        index,
+        bodyRange.end,
+      );
+      const firstRange = { start: index, end: Math.min(first.next, bodyRange.end) };
+      index = first.next;
+      if (pendingHigh !== null) {
+        if (first.value < 0xDC00 || first.value > 0xDFFF) {
+          return lexerError(
+            "invalid_unicode_surrogate",
+            `Invalid Unicode surrogate pair at offset ${String(pendingHigh.range.start)}`,
+            pendingHigh.range.start,
+            firstRange.end,
+          );
+        }
+        values[rangeIndex] += String.fromCodePoint(
+          0x10000
+            + ((pendingHigh.value - 0xD800) << 10)
+            + first.value
+            - 0xDC00,
+        );
+        pendingHigh = null;
+      } else if (first.value >= 0xD800 && first.value <= 0xDBFF) {
+        pendingHigh = { range: firstRange, value: first.value };
+      } else if (first.value >= 0xDC00 && first.value <= 0xDFFF) {
+        return lexerError(
+          "invalid_unicode_surrogate",
+          `Unexpected Unicode low surrogate at offset ${String(firstRange.start)}`,
+          firstRange.start,
+          firstRange.end,
+        );
+      } else {
+        values[rangeIndex] += String.fromCodePoint(first.value);
+      }
+    }
+  }
+  if (pendingHigh !== null) {
+    return lexerError(
+      "invalid_unicode_surrogate",
+      `High surrogate at offset ${String(pendingHigh.range.start)} is not followed by a low surrogate`,
+      pendingHigh.range.start,
+      pendingHigh.range.end,
+    );
+  }
+  return values;
+};
+
+function readDollarTag(sql: string, start: number): string | null {
+  if (sql[start] !== "$") {
+    return null;
+  }
+  if (sql[start + 1] === "$") {
+    return "$$";
+  }
+  const first = readCodePoint(sql, start + 1);
+  if (first === null || !isIdentifierStart(first.character)) {
+    return null;
+  }
+  let index = start + 1 + first.width;
+  while (index < sql.length) {
+    const current = readCodePoint(sql, index);
+    if (
+      current === null
+      || !(isIdentifierStart(current.character) || /[0-9]/u.test(current.character))
+    ) {
+      break;
+    }
+    index += current.width;
+  }
+  return sql[index] === "$" ? sql.slice(start, index + 1) : null;
+}
+
+const validNumericToken = (
+  sql: string,
+  start: number,
+  end: number,
+  form: SqlValidNumericToken["form"],
+): SqlValidNumericToken => {
+  const text = sql.slice(start, end);
+  return {
+    kind: "numeric",
+    form,
+    normalized: text.replaceAll("_", "").toLowerCase(),
+    range: { start, end },
+    text,
+    valid: true,
+  };
+};
+
+const invalidNumericCode = (text: string): SqlInvalidNumericCode => {
+  if (/__|_$|_\p{L}|_[.]|[.]_|_[eE]|[eE]_/u.test(text)) {
+    return "invalid_separator";
+  }
+  if (/^0[xX](?:_)?$/u.test(text) || /^0[oObB](?:_)?$/u.test(text)) {
+    return "missing_digits";
+  }
+  if (/[eE][+-]?(?:_)?$/u.test(text)) {
+    return "invalid_exponent";
+  }
+  if (/^0[bB].*[2-9A-Za-z]/u.test(text)
+    || /^0[oO].*[89A-Za-z]/u.test(text)
+    || /^0[xX].*[G-Zg-z]/u.test(text)) {
+    return "invalid_digit";
+  }
+  return "trailing_junk";
+};
+
+const invalidNumericToken = (
+  sql: string,
+  start: number,
+  end: number,
+): SqlInvalidNumericToken => {
+  const text = sql.slice(start, end);
+  const code = invalidNumericCode(text);
+  return {
+    diagnostic: {
+      code,
+      message: `Invalid PostgreSQL numeric literal ${JSON.stringify(text)}: ${code.replaceAll("_", " ")}`,
+    },
+    kind: "numeric",
+    range: { start, end },
+    text,
+    valid: false,
+  };
+};
+
+type NumericCandidate =
+  | Readonly<{
+    end: number;
+    form: SqlValidNumericToken["form"];
+    valid: true;
+  }>
+  | Readonly<{
+    end: number;
+    valid: false;
+  }>;
+
+const readSeparatedDigitsEnd = (
+  sql: string,
+  start: number,
+  isDigit: (character: string) => boolean,
+): number | null => {
+  let index = start;
+  if (!isDigit(sql[index] ?? "")) {
+    return null;
+  }
+  index++;
+  while (index < sql.length) {
+    if (isDigit(sql[index] ?? "")) {
+      index++;
+    } else if (
+      sql[index] === "_"
+      && isDigit(sql[index + 1] ?? "")
+    ) {
+      index += 2;
+    } else {
+      break;
+    }
+  }
+  return index;
+};
+
+const readDecimalDigitsEnd = (sql: string, start: number): number | null =>
+  readSeparatedDigitsEnd(sql, start, (character) => /[0-9]/u.test(character));
+
+const readRadixDigitsEnd = (
+  sql: string,
+  start: number,
+  isDigit: (character: string) => boolean,
+): number | null =>
+  readSeparatedDigitsEnd(
+    sql,
+    sql[start] === "_" ? start + 1 : start,
+    isDigit,
+  );
+
+const addNumericJunkCandidate = (
+  candidates: Array<NumericCandidate>,
+  sql: string,
+  tokenEnd: number,
+): void => {
+  const next = readCodePoint(sql, tokenEnd);
+  if (next !== null && isIdentifierStart(next.character)) {
+    candidates.push({
+      end: readIdentifierEnd(sql, tokenEnd),
+      valid: false,
+    });
+  }
+};
+
+const longestNumericCandidate = (
+  candidates: ReadonlyArray<NumericCandidate>,
+): NumericCandidate => {
+  const first = candidates[0];
+  if (first === undefined) {
+    throw new Error("Numeric scanning requires at least one candidate");
+  }
+  return candidates.reduce(
+    (selected, candidate) =>
+      candidate.end > selected.end ? candidate : selected,
+    first,
+  );
+};
+
+const scanNumeric = (
+  sql: string,
+  start: number,
+): NumericScan => {
+  const beginsWithDot = sql[start] === ".";
+  const decimalIntegerEnd = beginsWithDot
+    ? null
+    : readDecimalDigitsEnd(sql, start);
+  const candidates: Array<NumericCandidate> = [];
+  if (decimalIntegerEnd !== null) {
+    candidates.push({
+      end: decimalIntegerEnd,
+      form: "decimal",
+      valid: true,
+    });
+  }
+
+  const radix = !beginsWithDot && sql[start] === "0"
+    ? sql[start + 1]?.toLowerCase()
+    : undefined;
+  if (radix === "x" || radix === "o" || radix === "b") {
+    const digitPatterns = {
+      b: /[01]/u,
+      o: /[0-7]/u,
+      x: /[0-9A-Fa-f]/u,
+    } as const;
+    const forms = {
+      b: "binary",
+      o: "octal",
+      x: "hexadecimal",
+    } as const;
+    const radixEnd = readRadixDigitsEnd(
+      sql,
+      start + 2,
+      (character) => digitPatterns[radix].test(character),
+    );
+    if (radixEnd !== null) {
+      candidates.push({
+        end: radixEnd,
+        form: forms[radix],
+        valid: true,
+      });
+    }
+    candidates.push({
+      end: start + 2 + (sql[start + 2] === "_" ? 1 : 0),
+      valid: false,
+    });
+  }
+
+  let numericEnd: number | null = null;
+  if (beginsWithDot) {
+    numericEnd = readDecimalDigitsEnd(sql, start + 1);
+  } else if (
+    decimalIntegerEnd !== null
+    && sql[decimalIntegerEnd] === "."
+    && sql[decimalIntegerEnd + 1] !== "."
+  ) {
+    numericEnd = readDecimalDigitsEnd(sql, decimalIntegerEnd + 1)
+      ?? decimalIntegerEnd + 1;
+  }
+  if (numericEnd !== null) {
+    candidates.push({ end: numericEnd, form: "decimal", valid: true });
+  }
+
+  const realEnds: Array<number> = [];
+  for (const baseEnd of [decimalIntegerEnd, numericEnd]) {
+    if (
+      baseEnd === null
+      || (sql[baseEnd] !== "e" && sql[baseEnd] !== "E")
+    ) {
+      continue;
+    }
+    const exponentStart = baseEnd
+      + 1
+      + (sql[baseEnd + 1] === "+" || sql[baseEnd + 1] === "-" ? 1 : 0);
+    const realEnd = readDecimalDigitsEnd(sql, exponentStart);
+    if (realEnd === null) {
+      candidates.push({ end: exponentStart, valid: false });
+    } else {
+      candidates.push({ end: realEnd, form: "decimal", valid: true });
+      realEnds.push(realEnd);
+    }
+  }
+
+  if (decimalIntegerEnd !== null) {
+    addNumericJunkCandidate(candidates, sql, decimalIntegerEnd);
+  }
+  if (numericEnd !== null) {
+    addNumericJunkCandidate(candidates, sql, numericEnd);
+  }
+  for (const realEnd of realEnds) {
+    addNumericJunkCandidate(candidates, sql, realEnd);
+  }
+
+  const selected = longestNumericCandidate(candidates);
+  return {
+    end: selected.end,
+    token: selected.valid
+      ? validNumericToken(sql, start, selected.end, selected.form)
+      : invalidNumericToken(sql, start, selected.end),
+  };
+};
+
+const adjustOperatorEnd = (
+  sql: string,
+  start: number,
+  initialEnd: number,
+): number => {
+  let end = initialEnd;
+  const nonStandard = /[~!@#%^&|`?]/u;
+  while (
+    end - start > 1
+    && (sql[end - 1] === "+" || sql[end - 1] === "-")
+    && !nonStandard.test(sql.slice(start, end))
+  ) {
+    end--;
+  }
+  return end;
+};
+
+const stringSegments = (
+  segments: ReadonlyArray<QuotedSegment>,
+  values: ReadonlyArray<string>,
+  tokenRange: SqlSourceRange,
+): ReadonlyArray<SqlStringSegment> => {
+  if (values.length !== segments.length) {
+    return lexerError(
+      "internal_invariant",
+      `Internal SQL policy lexer invariant failed: decoded ${String(values.length)} string segments for ${String(segments.length)} source segments`,
+      tokenRange.start,
+      tokenRange.end,
+    );
+  }
+  return segments.map((segment, index) => {
+    const value = values[index];
+    if (value === undefined) {
+      return lexerError(
+        "internal_invariant",
+        `Internal SQL policy lexer invariant failed: decoded string segment ${String(index)} is missing`,
+        segment.range.start,
+        segment.range.end,
+      );
+    }
+    return {
+      range: segment.range,
+      value,
+    };
+  });
+};
+
+const hasSignificantToken = (
+  tokens: ReadonlyArray<SqlPolicyToken>,
+): boolean =>
+  tokens.some((token) =>
+    token.kind !== "comment" && token.kind !== "whitespace",
+  );
+
+const buildStatements = (
+  sql: string,
+  tokens: ReadonlyArray<SqlPolicyToken>,
+): ReadonlyArray<SqlLexedStatement> => {
+  const statements: Array<SqlLexedStatement> = [];
+  let segmentStart = 0;
+  let segmentTokens: Array<SqlPolicyToken> = [];
+  const pushSegment = (
+    end: number,
+    terminatorRange: SqlSourceRange | null,
+  ): void => {
+    if (hasSignificantToken(segmentTokens)) {
+      statements.push({
+        range: { start: segmentStart, end },
+        terminatorRange,
+        tokens: segmentTokens,
+      });
+    }
+    segmentStart = terminatorRange?.end ?? end;
+    segmentTokens = [];
+  };
+  for (const token of tokens) {
+    if (token.kind === "punctuation" && token.text === ";") {
+      pushSegment(token.range.start, token.range);
+    } else {
+      segmentTokens.push(token);
+    }
+  }
+  pushSegment(sql.length, null);
+  return statements;
+};
+
+export const lexSqlPolicyInfrastructure = (sql: string): SqlLexedScript => {
+  const invalidUnicodeIndex = invalidUtf16Index(sql);
+  if (invalidUnicodeIndex !== -1) {
+    return lexerError(
+      "invalid_character",
+      `Unpaired UTF-16 surrogate is not valid PostgreSQL UTF-8 input at offset ${String(invalidUnicodeIndex)}`,
+      invalidUnicodeIndex,
+      invalidUnicodeIndex + 1,
+    );
+  }
+  const nulIndex = sql.indexOf("\0");
+  if (nulIndex !== -1) {
+    return lexerError(
+      "invalid_character",
+      `NUL is not allowed in PostgreSQL SQL text at offset ${String(nulIndex)}`,
+      nulIndex,
+      nulIndex + 1,
+    );
+  }
+  const tokens: Array<SqlPolicyToken> = [];
+  const pushSimpleToken = (
+    kind: "operator" | "punctuation" | "whitespace",
+    start: number,
+    end: number,
+  ): void => {
+    tokens.push({ kind, range: { start, end }, text: sql.slice(start, end) });
+  };
+
+  for (let index = 0; index < sql.length;) {
+    const start = index;
+    const current = readCodePoint(sql, index);
+    if (current === null) {
+      break;
+    }
+    if (current.character === "\0") {
+      return lexerError(
+        "invalid_character",
+        `NUL is not allowed in PostgreSQL SQL text at offset ${String(index)}`,
+        index,
+        index + 1,
+      );
+    }
+    if (isSqlWhitespace(current.character)) {
+      index += current.width;
+      while (isSqlWhitespace(readCodePoint(sql, index)?.character ?? "")) {
+        index += readCodePoint(sql, index)?.width ?? 0;
+      }
+      pushSimpleToken("whitespace", start, index);
+      continue;
+    }
+    if (sql.startsWith("--", index)) {
+      index += 2;
+      while (
+        index < sql.length
+        && sql[index] !== "\n"
+        && sql[index] !== "\r"
+      ) {
+        index += readCodePoint(sql, index)?.width ?? 1;
+      }
+      tokens.push({
+        kind: "comment",
+        range: { start, end: index },
+        style: "line",
+        text: sql.slice(start, index),
+      });
+      continue;
+    }
+    if (sql.startsWith("/*", index)) {
+      index = readBlockCommentEnd(sql, index);
+      tokens.push({
+        kind: "comment",
+        range: { start, end: index },
+        style: "block",
+        text: sql.slice(start, index),
+      });
+      continue;
+    }
+
+    const dollarTag = readDollarTag(sql, index);
+    if (dollarTag !== null) {
+      const closingStart = sql.indexOf(dollarTag, index + dollarTag.length);
+      if (closingStart === -1) {
+        return lexerError(
+          "unterminated_dollar_string",
+          `Unterminated dollar-quoted string ${dollarTag} starting at offset ${String(start)}`,
+          start,
+          sql.length,
+        );
+      }
+      index = closingStart + dollarTag.length;
+      const valueRange = {
+        start: start + dollarTag.length,
+        end: closingStart,
+      };
+      const semanticValue = sql.slice(valueRange.start, valueRange.end);
+      tokens.push({
+        dollarTag,
+        kind: "string",
+        range: { start, end: index },
+        semanticSegments: [{ range: { start, end: index }, value: semanticValue }],
+        semanticValue,
+        style: "dollar",
+        text: sql.slice(start, index),
+        unicodeEscapeCharacter: null,
+      });
+      continue;
+    }
+    if (current.character === "$" && /[0-9]/u.test(sql[index + 1] ?? "")) {
+      index++;
+      while (/[0-9]/u.test(sql[index] ?? "")) {
+        index++;
+      }
+      const positionEnd = index;
+      const trailing = readCodePoint(sql, index);
+      if (trailing !== null && isIdentifierStart(trailing.character)) {
+        index = readIdentifierEnd(sql, index);
+      }
+      if (index !== positionEnd) {
+        return lexerError(
+          "invalid_parameter",
+          `Trailing junk after positional parameter at offset ${String(start)}`,
+          start,
+          index,
+        );
+      }
+      const positionText = sql.slice(start + 1, positionEnd);
+      const positionValue = BigInt(positionText);
+      if (positionValue > MAX_PARAMETER_NUMBER) {
+        return lexerError(
+          "parameter_number_too_large",
+          `Positional parameter ${sql.slice(start, positionEnd)} at offset ${String(start)} exceeds PostgreSQL's maximum parameter number ${String(MAX_PARAMETER_NUMBER)}`,
+          start,
+          positionEnd,
+        );
+      }
+      tokens.push({
+        kind: "parameter",
+        position: Number(positionValue),
+        positionText,
+        range: { start, end: index },
+        text: sql.slice(start, index),
+      });
+      continue;
+    }
+
+    const prefix = sql.slice(index, index + 2).toLowerCase();
+    if (prefix === "u&" && sql[index + 2] === "\"") {
+      const quoted = readQuotedSegment(
+        sql,
+        index + 2,
+        "\"",
+        true,
+        false,
+        "unterminated_quoted_identifier",
+      );
+      const escapeClause = readUnicodeEscapeClause(sql, quoted.range.end);
+      const decodedValues = decodeUnicodeSegments(
+        sql,
+        [quoted.bodyRange],
+        escapeClause.escapeCharacter,
+        "\"",
+      );
+      if (decodedValues.length !== 1) {
+        return lexerError(
+          "internal_invariant",
+          `Internal SQL policy lexer invariant failed: decoded ${String(decodedValues.length)} Unicode identifier segments instead of 1`,
+          start,
+          quoted.range.end,
+        );
+      }
+      const decoded = decodedValues[0];
+      if (decoded === undefined) {
+        return lexerError(
+          "internal_invariant",
+          "Internal SQL policy lexer invariant failed: decoded Unicode identifier segment is missing",
+          start,
+          quoted.range.end,
+        );
+      }
+      if (decoded.length === 0) {
+        return lexerError(
+          "invalid_quoted_identifier",
+          `PostgreSQL quoted identifiers cannot be empty at offset ${String(start)}`,
+          start,
+          quoted.range.end,
+        );
+      }
+      const normalization = identifierNormalization(decoded, true);
+      index = escapeClause.end;
+      tokens.push({
+        kind: "identifier",
+        ...normalization,
+        quoted: true,
+        range: { start, end: index },
+        text: sql.slice(start, index),
+        unicodeEscapeCharacter: escapeClause.escapeCharacter,
+        unicodeEscaped: true,
+      });
+      continue;
+    }
+    if (prefix === "u&" && sql[index + 2] === "'") {
+      const sequence = readQuotedSequence(
+        sql,
+        start,
+        index + 2,
+        true,
+        false,
+      );
+      const escapeClause = readUnicodeEscapeClause(sql, sequence.end);
+      const values = decodeUnicodeSegments(
+        sql,
+        sequence.segments.map((segment) => segment.bodyRange),
+        escapeClause.escapeCharacter,
+        "'",
+      );
+      index = escapeClause.end;
+      tokens.push({
+        dollarTag: null,
+        kind: "string",
+        range: { start, end: index },
+        semanticSegments: stringSegments(
+          sequence.segments,
+          values,
+          { start, end: index },
+        ),
+        semanticValue: values.join(""),
+        style: "unicode",
+        text: sql.slice(start, index),
+        unicodeEscapeCharacter: escapeClause.escapeCharacter,
+      });
+      continue;
+    }
+    const singlePrefix = sql[index]?.toLowerCase();
+    if (
+      (singlePrefix === "b"
+        || singlePrefix === "e"
+        || singlePrefix === "n"
+        || singlePrefix === "x")
+      && sql[index + 1] === "'"
+    ) {
+      const sequence = readQuotedSequence(
+        sql,
+        start,
+        index + 1,
+        singlePrefix !== "b" && singlePrefix !== "x",
+        singlePrefix === "e",
+      );
+      const styles = {
+        b: "bit",
+        e: "escape",
+        n: "national",
+        x: "hex",
+      } as const;
+      const values = singlePrefix === "e"
+        ? decodeEscapeSegments(sql, sequence.segments)
+        : sequence.segments.map((segment) =>
+          singlePrefix === "n"
+            ? decodeDoubledQuotes(sql, segment.bodyRange, "'")
+            : sql.slice(segment.bodyRange.start, segment.bodyRange.end),
+        );
+      index = sequence.end;
+      tokens.push({
+        dollarTag: null,
+        kind: "string",
+        range: { start, end: index },
+        semanticSegments: stringSegments(
+          sequence.segments,
+          values,
+          { start, end: index },
+        ),
+        semanticValue: values.join(""),
+        style: styles[singlePrefix],
+        text: sql.slice(start, index),
+        unicodeEscapeCharacter: null,
+      });
+      continue;
+    }
+    if (current.character === "'") {
+      const sequence = readQuotedSequence(
+        sql,
+        start,
+        index,
+        true,
+        false,
+      );
+      const values = sequence.segments.map((segment) =>
+        decodeDoubledQuotes(sql, segment.bodyRange, "'"),
+      );
+      index = sequence.end;
+      tokens.push({
+        dollarTag: null,
+        kind: "string",
+        range: { start, end: index },
+        semanticSegments: stringSegments(
+          sequence.segments,
+          values,
+          { start, end: index },
+        ),
+        semanticValue: values.join(""),
+        style: "ordinary",
+        text: sql.slice(start, index),
+        unicodeEscapeCharacter: null,
+      });
+      continue;
+    }
+    if (current.character === "\"") {
+      const quoted = readQuotedSegment(
+        sql,
+        index,
+        "\"",
+        true,
+        false,
+        "unterminated_quoted_identifier",
+      );
+      index = quoted.range.end;
+      const text = sql.slice(start, index);
+      const decoded = decodeDoubledQuotes(sql, quoted.bodyRange, "\"");
+      if (decoded.length === 0) {
+        return lexerError(
+          "invalid_quoted_identifier",
+          `PostgreSQL quoted identifiers cannot be empty at offset ${String(start)}`,
+          start,
+          index,
+        );
+      }
+      const normalization = identifierNormalization(decoded, true);
+      tokens.push({
+        kind: "identifier",
+        ...normalization,
+        quoted: true,
+        range: { start, end: index },
+        text,
+        unicodeEscapeCharacter: null,
+        unicodeEscaped: false,
+      });
+      continue;
+    }
+    if (
+      /[0-9]/u.test(current.character)
+      || (
+        current.character === "."
+        && /[0-9]/u.test(sql[index + 1] ?? "")
+      )
+    ) {
+      const numeric = scanNumeric(sql, index);
+      tokens.push(numeric.token);
+      index = numeric.end;
+      continue;
+    }
+    if (isIdentifierStart(current.character)) {
+      index = readIdentifierEnd(sql, index);
+      const text = sql.slice(start, index);
+      const normalization = identifierNormalization(text, false);
+      tokens.push({
+        kind: "identifier",
+        ...normalization,
+        quoted: false,
+        range: { start, end: index },
+        text,
+        unicodeEscapeCharacter: null,
+        unicodeEscaped: false,
+      });
+      continue;
+    }
+    if (sql.startsWith("::", index) || sql.startsWith(":=", index)) {
+      index += 2;
+      pushSimpleToken("operator", start, index);
+      continue;
+    }
+    if (sql.startsWith("..", index)) {
+      index += 2;
+      pushSimpleToken("operator", start, index);
+      continue;
+    }
+    if (OPERATOR_CHARACTERS.has(current.character)) {
+      index += current.width;
+      while (
+        OPERATOR_CHARACTERS.has(
+          readCodePoint(sql, index)?.character ?? "",
+        )
+        && !sql.startsWith("--", index)
+        && !sql.startsWith("/*", index)
+      ) {
+        index += readCodePoint(sql, index)?.width ?? 0;
+      }
+      index = adjustOperatorEnd(sql, start, index);
+      if (Buffer.byteLength(sql.slice(start, index), "utf8") > MAX_IDENTIFIER_BYTES) {
+        return lexerError(
+          "operator_too_long",
+          `PostgreSQL operator at offset ${String(start)} exceeds ${String(MAX_IDENTIFIER_BYTES)} bytes`,
+          start,
+          index,
+        );
+      }
+      pushSimpleToken("operator", start, index);
+      continue;
+    }
+    if (
+      PUNCTUATION_CHARACTERS.has(current.character)
+      || current.character === "."
+      || current.character === ":"
+      || current.character === "$"
+    ) {
+      index += current.width;
+      pushSimpleToken("punctuation", start, index);
+      continue;
+    }
+    index += current.width;
+    pushSimpleToken("punctuation", start, index);
+  }
+
+  return {
+    sql,
+    statements: buildStatements(sql, tokens),
+    tokens,
+  };
+};

--- a/packages/agent-shared/tsconfig.test.json
+++ b/packages/agent-shared/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": [],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a dormant, pure PostgreSQL lexer/token foundation for restricted SQL
- cover PostgreSQL lexical states, identifier normalization, numeric boundaries, diagnostics, and lossless ranges
- register direct lexer tests in the shared package and deployment workflow without changing production policy behavior

## Validation
- agent-shared tests (22/22), lint, and build
- SQL API tests (6/6), lint, and build
- web agent/chat tests (13/13), lint, and production build
- PostgreSQL differential probes
- git diff --check

The lexer is not imported or publicly exported by production code.