### PR TITLE
Add dormant restricted SQL parser kernel

### DIFF
--- a/packages/agent-shared/src/sql-policy-parser-kernel.ts
+++ b/packages/agent-shared/src/sql-policy-parser-kernel.ts
@@ -1,0 +1,504 @@
+import {
+  lexSqlPolicyInfrastructure,
+  type SqlCommentToken,
+  type SqlLexedScript,
+  type SqlNumericToken,
+  type SqlPolicyToken,
+  type SqlSourceRange,
+  type SqlWhitespaceToken,
+} from "./sql-policy-lexer.js";
+import {
+  emptySqlSourceRange,
+  throwSqlPolicyParserError,
+  type SqlPolicyParserErrorCode,
+} from "./sql-policy-parser-model.js";
+
+export type SqlParserToken = Exclude<
+  SqlPolicyToken,
+  SqlCommentToken | SqlWhitespaceToken
+>;
+
+export type SqlParserLimits = Readonly<{
+  maxSourceCodeUnits: number;
+  maxTokens: number;
+  maxNestingDepth: number;
+  maxWorkUnits: number;
+}>;
+
+export const DEFAULT_SQL_PARSER_LIMITS: SqlParserLimits = {
+  maxSourceCodeUnits: 1_000_000,
+  maxTokens: 100_000,
+  maxNestingDepth: 256,
+  maxWorkUnits: 500_000,
+};
+
+export type SqlParserStatementSpan = Readonly<{
+  range: SqlSourceRange;
+  terminatorRange: SqlSourceRange | null;
+  startIndex: number;
+  endIndex: number;
+}>;
+
+export type SqlDelimiterIndex = Readonly<{
+  matchingIndexes: ReadonlyMap<number, number>;
+  scanSteps: number;
+}>;
+
+export type SqlParserKernel = Readonly<{
+  sql: string;
+  sourceTokens: ReadonlyArray<SqlPolicyToken>;
+  tokens: ReadonlyArray<SqlParserToken>;
+  statements: ReadonlyArray<SqlParserStatementSpan>;
+  delimiters: SqlDelimiterIndex;
+  limits: SqlParserLimits;
+}>;
+
+export type SqlTokenCursor = Readonly<{
+  kernel: SqlParserKernel;
+  index: number;
+  endIndex: number;
+  workUnits: number;
+}>;
+
+type OpenDelimiter = Readonly<{
+  index: number;
+  text: "(" | "[";
+}>;
+
+const isPositiveInteger = (value: number): boolean =>
+  Number.isSafeInteger(value) && value > 0;
+
+const validateLimits = (limits: SqlParserLimits): void => {
+  if (!isPositiveInteger(limits.maxSourceCodeUnits)) {
+    return throwSqlPolicyParserError(
+      "invalid_configuration",
+      `SQL parser maxSourceCodeUnits must be a positive safe integer; received ${String(limits.maxSourceCodeUnits)}`,
+      emptySqlSourceRange(0),
+    );
+  }
+  if (!isPositiveInteger(limits.maxTokens)) {
+    return throwSqlPolicyParserError(
+      "invalid_configuration",
+      `SQL parser maxTokens must be a positive safe integer; received ${String(limits.maxTokens)}`,
+      emptySqlSourceRange(0),
+    );
+  }
+  if (!isPositiveInteger(limits.maxNestingDepth)) {
+    return throwSqlPolicyParserError(
+      "invalid_configuration",
+      `SQL parser maxNestingDepth must be a positive safe integer; received ${String(limits.maxNestingDepth)}`,
+      emptySqlSourceRange(0),
+    );
+  }
+  if (!isPositiveInteger(limits.maxWorkUnits)) {
+    return throwSqlPolicyParserError(
+      "invalid_configuration",
+      `SQL parser maxWorkUnits must be a positive safe integer; received ${String(limits.maxWorkUnits)}`,
+      emptySqlSourceRange(0),
+    );
+  }
+};
+
+const significantTokens = (
+  lexed: SqlLexedScript,
+): ReadonlyArray<SqlParserToken> =>
+  lexed.tokens.filter(
+    (token): token is SqlParserToken =>
+      token.kind !== "comment" && token.kind !== "whitespace",
+  );
+
+const errorRangeAtIndex = (
+  sql: string,
+  tokens: ReadonlyArray<SqlParserToken>,
+  index: number,
+): SqlSourceRange =>
+  tokens[index]?.range ?? emptySqlSourceRange(sql.length);
+
+const assertNumericTokensValid = (
+  sql: string,
+  tokens: ReadonlyArray<SqlParserToken>,
+): void => {
+  for (const token of tokens) {
+    if (token.kind !== "numeric" || token.valid) {
+      continue;
+    }
+    const invalid = token as SqlNumericToken & Readonly<{ valid: false }>;
+    return throwSqlPolicyParserError(
+      "invalid_numeric",
+      `Invalid PostgreSQL numeric token at offset ${String(token.range.start)}: ${invalid.diagnostic.message}`,
+      token.range,
+    );
+  }
+  void sql;
+};
+
+const expectedOpenDelimiter = (text: string): "(" | "[" | null => {
+  if (text === ")") {
+    return "(";
+  }
+  if (text === "]") {
+    return "[";
+  }
+  return null;
+};
+
+const expectedCloseDelimiter = (text: "(" | "["): ")" | "]" =>
+  text === "(" ? ")" : "]";
+
+const sqlOpenDelimiterToken = (
+  sql: string,
+  tokens: ReadonlyArray<SqlParserToken>,
+  open: OpenDelimiter,
+): SqlParserToken => {
+  const token = tokens[open.index];
+  if (token === undefined) {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `SQL parser opening delimiter token ${String(open.index)} disappeared during delimiter matching`,
+      errorRangeAtIndex(sql, tokens, open.index),
+    );
+  }
+  return token;
+};
+
+const buildDelimiterIndex = (
+  sql: string,
+  tokens: ReadonlyArray<SqlParserToken>,
+  limits: SqlParserLimits,
+): SqlDelimiterIndex => {
+  const matchingIndexes = new Map<number, number>();
+  const stack: Array<OpenDelimiter> = [];
+  let scanSteps = 0;
+
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index];
+    if (token === undefined) {
+      return throwSqlPolicyParserError(
+        "internal_invariant",
+        `SQL parser token ${String(index)} disappeared during delimiter indexing`,
+        errorRangeAtIndex(sql, tokens, index),
+      );
+    }
+    scanSteps++;
+    if (scanSteps > limits.maxWorkUnits) {
+      return throwSqlPolicyParserError(
+        "limit_complexity",
+        `SQL parser delimiter indexing exceeded maxWorkUnits=${String(limits.maxWorkUnits)} at token ${String(index)}`,
+        token.range,
+      );
+    }
+
+    if (token.text === ";") {
+      const unclosed = stack.at(-1);
+      if (unclosed !== undefined) {
+        const openToken = sqlOpenDelimiterToken(sql, tokens, unclosed);
+        return throwSqlPolicyParserError(
+          "invalid_delimiter",
+          `Expected ${expectedCloseDelimiter(unclosed.text)} before the statement terminator for delimiter at offset ${String(openToken.range.start)}`,
+          openToken.range,
+        );
+      }
+      continue;
+    }
+
+    if (token.text === "(" || token.text === "[") {
+      if (stack.length + 1 > limits.maxNestingDepth) {
+        return throwSqlPolicyParserError(
+          "limit_nesting",
+          `SQL parser nesting exceeds maxNestingDepth=${String(limits.maxNestingDepth)} at offset ${String(token.range.start)}`,
+          token.range,
+        );
+      }
+      stack.push({ index, text: token.text });
+      continue;
+    }
+
+    const expectedOpen = expectedOpenDelimiter(token.text);
+    if (expectedOpen === null) {
+      continue;
+    }
+    const open = stack.pop();
+    if (open === undefined) {
+      return throwSqlPolicyParserError(
+        "invalid_delimiter",
+        `Unexpected ${token.text} at offset ${String(token.range.start)}; expected an opening ${expectedOpen}`,
+        token.range,
+      );
+    }
+    if (open.text !== expectedOpen) {
+      const openToken = sqlOpenDelimiterToken(sql, tokens, open);
+      return throwSqlPolicyParserError(
+        "invalid_delimiter",
+        `Unexpected ${token.text} at offset ${String(token.range.start)}; expected ${expectedCloseDelimiter(open.text)} for opening ${open.text} at offset ${String(openToken.range.start)}`,
+        token.range,
+      );
+    }
+    matchingIndexes.set(open.index, index);
+    matchingIndexes.set(index, open.index);
+  }
+
+  const unclosed = stack.at(-1);
+  if (unclosed !== undefined) {
+    const openToken = sqlOpenDelimiterToken(sql, tokens, unclosed);
+    return throwSqlPolicyParserError(
+      "invalid_delimiter",
+      `Expected ${expectedCloseDelimiter(unclosed.text)} for delimiter at offset ${String(openToken.range.start)}`,
+      openToken.range,
+    );
+  }
+
+  return { matchingIndexes, scanSteps };
+};
+
+const buildStatementSpans = (
+  sql: string,
+  tokens: ReadonlyArray<SqlParserToken>,
+  lexed: SqlLexedScript,
+): ReadonlyArray<SqlParserStatementSpan> => {
+  const tokenSpans: Array<Readonly<{
+    startIndex: number;
+    endIndex: number;
+  }>> = [];
+  let startIndex = 0;
+
+  for (let index = 0; index <= tokens.length; index++) {
+    const token = tokens[index];
+    const atEnd = index === tokens.length;
+    if (!atEnd && token?.text !== ";") {
+      continue;
+    }
+    if (startIndex < index) {
+      const first = tokens[startIndex];
+      const last = tokens[index - 1];
+      if (first === undefined || last === undefined) {
+        return throwSqlPolicyParserError(
+          "internal_invariant",
+          `Cannot build SQL statement token span ${String(startIndex)}..${String(index)}`,
+          errorRangeAtIndex(sql, tokens, startIndex),
+        );
+      }
+      tokenSpans.push({ startIndex, endIndex: index });
+    }
+    startIndex = index + 1;
+  }
+
+  if (tokenSpans.length !== lexed.statements.length) {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `SQL lexer produced ${String(lexed.statements.length)} statements but the parser kernel indexed ${String(tokenSpans.length)}`,
+      emptySqlSourceRange(sql.length),
+    );
+  }
+  return tokenSpans.map((span, index) => {
+    const statement = lexed.statements[index];
+    if (statement === undefined) {
+      return throwSqlPolicyParserError(
+        "internal_invariant",
+        `SQL lexer statement ${String(index)} disappeared during parser indexing`,
+        emptySqlSourceRange(sql.length),
+      );
+    }
+    return {
+      ...span,
+      range: statement.range,
+      terminatorRange: statement.terminatorRange,
+    };
+  });
+};
+
+export const createSqlParserKernel = (
+  sql: string,
+  limits: SqlParserLimits,
+): SqlParserKernel => {
+  validateLimits(limits);
+  if (sql.length > limits.maxSourceCodeUnits) {
+    return throwSqlPolicyParserError(
+      "limit_source_length",
+      `SQL source length ${String(sql.length)} UTF-16 code units exceeds maxSourceCodeUnits=${String(limits.maxSourceCodeUnits)}; the first excess code unit is at offset ${String(limits.maxSourceCodeUnits)}`,
+      {
+        start: limits.maxSourceCodeUnits,
+        end: limits.maxSourceCodeUnits + 1,
+      },
+    );
+  }
+  const lexed = lexSqlPolicyInfrastructure(sql);
+  const tokens = significantTokens(lexed);
+  if (tokens.length > limits.maxTokens) {
+    const token = tokens[limits.maxTokens];
+    return throwSqlPolicyParserError(
+      "limit_tokens",
+      `SQL parser token count ${String(tokens.length)} exceeds maxTokens=${String(limits.maxTokens)}`,
+      token?.range ?? emptySqlSourceRange(sql.length),
+    );
+  }
+  assertNumericTokensValid(sql, tokens);
+  const delimiters = buildDelimiterIndex(sql, tokens, limits);
+  return {
+    sql,
+    delimiters,
+    limits,
+    sourceTokens: lexed.tokens,
+    statements: buildStatementSpans(sql, tokens, lexed),
+    tokens,
+  };
+};
+
+export const createSqlTokenCursor = (
+  kernel: SqlParserKernel,
+  startIndex: number,
+  endIndex: number,
+): SqlTokenCursor => {
+  if (
+    !Number.isSafeInteger(startIndex)
+    || !Number.isSafeInteger(endIndex)
+    || startIndex < 0
+    || startIndex > endIndex
+    || endIndex > kernel.tokens.length
+  ) {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `Invalid SQL token cursor bounds ${String(startIndex)}..${String(endIndex)} for ${String(kernel.tokens.length)} tokens`,
+      errorRangeAtIndex(kernel.sql, kernel.tokens, startIndex),
+    );
+  }
+  return {
+    kernel,
+    index: startIndex,
+    endIndex,
+    workUnits: kernel.delimiters.scanSteps,
+  };
+};
+
+const sqlTokenCursorRange = (
+  cursor: SqlTokenCursor,
+): SqlSourceRange => {
+  const current = cursor.index < cursor.endIndex
+    ? cursor.kernel.tokens[cursor.index]
+    : undefined;
+  return current?.range
+    ?? emptySqlSourceRange(
+      cursor.kernel.tokens[cursor.endIndex - 1]?.range.end
+      ?? cursor.kernel.sql.length,
+    );
+};
+
+export const sqlTokenAt = (
+  cursor: SqlTokenCursor,
+  offset: number,
+): SqlParserToken | undefined => {
+  if (!Number.isSafeInteger(offset) || offset < 0) {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `SQL token offset must be a non-negative safe integer; received ${String(offset)} for cursor ${String(cursor.index)}..${String(cursor.endIndex)}`,
+      sqlTokenCursorRange(cursor),
+    );
+  }
+  const index = cursor.index + offset;
+  if (!Number.isSafeInteger(index)) {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `SQL token index overflow for cursor ${String(cursor.index)} with offset ${String(offset)}`,
+      sqlTokenCursorRange(cursor),
+    );
+  }
+  return index >= cursor.endIndex ? undefined : cursor.kernel.tokens[index];
+};
+
+export const sqlCursorRange = (cursor: SqlTokenCursor): SqlSourceRange =>
+  sqlTokenCursorRange(cursor);
+
+export const advanceSqlTokenCursor = (
+  cursor: SqlTokenCursor,
+  count: number,
+  operation: string,
+): SqlTokenCursor => {
+  if (
+    !Number.isSafeInteger(count)
+    || count < 0
+    || cursor.index + count > cursor.endIndex
+  ) {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `Cannot advance SQL token cursor by ${String(count)} during ${operation} from ${String(cursor.index)} with end ${String(cursor.endIndex)}`,
+      sqlCursorRange(cursor),
+    );
+  }
+  const remainingWorkUnits =
+    cursor.kernel.limits.maxWorkUnits - cursor.workUnits;
+  if (remainingWorkUnits < 0) {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `SQL token cursor already exceeds maxWorkUnits=${String(cursor.kernel.limits.maxWorkUnits)} before ${operation}`,
+      sqlCursorRange(cursor),
+    );
+  }
+  if (count > remainingWorkUnits) {
+    const firstExcessIndex = cursor.index + remainingWorkUnits;
+    return throwSqlPolicyParserError(
+      "limit_complexity",
+      `SQL parser ${operation} exceeded maxWorkUnits=${String(cursor.kernel.limits.maxWorkUnits)} at token ${String(firstExcessIndex)}`,
+      errorRangeAtIndex(
+        cursor.kernel.sql,
+        cursor.kernel.tokens,
+        firstExcessIndex,
+      ),
+    );
+  }
+  return {
+    ...cursor,
+    index: cursor.index + count,
+    workUnits: cursor.workUnits + count,
+  };
+};
+
+export const matchingSqlDelimiterIndexAtCursor = (
+  cursor: SqlTokenCursor,
+): number => {
+  const token = sqlTokenAt(cursor, 0);
+  const match = cursor.kernel.delimiters.matchingIndexes.get(cursor.index);
+  if (
+    token === undefined
+    || (token.text !== "(" && token.text !== "[")
+    || match === undefined
+  ) {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `Token ${String(cursor.index)} is not an indexed opening SQL delimiter`,
+      sqlCursorRange(cursor),
+    );
+  }
+  return match;
+};
+
+export const matchingSqlDelimiterIndexWithinCursor = (
+  cursor: SqlTokenCursor,
+  boundaryErrorCode: SqlPolicyParserErrorCode,
+  subject: string,
+): number => {
+  const match = matchingSqlDelimiterIndexAtCursor(cursor);
+  if (match >= cursor.endIndex) {
+    return throwSqlPolicyParserError(
+      boundaryErrorCode,
+      `${subject} closes outside the current parse range`,
+      sqlCursorRange(cursor),
+    );
+  }
+  return match;
+};
+
+export const sqlRangeFromTokenIndexes = (
+  kernel: SqlParserKernel,
+  startIndex: number,
+  endIndex: number,
+): SqlSourceRange => {
+  const first = kernel.tokens[startIndex];
+  const last = kernel.tokens[endIndex - 1];
+  if (first === undefined || last === undefined || startIndex >= endIndex) {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `Cannot create SQL source range from empty token span ${String(startIndex)}..${String(endIndex)}`,
+      errorRangeAtIndex(kernel.sql, kernel.tokens, startIndex),
+    );
+  }
+  return { start: first.range.start, end: last.range.end };
+};

