### PR TITLE
Own and freeze SQL parser kernel state

### DIFF
--- a/packages/agent-shared/src/sql-policy-parser-kernel.test.ts
+++ b/packages/agent-shared/src/sql-policy-parser-kernel.test.ts
@@ -1,0 +1,363 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import {
+  createSqlParserKernel,
+  DEFAULT_SQL_PARSER_LIMITS,
+  type SqlParserLimits,
+} from "./sql-policy-parser-kernel.js";
+import {
+  SqlPolicyParserError,
+  type SqlPolicyParserErrorCode,
+} from "./sql-policy-parser-model.js";
+
+const limits = (
+  maxSourceCodeUnits: number,
+  maxTokens: number,
+  maxNestingDepth: number,
+  maxWorkUnits: number,
+): SqlParserLimits => ({
+  maxNestingDepth,
+  maxSourceCodeUnits,
+  maxTokens,
+  maxWorkUnits,
+});
+
+const expectParserError = (
+  action: () => void,
+  code: SqlPolicyParserErrorCode,
+  range: Readonly<{ start: number; end: number }>,
+): SqlPolicyParserError => {
+  let caught: Error | null = null;
+  try {
+    action();
+  } catch (error) {
+    if (error instanceof Error) {
+      caught = error;
+    }
+  }
+  assert.ok(caught instanceof SqlPolicyParserError);
+  assert.equal(caught.code, code);
+  assert.deepEqual(caught.range, range);
+  return caught;
+};
+
+const cannotSet = (
+  target: object,
+  property: PropertyKey,
+  value: string | number | null,
+): void => {
+  assert.equal(Reflect.set(target, property, value), false);
+};
+
+test("kernel immediately snapshots and freezes exact parser limits", (): void => {
+  const supplied = {
+    maxNestingDepth: 20,
+    maxSourceCodeUnits: 1_000,
+    maxTokens: 100,
+    maxWorkUnits: 200,
+  };
+  const kernel = createSqlParserKernel("select 1", supplied);
+
+  assert.notEqual(kernel.limits, supplied);
+  assert.deepEqual(kernel.limits, supplied);
+  assert.ok(Object.isFrozen(kernel.limits));
+  supplied.maxSourceCodeUnits = 1;
+  supplied.maxTokens = 1;
+  supplied.maxNestingDepth = 1;
+  supplied.maxWorkUnits = 1;
+  assert.deepEqual(kernel.limits, limits(1_000, 100, 20, 200));
+  cannotSet(kernel.limits, "maxTokens", 1);
+  assert.equal(kernel.limits.maxTokens, 100);
+
+  const withExtra = {
+    ...DEFAULT_SQL_PARSER_LIMITS,
+    extra: 1,
+  };
+  expectParserError(
+    () => createSqlParserKernel("select 1", withExtra),
+    "invalid_configuration",
+    { start: 0, end: 0 },
+  );
+});
+
+test("kernel rejects non-numeric own limit values without coercion", (): void => {
+  let coercionAttempts = 0;
+  const throwingToString = {
+    toString: (): string => {
+      coercionAttempts++;
+      throw new TypeError("limit toString must not run");
+    },
+  };
+  const throwingPrimitive = {
+    [Symbol.toPrimitive]: (): number => {
+      coercionAttempts++;
+      throw new TypeError("limit Symbol.toPrimitive must not run");
+    },
+  };
+  type InvalidLimitValue =
+    | bigint
+    | boolean
+    | number
+    | object
+    | string
+    | symbol
+    | null
+    | undefined;
+  const invalidValues: ReadonlyArray<Readonly<{
+    label: string;
+    value: InvalidLimitValue;
+  }>> = [
+    { label: "plain object", value: {} },
+    { label: "throwing toString", value: throwingToString },
+    { label: "throwing Symbol.toPrimitive", value: throwingPrimitive },
+    { label: "function", value: (): void => undefined },
+    { label: "symbol", value: Symbol("limit") },
+    { label: "bigint", value: 1n },
+    { label: "string", value: "1" },
+    { label: "boolean", value: true },
+    { label: "null", value: null },
+    { label: "undefined", value: undefined },
+    { label: "NaN", value: Number.NaN },
+    { label: "positive infinity", value: Number.POSITIVE_INFINITY },
+    { label: "negative infinity", value: Number.NEGATIVE_INFINITY },
+    { label: "fraction", value: 1.5 },
+    { label: "unsafe integer", value: Number.MAX_SAFE_INTEGER + 1 },
+    { label: "negative", value: -1 },
+    { label: "zero", value: 0 },
+  ];
+  const fields: ReadonlyArray<keyof SqlParserLimits> = [
+    "maxSourceCodeUnits",
+    "maxTokens",
+    "maxNestingDepth",
+    "maxWorkUnits",
+  ];
+
+  for (const field of fields) {
+    for (const invalid of invalidValues) {
+      const supplied = limits(1_000, 100, 20, 200);
+      Object.defineProperty(supplied, field, {
+        configurable: true,
+        enumerable: true,
+        value: invalid.value,
+        writable: true,
+      });
+      const attemptsBeforeValidation = coercionAttempts;
+      const error = expectParserError(
+        () => createSqlParserKernel("select 1", supplied),
+        "invalid_configuration",
+        { start: 0, end: 0 },
+      );
+      assert.match(error.message, new RegExp(field, "u"), invalid.label);
+      assert.equal(
+        coercionAttempts,
+        attemptsBeforeValidation,
+        invalid.label,
+      );
+    }
+  }
+});
+
+test("kernel deeply owns and freezes every lexer token shape", (): void => {
+  const sql = [
+    " \n--line\n/*block*/ ",
+    String.raw`plain "quoted" U&"d\0061t" `,
+    "'ordinary'\n'continued' ",
+    String.raw`E'\101' U&'\0061' N'national' B'1010' X'CAFE' `,
+    "$tag$dollar$tag$ $1 12.5 0x1f 0b10 0o7 + , ; next",
+  ].join("");
+  const kernel = createSqlParserKernel(sql, DEFAULT_SQL_PARSER_LIMITS);
+
+  assert.ok(Object.isFrozen(kernel));
+  assert.ok(Object.isFrozen(kernel.sourceTokens));
+  assert.ok(Object.isFrozen(kernel.tokens));
+  assert.equal(kernel.sourceTokens.map((token) => token.text).join(""), sql);
+  assert.deepEqual(
+    new Set(kernel.sourceTokens.map((token) => token.kind)),
+    new Set([
+      "comment",
+      "identifier",
+      "numeric",
+      "operator",
+      "parameter",
+      "punctuation",
+      "string",
+      "whitespace",
+    ]),
+  );
+
+  const stringStyles = new Set<string>();
+  const numericForms = new Set<string>();
+  const commentStyles = new Set<string>();
+  let sawQuotedIdentifier = false;
+  let sawUnicodeIdentifier = false;
+  for (const token of kernel.sourceTokens) {
+    assert.ok(Object.isFrozen(token));
+    assert.ok(Object.isFrozen(token.range));
+    assert.equal(sql.slice(token.range.start, token.range.end), token.text);
+    cannotSet(token.range, "start", 999);
+    cannotSet(token, "text", "changed");
+    if (token.kind === "comment") {
+      commentStyles.add(token.style);
+    }
+    if (token.kind === "identifier") {
+      sawQuotedIdentifier ||= token.quoted;
+      sawUnicodeIdentifier ||= token.unicodeEscaped;
+    }
+    if (token.kind === "numeric") {
+      assert.equal(token.valid, true);
+      if (token.valid) {
+        numericForms.add(token.form);
+      }
+    }
+    if (token.kind === "string") {
+      stringStyles.add(token.style);
+      assert.ok(Object.isFrozen(token.semanticSegments));
+      for (const segment of token.semanticSegments) {
+        assert.ok(Object.isFrozen(segment));
+        assert.ok(Object.isFrozen(segment.range));
+        cannotSet(segment, "value", "changed");
+        cannotSet(segment.range, "end", 0);
+      }
+      cannotSet(token.semanticSegments, "0", null);
+    }
+  }
+
+  assert.deepEqual(commentStyles, new Set(["block", "line"]));
+  assert.equal(sawQuotedIdentifier, true);
+  assert.equal(sawUnicodeIdentifier, true);
+  assert.deepEqual(
+    stringStyles,
+    new Set([
+      "bit",
+      "dollar",
+      "escape",
+      "hex",
+      "national",
+      "ordinary",
+      "unicode",
+    ]),
+  );
+  assert.deepEqual(
+    numericForms,
+    new Set(["binary", "decimal", "hexadecimal", "octal"]),
+  );
+  cannotSet(kernel.sourceTokens, "0", null);
+  cannotSet(kernel.tokens, "0", null);
+  assert.equal(kernel.sourceTokens.map((token) => token.text).join(""), sql);
+});
+
+test("statements and delimiter lookup are deeply immutable and reciprocal", (): void => {
+  const sql = "numeric /* gap */ (10, (2))[]; interval day to second(3)";
+  const kernel = createSqlParserKernel(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const lookup = kernel.delimiters.matchingIndexes;
+
+  assert.ok(Object.isFrozen(kernel.delimiters));
+  assert.ok(Object.isFrozen(lookup));
+  assert.ok(Object.isFrozen(lookup.get));
+  assert.ok(Object.isFrozen(kernel.statements));
+  assert.equal("set" in lookup, false);
+  assert.equal("delete" in lookup, false);
+  assert.equal("clear" in lookup, false);
+  assert.equal(kernel.delimiters.scanSteps, kernel.tokens.length);
+  assert.equal(kernel.statements.length, 2);
+  for (const statement of kernel.statements) {
+    assert.ok(Object.isFrozen(statement));
+    assert.ok(Object.isFrozen(statement.range));
+    if (statement.terminatorRange !== null) {
+      assert.ok(Object.isFrozen(statement.terminatorRange));
+      cannotSet(statement.terminatorRange, "start", 999);
+    }
+    cannotSet(statement.range, "end", 0);
+    cannotSet(statement, "endIndex", 0);
+  }
+
+  const openingIndexes = kernel.tokens.flatMap((token, index) =>
+    token.text === "(" || token.text === "[" ? [index] : []
+  );
+  assert.equal(lookup.size, openingIndexes.length * 2);
+  for (const openingIndex of openingIndexes) {
+    const closingIndex = lookup.get(openingIndex);
+    assert.notEqual(closingIndex, undefined);
+    if (closingIndex !== undefined) {
+      assert.equal(lookup.get(closingIndex), openingIndex);
+    }
+  }
+  assert.equal(lookup.get(-1), undefined);
+  assert.equal(lookup.get(kernel.tokens.length), undefined);
+  cannotSet(lookup, "size", 0);
+  cannotSet(kernel.statements, "0", null);
+});
+
+test("token limit reports the first excess before owned graph construction", (): void => {
+  const exact = expectParserError(
+    () => createSqlParserKernel("a b c", limits(100, 2, 8, 20)),
+    "limit_tokens",
+    { start: 4, end: 5 },
+  );
+  assert.match(exact.message, /token count 3 exceeds maxTokens=2/u);
+
+  const kernelUrl = new URL(
+    "./sql-policy-parser-kernel.ts",
+    import.meta.url,
+  ).href;
+  const probe = spawnSync(
+    process.execPath,
+    [
+      "--max-old-space-size=192",
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "-e",
+      `
+        const { createSqlParserKernel } = await import(${JSON.stringify(kernelUrl)});
+        const tokenCount = 1_000_000;
+        const sql = ",".repeat(tokenCount);
+        try {
+          createSqlParserKernel(sql, {
+            maxNestingDepth: 8,
+            maxSourceCodeUnits: sql.length,
+            maxTokens: 1,
+            maxWorkUnits: tokenCount + 1,
+          });
+          process.exitCode = 2;
+        } catch (error) {
+          process.stdout.write(JSON.stringify({
+            code: error.code,
+            message: error.message,
+            range: error.range,
+          }));
+        }
+      `,
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1_000_000,
+      timeout: 10_000,
+    },
+  );
+  assert.equal(probe.status, 0, probe.stderr);
+  assert.equal(
+    probe.stdout,
+    '{"code":"limit_tokens","message":"SQL parser token count 1000000 exceeds maxTokens=1","range":{"start":1,"end":2}}',
+  );
+});
+
+test("delimiter construction is linear with repeated constant-time lookup", (): void => {
+  const groups = 8_000;
+  const sql = "(x)".repeat(groups);
+  const kernel = createSqlParserKernel(
+    sql,
+    limits(sql.length, groups * 3, 8, groups * 3),
+  );
+
+  assert.equal(kernel.tokens.length, groups * 3);
+  assert.equal(kernel.delimiters.scanSteps, groups * 3);
+  assert.equal(kernel.delimiters.matchingIndexes.size, groups * 2);
+  for (let group = 0; group < groups; group++) {
+    const openIndex = group * 3;
+    const closeIndex = openIndex + 2;
+    assert.equal(kernel.delimiters.matchingIndexes.get(openIndex), closeIndex);
+    assert.equal(kernel.delimiters.matchingIndexes.get(closeIndex), openIndex);
+  }
+});

--- a/packages/agent-shared/src/sql-policy-parser-kernel.ts
+++ b/packages/agent-shared/src/sql-policy-parser-kernel.ts
@@ -2,7 +2,6 @@ import {
   lexSqlPolicyInfrastructure,
   type SqlCommentToken,
   type SqlLexedScript,
-  type SqlNumericToken,
   type SqlPolicyToken,
   type SqlSourceRange,
   type SqlWhitespaceToken,
@@ -25,12 +24,12 @@ export type SqlParserLimits = Readonly<{
   maxWorkUnits: number;
 }>;
 
-export const DEFAULT_SQL_PARSER_LIMITS: SqlParserLimits = {
+export const DEFAULT_SQL_PARSER_LIMITS: SqlParserLimits = Object.freeze({
   maxSourceCodeUnits: 1_000_000,
   maxTokens: 100_000,
   maxNestingDepth: 256,
   maxWorkUnits: 500_000,
-};
+});
 
 export type SqlParserStatementSpan = Readonly<{
   range: SqlSourceRange;
@@ -39,8 +38,13 @@ export type SqlParserStatementSpan = Readonly<{
   endIndex: number;
 }>;
 
+export type SqlDelimiterLookup = Readonly<{
+  get: (index: number) => number | undefined;
+  size: number;
+}>;
+
 export type SqlDelimiterIndex = Readonly<{
-  matchingIndexes: ReadonlyMap<number, number>;
+  matchingIndexes: SqlDelimiterLookup;
   scanSteps: number;
 }>;
 
@@ -68,44 +72,217 @@ type OpenDelimiter = Readonly<{
 const isPositiveInteger = (value: number): boolean =>
   Number.isSafeInteger(value) && value > 0;
 
-const validateLimits = (limits: SqlParserLimits): void => {
-  if (!isPositiveInteger(limits.maxSourceCodeUnits)) {
+const isNonNegativeInteger = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 0;
+
+const PARSER_LIMIT_FIELDS: ReadonlyArray<string> = Object.freeze([
+  "maxSourceCodeUnits",
+  "maxTokens",
+  "maxNestingDepth",
+  "maxWorkUnits",
+]);
+
+const hasExactOwnParserLimitFields = (limits: SqlParserLimits): boolean => {
+  if (
+    typeof limits !== "object"
+    || limits === null
+    || Array.isArray(limits)
+    || Object.getPrototypeOf(limits) !== Object.prototype
+  ) {
+    return false;
+  }
+  const keys = Reflect.ownKeys(limits);
+  if (
+    keys.length !== PARSER_LIMIT_FIELDS.length
+    || keys.some((key) => typeof key !== "string")
+    || PARSER_LIMIT_FIELDS.some((field) => !keys.includes(field))
+  ) {
+    return false;
+  }
+  return PARSER_LIMIT_FIELDS.every((field) => {
+    const descriptor = Object.getOwnPropertyDescriptor(limits, field);
+    return descriptor !== undefined && "value" in descriptor;
+  });
+};
+
+const validatePositiveLimit = (
+  field: keyof SqlParserLimits,
+  value: number,
+): void => {
+  if (typeof value !== "number") {
     return throwSqlPolicyParserError(
       "invalid_configuration",
-      `SQL parser maxSourceCodeUnits must be a positive safe integer; received ${String(limits.maxSourceCodeUnits)}`,
+      `SQL parser ${field} must be a primitive number; received value type ${typeof value}`,
       emptySqlSourceRange(0),
     );
   }
-  if (!isPositiveInteger(limits.maxTokens)) {
+  if (!isPositiveInteger(value)) {
     return throwSqlPolicyParserError(
       "invalid_configuration",
-      `SQL parser maxTokens must be a positive safe integer; received ${String(limits.maxTokens)}`,
-      emptySqlSourceRange(0),
-    );
-  }
-  if (!isPositiveInteger(limits.maxNestingDepth)) {
-    return throwSqlPolicyParserError(
-      "invalid_configuration",
-      `SQL parser maxNestingDepth must be a positive safe integer; received ${String(limits.maxNestingDepth)}`,
-      emptySqlSourceRange(0),
-    );
-  }
-  if (!isPositiveInteger(limits.maxWorkUnits)) {
-    return throwSqlPolicyParserError(
-      "invalid_configuration",
-      `SQL parser maxWorkUnits must be a positive safe integer; received ${String(limits.maxWorkUnits)}`,
+      `SQL parser ${field} must be a positive safe integer; received ${String(value)}`,
       emptySqlSourceRange(0),
     );
   }
 };
 
+const validateLimits = (limits: SqlParserLimits): void => {
+  validatePositiveLimit("maxSourceCodeUnits", limits.maxSourceCodeUnits);
+  validatePositiveLimit("maxTokens", limits.maxTokens);
+  validatePositiveLimit("maxNestingDepth", limits.maxNestingDepth);
+  validatePositiveLimit("maxWorkUnits", limits.maxWorkUnits);
+};
+
+const snapshotParserLimits = (limits: SqlParserLimits): SqlParserLimits => {
+  if (!hasExactOwnParserLimitFields(limits)) {
+    return throwSqlPolicyParserError(
+      "invalid_configuration",
+      `SQL parser limits must be a plain object with exactly the own data fields ${PARSER_LIMIT_FIELDS.join(", ")}`,
+      emptySqlSourceRange(0),
+    );
+  }
+  const owned: SqlParserLimits = {
+    maxNestingDepth: limits.maxNestingDepth,
+    maxSourceCodeUnits: limits.maxSourceCodeUnits,
+    maxTokens: limits.maxTokens,
+    maxWorkUnits: limits.maxWorkUnits,
+  };
+  validateLimits(owned);
+  return Object.freeze(owned);
+};
+
+const ownSqlSourceRange = (range: SqlSourceRange): SqlSourceRange =>
+  Object.freeze({ start: range.start, end: range.end });
+
+const unsupportedSqlPolicyToken = (token: never): never => {
+  void token;
+  return throwSqlPolicyParserError(
+    "internal_invariant",
+    "SQL lexer returned an unsupported token discriminant",
+    emptySqlSourceRange(0),
+  );
+};
+
+const ownSqlPolicyToken = (token: SqlPolicyToken): SqlPolicyToken => {
+  const range = ownSqlSourceRange(token.range);
+  if (token.kind === "whitespace") {
+    return Object.freeze({ kind: "whitespace", range, text: token.text });
+  }
+  if (token.kind === "comment") {
+    return Object.freeze({
+      kind: "comment",
+      range,
+      style: token.style,
+      text: token.text,
+    });
+  }
+  if (token.kind === "identifier") {
+    return Object.freeze({
+      kind: "identifier",
+      normalized: token.normalized,
+      quoted: token.quoted,
+      range,
+      text: token.text,
+      truncated: token.truncated,
+      unicodeEscapeCharacter: token.unicodeEscapeCharacter,
+      unicodeEscaped: token.unicodeEscaped,
+      untruncatedNormalized: token.untruncatedNormalized,
+    });
+  }
+  if (token.kind === "string") {
+    const semanticSegments = Object.freeze(
+      token.semanticSegments.map((segment) =>
+        Object.freeze({
+          range: ownSqlSourceRange(segment.range),
+          value: segment.value,
+        }),
+      ),
+    );
+    return Object.freeze({
+      dollarTag: token.dollarTag,
+      kind: "string",
+      range,
+      semanticSegments,
+      semanticValue: token.semanticValue,
+      style: token.style,
+      text: token.text,
+      unicodeEscapeCharacter: token.unicodeEscapeCharacter,
+    });
+  }
+  if (token.kind === "parameter") {
+    return Object.freeze({
+      kind: "parameter",
+      position: token.position,
+      positionText: token.positionText,
+      range,
+      text: token.text,
+    });
+  }
+  if (token.kind === "numeric") {
+    if (token.valid) {
+      return Object.freeze({
+        form: token.form,
+        kind: "numeric",
+        normalized: token.normalized,
+        range,
+        text: token.text,
+        valid: true,
+      });
+    }
+    return Object.freeze({
+      diagnostic: Object.freeze({
+        code: token.diagnostic.code,
+        message: token.diagnostic.message,
+      }),
+      kind: "numeric",
+      range,
+      text: token.text,
+      valid: false,
+    });
+  }
+  if (token.kind === "operator") {
+    return Object.freeze({ kind: "operator", range, text: token.text });
+  }
+  if (token.kind === "punctuation") {
+    return Object.freeze({ kind: "punctuation", range, text: token.text });
+  }
+  return unsupportedSqlPolicyToken(token);
+};
+
+const ownSqlSourceTokens = (
+  tokens: ReadonlyArray<SqlPolicyToken>,
+): ReadonlyArray<SqlPolicyToken> =>
+  Object.freeze(tokens.map(ownSqlPolicyToken));
+
+type SignificantTokenLimitScan = Readonly<{
+  count: number;
+  firstExcess: SqlPolicyToken | null;
+}>;
+
+const scanSignificantTokenLimit = (
+  tokens: ReadonlyArray<SqlPolicyToken>,
+  maxTokens: number,
+): SignificantTokenLimitScan => {
+  let count = 0;
+  let firstExcess: SqlPolicyToken | null = null;
+  for (const token of tokens) {
+    if (token.kind === "comment" || token.kind === "whitespace") {
+      continue;
+    }
+    if (count === maxTokens) {
+      firstExcess = token;
+    }
+    count++;
+  }
+  return { count, firstExcess };
+};
+
 const significantTokens = (
-  lexed: SqlLexedScript,
+  sourceTokens: ReadonlyArray<SqlPolicyToken>,
 ): ReadonlyArray<SqlParserToken> =>
-  lexed.tokens.filter(
+  Object.freeze(sourceTokens.filter(
     (token): token is SqlParserToken =>
       token.kind !== "comment" && token.kind !== "whitespace",
-  );
+  ));
 
 const errorRangeAtIndex = (
   sql: string,
@@ -115,21 +292,18 @@ const errorRangeAtIndex = (
   tokens[index]?.range ?? emptySqlSourceRange(sql.length);
 
 const assertNumericTokensValid = (
-  sql: string,
   tokens: ReadonlyArray<SqlParserToken>,
 ): void => {
   for (const token of tokens) {
     if (token.kind !== "numeric" || token.valid) {
       continue;
     }
-    const invalid = token as SqlNumericToken & Readonly<{ valid: false }>;
     return throwSqlPolicyParserError(
       "invalid_numeric",
-      `Invalid PostgreSQL numeric token at offset ${String(token.range.start)}: ${invalid.diagnostic.message}`,
+      `Invalid PostgreSQL numeric token at offset ${String(token.range.start)}: ${token.diagnostic.message}`,
       token.range,
     );
   }
-  void sql;
 };
 
 const expectedOpenDelimiter = (text: string): "(" | "[" | null => {
@@ -166,9 +340,13 @@ const buildDelimiterIndex = (
   tokens: ReadonlyArray<SqlParserToken>,
   limits: SqlParserLimits,
 ): SqlDelimiterIndex => {
-  const matchingIndexes = new Map<number, number>();
+  const matchingIndexes: Array<number | null> = Array.from(
+    { length: tokens.length },
+    (): null => null,
+  );
   const stack: Array<OpenDelimiter> = [];
   let scanSteps = 0;
+  let matchedDelimiterCount = 0;
 
   for (let index = 0; index < tokens.length; index++) {
     const token = tokens[index];
@@ -233,8 +411,9 @@ const buildDelimiterIndex = (
         token.range,
       );
     }
-    matchingIndexes.set(open.index, index);
-    matchingIndexes.set(index, open.index);
+    matchingIndexes[open.index] = index;
+    matchingIndexes[index] = open.index;
+    matchedDelimiterCount += 2;
   }
 
   const unclosed = stack.at(-1);
@@ -247,7 +426,20 @@ const buildDelimiterIndex = (
     );
   }
 
-  return { matchingIndexes, scanSteps };
+  const ownedMatches = Object.freeze(matchingIndexes);
+  const get = Object.freeze((index: number): number | undefined => {
+    if (!isNonNegativeInteger(index) || index >= ownedMatches.length) {
+      return undefined;
+    }
+    return ownedMatches[index] ?? undefined;
+  });
+  return Object.freeze({
+    matchingIndexes: Object.freeze({
+      get,
+      size: matchedDelimiterCount,
+    }),
+    scanSteps,
+  });
 };
 
 const buildStatementSpans = (
@@ -289,7 +481,7 @@ const buildStatementSpans = (
       emptySqlSourceRange(sql.length),
     );
   }
-  return tokenSpans.map((span, index) => {
+  return Object.freeze(tokenSpans.map((span, index) => {
     const statement = lexed.statements[index];
     if (statement === undefined) {
       return throwSqlPolicyParserError(
@@ -298,49 +490,57 @@ const buildStatementSpans = (
         emptySqlSourceRange(sql.length),
       );
     }
-    return {
-      ...span,
-      range: statement.range,
-      terminatorRange: statement.terminatorRange,
-    };
-  });
+    return Object.freeze({
+      endIndex: span.endIndex,
+      range: ownSqlSourceRange(statement.range),
+      startIndex: span.startIndex,
+      terminatorRange: statement.terminatorRange === null
+        ? null
+        : ownSqlSourceRange(statement.terminatorRange),
+    });
+  }));
 };
 
 export const createSqlParserKernel = (
   sql: string,
   limits: SqlParserLimits,
 ): SqlParserKernel => {
-  validateLimits(limits);
-  if (sql.length > limits.maxSourceCodeUnits) {
+  const ownedLimits = snapshotParserLimits(limits);
+  if (sql.length > ownedLimits.maxSourceCodeUnits) {
     return throwSqlPolicyParserError(
       "limit_source_length",
-      `SQL source length ${String(sql.length)} UTF-16 code units exceeds maxSourceCodeUnits=${String(limits.maxSourceCodeUnits)}; the first excess code unit is at offset ${String(limits.maxSourceCodeUnits)}`,
+      `SQL source length ${String(sql.length)} UTF-16 code units exceeds maxSourceCodeUnits=${String(ownedLimits.maxSourceCodeUnits)}; the first excess code unit is at offset ${String(ownedLimits.maxSourceCodeUnits)}`,
       {
-        start: limits.maxSourceCodeUnits,
-        end: limits.maxSourceCodeUnits + 1,
+        start: ownedLimits.maxSourceCodeUnits,
+        end: ownedLimits.maxSourceCodeUnits + 1,
       },
     );
   }
   const lexed = lexSqlPolicyInfrastructure(sql);
-  const tokens = significantTokens(lexed);
-  if (tokens.length > limits.maxTokens) {
-    const token = tokens[limits.maxTokens];
+  const limitScan = scanSignificantTokenLimit(
+    lexed.tokens,
+    ownedLimits.maxTokens,
+  );
+  if (limitScan.firstExcess !== null) {
     return throwSqlPolicyParserError(
       "limit_tokens",
-      `SQL parser token count ${String(tokens.length)} exceeds maxTokens=${String(limits.maxTokens)}`,
-      token?.range ?? emptySqlSourceRange(sql.length),
+      `SQL parser token count ${String(limitScan.count)} exceeds maxTokens=${String(ownedLimits.maxTokens)}`,
+      limitScan.firstExcess.range,
     );
   }
-  assertNumericTokensValid(sql, tokens);
-  const delimiters = buildDelimiterIndex(sql, tokens, limits);
-  return {
-    sql,
+  const sourceTokens = ownSqlSourceTokens(lexed.tokens);
+  const tokens = significantTokens(sourceTokens);
+  assertNumericTokensValid(tokens);
+  const delimiters = buildDelimiterIndex(sql, tokens, ownedLimits);
+  const statements = buildStatementSpans(sql, tokens, lexed);
+  return Object.freeze({
     delimiters,
-    limits,
-    sourceTokens: lexed.tokens,
-    statements: buildStatementSpans(sql, tokens, lexed),
+    limits: ownedLimits,
+    sourceTokens,
+    sql,
+    statements,
     tokens,
-  };
+  });
 };
 
 export const createSqlTokenCursor = (


### PR DESCRIPTION
## Summary
- snapshot and deeply freeze dormant parser-kernel state
- replace mutable delimiter Map exposure with immutable O(1) lookup
- reject token-limit excess before the second owned token graph
- add ownership, limit, allocation, and scaling coverage

## Validation
- agent-shared: 53 tests, lint, build
- SQL API: 6 tests, lint, build
- web agent/chat: 160 tests + 3 SSE tests, lint, production build
- final fresh review: CLEAN, NO-SPLIT