--- a/packages/agent-shared/src/sql-policy-parser-keywords.ts
+++ b/packages/agent-shared/src/sql-policy-parser-keywords.ts
@@ -1,0 +1,230 @@
+import type { SqlIdentifierToken } from "./sql-policy-lexer.js";
+import type { SqlParserToken } from "./sql-policy-parser-kernel.js";
+import type { SqlIntervalField } from "./sql-policy-type-model.js";
+
+const RESERVED_KEYWORDS: ReadonlySet<string> = new Set([
+  "all",
+  "analyse",
+  "analyze",
+  "and",
+  "any",
+  "array",
+  "as",
+  "asc",
+  "asymmetric",
+  "both",
+  "case",
+  "cast",
+  "check",
+  "collate",
+  "column",
+  "constraint",
+  "create",
+  "current_catalog",
+  "current_date",
+  "current_role",
+  "current_time",
+  "current_timestamp",
+  "current_user",
+  "default",
+  "deferrable",
+  "desc",
+  "distinct",
+  "do",
+  "else",
+  "end",
+  "except",
+  "false",
+  "fetch",
+  "for",
+  "foreign",
+  "from",
+  "grant",
+  "group",
+  "having",
+  "in",
+  "initially",
+  "intersect",
+  "into",
+  "lateral",
+  "leading",
+  "limit",
+  "localtime",
+  "localtimestamp",
+  "not",
+  "null",
+  "offset",
+  "on",
+  "only",
+  "or",
+  "order",
+  "placing",
+  "primary",
+  "references",
+  "returning",
+  "select",
+  "session_user",
+  "some",
+  "symmetric",
+  "system_user",
+  "table",
+  "then",
+  "to",
+  "trailing",
+  "true",
+  "union",
+  "unique",
+  "user",
+  "using",
+  "variadic",
+  "when",
+  "where",
+  "window",
+  "with",
+]);
+
+const COL_NAME_KEYWORDS: ReadonlySet<string> = new Set([
+  "between",
+  "bigint",
+  "bit",
+  "boolean",
+  "char",
+  "character",
+  "coalesce",
+  "dec",
+  "decimal",
+  "exists",
+  "extract",
+  "float",
+  "greatest",
+  "grouping",
+  "inout",
+  "int",
+  "integer",
+  "interval",
+  "json",
+  "json_array",
+  "json_arrayagg",
+  "json_exists",
+  "json_object",
+  "json_objectagg",
+  "json_query",
+  "json_scalar",
+  "json_serialize",
+  "json_table",
+  "json_value",
+  "least",
+  "merge_action",
+  "national",
+  "nchar",
+  "none",
+  "normalize",
+  "nullif",
+  "numeric",
+  "out",
+  "overlay",
+  "position",
+  "precision",
+  "real",
+  "row",
+  "setof",
+  "smallint",
+  "substring",
+  "time",
+  "timestamp",
+  "treat",
+  "trim",
+  "values",
+  "varchar",
+  "xmlattributes",
+  "xmlconcat",
+  "xmlelement",
+  "xmlexists",
+  "xmlforest",
+  "xmlnamespaces",
+  "xmlparse",
+  "xmlpi",
+  "xmlroot",
+  "xmlserialize",
+  "xmltable",
+]);
+
+const TYPE_FUNC_NAME_KEYWORDS: ReadonlySet<string> = new Set([
+  "authorization",
+  "binary",
+  "collation",
+  "concurrently",
+  "cross",
+  "current_schema",
+  "freeze",
+  "full",
+  "ilike",
+  "inner",
+  "is",
+  "isnull",
+  "join",
+  "left",
+  "like",
+  "natural",
+  "notnull",
+  "outer",
+  "overlaps",
+  "right",
+  "similar",
+  "tablesample",
+  "verbose",
+]);
+
+const TYPE_FUNCTION_DISALLOWED_KEYWORDS: ReadonlySet<string> = new Set([
+  ...RESERVED_KEYWORDS,
+  ...COL_NAME_KEYWORDS,
+]);
+
+export const POSTGRESQL_INTERVAL_FIELDS: ReadonlySet<string> = new Set([
+  "day",
+  "hour",
+  "minute",
+  "month",
+  "second",
+  "year",
+]);
+
+export const POSTGRESQL_INTERVAL_FIELD_PAIRS: ReadonlySet<string> = new Set([
+  "day:hour",
+  "day:minute",
+  "day:second",
+  "hour:minute",
+  "hour:second",
+  "minute:second",
+  "year:month",
+]);
+
+export const postgreSqlTokenWord = (
+  token: SqlParserToken | undefined,
+): string | null =>
+  token?.kind === "identifier" && !token.quoted
+    ? token.untruncatedNormalized
+    : null;
+
+export const isPostgreSqlColId = (
+  token: SqlIdentifierToken,
+): boolean =>
+  token.quoted
+  || (
+    !RESERVED_KEYWORDS.has(token.untruncatedNormalized)
+    && !TYPE_FUNC_NAME_KEYWORDS.has(token.untruncatedNormalized)
+  );
+
+export const isPostgreSqlTypeModifierIdentifier = (
+  token: SqlIdentifierToken,
+): boolean => isPostgreSqlColId(token);
+
+export const isPostgreSqlTypeFunctionName = (
+  token: SqlIdentifierToken,
+): boolean =>
+  token.quoted
+  || !TYPE_FUNCTION_DISALLOWED_KEYWORDS.has(token.untruncatedNormalized);
+
+export const isPostgreSqlIntervalField = (
+  value: string,
+): value is SqlIntervalField => POSTGRESQL_INTERVAL_FIELDS.has(value);

--- a/packages/agent-shared/src/sql-policy-parser-model.ts
+++ b/packages/agent-shared/src/sql-policy-parser-model.ts
@@ -1,0 +1,43 @@
+import type { SqlSourceRange } from "./sql-policy-lexer.js";
+
+export type SqlPolicyParserErrorCode =
+  | "internal_invariant"
+  | "invalid_configuration"
+  | "invalid_delimiter"
+  | "invalid_numeric"
+  | "invalid_type_modifier"
+  | "invalid_type_name"
+  | "invalid_typed_constant"
+  | "limit_complexity"
+  | "limit_nesting"
+  | "limit_source_length"
+  | "limit_tokens"
+  | "unexpected_token";
+
+export class SqlPolicyParserError extends Error {
+  readonly code: SqlPolicyParserErrorCode;
+  readonly range: SqlSourceRange;
+
+  constructor(
+    code: SqlPolicyParserErrorCode,
+    message: string,
+    range: SqlSourceRange,
+  ) {
+    super(message);
+    this.code = code;
+    this.range = range;
+  }
+}
+
+export const throwSqlPolicyParserError = (
+  code: SqlPolicyParserErrorCode,
+  message: string,
+  range: SqlSourceRange,
+): never => {
+  throw new SqlPolicyParserError(code, message, range);
+};
+
+export const emptySqlSourceRange = (offset: number): SqlSourceRange => ({
+  start: offset,
+  end: offset,
+});

--- a/packages/agent-shared/src/sql-policy-type-model.ts
+++ b/packages/agent-shared/src/sql-policy-type-model.ts
@@ -1,0 +1,84 @@
+import type {
+  SqlIdentifierToken,
+  SqlSourceRange,
+  SqlStringToken,
+} from "./sql-policy-lexer.js";
+import type { SqlTokenCursor } from "./sql-policy-parser-kernel.js";
+
+export type SqlTypeModifierNode = Readonly<{
+  kind: "identifier" | "numeric" | "string";
+  normalizedValue: string;
+  range: SqlSourceRange;
+  sql: string;
+  valueRange: SqlSourceRange;
+}>;
+
+export type SqlArrayBoundNode = Readonly<{
+  notation: "array" | "brackets";
+  range: SqlSourceRange;
+  size: string | null;
+}>;
+
+export type SqlIntervalField =
+  | "day"
+  | "hour"
+  | "minute"
+  | "month"
+  | "second"
+  | "year";
+
+export type SqlIntervalQualifierNode = Readonly<{
+  endField: SqlIntervalField;
+  range: SqlSourceRange;
+  secondPrecision: string | null;
+  sql: string;
+  startField: SqlIntervalField;
+}>;
+
+export type SqlTimeZoneNode = Readonly<{
+  kind: "with" | "without";
+  range: SqlSourceRange;
+}>;
+
+export type SqlTypeNameForm =
+  | "bigint"
+  | "bit"
+  | "boolean"
+  | "character"
+  | "decimal"
+  | "double_precision"
+  | "float"
+  | "generic"
+  | "integer"
+  | "interval"
+  | "json"
+  | "real"
+  | "smallint"
+  | "time"
+  | "timestamp";
+
+export type SqlTypeNameNode = Readonly<{
+  arrayBounds: ReadonlyArray<SqlArrayBoundNode>;
+  form: SqlTypeNameForm;
+  intervalQualifier: SqlIntervalQualifierNode | null;
+  modifiers: ReadonlyArray<SqlTypeModifierNode>;
+  nameParts: ReadonlyArray<SqlIdentifierToken>;
+  nameRange: SqlSourceRange;
+  range: SqlSourceRange;
+  setOf: boolean;
+  sql: string;
+  timeZone: SqlTimeZoneNode | null;
+}>;
+
+export type SqlTypedConstantNode = Readonly<{
+  intervalQualifier: SqlIntervalQualifierNode | null;
+  range: SqlSourceRange;
+  sql: string;
+  typeName: SqlTypeNameNode;
+  value: SqlStringToken;
+}>;
+
+export type SqlTypeParseResult<Node> = Readonly<{
+  cursor: SqlTokenCursor;
+  node: Node;
+}>;

--- a/packages/agent-shared/src/sql-policy-type-modifiers.ts
+++ b/packages/agent-shared/src/sql-policy-type-modifiers.ts
@@ -1,0 +1,518 @@
+import type {
+  SqlStringToken,
+  SqlValidNumericToken,
+} from "./sql-policy-lexer.js";
+import {
+  POSTGRESQL_INTERVAL_FIELD_PAIRS,
+  POSTGRESQL_INTERVAL_FIELDS,
+  isPostgreSqlTypeModifierIdentifier,
+  postgreSqlTokenWord,
+} from "./sql-policy-parser-keywords.js";
+import {
+  advanceSqlTokenCursor,
+  matchingSqlDelimiterIndexWithinCursor,
+  sqlCursorRange,
+  sqlRangeFromTokenIndexes,
+  sqlTokenAt,
+  type SqlParserToken,
+  type SqlTokenCursor,
+} from "./sql-policy-parser-kernel.js";
+import { throwSqlPolicyParserError } from "./sql-policy-parser-model.js";
+import type {
+  SqlIntervalField,
+  SqlIntervalQualifierNode,
+  SqlTypeModifierNode,
+  SqlTypeParseResult,
+} from "./sql-policy-type-model.js";
+
+export type ParsedIntegerModifier = Readonly<{
+  cursor: SqlTokenCursor;
+  modifier: SqlTypeModifierNode;
+  value: bigint;
+}>;
+
+export type ParsedModifierList = Readonly<{
+  cursor: SqlTokenCursor;
+  modifiers: ReadonlyArray<SqlTypeModifierNode>;
+}>;
+
+const isText = (
+  cursor: SqlTokenCursor,
+  offset: number,
+  expected: string,
+): boolean => sqlTokenAt(cursor, offset)?.text === expected;
+
+const isWord = (
+  cursor: SqlTokenCursor,
+  offset: number,
+  expected: string,
+): boolean => postgreSqlTokenWord(sqlTokenAt(cursor, offset)) === expected;
+
+export const isPostgreSqlStringConstant = (
+  token: SqlParserToken | undefined,
+): token is SqlStringToken =>
+  token?.kind === "string"
+  && token.style !== "bit"
+  && token.style !== "hex";
+
+type PostgreSqlNumericConstant =
+  | Readonly<{
+    semanticValue: string;
+    tokenKind: "fconst";
+  }>
+  | Readonly<{
+    semanticValue: string;
+    tokenKind: "iconst";
+    value: bigint;
+  }>;
+
+export type PostgreSqlIntegerConstant = Readonly<{
+  semanticValue: string;
+  value: bigint;
+}>;
+
+const hasPostgreSqlIntegerTokenSyntax = (
+  token: SqlValidNumericToken,
+): boolean =>
+  token.form !== "decimal"
+  || (
+    !token.text.includes(".")
+    && !token.text.includes("e")
+    && !token.text.includes("E")
+  );
+
+const parsePostgreSqlIntegerTokenValue = (
+  token: SqlValidNumericToken,
+): bigint | null => {
+  const base = token.form === "binary"
+    ? 2
+    : token.form === "octal"
+      ? 8
+      : token.form === "hexadecimal"
+        ? 16
+        : 10;
+  const digits = token.form === "decimal"
+    ? token.normalized
+    : token.normalized.slice(2);
+  let value = 0n;
+  for (const digit of digits) {
+    const digitValue = "0123456789abcdef".indexOf(digit);
+    if (digitValue < 0 || digitValue >= base) {
+      return throwSqlPolicyParserError(
+        "internal_invariant",
+        `Valid PostgreSQL ${token.form} integer token ${token.text} contains digit ${digit}`,
+        token.range,
+      );
+    }
+    value = (value * BigInt(base)) + BigInt(digitValue);
+    if (value > 2_147_483_647n) {
+      return null;
+    }
+  }
+  return value;
+};
+
+const classifyPostgreSqlNumericConstant = (
+  token: SqlParserToken | undefined,
+): PostgreSqlNumericConstant | null => {
+  if (token?.kind !== "numeric" || !token.valid) {
+    return null;
+  }
+  if (!hasPostgreSqlIntegerTokenSyntax(token)) {
+    return {
+      semanticValue: token.text,
+      tokenKind: "fconst",
+    };
+  }
+  const value = parsePostgreSqlIntegerTokenValue(token);
+  if (value === null) {
+    return {
+      semanticValue: token.text,
+      tokenKind: "fconst",
+    };
+  }
+  return {
+    semanticValue: value.toString(10),
+    tokenKind: "iconst",
+    value,
+  };
+};
+
+export const postgreSqlIntegerConstant = (
+  token: SqlParserToken | undefined,
+): PostgreSqlIntegerConstant | null => {
+  const constant = classifyPostgreSqlNumericConstant(token);
+  return constant?.tokenKind === "iconst"
+    ? {
+      semanticValue: constant.semanticValue,
+      value: constant.value,
+    }
+    : null;
+};
+
+const makeModifier = (
+  cursor: SqlTokenCursor,
+  startIndex: number,
+  endIndex: number,
+  kind: SqlTypeModifierNode["kind"],
+  valueToken: SqlParserToken,
+  negative: boolean,
+): SqlTypeModifierNode => {
+  const range = sqlRangeFromTokenIndexes(
+    cursor.kernel,
+    startIndex,
+    endIndex,
+  );
+  let normalizedValue: string;
+  if (valueToken.kind === "numeric" && valueToken.valid) {
+    const constant = classifyPostgreSqlNumericConstant(valueToken);
+    if (constant === null) {
+      return throwSqlPolicyParserError(
+        "internal_invariant",
+        `Cannot classify valid PostgreSQL numeric type modifier token ${valueToken.text}`,
+        valueToken.range,
+      );
+    }
+    if (!negative) {
+      normalizedValue = constant.semanticValue;
+    } else if (constant.tokenKind === "iconst") {
+      normalizedValue = (-constant.value).toString(10);
+    } else {
+      normalizedValue = `-${constant.semanticValue}`;
+    }
+  } else if (isPostgreSqlStringConstant(valueToken)) {
+    normalizedValue = valueToken.semanticValue;
+  } else if (valueToken.kind === "identifier") {
+    normalizedValue = valueToken.normalized;
+  } else {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `Cannot normalize PostgreSQL ${kind} type modifier token ${valueToken.text}`,
+      valueToken.range,
+    );
+  }
+  return {
+    kind,
+    normalizedValue,
+    range,
+    sql: cursor.kernel.sql.slice(range.start, range.end),
+    valueRange: valueToken.range,
+  };
+};
+
+export const parsePostgreSqlIntegerModifier = (
+  cursor: SqlTokenCursor,
+  purpose: string,
+): ParsedIntegerModifier => {
+  if (!isText(cursor, 0, "(")) {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      `Expected ( before ${purpose}`,
+      sqlCursorRange(cursor),
+    );
+  }
+  const closeIndex = matchingSqlDelimiterIndexWithinCursor(
+    cursor,
+    "invalid_type_modifier",
+    purpose,
+  );
+  if (closeIndex !== cursor.index + 2) {
+    return throwSqlPolicyParserError(
+      "invalid_type_modifier",
+      `${purpose} requires exactly one PostgreSQL integer constant`,
+      sqlCursorRange(cursor),
+    );
+  }
+  const valueToken = sqlTokenAt(cursor, 1);
+  const integerConstant = postgreSqlIntegerConstant(valueToken);
+  if (valueToken === undefined || integerConstant === null) {
+    return throwSqlPolicyParserError(
+      "invalid_type_modifier",
+      `${purpose} requires an integer constant between 0 and 2147483647`,
+      valueToken?.range ?? sqlCursorRange(cursor),
+    );
+  }
+  const startIndex = cursor.index + 1;
+  const next = advanceSqlTokenCursor(cursor, 3, purpose);
+  return {
+    cursor: next,
+    modifier: makeModifier(
+      cursor,
+      startIndex,
+      startIndex + 1,
+      "numeric",
+      valueToken,
+      false,
+    ),
+    value: integerConstant.value,
+  };
+};
+
+const parseSimpleTypeModifier = (
+  cursor: SqlTokenCursor,
+  closeIndex: number,
+): Readonly<{
+  cursor: SqlTokenCursor;
+  modifier: SqlTypeModifierNode;
+}> => {
+  const startIndex = cursor.index;
+  let current = cursor;
+  let negative = false;
+  let unaryOperatorCount = 0;
+  const wrapperCloseIndexes: Array<number> = [];
+
+  while (current.index < closeIndex) {
+    const token = sqlTokenAt(current, 0);
+    if (token?.text === "+") {
+      return throwSqlPolicyParserError(
+        "invalid_type_modifier",
+        "PostgreSQL unary plus type modifiers do not resolve to a simple constant",
+        token.range,
+      );
+    }
+    if (token?.text === "-") {
+      unaryOperatorCount++;
+      negative = !negative;
+      current = advanceSqlTokenCursor(
+        current,
+        1,
+        "PostgreSQL unary type modifier operator",
+      );
+      continue;
+    }
+    if (token?.text === "(") {
+      const wrapperCloseIndex = matchingSqlDelimiterIndexWithinCursor(
+        current,
+        "invalid_type_modifier",
+        "Parenthesized PostgreSQL type modifier",
+      );
+      if (wrapperCloseIndex >= closeIndex) {
+        return throwSqlPolicyParserError(
+          "invalid_type_modifier",
+          "Parenthesized PostgreSQL type modifier closes outside its modifier item",
+          token.range,
+        );
+      }
+      wrapperCloseIndexes.push(wrapperCloseIndex);
+      current = advanceSqlTokenCursor(
+        current,
+        1,
+        "PostgreSQL parenthesized type modifier",
+      );
+      continue;
+    }
+    break;
+  }
+
+  const valueToken = sqlTokenAt(current, 0);
+  if (valueToken === undefined || current.index >= closeIndex) {
+    return throwSqlPolicyParserError(
+      "invalid_type_modifier",
+      "PostgreSQL type modifier lists cannot contain an empty item",
+      sqlCursorRange(current),
+    );
+  }
+
+  let kind: SqlTypeModifierNode["kind"];
+  if (valueToken.kind === "numeric" && valueToken.valid) {
+    kind = "numeric";
+  } else if (
+    unaryOperatorCount === 0
+    && isPostgreSqlStringConstant(valueToken)
+  ) {
+    kind = "string";
+  } else if (
+    unaryOperatorCount === 0
+    && valueToken.kind === "identifier"
+    && isPostgreSqlTypeModifierIdentifier(valueToken)
+  ) {
+    kind = "identifier";
+  } else {
+    return throwSqlPolicyParserError(
+      "invalid_type_modifier",
+      unaryOperatorCount > 0
+        ? "PostgreSQL unary type modifier operators may only wrap a numeric constant"
+        : `PostgreSQL type modifiers must resolve to a simple numeric constant, string constant, or identifier; found ${valueToken.text}`,
+      valueToken.range,
+    );
+  }
+
+  current = advanceSqlTokenCursor(
+    current,
+    1,
+    `PostgreSQL ${kind} type modifier value`,
+  );
+  for (
+    let wrapperIndex = wrapperCloseIndexes.length - 1;
+    wrapperIndex >= 0;
+    wrapperIndex--
+  ) {
+    const expectedCloseIndex = wrapperCloseIndexes[wrapperIndex];
+    const token = sqlTokenAt(current, 0);
+    if (expectedCloseIndex === undefined || current.index !== expectedCloseIndex) {
+      return throwSqlPolicyParserError(
+        "invalid_type_modifier",
+        `Parenthesized PostgreSQL type modifier contains unsupported expression token ${token?.text ?? "at end of input"}`,
+        token?.range ?? sqlCursorRange(current),
+      );
+    }
+    current = advanceSqlTokenCursor(
+      current,
+      1,
+      "PostgreSQL parenthesized type modifier closing delimiter",
+    );
+  }
+
+  return {
+    cursor: current,
+    modifier: makeModifier(
+      cursor,
+      startIndex,
+      current.index,
+      kind,
+      valueToken,
+      negative,
+    ),
+  };
+};
+
+export const parsePostgreSqlTypeModifierList = (
+  cursor: SqlTokenCursor,
+): ParsedModifierList => {
+  const open = sqlTokenAt(cursor, 0);
+  if (open?.text !== "(") {
+    return throwSqlPolicyParserError(
+      "internal_invariant",
+      "Expected an opening parenthesis for a PostgreSQL type modifier list",
+      sqlCursorRange(cursor),
+    );
+  }
+  const closeIndex = matchingSqlDelimiterIndexWithinCursor(
+    cursor,
+    "invalid_type_modifier",
+    "PostgreSQL type modifier list",
+  );
+
+  let current = advanceSqlTokenCursor(
+    cursor,
+    1,
+    "PostgreSQL type modifier list",
+  );
+  if (current.index === closeIndex) {
+    return throwSqlPolicyParserError(
+      "invalid_type_modifier",
+      "PostgreSQL type modifier lists require at least one item",
+      open.range,
+    );
+  }
+
+  const modifiers: Array<SqlTypeModifierNode> = [];
+  while (current.index < closeIndex) {
+    const parsed = parseSimpleTypeModifier(current, closeIndex);
+    modifiers.push(parsed.modifier);
+    current = parsed.cursor;
+    if (current.index === closeIndex) {
+      break;
+    }
+    const separator = sqlTokenAt(current, 0);
+    if (separator?.text !== ",") {
+      return throwSqlPolicyParserError(
+        "invalid_type_modifier",
+        `Expected , or ) after PostgreSQL type modifier; found ${separator?.text ?? "end of input"}`,
+        separator?.range ?? sqlCursorRange(current),
+      );
+    }
+    current = advanceSqlTokenCursor(
+      current,
+      1,
+      "PostgreSQL type modifier separator",
+    );
+    if (current.index === closeIndex) {
+      return throwSqlPolicyParserError(
+        "invalid_type_modifier",
+        "PostgreSQL type modifier lists cannot end with a comma",
+        separator.range,
+      );
+    }
+  }
+  return {
+    cursor: advanceSqlTokenCursor(
+      current,
+      1,
+      "PostgreSQL type modifier list closing parenthesis",
+    ),
+    modifiers,
+  };
+};
+
+export const parsePostgreSqlIntervalQualifier = (
+  cursor: SqlTokenCursor,
+): SqlTypeParseResult<SqlIntervalQualifierNode> | null => {
+  const firstWord = postgreSqlTokenWord(sqlTokenAt(cursor, 0));
+  if (
+    firstWord === null
+    || !POSTGRESQL_INTERVAL_FIELDS.has(firstWord)
+  ) {
+    return null;
+  }
+  const startIndex = cursor.index;
+  let current = advanceSqlTokenCursor(
+    cursor,
+    1,
+    "PostgreSQL interval qualifier",
+  );
+  let endField = firstWord as SqlIntervalField;
+
+  if (isWord(current, 0, "to")) {
+    const secondWord = postgreSqlTokenWord(sqlTokenAt(current, 1));
+    if (
+      secondWord === null
+      || !POSTGRESQL_INTERVAL_FIELD_PAIRS.has(`${firstWord}:${secondWord}`)
+    ) {
+      return throwSqlPolicyParserError(
+        "invalid_type_modifier",
+        `PostgreSQL does not allow INTERVAL ${firstWord.toUpperCase()} TO ${(secondWord ?? sqlTokenAt(current, 1)?.text ?? "end of input").toUpperCase()}`,
+        sqlTokenAt(current, 1)?.range ?? sqlCursorRange(current),
+      );
+    }
+    endField = secondWord as SqlIntervalField;
+    current = advanceSqlTokenCursor(
+      current,
+      2,
+      "PostgreSQL interval field range",
+    );
+  }
+
+  let secondPrecision: string | null = null;
+  if (isText(current, 0, "(")) {
+    if (endField !== "second") {
+      return throwSqlPolicyParserError(
+        "invalid_type_modifier",
+        "Only the SECOND field may have precision in a PostgreSQL interval qualifier",
+        sqlCursorRange(current),
+      );
+    }
+    const precision = parsePostgreSqlIntegerModifier(
+      current,
+      "PostgreSQL interval SECOND precision",
+    );
+    secondPrecision = precision.modifier.normalizedValue;
+    current = precision.cursor;
+  }
+
+  const range = sqlRangeFromTokenIndexes(
+    cursor.kernel,
+    startIndex,
+    current.index,
+  );
+  return {
+    cursor: current,
+    node: {
+      endField,
+      range,
+      secondPrecision,
+      sql: cursor.kernel.sql.slice(range.start, range.end),
+      startField: firstWord as SqlIntervalField,
+    },
+  };
+};

--- a/packages/agent-shared/src/sql-policy-type-parser.test.ts
+++ b/packages/agent-shared/src/sql-policy-type-parser.test.ts
@@ -1,0 +1,1674 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createSqlParserKernel,
+  createSqlTokenCursor,
+  DEFAULT_SQL_PARSER_LIMITS,
+  sqlTokenAt,
+  type SqlParserLimits,
+} from "./sql-policy-parser-kernel.js";
+import {
+  SqlPolicyParserError,
+  type SqlPolicyParserErrorCode,
+} from "./sql-policy-parser-model.js";
+import {
+  parsePostgreSqlTypedConstantAtCursor,
+  parsePostgreSqlTypedConstantInfrastructure,
+  parsePostgreSqlTypeNameAtCursor,
+  parsePostgreSqlTypeNameInfrastructure,
+} from "./sql-policy-type-parser.js";
+
+const limits = (
+  maxSourceCodeUnits: number,
+  maxTokens: number,
+  maxNestingDepth: number,
+  maxWorkUnits: number,
+): SqlParserLimits => ({
+  maxNestingDepth,
+  maxSourceCodeUnits,
+  maxTokens,
+  maxWorkUnits,
+});
+
+const expectParserError = (
+  action: () => unknown,
+  code: SqlPolicyParserErrorCode,
+  range: Readonly<{ start: number; end: number }> | null,
+): SqlPolicyParserError => {
+  let caught: unknown;
+  try {
+    action();
+  } catch (error: unknown) {
+    caught = error;
+  }
+  assert.ok(caught instanceof SqlPolicyParserError);
+  assert.equal(caught.code, code);
+  if (range !== null) {
+    assert.deepEqual(caught.range, range);
+  }
+  return caught;
+};
+
+test("kernel builds one lossless linear delimiter index", (): void => {
+  const sql = "numeric /* gap */ (10, (2))[]; interval day to second(3)";
+  const kernel = createSqlParserKernel(sql, DEFAULT_SQL_PARSER_LIMITS);
+
+  assert.equal(kernel.delimiters.scanSteps, kernel.tokens.length);
+  assert.equal(kernel.statements.length, 2);
+  assert.equal(kernel.statements[0]?.terminatorRange?.start, 29);
+  assert.equal(
+    kernel.sourceTokens.map((token) => token.text).join(""),
+    sql,
+  );
+  for (const token of kernel.tokens) {
+    assert.equal(sql.slice(token.range.start, token.range.end), token.text);
+  }
+
+  const openingIndexes = kernel.tokens
+    .map((token, index) => ({ index, text: token.text }))
+    .filter(({ text }) => text === "(" || text === "[")
+    .map(({ index }) => index);
+  assert.equal(kernel.delimiters.matchingIndexes.size, openingIndexes.length * 2);
+  for (const openingIndex of openingIndexes) {
+    const closingIndex = kernel.delimiters.matchingIndexes.get(openingIndex);
+    assert.notEqual(closingIndex, undefined);
+    assert.equal(
+      kernel.delimiters.matchingIndexes.get(closingIndex as number),
+      openingIndex,
+    );
+  }
+});
+
+test("kernel reports exact delimiter and numeric errors", (): void => {
+  const mismatchCases: ReadonlyArray<Readonly<{
+    message: string;
+    range: Readonly<{ start: number; end: number }>;
+    sql: string;
+  }>> = [
+    {
+      message: "Unexpected ) at offset 1; expected ] for opening [ at offset 0",
+      range: { start: 1, end: 2 },
+      sql: "[)",
+    },
+    {
+      message: "Unexpected ] at offset 1; expected ) for opening ( at offset 0",
+      range: { start: 1, end: 2 },
+      sql: "(]",
+    },
+    {
+      message: "Unexpected ) at offset 2; expected ] for opening [ at offset 1",
+      range: { start: 2, end: 3 },
+      sql: "([)]",
+    },
+  ];
+  for (const mismatch of mismatchCases) {
+    const error = expectParserError(
+      () => createSqlParserKernel(
+        mismatch.sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "invalid_delimiter",
+      mismatch.range,
+    );
+    assert.equal(error.message, mismatch.message);
+  }
+
+  const missingOpenCases: ReadonlyArray<Readonly<{
+    message: string;
+    sql: string;
+  }>> = [
+    {
+      message: "Unexpected ) at offset 0; expected an opening (",
+      sql: ")",
+    },
+    {
+      message: "Unexpected ] at offset 0; expected an opening [",
+      sql: "]",
+    },
+  ];
+  for (const missingOpen of missingOpenCases) {
+    const error = expectParserError(
+      () => createSqlParserKernel(
+        missingOpen.sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "invalid_delimiter",
+      { start: 0, end: 1 },
+    );
+    assert.equal(error.message, missingOpen.message);
+  }
+
+  const missing = expectParserError(
+    () => createSqlParserKernel("(integer", DEFAULT_SQL_PARSER_LIMITS),
+    "invalid_delimiter",
+    { start: 0, end: 1 },
+  );
+  assert.match(missing.message, /Expected \)/u);
+
+  const missingBracket = expectParserError(
+    () => createSqlParserKernel("[integer", DEFAULT_SQL_PARSER_LIMITS),
+    "invalid_delimiter",
+    { start: 0, end: 1 },
+  );
+  assert.match(missingBracket.message, /Expected \]/u);
+
+  const beforeTerminator = expectParserError(
+    () => createSqlParserKernel("(integer;", DEFAULT_SQL_PARSER_LIMITS),
+    "invalid_delimiter",
+    { start: 0, end: 1 },
+  );
+  assert.match(beforeTerminator.message, /before the statement terminator/u);
+
+  expectParserError(
+    () => createSqlParserKernel("1e+", DEFAULT_SQL_PARSER_LIMITS),
+    "invalid_numeric",
+    { start: 0, end: 3 },
+  );
+});
+
+test("kernel enforces token, nesting, and complexity budgets", (): void => {
+  const tokenError = expectParserError(
+    () => createSqlParserKernel("a b c", limits(100, 2, 8, 20)),
+    "limit_tokens",
+    { start: 4, end: 5 },
+  );
+  assert.match(tokenError.message, /maxTokens=2/u);
+
+  const nested = `${"(".repeat(300)}x${")".repeat(300)}`;
+  const nestingError = expectParserError(
+    () => createSqlParserKernel(
+      nested,
+      limits(nested.length, 1_000, 64, 5_000),
+    ),
+    "limit_nesting",
+    { start: 64, end: 65 },
+  );
+  assert.match(nestingError.message, /maxNestingDepth=64/u);
+  assert.notEqual(nestingError.name, "RangeError");
+
+  const complexityError = expectParserError(
+    () => createSqlParserKernel("a b c d", limits(100, 10, 8, 3)),
+    "limit_complexity",
+    { start: 6, end: 7 },
+  );
+  assert.match(complexityError.message, /maxWorkUnits=3/u);
+
+  expectParserError(
+    () => createSqlParserKernel("integer", limits(100, 0, 8, 20)),
+    "invalid_configuration",
+    { start: 0, end: 0 },
+  );
+  expectParserError(
+    () => createSqlParserKernel("integer", limits(0, 10, 8, 20)),
+    "invalid_configuration",
+    { start: 0, end: 0 },
+  );
+});
+
+test("kernel source preflight bounds every UTF-16 source form before lexing", (): void => {
+  const boundary = 64;
+  const repeatedBlockComments = "/*x*/".repeat(10);
+  const repeatedLineComments = "--x\n".repeat(10);
+  const sourceAtLength = (
+    prefix: string,
+    length: number,
+    suffix: string,
+  ): string => {
+    const paddingLength = length - prefix.length - suffix.length;
+    assert.ok(paddingLength >= 0);
+    return `${prefix}${" ".repeat(paddingLength)}${suffix}`;
+  };
+  const statementSource = (length: number): string =>
+    `${"x;".repeat(Math.floor(length / 2))}${length % 2 === 0 ? "" : "x"}`;
+  const cases: ReadonlyArray<Readonly<{
+    at: string;
+    below: string;
+    label: string;
+    over: string;
+  }>> = [
+    {
+      at: " ".repeat(boundary),
+      below: " ".repeat(boundary - 1),
+      label: "whitespace",
+      over: " ".repeat(boundary + 1),
+    },
+    {
+      at: sourceAtLength(repeatedBlockComments, boundary, ""),
+      below: sourceAtLength(repeatedBlockComments, boundary - 1, ""),
+      label: "repeated block comments",
+      over: sourceAtLength(repeatedBlockComments, boundary + 1, ""),
+    },
+    {
+      at: sourceAtLength(repeatedLineComments, boundary, ""),
+      below: sourceAtLength(repeatedLineComments, boundary - 1, ""),
+      label: "repeated line comments",
+      over: sourceAtLength(repeatedLineComments, boundary + 1, ""),
+    },
+    {
+      at: "a".repeat(boundary),
+      below: "a".repeat(boundary - 1),
+      label: "single identifier token",
+      over: "a".repeat(boundary + 1),
+    },
+    {
+      at: sourceAtLength("'", boundary, "'"),
+      below: sourceAtLength("'", boundary - 1, "'"),
+      label: "single string token",
+      over: sourceAtLength("'", boundary + 1, "'"),
+    },
+    {
+      at: sourceAtLength("/*", boundary, "*/"),
+      below: sourceAtLength("/*", boundary - 1, "*/"),
+      label: "single block comment",
+      over: sourceAtLength("/*", boundary + 1, "*/"),
+    },
+    {
+      at: statementSource(boundary),
+      below: statementSource(boundary - 1),
+      label: "many statements",
+      over: statementSource(boundary + 1),
+    },
+  ];
+
+  for (const sourceCase of cases) {
+    for (const sql of [sourceCase.below, sourceCase.at]) {
+      assert.doesNotThrow(
+        () => createSqlParserKernel(
+          sql,
+          limits(boundary, 1_000, 32, 2_000),
+        ),
+        `${sourceCase.label}: ${String(sql.length)}`,
+      );
+    }
+    const error = expectParserError(
+      () => createSqlParserKernel(
+        sourceCase.over,
+        limits(boundary, 1_000, 32, 2_000),
+      ),
+      "limit_source_length",
+      { start: boundary, end: boundary + 1 },
+    );
+    assert.match(error.message, /UTF-16 code units/u, sourceCase.label);
+    assert.match(error.message, /maxSourceCodeUnits=64/u, sourceCase.label);
+  }
+
+  const multibyteBoundary = 5;
+  for (const sql of ["é😀x", "é😀xé"]) {
+    assert.equal(sql.length, multibyteBoundary - 1 + (sql.endsWith("é") ? 1 : 0));
+    assert.doesNotThrow(() =>
+      createSqlParserKernel(
+        sql,
+        limits(multibyteBoundary, 10, 4, 20),
+      ),
+    );
+  }
+  const multibyteOver = "é😀xéx";
+  assert.equal(multibyteOver.length, multibyteBoundary + 1);
+  expectParserError(
+    () => createSqlParserKernel(
+      multibyteOver,
+      limits(multibyteBoundary, 10, 4, 20),
+    ),
+    "limit_source_length",
+    { start: multibyteBoundary, end: multibyteBoundary + 1 },
+  );
+
+  for (const invalidBeforeBoundary of [
+    `\0${"x".repeat(boundary)}`,
+    `\uD800${"x".repeat(boundary)}`,
+  ]) {
+    expectParserError(
+      () => createSqlParserKernel(
+        invalidBeforeBoundary,
+        limits(boundary, 10, 4, 20),
+      ),
+      "limit_source_length",
+      { start: boundary, end: boundary + 1 },
+    );
+  }
+});
+
+test("hostile delimiter nesting is iterative and charged once", (): void => {
+  const depth = 20_000;
+  const sql = `${"(".repeat(depth)}x${")".repeat(depth)}`;
+  const kernel = createSqlParserKernel(
+    sql,
+    limits(sql.length, sql.length + 1, depth + 1, sql.length + 1),
+  );
+
+  assert.equal(kernel.tokens.length, (depth * 2) + 1);
+  assert.equal(kernel.delimiters.scanSteps, kernel.tokens.length);
+  assert.equal(
+    kernel.delimiters.matchingIndexes.get(0),
+    kernel.tokens.length - 1,
+  );
+});
+
+test("cursor consumers expose deterministic work accounting", (): void => {
+  const sql = "numeric(10, 2) trailing";
+  const kernel = createSqlParserKernel(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const cursor = createSqlTokenCursor(kernel, 0, kernel.tokens.length);
+  const parsed = parsePostgreSqlTypeNameAtCursor(cursor, "typename");
+
+  assert.notEqual(parsed, null);
+  assert.equal(parsed?.node.sql, "numeric(10, 2)");
+  assert.equal(parsed?.cursor.index, 6);
+  assert.equal(
+    parsed?.cursor.workUnits,
+    kernel.delimiters.scanSteps + 6,
+  );
+  assert.equal(kernel.tokens[parsed?.cursor.index]?.text, "trailing");
+
+  expectParserError(
+    () => parsePostgreSqlTypeNameInfrastructure(
+      "numeric(10, 2)",
+      limits(100, 20, 8, 9),
+    ),
+    "limit_complexity",
+    null,
+  );
+});
+
+test("cursor token access enforces both bounds and safe offsets", (): void => {
+  const kernel = createSqlParserKernel(
+    "first; second",
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const cursor = createSqlTokenCursor(kernel, 2, 3);
+
+  assert.equal(sqlTokenAt(cursor, 0)?.text, "second");
+  assert.equal(sqlTokenAt(cursor, 1), undefined);
+  assert.equal(sqlTokenAt(cursor, 100), undefined);
+
+  for (const offset of [
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    0.5,
+    Number.MAX_SAFE_INTEGER + 1,
+    Number.MAX_SAFE_INTEGER,
+  ]) {
+    const error = expectParserError(
+      () => sqlTokenAt(cursor, offset),
+      "internal_invariant",
+      { start: 7, end: 13 },
+    );
+    assert.match(error.message, /SQL token (?:offset|index overflow)/u);
+  }
+});
+
+test("multi-token work charges report the exact first excess token", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    requiredWorkUnits: number;
+    sql: string;
+  }>> = [
+    { requiredWorkUnits: 4, sql: "double precision" },
+    { requiredWorkUnits: 8, sql: "timestamp with time zone" },
+    { requiredWorkUnits: 16, sql: "numeric(((1)))" },
+    { requiredWorkUnits: 6, sql: "schema.type" },
+  ];
+
+  for (const workCase of cases) {
+    const baseline = createSqlParserKernel(
+      workCase.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const lastToken = baseline.tokens.at(-1);
+    assert.notEqual(lastToken, undefined);
+    const below = workCase.requiredWorkUnits - 1;
+    const error = expectParserError(
+      () => parsePostgreSqlTypeNameInfrastructure(
+        workCase.sql,
+        limits(workCase.sql.length, 100, 20, below),
+      ),
+      "limit_complexity",
+      lastToken?.range ?? null,
+    );
+    assert.match(
+      error.message,
+      new RegExp(`at token ${String(baseline.tokens.length - 1)}$`, "u"),
+      workCase.sql,
+    );
+
+    for (const maxWorkUnits of [
+      workCase.requiredWorkUnits,
+      workCase.requiredWorkUnits + 1,
+    ]) {
+      assert.equal(
+        parsePostgreSqlTypeNameInfrastructure(
+          workCase.sql,
+          limits(workCase.sql.length, 100, 20, maxWorkUnits),
+        ).sql,
+        workCase.sql,
+      );
+    }
+  }
+});
+
+test("Typename records qualified names, modifiers, arrays, and exact ranges", (): void => {
+  const sql = `  "SomeSchema" /* path */ . "MyType"(7, 'x', mod) [2][]  `;
+  const node = parsePostgreSqlTypeNameInfrastructure(
+    sql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+
+  assert.equal(
+    node.sql,
+    `"SomeSchema" /* path */ . "MyType"(7, 'x', mod) [2][]`,
+  );
+  assert.deepEqual(node.range, { start: 2, end: sql.length - 2 });
+  assert.equal(
+    sql.slice(node.nameRange.start, node.nameRange.end),
+    `"SomeSchema" /* path */ . "MyType"`,
+  );
+  assert.deepEqual(
+    node.nameParts.map((part) => ({
+      normalized: part.normalized,
+      quoted: part.quoted,
+      range: part.range,
+    })),
+    [
+      {
+        normalized: "SomeSchema",
+        quoted: true,
+        range: { start: 2, end: 14 },
+      },
+      {
+        normalized: "MyType",
+        quoted: true,
+        range: { start: 28, end: 36 },
+      },
+    ],
+  );
+  assert.deepEqual(
+    node.modifiers.map((modifier) => ({
+      kind: modifier.kind,
+      range: modifier.range,
+      sql: modifier.sql,
+    })),
+    [
+      { kind: "numeric", range: { start: 37, end: 38 }, sql: "7" },
+      { kind: "string", range: { start: 40, end: 43 }, sql: "'x'" },
+      { kind: "identifier", range: { start: 45, end: 48 }, sql: "mod" },
+    ],
+  );
+  assert.deepEqual(
+    node.arrayBounds.map((bound) => ({
+      notation: bound.notation,
+      range: bound.range,
+      size: bound.size,
+    })),
+    [
+      {
+        notation: "brackets",
+        range: { start: 50, end: 53 },
+        size: "2",
+      },
+      {
+        notation: "brackets",
+        range: { start: 53, end: 55 },
+        size: null,
+      },
+    ],
+  );
+});
+
+test("Typename iteratively unwraps PostgreSQL simple modifier expressions", (): void => {
+  for (const sql of [
+    "numeric((1))",
+    "numeric(((1)))",
+    "numeric(- -1)",
+    "numeric(2,((-1)))",
+  ]) {
+    assert.equal(
+      parsePostgreSqlTypeNameInfrastructure(
+        sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ).sql,
+      sql,
+    );
+  }
+
+  const sql = "custom_type(((1)), ((mode)), (('x')), - -1, -((1)))";
+  const node = parsePostgreSqlTypeNameInfrastructure(
+    sql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.deepEqual(
+    node.modifiers.map((modifier) => ({
+      kind: modifier.kind,
+      normalizedValue: modifier.normalizedValue,
+      sql: modifier.sql,
+      valueSql: sql.slice(
+        modifier.valueRange.start,
+        modifier.valueRange.end,
+      ),
+    })),
+    [
+      {
+        kind: "numeric",
+        normalizedValue: "1",
+        sql: "((1))",
+        valueSql: "1",
+      },
+      {
+        kind: "identifier",
+        normalizedValue: "mode",
+        sql: "((mode))",
+        valueSql: "mode",
+      },
+      {
+        kind: "string",
+        normalizedValue: "x",
+        sql: "(('x'))",
+        valueSql: "'x'",
+      },
+      {
+        kind: "numeric",
+        normalizedValue: "1",
+        sql: "- -1",
+        valueSql: "1",
+      },
+      {
+        kind: "numeric",
+        normalizedValue: "-1",
+        sql: "-((1))",
+        valueSql: "1",
+      },
+    ],
+  );
+
+  const wrapped = parsePostgreSqlTypeNameInfrastructure(
+    "numeric((1))",
+    DEFAULT_SQL_PARSER_LIMITS,
+  ).modifiers[0];
+  assert.deepEqual(wrapped?.range, { start: 8, end: 11 });
+  assert.deepEqual(wrapped?.valueRange, { start: 9, end: 10 });
+
+  const kernel = createSqlParserKernel(
+    "numeric(((1)))",
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const cursor = createSqlTokenCursor(kernel, 0, kernel.tokens.length);
+  const parsed = parsePostgreSqlTypeNameAtCursor(cursor, "typename");
+  assert.equal(
+    parsed?.cursor.workUnits,
+    kernel.delimiters.scanSteps + kernel.tokens.length,
+  );
+});
+
+test("unary plus remains a non-simple PostgreSQL type modifier", (): void => {
+  const invalidModifiers: ReadonlyArray<string> = [
+    "+1",
+    "(+1)",
+    "+(1)",
+    "++1",
+    "+-1",
+    "-+1",
+    "+1.0",
+    "((+1.0))",
+  ];
+  for (const modifier of invalidModifiers) {
+    expectParserError(
+      () => parsePostgreSqlTypeNameInfrastructure(
+        `custom_type(${modifier})`,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "invalid_type_modifier",
+      null,
+    );
+    expectParserError(
+      () => parsePostgreSqlTypedConstantInfrastructure(
+        `custom_type(${modifier}) 'value'`,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "invalid_type_modifier",
+      null,
+    );
+  }
+
+  const direct = parsePostgreSqlTypeNameInfrastructure(
+    "custom_type(- -0001, - - -1_000.0, ((- -0x10)))",
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.deepEqual(
+    direct.modifiers.map((modifier) => modifier.normalizedValue),
+    ["1", "-1_000.0", "16"],
+  );
+
+  const typed = parsePostgreSqlTypedConstantInfrastructure(
+    "custom_type((- -0001), ((- - -1.0))) 'value'",
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.deepEqual(
+    typed.typeName.modifiers.map(
+      (modifier) => modifier.normalizedValue,
+    ),
+    ["1", "-1.0"],
+  );
+});
+
+test("type modifier identifiers follow PostgreSQL ColumnRef semantics", (): void => {
+  const invalidTypenames: ReadonlyArray<Readonly<{
+    range: Readonly<{ start: number; end: number }>;
+    sql: string;
+  }>> = [
+    {
+      range: { start: 8, end: 22 },
+      sql: "numeric(current_schema)",
+    },
+    {
+      range: { start: 10, end: 24 },
+      sql: "numeric(((current_schema)))",
+    },
+    {
+      range: { start: 12, end: 18 },
+      sql: "custom_type(binary)",
+    },
+    {
+      range: { start: 12, end: 17 },
+      sql: "custom_type(cross)",
+    },
+    {
+      range: { start: 12, end: 19 },
+      sql: "custom_type(verbose)",
+    },
+    {
+      range: { start: 12, end: 24 },
+      sql: "custom_type(current_user)",
+    },
+  ];
+  for (const invalid of invalidTypenames) {
+    expectParserError(
+      () => parsePostgreSqlTypeNameInfrastructure(
+        invalid.sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "invalid_type_modifier",
+      invalid.range,
+    );
+  }
+
+  for (const invalid of [
+    "custom_type(current_schema) 'value'",
+    "custom_type(((current_schema))) 'value'",
+  ]) {
+    expectParserError(
+      () => parsePostgreSqlTypedConstantInfrastructure(
+        invalid,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "invalid_type_modifier",
+      null,
+    );
+  }
+
+  const validSql =
+    `custom_type("current_schema", mode, by, numeric, "binary")`;
+  const valid = parsePostgreSqlTypeNameInfrastructure(
+    validSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.deepEqual(
+    valid.modifiers.map((modifier) => ({
+      kind: modifier.kind,
+      normalizedValue: modifier.normalizedValue,
+      sql: modifier.sql,
+      valueSql: validSql.slice(
+        modifier.valueRange.start,
+        modifier.valueRange.end,
+      ),
+    })),
+    [
+      {
+        kind: "identifier",
+        normalizedValue: "current_schema",
+        sql: `"current_schema"`,
+        valueSql: `"current_schema"`,
+      },
+      {
+        kind: "identifier",
+        normalizedValue: "mode",
+        sql: "mode",
+        valueSql: "mode",
+      },
+      {
+        kind: "identifier",
+        normalizedValue: "by",
+        sql: "by",
+        valueSql: "by",
+      },
+      {
+        kind: "identifier",
+        normalizedValue: "numeric",
+        sql: "numeric",
+        valueSql: "numeric",
+      },
+      {
+        kind: "identifier",
+        normalizedValue: "binary",
+        sql: `"binary"`,
+        valueSql: `"binary"`,
+      },
+    ],
+  );
+
+  const typedQuoted = parsePostgreSqlTypedConstantInfrastructure(
+    `custom_type((("current_schema"))) 'value'`,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.equal(
+    typedQuoted.typeName.modifiers[0]?.normalizedValue,
+    "current_schema",
+  );
+
+  for (const typeName of ["current_schema", "current_schema.member"]) {
+    assert.equal(
+      parsePostgreSqlTypeNameInfrastructure(
+        typeName,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ).sql,
+      typeName,
+    );
+  }
+  for (const typedConstant of [
+    "current_schema 'value'",
+    "current_schema(mode) 'value'",
+  ]) {
+    assert.equal(
+      parsePostgreSqlTypedConstantInfrastructure(
+        typedConstant,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ).sql,
+      typedConstant,
+    );
+  }
+});
+
+test("qualified typed constants follow PostgreSQL ColId categories", (): void => {
+  const typeFunctionKeywords: ReadonlyArray<string> = [
+    "authorization",
+    "binary",
+    "collation",
+    "concurrently",
+    "cross",
+    "current_schema",
+    "freeze",
+    "full",
+    "ilike",
+    "inner",
+    "is",
+    "isnull",
+    "join",
+    "left",
+    "like",
+    "natural",
+    "notnull",
+    "outer",
+    "overlaps",
+    "right",
+    "similar",
+    "tablesample",
+    "verbose",
+  ];
+  for (const keyword of typeFunctionKeywords) {
+    const sql = `${keyword}.member 'value'`;
+    const error = expectParserError(
+      () => parsePostgreSqlTypedConstantInfrastructure(
+        sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "invalid_typed_constant",
+      { start: keyword.length, end: keyword.length + 1 },
+    );
+    assert.match(error.message, /require a ColId before \./u);
+  }
+
+  for (const reserved of ["select", "current_user"]) {
+    const sql = `${reserved}.member 'value'`;
+    expectParserError(
+      () => parsePostgreSqlTypedConstantInfrastructure(
+        sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "invalid_typed_constant",
+      { start: reserved.length, end: reserved.length + 1 },
+    );
+  }
+
+  for (const valid of [
+    `schema.member 'value'`,
+    `by.member 'value'`,
+    `numeric.member 'value'`,
+    `"current_schema".member 'value'`,
+    `"select".member 'value'`,
+  ]) {
+    assert.equal(
+      parsePostgreSqlTypedConstantInfrastructure(
+        valid,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ).sql,
+      valid,
+    );
+  }
+
+  for (const unqualified of [
+    `current_schema 'value'`,
+    `binary 'value'`,
+    `cross 'value'`,
+  ]) {
+    assert.equal(
+      parsePostgreSqlTypedConstantInfrastructure(
+        unqualified,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ).sql,
+      unqualified,
+    );
+  }
+
+  for (const typeName of [
+    "current_schema.member",
+    "binary.member",
+    "cross.member",
+  ]) {
+    assert.equal(
+      parsePostgreSqlTypeNameInfrastructure(
+        typeName,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ).sql,
+      typeName,
+    );
+  }
+});
+
+test("numeric modifier semantics match PostgreSQL ICONST and FCONST actions", (): void => {
+  const sql =
+    "custom_type(0001, 0b1_000, 0o10, 0Xf_F, 1_000.0, 1.0E+2, 2_147_483_648, - -0x10, - - -1_000.0)";
+  const node = parsePostgreSqlTypeNameInfrastructure(
+    sql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.deepEqual(
+    node.modifiers.map((modifier) => ({
+      normalizedValue: modifier.normalizedValue,
+      sql: modifier.sql,
+      valueSql: sql.slice(
+        modifier.valueRange.start,
+        modifier.valueRange.end,
+      ),
+    })),
+    [
+      { normalizedValue: "1", sql: "0001", valueSql: "0001" },
+      { normalizedValue: "8", sql: "0b1_000", valueSql: "0b1_000" },
+      { normalizedValue: "8", sql: "0o10", valueSql: "0o10" },
+      { normalizedValue: "255", sql: "0Xf_F", valueSql: "0Xf_F" },
+      { normalizedValue: "1_000.0", sql: "1_000.0", valueSql: "1_000.0" },
+      { normalizedValue: "1.0E+2", sql: "1.0E+2", valueSql: "1.0E+2" },
+      {
+        normalizedValue: "2_147_483_648",
+        sql: "2_147_483_648",
+        valueSql: "2_147_483_648",
+      },
+      { normalizedValue: "16", sql: "- -0x10", valueSql: "0x10" },
+      {
+        normalizedValue: "-1_000.0",
+        sql: "- - -1_000.0",
+        valueSql: "1_000.0",
+      },
+    ],
+  );
+
+  const typedSql =
+    "custom_type(00_01, 0Xf_F, 1_000.0, - - -2_147_483_648) 'value'";
+  const typed = parsePostgreSqlTypedConstantInfrastructure(
+    typedSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.deepEqual(
+    typed.typeName.modifiers.map((modifier) => modifier.normalizedValue),
+    ["1", "255", "1_000.0", "-2_147_483_648"],
+  );
+  assert.equal(typed.sql, typedSql);
+});
+
+test("Iconst-only type syntax uses canonical exact integer values", (): void => {
+  const bracketArrays = parsePostgreSqlTypeNameInfrastructure(
+    "integer[0004][0b100][0o10][0X10]",
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.deepEqual(
+    bracketArrays.arrayBounds.map((bound) => bound.size),
+    ["4", "4", "8", "16"],
+  );
+
+  const array = parsePostgreSqlTypeNameInfrastructure(
+    "integer ARRAY[0Xf_F]",
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.equal(array.arrayBounds[0]?.size, "255");
+  assert.equal(
+    parsePostgreSqlTypeNameInfrastructure(
+      "integer[0X7FFF_FFFF]",
+      DEFAULT_SQL_PARSER_LIMITS,
+    ).arrayBounds[0]?.size,
+    "2147483647",
+  );
+  assert.equal(
+    parsePostgreSqlTypeNameInfrastructure(
+      "char(2_147_483_647)",
+      DEFAULT_SQL_PARSER_LIMITS,
+    ).modifiers[0]?.normalizedValue,
+    "2147483647",
+  );
+
+  const interval = parsePostgreSqlTypeNameInfrastructure(
+    "interval day to second(0X3)",
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.equal(interval.intervalQualifier?.secondPrecision, "3");
+  assert.equal(interval.intervalQualifier?.sql, "day to second(0X3)");
+
+  const typed = parsePostgreSqlTypedConstantInfrastructure(
+    "interval(00_03) '1.234'",
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  assert.equal(typed.typeName.modifiers[0]?.normalizedValue, "3");
+  assert.equal(
+    parsePostgreSqlTypeNameInfrastructure(
+      "float(0x35)",
+      DEFAULT_SQL_PARSER_LIMITS,
+    ).modifiers[0]?.normalizedValue,
+    "53",
+  );
+
+  const invalidCases: ReadonlyArray<Readonly<{
+    code: SqlPolicyParserErrorCode;
+    sql: string;
+  }>> = [
+    { code: "invalid_type_modifier", sql: "char(2147483648)" },
+    { code: "invalid_type_modifier", sql: "float(0x36)" },
+    { code: "invalid_type_modifier", sql: "interval(0X80000000)" },
+    {
+      code: "invalid_type_modifier",
+      sql: "interval second(2_147_483_648)",
+    },
+    { code: "invalid_type_name", sql: "integer[2147483648]" },
+    { code: "invalid_type_name", sql: "integer ARRAY[0X80000000]" },
+  ];
+  for (const invalid of invalidCases) {
+    expectParserError(
+      () => parsePostgreSqlTypeNameInfrastructure(
+        invalid.sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      invalid.code,
+      null,
+    );
+  }
+});
+
+test("Typename rejects malformed or over-budget modifier wrappers", (): void => {
+  const invalidCases: ReadonlyArray<Readonly<{
+    code: SqlPolicyParserErrorCode;
+    sql: string;
+  }>> = [
+    { code: "invalid_type_modifier", sql: "numeric(())" },
+    { code: "invalid_type_modifier", sql: "numeric((1)+)" },
+    { code: "invalid_type_modifier", sql: "numeric((+1))" },
+    { code: "invalid_type_modifier", sql: "numeric((+mode))" },
+    { code: "invalid_type_modifier", sql: "numeric((1,2))" },
+    { code: "invalid_delimiter", sql: "numeric((1)" },
+  ];
+  for (const invalid of invalidCases) {
+    expectParserError(
+      () => parsePostgreSqlTypeNameInfrastructure(
+        invalid.sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      invalid.code,
+      null,
+    );
+  }
+
+  const nested = "numeric((((1))))";
+  expectParserError(
+    () => parsePostgreSqlTypeNameInfrastructure(
+      nested,
+      limits(nested.length, 50, 2, 100),
+    ),
+    "limit_nesting",
+    null,
+  );
+  const tokenCount = createSqlParserKernel(
+    nested,
+    DEFAULT_SQL_PARSER_LIMITS,
+  ).tokens.length;
+  expectParserError(
+    () => parsePostgreSqlTypeNameInfrastructure(
+      nested,
+      limits(nested.length, 50, 20, tokenCount + 2),
+    ),
+    "limit_complexity",
+    null,
+  );
+});
+
+test("type delimiter consumers reject closes outside bounded cursors", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    code: "invalid_type_modifier" | "invalid_type_name";
+    endIndex: number;
+    range: Readonly<{ start: number; end: number }>;
+    sql: string;
+  }>> = [
+    {
+      code: "invalid_type_modifier",
+      endIndex: 3,
+      range: { start: 4, end: 5 },
+      sql: "char(3)",
+    },
+    {
+      code: "invalid_type_name",
+      endIndex: 3,
+      range: { start: 7, end: 8 },
+      sql: "integer[3]",
+    },
+    {
+      code: "invalid_type_name",
+      endIndex: 2,
+      range: { start: 7, end: 8 },
+      sql: "integer[]",
+    },
+    {
+      code: "invalid_type_name",
+      endIndex: 4,
+      range: { start: 13, end: 14 },
+      sql: "integer ARRAY[3]",
+    },
+    {
+      code: "invalid_type_modifier",
+      endIndex: 7,
+      range: { start: 11, end: 12 },
+      sql: "custom_type(((1)))",
+    },
+  ];
+
+  for (const boundedCase of cases) {
+    const kernel = createSqlParserKernel(
+      boundedCase.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const complete = parsePostgreSqlTypeNameAtCursor(
+      createSqlTokenCursor(kernel, 0, kernel.tokens.length),
+      "typename",
+    );
+    assert.equal(complete?.cursor.index, kernel.tokens.length);
+
+    const error = expectParserError(
+      () => parsePostgreSqlTypeNameAtCursor(
+        createSqlTokenCursor(kernel, 0, boundedCase.endIndex),
+        "typename",
+      ),
+      boundedCase.code,
+      boundedCase.range,
+    );
+    assert.doesNotMatch(error.message, /internal invariant/iu);
+    assert.match(error.message, /outside the current parse range/u);
+  }
+});
+
+test("datetime timezone parsing mirrors PostgreSQL lookahead", (): void => {
+  const validCases: ReadonlyArray<Readonly<{
+    kind: "with" | "without";
+    sql: string;
+    typeSql: string;
+  }>> = [
+    {
+      kind: "with",
+      sql: "timestamp with time zone trailing",
+      typeSql: "timestamp with time zone",
+    },
+    {
+      kind: "without",
+      sql: "time without time zone trailing",
+      typeSql: "time without time zone",
+    },
+    {
+      kind: "with",
+      sql: "timestamp(3) with time zone trailing",
+      typeSql: "timestamp(3) with time zone",
+    },
+  ];
+  for (const valid of validCases) {
+    const kernel = createSqlParserKernel(
+      valid.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const parsed = parsePostgreSqlTypeNameAtCursor(
+      createSqlTokenCursor(kernel, 0, kernel.tokens.length),
+      "typename",
+    );
+    if (parsed === null) {
+      assert.fail(`Expected PostgreSQL datetime type: ${valid.sql}`);
+    }
+    assert.equal(parsed.node.sql, valid.typeSql);
+    assert.equal(parsed.node.timeZone?.kind, valid.kind);
+    assert.equal(sqlTokenAt(parsed.cursor, 0)?.text, "trailing");
+  }
+
+  const ordinaryNeighbors: ReadonlyArray<Readonly<{
+    range: Readonly<{ start: number; end: number }>;
+    sql: string;
+  }>> = [
+    {
+      range: { start: 10, end: 14 },
+      sql: "timestamp with foo",
+    },
+    {
+      range: { start: 10, end: 17 },
+      sql: "timestamp without foo",
+    },
+    {
+      range: { start: 10, end: 17 },
+      sql: "timestamp without ordinality",
+    },
+    {
+      range: { start: 10, end: 16 },
+      sql: `timestamp "with" time zone`,
+    },
+    {
+      range: { start: 10, end: 14 },
+      sql: `timestamp with "time" zone`,
+    },
+    {
+      range: { start: 10, end: 14 },
+      sql: `timestamp with "ordinality"`,
+    },
+  ];
+  for (const neighbor of ordinaryNeighbors) {
+    const kernel = createSqlParserKernel(
+      neighbor.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const cursor = createSqlTokenCursor(kernel, 0, kernel.tokens.length);
+    const parsed = parsePostgreSqlTypeNameAtCursor(cursor, "typename");
+    assert.equal(parsed?.node.sql, "timestamp");
+    assert.equal(parsed?.node.timeZone, null);
+    assert.equal(parsed?.cursor.index, 1);
+
+    expectParserError(
+      () => parsePostgreSqlTypeNameInfrastructure(
+        neighbor.sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "unexpected_token",
+      neighbor.range,
+    );
+  }
+
+  const committedInvalid: ReadonlyArray<Readonly<{
+    range: Readonly<{ start: number; end: number }>;
+    sql: string;
+  }>> = [
+    {
+      range: { start: 20, end: 26 },
+      sql: `timestamp with time "zone"`,
+    },
+    {
+      range: { start: 20, end: 23 },
+      sql: "timestamp with time foo",
+    },
+    {
+      range: { start: 18, end: 21 },
+      sql: "time without time foo",
+    },
+    {
+      range: { start: 15, end: 25 },
+      sql: "timestamp with ordinality",
+    },
+  ];
+  for (const invalid of committedInvalid) {
+    expectParserError(
+      () => parsePostgreSqlTypeNameInfrastructure(
+        invalid.sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "invalid_type_name",
+      invalid.range,
+    );
+  }
+});
+
+test("Typename accepts PostgreSQL 18 built-in and array productions", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    arrays: ReadonlyArray<Readonly<{
+      notation: "array" | "brackets";
+      size: string | null;
+    }>>;
+    form: string;
+    modifiers: ReadonlyArray<string>;
+    qualifier: string | null;
+    sql: string;
+    timeZone: "with" | "without" | null;
+  }>> = [
+    {
+      arrays: [],
+      form: "integer",
+      modifiers: [],
+      qualifier: null,
+      sql: "setof integer",
+      timeZone: null,
+    },
+    {
+      arrays: [{ notation: "array", size: "4" }],
+      form: "double_precision",
+      modifiers: [],
+      qualifier: null,
+      sql: "double precision ARRAY[4]",
+      timeZone: null,
+    },
+    {
+      arrays: [{ notation: "brackets", size: null }],
+      form: "timestamp",
+      modifiers: ["3"],
+      qualifier: null,
+      sql: "timestamp(3) with time zone[]",
+      timeZone: "with",
+    },
+    {
+      arrays: [],
+      form: "character",
+      modifiers: ["20"],
+      qualifier: null,
+      sql: "national character varying(20)",
+      timeZone: null,
+    },
+    {
+      arrays: [{ notation: "brackets", size: null }],
+      form: "interval",
+      modifiers: [],
+      qualifier: "day to second(6)",
+      sql: "interval day to second(6)[]",
+      timeZone: null,
+    },
+    {
+      arrays: [],
+      form: "interval",
+      modifiers: ["3"],
+      qualifier: null,
+      sql: "interval(3)",
+      timeZone: null,
+    },
+    {
+      arrays: [
+        { notation: "brackets", size: "2" },
+        { notation: "brackets", size: "3" },
+      ],
+      form: "integer",
+      modifiers: [],
+      qualifier: null,
+      sql: "integer[2][3]",
+      timeZone: null,
+    },
+    {
+      arrays: [{ notation: "array", size: null }],
+      form: "bit",
+      modifiers: ["8"],
+      qualifier: null,
+      sql: "bit varying(8) ARRAY",
+      timeZone: null,
+    },
+    {
+      arrays: [],
+      form: "generic",
+      modifiers: ["10", "2"],
+      qualifier: null,
+      sql: "pg_catalog.numeric(10, 2)",
+      timeZone: null,
+    },
+  ];
+
+  for (const expected of cases) {
+    const node = parsePostgreSqlTypeNameInfrastructure(
+      expected.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    assert.equal(node.form, expected.form, expected.sql);
+    assert.equal(node.intervalQualifier?.sql ?? null, expected.qualifier);
+    assert.deepEqual(
+      node.modifiers.map((modifier) => modifier.sql),
+      expected.modifiers,
+      expected.sql,
+    );
+    assert.deepEqual(
+      node.arrayBounds.map((bound) => ({
+        notation: bound.notation,
+        size: bound.size,
+      })),
+      expected.arrays,
+      expected.sql,
+    );
+    assert.equal(node.timeZone?.kind ?? null, expected.timeZone);
+  }
+
+  for (const sql of ["float(1)", "float(24)", "float(25)", "float(53)"]) {
+    assert.equal(
+      parsePostgreSqlTypeNameInfrastructure(
+        sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ).sql,
+      sql,
+    );
+  }
+});
+
+test("Typename rejects invalid PostgreSQL 18 neighboring productions", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    code: SqlPolicyParserErrorCode;
+    range: Readonly<{ start: number; end: number }>;
+    sql: string;
+  }>> = [
+    {
+      code: "invalid_type_name",
+      range: { start: 10, end: 15 },
+      sql: "integer[] ARRAY",
+    },
+    {
+      code: "invalid_type_name",
+      range: { start: 11, end: 16 },
+      sql: "integer[2] ARRAY[3]",
+    },
+    {
+      code: "invalid_type_modifier",
+      range: { start: 4, end: 5 },
+      sql: "json(1)",
+    },
+    {
+      code: "invalid_type_modifier",
+      range: { start: 6, end: 7 },
+      sql: "float(0)",
+    },
+    {
+      code: "invalid_type_modifier",
+      range: { start: 6, end: 8 },
+      sql: "float(54)",
+    },
+    {
+      code: "invalid_type_modifier",
+      range: { start: 12, end: 15 },
+      sql: "interval(3) day to second",
+    },
+    {
+      code: "invalid_type_modifier",
+      range: { start: 10, end: 11 },
+      sql: "numeric(1 +)",
+    },
+    {
+      code: "invalid_type_modifier",
+      range: { start: 5, end: 8 },
+      sql: "char(foo)",
+    },
+    {
+      code: "invalid_type_name",
+      range: { start: 14, end: 15 },
+      sql: "integer ARRAY[]",
+    },
+    {
+      code: "invalid_type_modifier",
+      range: { start: 17, end: 20 },
+      sql: "interval year to day",
+    },
+  ];
+
+  for (const expected of cases) {
+    expectParserError(
+      () => parsePostgreSqlTypeNameInfrastructure(
+        expected.sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      expected.code,
+      expected.range,
+    );
+  }
+});
+
+test("typed-constant speculation preserves generic function applications", (): void => {
+  const functionCases: ReadonlyArray<Readonly<{
+    nameWorkUnits: number;
+    sql: string;
+  }>> = [
+    { nameWorkUnits: 1, sql: "foo()" },
+    { nameWorkUnits: 1, sql: "foo(1 + 2)" },
+    { nameWorkUnits: 1, sql: "foo(current_schema)" },
+    { nameWorkUnits: 3, sql: "schema.foo(((1 + 2)))" },
+  ];
+  for (const functionCase of functionCases) {
+    const baseline = createSqlParserKernel(
+      functionCase.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const kernel = createSqlParserKernel(
+      functionCase.sql,
+      limits(
+        functionCase.sql.length,
+        baseline.tokens.length,
+        DEFAULT_SQL_PARSER_LIMITS.maxNestingDepth,
+        baseline.delimiters.scanSteps + functionCase.nameWorkUnits,
+      ),
+    );
+    const cursor = createSqlTokenCursor(kernel, 0, kernel.tokens.length);
+
+    assert.equal(parsePostgreSqlTypedConstantAtCursor(cursor), null);
+    assert.equal(cursor.index, 0);
+    assert.equal(cursor.workUnits, kernel.delimiters.scanSteps);
+    assert.equal(kernel.delimiters.scanSteps, kernel.tokens.length);
+  }
+
+  const boundedSql = "foo(1) 'value' trailing";
+  const boundedKernel = createSqlParserKernel(
+    boundedSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const closeIndex = boundedKernel.delimiters.matchingIndexes.get(1);
+  assert.equal(closeIndex, 3);
+  for (const endIndex of [3, 4]) {
+    assert.equal(
+      parsePostgreSqlTypedConstantAtCursor(
+        createSqlTokenCursor(boundedKernel, 0, endIndex),
+      ),
+      null,
+    );
+  }
+
+  const committedErrors: ReadonlyArray<Readonly<{
+    range: Readonly<{ start: number; end: number }>;
+    sql: string;
+  }>> = [
+    {
+      range: { start: 3, end: 4 },
+      sql: "foo() 'value'",
+    },
+    {
+      range: { start: 5, end: 6 },
+      sql: "foo(1+2) 'value'",
+    },
+    {
+      range: { start: 4, end: 18 },
+      sql: "foo(current_schema) 'value'",
+    },
+  ];
+  for (const committed of committedErrors) {
+    expectParserError(
+      () => parsePostgreSqlTypedConstantInfrastructure(
+        committed.sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      "invalid_type_modifier",
+      committed.range,
+    );
+  }
+
+  const committedSql = "foo(((1))) 'value' + trailing";
+  const committedKernel = createSqlParserKernel(
+    committedSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const committed = parsePostgreSqlTypedConstantAtCursor(
+    createSqlTokenCursor(
+      committedKernel,
+      0,
+      committedKernel.tokens.length,
+    ),
+  );
+  if (committed === null) {
+    assert.fail("Expected committed PostgreSQL typed constant");
+  }
+  assert.equal(committed.node.sql, "foo(((1))) 'value'");
+  assert.equal(committed.node.typeName.modifiers[0]?.normalizedValue, "1");
+  assert.equal(sqlTokenAt(committed.cursor, 0)?.text, "+");
+  assert.equal(
+    committed.cursor.workUnits,
+    committedKernel.delimiters.scanSteps + committed.cursor.index,
+  );
+});
+
+test("typed constants follow ConstTypename and interval productions", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    form: string;
+    qualifier: string | null;
+    sql: string;
+    typeSql: string;
+    value: string;
+  }>> = [
+    {
+      form: "generic",
+      qualifier: null,
+      sql: "schema.money(10, 2) '12.30'",
+      typeSql: "schema.money(10, 2)",
+      value: "12.30",
+    },
+    {
+      form: "double_precision",
+      qualifier: null,
+      sql: "double precision '1.2'",
+      typeSql: "double precision",
+      value: "1.2",
+    },
+    {
+      form: "interval",
+      qualifier: "day to second(3)",
+      sql: "interval '1 day' day to second(3)",
+      typeSql: "interval",
+      value: "1 day",
+    },
+    {
+      form: "interval",
+      qualifier: null,
+      sql: "interval(3) '1.234'",
+      typeSql: "interval(3)",
+      value: "1.234",
+    },
+    {
+      form: "json",
+      qualifier: null,
+      sql: `json '{"a":1}'`,
+      typeSql: "json",
+      value: '{"a":1}',
+    },
+    {
+      form: "generic",
+      qualifier: null,
+      sql: `integer.payload '1'`,
+      typeSql: "integer.payload",
+      value: "1",
+    },
+  ];
+
+  for (const expected of cases) {
+    const node = parsePostgreSqlTypedConstantInfrastructure(
+      expected.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    assert.equal(node.sql, expected.sql);
+    assert.deepEqual(node.range, { start: 0, end: expected.sql.length });
+    assert.equal(node.typeName.form, expected.form);
+    assert.equal(node.typeName.sql, expected.typeSql);
+    assert.equal(node.value.semanticValue, expected.value);
+    assert.equal(node.intervalQualifier?.sql ?? null, expected.qualifier);
+    assert.equal(node.typeName.arrayBounds.length, 0);
+    assert.equal(node.typeName.setOf, false);
+  }
+});
+
+test("typed constants accept PostgreSQL parenthesized simple modifiers", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    modifier: string;
+    normalizedValue: string;
+    sql: string;
+  }>> = [
+    {
+      modifier: "(1)",
+      normalizedValue: "1",
+      sql: "numeric((1)) '1'",
+    },
+    {
+      modifier: "((1))",
+      normalizedValue: "1",
+      sql: "numeric(((1))) '1'",
+    },
+    {
+      modifier: "(mode)",
+      normalizedValue: "mode",
+      sql: "custom_type((mode)) 'value'",
+    },
+  ];
+  for (const expected of cases) {
+    const node = parsePostgreSqlTypedConstantInfrastructure(
+      expected.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    assert.equal(node.sql, expected.sql);
+    assert.equal(node.typeName.modifiers[0]?.sql, expected.modifier);
+    assert.equal(
+      node.typeName.modifiers[0]?.normalizedValue,
+      expected.normalizedValue,
+    );
+  }
+});
+
+test("typed constants reject casts, named modifiers, and malformed intervals", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    code: SqlPolicyParserErrorCode;
+    sql: string;
+  }>> = [
+    { code: "invalid_typed_constant", sql: "integer[] '1'" },
+    { code: "invalid_typed_constant", sql: "interval(3) '1' day" },
+    { code: "invalid_type_modifier", sql: "foo() 'x'" },
+    { code: "invalid_type_modifier", sql: "foo(1 => 2) 'x'" },
+    { code: "invalid_type_modifier", sql: "interval '1' year to day" },
+    { code: "invalid_typed_constant", sql: "bit B'1'" },
+    { code: "unexpected_token", sql: "integer '1' trailing" },
+  ];
+
+  for (const expected of cases) {
+    expectParserError(
+      () => parsePostgreSqlTypedConstantInfrastructure(
+        expected.sql,
+        DEFAULT_SQL_PARSER_LIMITS,
+      ),
+      expected.code,
+      null,
+    );
+  }
+});
+
+test("typed-constant cursor parsing leaves neighboring expression tokens", (): void => {
+  const sql = "interval '2' hour + value";
+  const kernel = createSqlParserKernel(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const cursor = createSqlTokenCursor(kernel, 0, kernel.tokens.length);
+  const parsed = parsePostgreSqlTypedConstantAtCursor(cursor);
+
+  assert.notEqual(parsed, null);
+  assert.equal(parsed?.node.sql, "interval '2' hour");
+  assert.equal(parsed?.node.intervalQualifier?.sql, "hour");
+  assert.equal(kernel.tokens[parsed?.cursor.index]?.text, "+");
+});

--- a/packages/agent-shared/src/sql-policy-type-parser.ts
+++ b/packages/agent-shared/src/sql-policy-type-parser.ts
@@ -1,0 +1,853 @@
+import type {
+  SqlIdentifierToken,
+  SqlSourceRange,
+} from "./sql-policy-lexer.js";
+import {
+  isPostgreSqlColId as isColId,
+  isPostgreSqlTypeFunctionName as isTypeFunctionName,
+  POSTGRESQL_INTERVAL_FIELD_PAIRS as INTERVAL_FIELD_PAIRS,
+  POSTGRESQL_INTERVAL_FIELDS as INTERVAL_FIELDS,
+  postgreSqlTokenWord as tokenWord,
+} from "./sql-policy-parser-keywords.js";
+import {
+  advanceSqlTokenCursor,
+  createSqlParserKernel,
+  createSqlTokenCursor,
+  matchingSqlDelimiterIndexAtCursor,
+  matchingSqlDelimiterIndexWithinCursor,
+  sqlCursorRange,
+  sqlRangeFromTokenIndexes,
+  sqlTokenAt,
+  type SqlParserKernel,
+  type SqlParserLimits,
+  type SqlTokenCursor,
+} from "./sql-policy-parser-kernel.js";
+import { throwSqlPolicyParserError } from "./sql-policy-parser-model.js";
+import {
+  isPostgreSqlStringConstant as isStringConstant,
+  parsePostgreSqlIntegerModifier as parseIntegerModifier,
+  parsePostgreSqlIntervalQualifier as parseIntervalQualifier,
+  parsePostgreSqlTypeModifierList as parseModifierList,
+  postgreSqlIntegerConstant,
+} from "./sql-policy-type-modifiers.js";
+import type {
+  SqlArrayBoundNode,
+  SqlIntervalQualifierNode,
+  SqlTimeZoneNode,
+  SqlTypedConstantNode,
+  SqlTypeModifierNode,
+  SqlTypeNameForm,
+  SqlTypeNameNode,
+  SqlTypeParseResult,
+} from "./sql-policy-type-model.js";
+
+export type {
+  SqlArrayBoundNode,
+  SqlIntervalQualifierNode,
+  SqlTimeZoneNode,
+  SqlTypedConstantNode,
+  SqlTypeModifierNode,
+  SqlTypeNameForm,
+  SqlTypeNameNode,
+  SqlTypeParseResult,
+} from "./sql-policy-type-model.js";
+
+type TypeNameContext = "typed_constant" | "typename";
+
+type ParsedTypeBase = Readonly<{
+  cursor: SqlTokenCursor;
+  form: SqlTypeNameForm;
+  intervalQualifier: SqlIntervalQualifierNode | null;
+  modifiers: ReadonlyArray<SqlTypeModifierNode>;
+  nameParts: ReadonlyArray<SqlIdentifierToken>;
+  nameRange: SqlSourceRange;
+  timeZone: SqlTimeZoneNode | null;
+}>;
+
+const isWord = (
+  cursor: SqlTokenCursor,
+  offset: number,
+  expected: string,
+): boolean => tokenWord(sqlTokenAt(cursor, offset)) === expected;
+
+const isText = (
+  cursor: SqlTokenCursor,
+  offset: number,
+  expected: string,
+): boolean => sqlTokenAt(cursor, offset)?.text === expected;
+
+const identifierAt = (
+  cursor: SqlTokenCursor,
+  offset: number,
+): SqlIdentifierToken | null => {
+  const token = sqlTokenAt(cursor, offset);
+  return token?.kind === "identifier" ? token : null;
+};
+
+const parseGenericType = (
+  cursor: SqlTokenCursor,
+  context: TypeNameContext,
+): ParsedTypeBase | null => {
+  const first = identifierAt(cursor, 0);
+  if (first === null) {
+    return null;
+  }
+  const qualified = isText(cursor, 1, ".");
+  if (
+    context === "typed_constant"
+    && qualified
+    && !isColId(first)
+  ) {
+    const dot = sqlTokenAt(cursor, 1);
+    if (dot === undefined) {
+      return throwSqlPolicyParserError(
+        "internal_invariant",
+        "Qualified PostgreSQL typed-constant type name lost its . token",
+        sqlCursorRange(cursor),
+      );
+    }
+    return throwSqlPolicyParserError(
+      "invalid_typed_constant",
+      `PostgreSQL qualified typed-constant type names require a ColId before .; ${first.text} is not a ColId`,
+      dot.range,
+    );
+  }
+  const firstAllowed = context === "typed_constant" && qualified
+    ? true
+    : isTypeFunctionName(first);
+  if (!firstAllowed) {
+    return null;
+  }
+
+  const nameStart = cursor.index;
+  const nameParts: Array<SqlIdentifierToken> = [first];
+  let current = advanceSqlTokenCursor(
+    cursor,
+    1,
+    "PostgreSQL generic type name",
+  );
+  while (isText(current, 0, ".")) {
+    const attribute = identifierAt(current, 1);
+    if (attribute === null) {
+      return throwSqlPolicyParserError(
+        "invalid_type_name",
+        "Expected a PostgreSQL identifier after . in a qualified type name",
+        sqlTokenAt(current, 0)?.range ?? sqlCursorRange(current),
+      );
+    }
+    nameParts.push(attribute);
+    current = advanceSqlTokenCursor(
+      current,
+      2,
+      "PostgreSQL qualified type name",
+    );
+  }
+  const nameRange = sqlRangeFromTokenIndexes(
+    cursor.kernel,
+    nameStart,
+    current.index,
+  );
+
+  let modifiers: ReadonlyArray<SqlTypeModifierNode> = [];
+  if (isText(current, 0, "(")) {
+    if (context === "typed_constant") {
+      const closeIndex = matchingSqlDelimiterIndexAtCursor(current);
+      if (
+        closeIndex >= current.endIndex
+        || !isStringConstant(
+          sqlTokenAt(
+            current,
+            closeIndex - current.index + 1,
+          ),
+        )
+      ) {
+        return null;
+      }
+    }
+    const parsed = parseModifierList(current);
+    modifiers = parsed.modifiers;
+    current = parsed.cursor;
+  }
+  return {
+    cursor: current,
+    form: "generic",
+    intervalQualifier: null,
+    modifiers,
+    nameParts,
+    nameRange,
+    timeZone: null,
+  };
+};
+
+const parseTimeZone = (
+  cursor: SqlTokenCursor,
+): Readonly<{
+  cursor: SqlTokenCursor;
+  node: SqlTimeZoneNode | null;
+}> => {
+  const firstWord = tokenWord(sqlTokenAt(cursor, 0));
+  const secondWord = tokenWord(sqlTokenAt(cursor, 1));
+  const hasLookaheadToken =
+    (
+      firstWord === "with"
+      && (secondWord === "time" || secondWord === "ordinality")
+    )
+    || (firstWord === "without" && secondWord === "time");
+  if (!hasLookaheadToken) {
+    return { cursor, node: null };
+  }
+  if (
+    secondWord !== "time"
+    || !isWord(cursor, 2, "zone")
+  ) {
+    const unexpectedOffset = secondWord === "time" ? 2 : 1;
+    return throwSqlPolicyParserError(
+      "invalid_type_name",
+      `Expected TIME ZONE after ${firstWord.toUpperCase()} in a PostgreSQL datetime type`,
+      sqlTokenAt(cursor, unexpectedOffset)?.range ?? sqlCursorRange(cursor),
+    );
+  }
+  const range = sqlRangeFromTokenIndexes(
+    cursor.kernel,
+    cursor.index,
+    cursor.index + 3,
+  );
+  return {
+    cursor: advanceSqlTokenCursor(
+      cursor,
+      3,
+      "PostgreSQL datetime time zone",
+    ),
+    node: { kind: firstWord, range },
+  };
+};
+
+const typeBase = (
+  cursor: SqlTokenCursor,
+  form: SqlTypeNameForm,
+  nameParts: ReadonlyArray<SqlIdentifierToken>,
+  nameStart: number,
+  modifiers: ReadonlyArray<SqlTypeModifierNode>,
+  intervalQualifier: SqlIntervalQualifierNode | null,
+  timeZone: SqlTimeZoneNode | null,
+): ParsedTypeBase => ({
+  cursor,
+  form,
+  intervalQualifier,
+  modifiers,
+  nameParts,
+  nameRange: sqlRangeFromTokenIndexes(
+    cursor.kernel,
+    nameStart,
+    nameStart + nameParts.length,
+  ),
+  timeZone,
+});
+
+const simpleTypeForm = (
+  word: string,
+): SqlTypeNameForm | null => {
+  switch (word) {
+    case "bigint":
+      return "bigint";
+    case "boolean":
+      return "boolean";
+    case "int":
+    case "integer":
+      return "integer";
+    case "json":
+      return "json";
+    case "real":
+      return "real";
+    case "smallint":
+      return "smallint";
+    default:
+      return null;
+  }
+};
+
+const parseSpecialType = (
+  cursor: SqlTokenCursor,
+  context: TypeNameContext,
+): ParsedTypeBase | null => {
+  const first = identifierAt(cursor, 0);
+  const word = tokenWord(first ?? undefined);
+  if (first === null || word === null || isText(cursor, 1, ".")) {
+    return null;
+  }
+  const nameStart = cursor.index;
+
+  const form = simpleTypeForm(word);
+  if (form !== null) {
+    const current = advanceSqlTokenCursor(
+      cursor,
+      1,
+      `PostgreSQL ${word} type`,
+    );
+    if (isText(current, 0, "(")) {
+      return throwSqlPolicyParserError(
+        "invalid_type_modifier",
+        `PostgreSQL type ${word.toUpperCase()} does not allow type modifiers`,
+        sqlCursorRange(current),
+      );
+    }
+    return typeBase(
+      current,
+      form,
+      [first],
+      nameStart,
+      [],
+      null,
+      null,
+    );
+  }
+
+  if (word === "float") {
+    let current = advanceSqlTokenCursor(cursor, 1, "PostgreSQL FLOAT type");
+    let modifiers: ReadonlyArray<SqlTypeModifierNode> = [];
+    if (isText(current, 0, "(")) {
+      const precision = parseIntegerModifier(
+        current,
+        "PostgreSQL FLOAT precision",
+      );
+      if (precision.value < 1n || precision.value > 53n) {
+        return throwSqlPolicyParserError(
+          "invalid_type_modifier",
+          `PostgreSQL FLOAT precision must be between 1 and 53; received ${String(precision.value)}`,
+          precision.modifier.range,
+        );
+      }
+      modifiers = [precision.modifier];
+      current = precision.cursor;
+    }
+    return typeBase(
+      current,
+      "float",
+      [first],
+      nameStart,
+      modifiers,
+      null,
+      null,
+    );
+  }
+
+  if (word === "double" && isWord(cursor, 1, "precision")) {
+    const precision = identifierAt(cursor, 1);
+    if (precision === null) {
+      return throwSqlPolicyParserError(
+        "internal_invariant",
+        "PostgreSQL PRECISION token is not an identifier",
+        sqlCursorRange(cursor),
+      );
+    }
+    const current = advanceSqlTokenCursor(
+      cursor,
+      2,
+      "PostgreSQL DOUBLE PRECISION type",
+    );
+    if (isText(current, 0, "(")) {
+      return throwSqlPolicyParserError(
+        "invalid_type_modifier",
+        "PostgreSQL type DOUBLE PRECISION does not allow type modifiers",
+        sqlCursorRange(current),
+      );
+    }
+    return typeBase(
+      current,
+      "double_precision",
+      [first, precision],
+      nameStart,
+      [],
+      null,
+      null,
+    );
+  }
+
+  if (word === "decimal" || word === "dec" || word === "numeric") {
+    let current = advanceSqlTokenCursor(
+      cursor,
+      1,
+      `PostgreSQL ${word} type`,
+    );
+    let modifiers: ReadonlyArray<SqlTypeModifierNode> = [];
+    if (isText(current, 0, "(")) {
+      const parsed = parseModifierList(current);
+      modifiers = parsed.modifiers;
+      current = parsed.cursor;
+    }
+    return typeBase(
+      current,
+      "decimal",
+      [first],
+      nameStart,
+      modifiers,
+      null,
+      null,
+    );
+  }
+
+  if (word === "bit") {
+    const nameParts: Array<SqlIdentifierToken> = [first];
+    let current = advanceSqlTokenCursor(cursor, 1, "PostgreSQL BIT type");
+    if (isWord(current, 0, "varying")) {
+      const varying = identifierAt(current, 0);
+      if (varying !== null) {
+        nameParts.push(varying);
+      }
+      current = advanceSqlTokenCursor(
+        current,
+        1,
+        "PostgreSQL BIT VARYING type",
+      );
+    }
+    let modifiers: ReadonlyArray<SqlTypeModifierNode> = [];
+    if (isText(current, 0, "(")) {
+      const parsed = parseModifierList(current);
+      modifiers = parsed.modifiers;
+      current = parsed.cursor;
+    }
+    return typeBase(
+      current,
+      "bit",
+      nameParts,
+      nameStart,
+      modifiers,
+      null,
+      null,
+    );
+  }
+
+  if (
+    word === "char"
+    || word === "character"
+    || word === "varchar"
+    || word === "nchar"
+    || word === "national"
+  ) {
+    const nameParts: Array<SqlIdentifierToken> = [first];
+    let current = advanceSqlTokenCursor(
+      cursor,
+      1,
+      "PostgreSQL character type",
+    );
+    if (word === "national") {
+      if (!isWord(current, 0, "char") && !isWord(current, 0, "character")) {
+        return null;
+      }
+      const nationalKind = identifierAt(current, 0);
+      if (nationalKind !== null) {
+        nameParts.push(nationalKind);
+      }
+      current = advanceSqlTokenCursor(
+        current,
+        1,
+        "PostgreSQL national character type",
+      );
+    }
+    if (
+      word !== "varchar"
+      && isWord(current, 0, "varying")
+    ) {
+      const varying = identifierAt(current, 0);
+      if (varying !== null) {
+        nameParts.push(varying);
+      }
+      current = advanceSqlTokenCursor(
+        current,
+        1,
+        "PostgreSQL varying character type",
+      );
+    }
+    let modifiers: ReadonlyArray<SqlTypeModifierNode> = [];
+    if (isText(current, 0, "(")) {
+      const length = parseIntegerModifier(
+        current,
+        "PostgreSQL character length",
+      );
+      modifiers = [length.modifier];
+      current = length.cursor;
+    }
+    return typeBase(
+      current,
+      "character",
+      nameParts,
+      nameStart,
+      modifiers,
+      null,
+      null,
+    );
+  }
+
+  if (word === "time" || word === "timestamp") {
+    let current = advanceSqlTokenCursor(
+      cursor,
+      1,
+      `PostgreSQL ${word} type`,
+    );
+    let modifiers: ReadonlyArray<SqlTypeModifierNode> = [];
+    if (isText(current, 0, "(")) {
+      const precision = parseIntegerModifier(
+        current,
+        `PostgreSQL ${word.toUpperCase()} precision`,
+      );
+      modifiers = [precision.modifier];
+      current = precision.cursor;
+    }
+    const timeZone = parseTimeZone(current);
+    current = timeZone.cursor;
+    return typeBase(
+      current,
+      word,
+      [first],
+      nameStart,
+      modifiers,
+      null,
+      timeZone.node,
+    );
+  }
+
+  if (word === "interval") {
+    let current = advanceSqlTokenCursor(
+      cursor,
+      1,
+      "PostgreSQL INTERVAL type",
+    );
+    let modifiers: ReadonlyArray<SqlTypeModifierNode> = [];
+    let qualifier: SqlIntervalQualifierNode | null = null;
+    if (isText(current, 0, "(")) {
+      const precision = parseIntegerModifier(
+        current,
+        "PostgreSQL INTERVAL leading precision",
+      );
+      modifiers = [precision.modifier];
+      current = precision.cursor;
+      const followingField = tokenWord(sqlTokenAt(current, 0));
+      if (
+        followingField !== null
+        && INTERVAL_FIELDS.has(followingField)
+      ) {
+        return throwSqlPolicyParserError(
+          "invalid_type_modifier",
+          "PostgreSQL INTERVAL leading precision cannot be combined with an interval field qualifier",
+          sqlCursorRange(current),
+        );
+      }
+    } else if (context === "typename") {
+      const parsedQualifier = parseIntervalQualifier(current);
+      if (parsedQualifier !== null) {
+        qualifier = parsedQualifier.node;
+        current = parsedQualifier.cursor;
+      }
+    }
+    return typeBase(
+      current,
+      "interval",
+      [first],
+      nameStart,
+      modifiers,
+      qualifier,
+      null,
+    );
+  }
+
+  return null;
+};
+
+const parseArrayBounds = (
+  cursor: SqlTokenCursor,
+): Readonly<{
+  bounds: ReadonlyArray<SqlArrayBoundNode>;
+  cursor: SqlTokenCursor;
+}> => {
+  const bounds: Array<SqlArrayBoundNode> = [];
+  let current = cursor;
+
+  while (isText(current, 0, "[")) {
+    const startIndex = current.index;
+    const closeIndex = matchingSqlDelimiterIndexWithinCursor(
+      current,
+      "invalid_type_name",
+      "PostgreSQL bracket array bound",
+    );
+    if (
+      closeIndex !== startIndex + 1
+      && closeIndex !== startIndex + 2
+    ) {
+      return throwSqlPolicyParserError(
+        "invalid_type_name",
+        "PostgreSQL [] array bounds may contain at most one integer constant",
+        sqlCursorRange(current),
+      );
+    }
+    let size: string | null = null;
+    if (closeIndex === startIndex + 2) {
+      const valueToken = sqlTokenAt(current, 1);
+      const integerConstant = postgreSqlIntegerConstant(valueToken);
+      if (integerConstant === null) {
+        return throwSqlPolicyParserError(
+          "invalid_type_name",
+          "PostgreSQL array bounds require an integer constant between 0 and 2147483647",
+          valueToken?.range ?? sqlCursorRange(current),
+        );
+      }
+      size = integerConstant.semanticValue;
+    }
+    const range = sqlRangeFromTokenIndexes(
+      current.kernel,
+      startIndex,
+      closeIndex + 1,
+    );
+    bounds.push({ notation: "brackets", range, size });
+    current = advanceSqlTokenCursor(
+      current,
+      closeIndex - startIndex + 1,
+      "PostgreSQL bracket array bound",
+    );
+  }
+
+  if (isWord(current, 0, "array")) {
+    if (bounds.length > 0) {
+      return throwSqlPolicyParserError(
+        "invalid_type_name",
+        "PostgreSQL Typename cannot combine [] array bounds with ARRAY syntax",
+        sqlCursorRange(current),
+      );
+    }
+    const startIndex = current.index;
+    current = advanceSqlTokenCursor(
+      current,
+      1,
+      "PostgreSQL ARRAY type decoration",
+    );
+    let size: string | null = null;
+    if (isText(current, 0, "[")) {
+      const closeIndex = matchingSqlDelimiterIndexWithinCursor(
+        current,
+        "invalid_type_name",
+        "PostgreSQL sized ARRAY type decoration",
+      );
+      const valueToken = sqlTokenAt(current, 1);
+      const integerConstant = postgreSqlIntegerConstant(valueToken);
+      if (
+        closeIndex !== current.index + 2
+        || integerConstant === null
+      ) {
+        return throwSqlPolicyParserError(
+          "invalid_type_name",
+          "PostgreSQL ARRAY[n] requires exactly one integer constant between 0 and 2147483647",
+          valueToken?.range ?? sqlCursorRange(current),
+        );
+      }
+      size = integerConstant.semanticValue;
+      current = advanceSqlTokenCursor(
+        current,
+        3,
+        "PostgreSQL sized ARRAY type decoration",
+      );
+    }
+    const range = sqlRangeFromTokenIndexes(
+      current.kernel,
+      startIndex,
+      current.index,
+    );
+    bounds.push({ notation: "array", range, size });
+    if (isText(current, 0, "[") || isWord(current, 0, "array")) {
+      return throwSqlPolicyParserError(
+        "invalid_type_name",
+        "PostgreSQL ARRAY type syntax is one-dimensional and cannot be followed by another array decoration",
+        sqlCursorRange(current),
+      );
+    }
+  }
+  return { bounds, cursor: current };
+};
+
+export const parsePostgreSqlTypeNameAtCursor = (
+  cursor: SqlTokenCursor,
+  context: TypeNameContext,
+): SqlTypeParseResult<SqlTypeNameNode> | null => {
+  const startIndex = cursor.index;
+  let current = cursor;
+  let setOf = false;
+  if (context === "typename" && isWord(current, 0, "setof")) {
+    setOf = true;
+    current = advanceSqlTokenCursor(
+      current,
+      1,
+      "PostgreSQL SETOF type",
+    );
+  }
+
+  const special = parseSpecialType(current, context);
+  const base = special ?? parseGenericType(current, context);
+  if (base === null) {
+    return null;
+  }
+  current = base.cursor;
+
+  let arrayBounds: ReadonlyArray<SqlArrayBoundNode> = [];
+  if (context === "typename") {
+    const arrays = parseArrayBounds(current);
+    arrayBounds = arrays.bounds;
+    current = arrays.cursor;
+  }
+
+  const range = sqlRangeFromTokenIndexes(
+    cursor.kernel,
+    startIndex,
+    current.index,
+  );
+  return {
+    cursor: current,
+    node: {
+      arrayBounds,
+      form: base.form,
+      intervalQualifier: base.intervalQualifier,
+      modifiers: base.modifiers,
+      nameParts: base.nameParts,
+      nameRange: base.nameRange,
+      range,
+      setOf,
+      sql: cursor.kernel.sql.slice(range.start, range.end),
+      timeZone: base.timeZone,
+    },
+  };
+};
+
+export const parsePostgreSqlTypedConstantAtCursor = (
+  cursor: SqlTokenCursor,
+): SqlTypeParseResult<SqlTypedConstantNode> | null => {
+  const parsedType = parsePostgreSqlTypeNameAtCursor(
+    cursor,
+    "typed_constant",
+  );
+  if (parsedType === null) {
+    return null;
+  }
+  const value = sqlTokenAt(parsedType.cursor, 0);
+  if (!isStringConstant(value)) {
+    return null;
+  }
+  let current = advanceSqlTokenCursor(
+    parsedType.cursor,
+    1,
+    "PostgreSQL typed constant value",
+  );
+  let qualifier: SqlIntervalQualifierNode | null = null;
+  if (parsedType.node.form === "interval") {
+    if (parsedType.node.modifiers.length > 0) {
+      const following = tokenWord(sqlTokenAt(current, 0));
+      if (following !== null && INTERVAL_FIELDS.has(following)) {
+        return throwSqlPolicyParserError(
+          "invalid_typed_constant",
+          "PostgreSQL INTERVAL leading precision typed constants cannot have a postfix field qualifier",
+          sqlCursorRange(current),
+        );
+      }
+    } else {
+      const parsedQualifier = parseIntervalQualifier(current);
+      if (parsedQualifier !== null) {
+        qualifier = parsedQualifier.node;
+        current = parsedQualifier.cursor;
+      }
+    }
+  }
+  const range = sqlRangeFromTokenIndexes(
+    cursor.kernel,
+    cursor.index,
+    current.index,
+  );
+  return {
+    cursor: current,
+    node: {
+      intervalQualifier: qualifier,
+      range,
+      sql: cursor.kernel.sql.slice(range.start, range.end),
+      typeName: parsedType.node,
+      value,
+    },
+  };
+};
+
+const directFragmentCursor = (
+  kernel: SqlParserKernel,
+  subject: string,
+): SqlTokenCursor => {
+  const statement = kernel.statements[0];
+  if (
+    statement === undefined
+    || kernel.statements.length !== 1
+    || statement.startIndex !== 0
+    || statement.endIndex !== kernel.tokens.length
+    || statement.terminatorRange !== null
+  ) {
+    const unexpected = kernel.statements[1]?.range
+      ?? statement?.terminatorRange
+      ?? kernel.tokens[0]?.range
+      ?? { start: 0, end: 0 };
+    return throwSqlPolicyParserError(
+      "unexpected_token",
+      `${subject} requires exactly one non-empty SQL fragment without a statement terminator`,
+      unexpected,
+    );
+  }
+  return createSqlTokenCursor(
+    kernel,
+    statement.startIndex,
+    statement.endIndex,
+  );
+};
+
+const assertFullyConsumed = (
+  result: SqlTypeParseResult<SqlTypeNameNode | SqlTypedConstantNode>,
+  subject: string,
+): void => {
+  if (result.cursor.index === result.cursor.endIndex) {
+    return;
+  }
+  const token = sqlTokenAt(result.cursor, 0);
+  return throwSqlPolicyParserError(
+    "unexpected_token",
+    `Unexpected token ${token?.text ?? "at end of input"} after ${subject}`,
+    token?.range ?? sqlCursorRange(result.cursor),
+  );
+};
+
+export const parsePostgreSqlTypeNameInfrastructure = (
+  sql: string,
+  limits: SqlParserLimits,
+): SqlTypeNameNode => {
+  const kernel = createSqlParserKernel(sql, limits);
+  const cursor = directFragmentCursor(kernel, "PostgreSQL Typename parsing");
+  const result = parsePostgreSqlTypeNameAtCursor(cursor, "typename");
+  if (result === null) {
+    return throwSqlPolicyParserError(
+      "invalid_type_name",
+      "Expected a PostgreSQL 18 Typename",
+      sqlCursorRange(cursor),
+    );
+  }
+  assertFullyConsumed(result, "PostgreSQL Typename");
+  return result.node;
+};
+
+export const parsePostgreSqlTypedConstantInfrastructure = (
+  sql: string,
+  limits: SqlParserLimits,
+): SqlTypedConstantNode => {
+  const kernel = createSqlParserKernel(sql, limits);
+  const cursor = directFragmentCursor(
+    kernel,
+    "PostgreSQL typed-constant parsing",
+  );
+  const result = parsePostgreSqlTypedConstantAtCursor(cursor);
+  if (result === null) {
+    return throwSqlPolicyParserError(
+      "invalid_typed_constant",
+      "Expected a complete PostgreSQL 18 typed constant",
+      sqlCursorRange(cursor),
+    );
+  }
+  assertFullyConsumed(result, "PostgreSQL typed constant");
+  return result.node;
+};


### PR DESCRIPTION
## Summary
- add a dormant PostgreSQL-compatible parser kernel over the existing SQL lexer
- add exact PostgreSQL 18 type and typed-constant grammar support
- add direct parser, limit, delimiter, range, and differential coverage

## Behavior
- no production policy import or public package export
- no runtime behavior change

## Validation
- agent-shared tests, type checks, lint, and build
- unchanged lexer and restricted SQL policy tests
- SQL API tests, lint, and build
- web agent/chat tests, lint, and production build
- PostgreSQL 18.4 differential and complexity probes