### PR TITLE
Add charged typed constant parse attempts

### DIFF
--- a/packages/agent-shared/src/sql-policy-type-model.ts
+++ b/packages/agent-shared/src/sql-policy-type-model.ts
@@ -78,6 +78,17 @@ export type SqlTypedConstantNode = Readonly<{
   value: SqlStringToken;
 }>;
 
+export type SqlTypedConstantParseAttempt =
+  | Readonly<{
+    cursor: SqlTokenCursor;
+    matched: false;
+  }>
+  | Readonly<{
+    cursor: SqlTokenCursor;
+    matched: true;
+    node: SqlTypedConstantNode;
+  }>;
+
 export type SqlTypeParseResult<Node> = Readonly<{
   cursor: SqlTokenCursor;
   node: Node;

--- a/packages/agent-shared/src/sql-policy-type-modifiers.ts
+++ b/packages/agent-shared/src/sql-policy-type-modifiers.ts
@@ -10,7 +10,10 @@ import {
 } from "./sql-policy-parser-keywords.js";
 import {
   advanceSqlTokenCursor,
+  consumeSqlTokenCursor,
+  inspectSqlTokenCursor,
   matchingSqlDelimiterIndexWithinCursor,
+  restoreSqlTokenCursorPosition,
   sqlCursorRange,
   sqlRangeFromTokenIndexes,
   sqlTokenAt,
@@ -36,17 +39,22 @@ export type ParsedModifierList = Readonly<{
   modifiers: ReadonlyArray<SqlTypeModifierNode>;
 }>;
 
+export type PostgreSqlIntervalQualifierParseAttempt =
+  | Readonly<{
+    cursor: SqlTokenCursor;
+    matched: false;
+  }>
+  | Readonly<{
+    cursor: SqlTokenCursor;
+    matched: true;
+    node: SqlIntervalQualifierNode;
+  }>;
+
 const isText = (
   cursor: SqlTokenCursor,
   offset: number,
   expected: string,
 ): boolean => sqlTokenAt(cursor, offset)?.text === expected;
-
-const isWord = (
-  cursor: SqlTokenCursor,
-  offset: number,
-  expected: string,
-): boolean => postgreSqlTokenWord(sqlTokenAt(cursor, offset)) === expected;
 
 export const isPostgreSqlStringConstant = (
   token: SqlParserToken | undefined,
@@ -445,46 +453,75 @@ export const parsePostgreSqlTypeModifierList = (
   };
 };
 
-export const parsePostgreSqlIntervalQualifier = (
+export const parsePostgreSqlIntervalQualifierAttempt = (
   cursor: SqlTokenCursor,
-): SqlTypeParseResult<SqlIntervalQualifierNode> | null => {
-  const firstWord = postgreSqlTokenWord(sqlTokenAt(cursor, 0));
+): PostgreSqlIntervalQualifierParseAttempt => {
+  const firstInspection = inspectSqlTokenCursor(
+    cursor,
+    0,
+    "PostgreSQL interval qualifier first field inspection",
+  );
+  const firstWord = postgreSqlTokenWord(firstInspection.token);
   if (
     firstWord === null
     || !POSTGRESQL_INTERVAL_FIELDS.has(firstWord)
   ) {
-    return null;
+    return {
+      cursor: restoreSqlTokenCursorPosition(cursor, firstInspection.cursor),
+      matched: false,
+    };
   }
   const startIndex = cursor.index;
-  let current = advanceSqlTokenCursor(
-    cursor,
-    1,
-    "PostgreSQL interval qualifier",
-  );
+  let current = consumeSqlTokenCursor(
+    firstInspection.cursor,
+    "PostgreSQL interval qualifier first field",
+  ).cursor;
   let endField = firstWord as SqlIntervalField;
 
-  if (isWord(current, 0, "to")) {
-    const secondWord = postgreSqlTokenWord(sqlTokenAt(current, 1));
+  let nextInspection = inspectSqlTokenCursor(
+    current,
+    0,
+    "PostgreSQL interval qualifier TO inspection",
+  );
+  current = nextInspection.cursor;
+  if (postgreSqlTokenWord(nextInspection.token) === "to") {
+    const toRange = sqlCursorRange(current);
+    current = consumeSqlTokenCursor(
+      current,
+      "PostgreSQL interval qualifier TO",
+    ).cursor;
+    const secondInspection = inspectSqlTokenCursor(
+      current,
+      0,
+      "PostgreSQL interval qualifier second field inspection",
+    );
+    current = secondInspection.cursor;
+    const secondWord = postgreSqlTokenWord(secondInspection.token);
     if (
       secondWord === null
       || !POSTGRESQL_INTERVAL_FIELD_PAIRS.has(`${firstWord}:${secondWord}`)
     ) {
       return throwSqlPolicyParserError(
         "invalid_type_modifier",
-        `PostgreSQL does not allow INTERVAL ${firstWord.toUpperCase()} TO ${(secondWord ?? sqlTokenAt(current, 1)?.text ?? "end of input").toUpperCase()}`,
-        sqlTokenAt(current, 1)?.range ?? sqlCursorRange(current),
+        `PostgreSQL does not allow INTERVAL ${firstWord.toUpperCase()} TO ${(secondWord ?? secondInspection.token?.text ?? "end of input").toUpperCase()}`,
+        secondInspection.token?.range ?? toRange,
       );
     }
     endField = secondWord as SqlIntervalField;
-    current = advanceSqlTokenCursor(
+    current = consumeSqlTokenCursor(
       current,
-      2,
-      "PostgreSQL interval field range",
+      "PostgreSQL interval qualifier second field",
+    ).cursor;
+    nextInspection = inspectSqlTokenCursor(
+      current,
+      0,
+      "PostgreSQL interval qualifier precision inspection",
     );
+    current = nextInspection.cursor;
   }
 
   let secondPrecision: string | null = null;
-  if (isText(current, 0, "(")) {
+  if (nextInspection.token?.text === "(") {
     if (endField !== "second") {
       return throwSqlPolicyParserError(
         "invalid_type_modifier",
@@ -507,6 +544,7 @@ export const parsePostgreSqlIntervalQualifier = (
   );
   return {
     cursor: current,
+    matched: true,
     node: {
       endField,
       range,
@@ -515,4 +553,13 @@ export const parsePostgreSqlIntervalQualifier = (
       startField: firstWord as SqlIntervalField,
     },
   };
+};
+
+export const parsePostgreSqlIntervalQualifier = (
+  cursor: SqlTokenCursor,
+): SqlTypeParseResult<SqlIntervalQualifierNode> | null => {
+  const attempt = parsePostgreSqlIntervalQualifierAttempt(cursor);
+  return attempt.matched
+    ? { cursor: attempt.cursor, node: attempt.node }
+    : null;
 };

--- a/packages/agent-shared/src/sql-policy-type-parser.test.ts
+++ b/packages/agent-shared/src/sql-policy-type-parser.test.ts
@@ -12,6 +12,9 @@ import {
   type SqlPolicyParserErrorCode,
 } from "./sql-policy-parser-model.js";
 import {
+  parsePostgreSqlIntervalQualifierAttempt,
+} from "./sql-policy-type-modifiers.js";
+import {
   parsePostgreSqlTypedConstantAtCursor,
   parsePostgreSqlTypedConstantInfrastructure,
   parsePostgreSqlTypeNameAtCursor,
@@ -1457,7 +1460,14 @@ test("typed-constant speculation preserves generic function applications", (): v
     );
     const cursor = createSqlTokenCursor(kernel, 0, kernel.tokens.length);
 
-    assert.equal(parsePostgreSqlTypedConstantAtCursor(cursor), null);
+    const attempt = parsePostgreSqlTypedConstantAtCursor(cursor);
+    assert.equal(attempt.matched, false);
+    assert.equal(attempt.cursor.index, cursor.index);
+    assert.equal(attempt.cursor.endIndex, cursor.endIndex);
+    assert.equal(
+      attempt.cursor.workUnits,
+      cursor.workUnits + functionCase.nameWorkUnits,
+    );
     assert.equal(cursor.index, 0);
     assert.equal(cursor.workUnits, kernel.delimiters.scanSteps);
     assert.equal(kernel.delimiters.scanSteps, kernel.tokens.length);
@@ -1471,12 +1481,12 @@ test("typed-constant speculation preserves generic function applications", (): v
   const closeIndex = boundedKernel.delimiters.matchingIndexes.get(1);
   assert.equal(closeIndex, 3);
   for (const endIndex of [3, 4]) {
-    assert.equal(
-      parsePostgreSqlTypedConstantAtCursor(
-        createSqlTokenCursor(boundedKernel, 0, endIndex),
-      ),
-      null,
+    const attempt = parsePostgreSqlTypedConstantAtCursor(
+      createSqlTokenCursor(boundedKernel, 0, endIndex),
     );
+    assert.equal(attempt.matched, false);
+    assert.equal(attempt.cursor.index, 0);
+    assert.equal(attempt.cursor.endIndex, endIndex);
   }
 
   const committedErrors: ReadonlyArray<Readonly<{
@@ -1519,7 +1529,7 @@ test("typed-constant speculation preserves generic function applications", (): v
       committedKernel.tokens.length,
     ),
   );
-  if (committed === null) {
+  if (!committed.matched) {
     assert.fail("Expected committed PostgreSQL typed constant");
   }
   assert.equal(committed.node.sql, "foo(((1))) 'value'");
@@ -1527,7 +1537,490 @@ test("typed-constant speculation preserves generic function applications", (): v
   assert.equal(sqlTokenAt(committed.cursor, 0)?.text, "+");
   assert.equal(
     committed.cursor.workUnits,
-    committedKernel.delimiters.scanSteps + committed.cursor.index,
+    committedKernel.delimiters.scanSteps + committed.cursor.index + 1,
+  );
+});
+
+test("typed-constant no-match attempts restore position and retain work", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    endIndex: number | null;
+    expectedAttemptWork: number;
+    name: string;
+    sql: string;
+  }>> = [
+    {
+      endIndex: null,
+      expectedAttemptWork: 1,
+      name: "immediate non-type",
+      sql: "select",
+    },
+    {
+      endIndex: 0,
+      expectedAttemptWork: 1,
+      name: "source EOF",
+      sql: "",
+    },
+    {
+      endIndex: null,
+      expectedAttemptWork: 2,
+      name: "parsed type and non-string",
+      sql: "integer + 1",
+    },
+    {
+      endIndex: null,
+      expectedAttemptWork: 4,
+      name: "qualified type and non-string",
+      sql: "schema.money + 1",
+    },
+    {
+      endIndex: null,
+      expectedAttemptWork: 2,
+      name: "interval field before value",
+      sql: "interval day + 1",
+    },
+    {
+      endIndex: null,
+      expectedAttemptWork: 5,
+      name: "interval precision and non-string",
+      sql: "interval(3) + 1",
+    },
+    {
+      endIndex: 1,
+      expectedAttemptWork: 2,
+      name: "parsed type and bounded EOF",
+      sql: "integer trailing",
+    },
+  ];
+
+  for (const noMatchCase of cases) {
+    const kernel = createSqlParserKernel(
+      noMatchCase.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const endIndex = noMatchCase.endIndex ?? kernel.tokens.length;
+    const cursor = createSqlTokenCursor(kernel, 0, endIndex);
+    const attempt = parsePostgreSqlTypedConstantAtCursor(cursor);
+
+    assert.equal(attempt.matched, false, noMatchCase.name);
+    assert.equal(attempt.cursor.kernel, cursor.kernel, noMatchCase.name);
+    assert.equal(attempt.cursor.index, cursor.index, noMatchCase.name);
+    assert.equal(attempt.cursor.endIndex, cursor.endIndex, noMatchCase.name);
+    assert.equal(
+      attempt.cursor.workUnits,
+      cursor.workUnits + noMatchCase.expectedAttemptWork,
+      noMatchCase.name,
+    );
+    assert.equal(cursor.index, 0, noMatchCase.name);
+    assert.equal(
+      cursor.workUnits,
+      kernel.delimiters.scanSteps,
+      noMatchCase.name,
+    );
+  }
+});
+
+test("threaded typed-constant no-match attempts exhaust cumulative work", (): void => {
+  const sql = "select";
+  const baseline = createSqlParserKernel(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const kernel = createSqlParserKernel(
+    sql,
+    limits(sql.length, 1, 4, baseline.delimiters.scanSteps + 2),
+  );
+  const initial = createSqlTokenCursor(kernel, 0, kernel.tokens.length);
+  let current = initial;
+
+  for (let attemptIndex = 0; attemptIndex < 2; attemptIndex++) {
+    const attempt = parsePostgreSqlTypedConstantAtCursor(current);
+    assert.equal(attempt.matched, false);
+    current = attempt.cursor;
+    assert.equal(current.index, initial.index);
+    assert.equal(current.workUnits, initial.workUnits + attemptIndex + 1);
+  }
+
+  const error = expectParserError(
+    () => parsePostgreSqlTypedConstantAtCursor(current),
+    "limit_complexity",
+    { start: 0, end: sql.length },
+  );
+  assert.match(error.message, /at token 0$/u);
+  assert.equal(current.index, initial.index);
+  assert.equal(current.workUnits, kernel.limits.maxWorkUnits);
+});
+
+test("typed-constant value decisions have exact work boundaries", (): void => {
+  const nonStringSql = "integer +";
+  const nonStringBaseline = createSqlParserKernel(
+    nonStringSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const nonStringKernel = createSqlParserKernel(
+    nonStringSql,
+    limits(
+      nonStringSql.length,
+      nonStringBaseline.tokens.length,
+      4,
+      nonStringBaseline.delimiters.scanSteps + 2,
+    ),
+  );
+  const nonString = parsePostgreSqlTypedConstantAtCursor(
+    createSqlTokenCursor(nonStringKernel, 0, nonStringKernel.tokens.length),
+  );
+  assert.equal(nonString.matched, false);
+  assert.equal(nonString.cursor.index, 0);
+  assert.equal(nonString.cursor.workUnits, nonStringKernel.limits.maxWorkUnits);
+
+  const inspectLimitedKernel = createSqlParserKernel(
+    nonStringSql,
+    limits(
+      nonStringSql.length,
+      nonStringBaseline.tokens.length,
+      4,
+      nonStringBaseline.delimiters.scanSteps + 1,
+    ),
+  );
+  expectParserError(
+    () => parsePostgreSqlTypedConstantAtCursor(
+      createSqlTokenCursor(
+        inspectLimitedKernel,
+        0,
+        inspectLimitedKernel.tokens.length,
+      ),
+    ),
+    "limit_complexity",
+    { start: 8, end: 9 },
+  );
+
+  const valueSql = `integer '1'`;
+  const valueBaseline = createSqlParserKernel(
+    valueSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const exactKernel = createSqlParserKernel(
+    valueSql,
+    limits(
+      valueSql.length,
+      valueBaseline.tokens.length,
+      4,
+      valueBaseline.delimiters.scanSteps + 3,
+    ),
+  );
+  const exact = parsePostgreSqlTypedConstantAtCursor(
+    createSqlTokenCursor(exactKernel, 0, exactKernel.tokens.length),
+  );
+  assert.equal(exact.matched, true);
+  if (!exact.matched) {
+    assert.fail("Expected exact-budget PostgreSQL typed constant");
+  }
+  assert.equal(exact.node.sql, valueSql);
+  assert.equal(exact.cursor.index, exactKernel.tokens.length);
+  assert.equal(exact.cursor.workUnits, exactKernel.limits.maxWorkUnits);
+
+  const consumeLimitedKernel = createSqlParserKernel(
+    valueSql,
+    limits(
+      valueSql.length,
+      valueBaseline.tokens.length,
+      4,
+      valueBaseline.delimiters.scanSteps + 2,
+    ),
+  );
+  expectParserError(
+    () => parsePostgreSqlTypedConstantAtCursor(
+      createSqlTokenCursor(
+        consumeLimitedKernel,
+        0,
+        consumeLimitedKernel.tokens.length,
+      ),
+    ),
+    "limit_complexity",
+    { start: 8, end: 11 },
+  );
+});
+
+test("interval qualifier attempts charge bounded lookaheads predictably", (): void => {
+  const absentSql = "trailing";
+  const absentKernel = createSqlParserKernel(
+    absentSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const absentCursor = createSqlTokenCursor(
+    absentKernel,
+    0,
+    absentKernel.tokens.length,
+  );
+  const absent = parsePostgreSqlIntervalQualifierAttempt(absentCursor);
+  assert.equal(absent.matched, false);
+  assert.equal(absent.cursor.index, absentCursor.index);
+  assert.equal(absent.cursor.endIndex, absentCursor.endIndex);
+  assert.equal(absent.cursor.workUnits, absentCursor.workUnits + 1);
+
+  const validCases: ReadonlyArray<Readonly<{
+    expectedIndex: number;
+    expectedSql: string;
+    expectedWork: number;
+    sql: string;
+  }>> = [
+    {
+      expectedIndex: 1,
+      expectedSql: "hour",
+      expectedWork: 3,
+      sql: "hour trailing",
+    },
+    {
+      expectedIndex: 6,
+      expectedSql: "day to second(3)",
+      expectedWork: 10,
+      sql: "day to second(3) trailing",
+    },
+  ];
+  for (const validCase of validCases) {
+    const kernel = createSqlParserKernel(
+      validCase.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const cursor = createSqlTokenCursor(kernel, 0, kernel.tokens.length);
+    const attempt = parsePostgreSqlIntervalQualifierAttempt(cursor);
+    assert.equal(attempt.matched, true, validCase.sql);
+    if (!attempt.matched) {
+      assert.fail(`Expected interval qualifier: ${validCase.sql}`);
+    }
+    assert.equal(attempt.node.sql, validCase.expectedSql);
+    assert.equal(attempt.cursor.index, validCase.expectedIndex);
+    assert.equal(
+      attempt.cursor.workUnits,
+      cursor.workUnits + validCase.expectedWork,
+    );
+    assert.equal(sqlTokenAt(attempt.cursor, 0)?.text, "trailing");
+  }
+
+  const malformedSql = "year to day";
+  const malformedKernel = createSqlParserKernel(
+    malformedSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  expectParserError(
+    () => parsePostgreSqlIntervalQualifierAttempt(
+      createSqlTokenCursor(
+        malformedKernel,
+        0,
+        malformedKernel.tokens.length,
+      ),
+    ),
+    "invalid_type_modifier",
+    { start: 8, end: 11 },
+  );
+
+  const missingSecondSql = "year to";
+  const missingSecondKernel = createSqlParserKernel(
+    missingSecondSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  expectParserError(
+    () => parsePostgreSqlIntervalQualifierAttempt(
+      createSqlTokenCursor(
+        missingSecondKernel,
+        0,
+        missingSecondKernel.tokens.length,
+      ),
+    ),
+    "invalid_type_modifier",
+    { start: 5, end: 7 },
+  );
+
+  const boundedSql = "year to trailing";
+  const boundedKernel = createSqlParserKernel(
+    boundedSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  expectParserError(
+    () => parsePostgreSqlIntervalQualifierAttempt(
+      createSqlTokenCursor(boundedKernel, 0, 2),
+    ),
+    "invalid_type_modifier",
+    { start: 5, end: 7 },
+  );
+});
+
+test("interval qualifier inspection honors exact and first-excess limits", (): void => {
+  const sql = "hour trailing";
+  const baseline = createSqlParserKernel(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const exactKernel = createSqlParserKernel(
+    sql,
+    limits(sql.length, baseline.tokens.length, 4, baseline.delimiters.scanSteps + 3),
+  );
+  const exact = parsePostgreSqlIntervalQualifierAttempt(
+    createSqlTokenCursor(exactKernel, 0, exactKernel.tokens.length),
+  );
+  assert.equal(exact.matched, true);
+  assert.equal(exact.cursor.workUnits, exactKernel.limits.maxWorkUnits);
+
+  const limitedKernel = createSqlParserKernel(
+    sql,
+    limits(sql.length, baseline.tokens.length, 4, baseline.delimiters.scanSteps + 2),
+  );
+  const error = expectParserError(
+    () => parsePostgreSqlIntervalQualifierAttempt(
+      createSqlTokenCursor(limitedKernel, 0, limitedKernel.tokens.length),
+    ),
+    "limit_complexity",
+    { start: 5, end: 13 },
+  );
+  assert.match(error.message, /at token 1$/u);
+
+  const absentKernel = createSqlParserKernel(
+    "other",
+    limits(5, 1, 4, 1),
+  );
+  expectParserError(
+    () => parsePostgreSqlIntervalQualifierAttempt(
+      createSqlTokenCursor(absentKernel, 0, absentKernel.tokens.length),
+    ),
+    "limit_complexity",
+    { start: 0, end: 5 },
+  );
+});
+
+test("typed-constant interval paths retain exact charged work", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    expectedIndex: number;
+    expectedQualifier: string | null;
+    expectedWork: number;
+    sql: string;
+  }>> = [
+    {
+      expectedIndex: 2,
+      expectedQualifier: null,
+      expectedWork: 4,
+      sql: `interval '1'`,
+    },
+    {
+      expectedIndex: 3,
+      expectedQualifier: "hour",
+      expectedWork: 6,
+      sql: `interval '1' hour`,
+    },
+    {
+      expectedIndex: 8,
+      expectedQualifier: "day to second(3)",
+      expectedWork: 13,
+      sql: `interval '1' day to second(3)`,
+    },
+    {
+      expectedIndex: 5,
+      expectedQualifier: null,
+      expectedWork: 7,
+      sql: `interval(3) '1'`,
+    },
+  ];
+
+  for (const typedCase of cases) {
+    const kernel = createSqlParserKernel(
+      typedCase.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const cursor = createSqlTokenCursor(kernel, 0, kernel.tokens.length);
+    const attempt = parsePostgreSqlTypedConstantAtCursor(cursor);
+    assert.equal(attempt.matched, true, typedCase.sql);
+    if (!attempt.matched) {
+      assert.fail(`Expected interval typed constant: ${typedCase.sql}`);
+    }
+    assert.equal(attempt.node.sql, typedCase.sql);
+    assert.equal(
+      attempt.node.intervalQualifier?.sql ?? null,
+      typedCase.expectedQualifier,
+    );
+    assert.equal(attempt.cursor.index, typedCase.expectedIndex);
+    assert.equal(
+      attempt.cursor.workUnits,
+      cursor.workUnits + typedCase.expectedWork,
+    );
+  }
+});
+
+test("typed-constant attempts keep committed errors and bounded ranges", (): void => {
+  const conflictSql = "interval(3) '1' day";
+  const conflictKernel = createSqlParserKernel(
+    conflictSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  expectParserError(
+    () => parsePostgreSqlTypedConstantAtCursor(
+      createSqlTokenCursor(conflictKernel, 0, conflictKernel.tokens.length),
+    ),
+    "invalid_typed_constant",
+    { start: 16, end: 19 },
+  );
+
+  const malformedSql = "interval '1' year to day";
+  const malformedKernel = createSqlParserKernel(
+    malformedSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  expectParserError(
+    () => parsePostgreSqlTypedConstantAtCursor(
+      createSqlTokenCursor(
+        malformedKernel,
+        0,
+        malformedKernel.tokens.length,
+      ),
+    ),
+    "invalid_type_modifier",
+    { start: 21, end: 24 },
+  );
+
+  const missingSecondSql = "interval '1' year to";
+  const missingSecondKernel = createSqlParserKernel(
+    missingSecondSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  expectParserError(
+    () => parsePostgreSqlTypedConstantAtCursor(
+      createSqlTokenCursor(
+        missingSecondKernel,
+        0,
+        missingSecondKernel.tokens.length,
+      ),
+    ),
+    "invalid_type_modifier",
+    { start: 18, end: 20 },
+  );
+
+  const boundedSql = "integer trailing";
+  const boundedBaseline = createSqlParserKernel(
+    boundedSql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const boundedKernel = createSqlParserKernel(
+    boundedSql,
+    limits(
+      boundedSql.length,
+      boundedBaseline.tokens.length,
+      4,
+      boundedBaseline.delimiters.scanSteps + 1,
+    ),
+  );
+  const boundedCursor = createSqlTokenCursor(boundedKernel, 0, 1);
+  const boundedError = expectParserError(
+    () => parsePostgreSqlTypedConstantAtCursor(boundedCursor),
+    "limit_complexity",
+    { start: 7, end: 7 },
+  );
+  assert.match(boundedError.message, /at token 1$/u);
+
+  const emptyKernel = createSqlParserKernel(
+    "",
+    limits(1, 1, 4, 1),
+  );
+  const emptyAttempt = parsePostgreSqlTypedConstantAtCursor(
+    createSqlTokenCursor(emptyKernel, 0, 0),
+  );
+  assert.equal(emptyAttempt.matched, false);
+  assert.equal(emptyAttempt.cursor.index, 0);
+  assert.equal(emptyAttempt.cursor.workUnits, 1);
+  expectParserError(
+    () => parsePostgreSqlTypedConstantAtCursor(emptyAttempt.cursor),
+    "limit_complexity",
+    { start: 0, end: 0 },
   );
 });
 
@@ -1667,8 +2160,11 @@ test("typed-constant cursor parsing leaves neighboring expression tokens", (): v
   const cursor = createSqlTokenCursor(kernel, 0, kernel.tokens.length);
   const parsed = parsePostgreSqlTypedConstantAtCursor(cursor);
 
-  assert.notEqual(parsed, null);
-  assert.equal(parsed?.node.sql, "interval '2' hour");
-  assert.equal(parsed?.node.intervalQualifier?.sql, "hour");
-  assert.equal(kernel.tokens[parsed?.cursor.index]?.text, "+");
+  assert.equal(parsed.matched, true);
+  if (!parsed.matched) {
+    assert.fail("Expected PostgreSQL typed constant");
+  }
+  assert.equal(parsed.node.sql, "interval '2' hour");
+  assert.equal(parsed.node.intervalQualifier?.sql, "hour");
+  assert.equal(kernel.tokens[parsed.cursor.index]?.text, "+");
 });

--- a/packages/agent-shared/src/sql-policy-type-parser.ts
+++ b/packages/agent-shared/src/sql-policy-type-parser.ts
@@ -11,10 +11,13 @@ import {
 } from "./sql-policy-parser-keywords.js";
 import {
   advanceSqlTokenCursor,
+  consumeSqlTokenCursor,
   createSqlParserKernel,
   createSqlTokenCursor,
+  inspectSqlTokenCursor,
   matchingSqlDelimiterIndexAtCursor,
   matchingSqlDelimiterIndexWithinCursor,
+  restoreSqlTokenCursorPosition,
   sqlCursorRange,
   sqlRangeFromTokenIndexes,
   sqlTokenAt,
@@ -27,6 +30,7 @@ import {
   isPostgreSqlStringConstant as isStringConstant,
   parsePostgreSqlIntegerModifier as parseIntegerModifier,
   parsePostgreSqlIntervalQualifier as parseIntervalQualifier,
+  parsePostgreSqlIntervalQualifierAttempt as parseIntervalQualifierAttempt,
   parsePostgreSqlTypeModifierList as parseModifierList,
   postgreSqlIntegerConstant,
 } from "./sql-policy-type-modifiers.js";
@@ -34,6 +38,7 @@ import type {
   SqlArrayBoundNode,
   SqlIntervalQualifierNode,
   SqlTimeZoneNode,
+  SqlTypedConstantParseAttempt,
   SqlTypedConstantNode,
   SqlTypeModifierNode,
   SqlTypeNameForm,
@@ -45,6 +50,7 @@ export type {
   SqlArrayBoundNode,
   SqlIntervalQualifierNode,
   SqlTimeZoneNode,
+  SqlTypedConstantParseAttempt,
   SqlTypedConstantNode,
   SqlTypeModifierNode,
   SqlTypeNameForm,
@@ -63,6 +69,35 @@ type ParsedTypeBase = Readonly<{
   nameRange: SqlSourceRange;
   timeZone: SqlTimeZoneNode | null;
 }>;
+
+type ParsedTypeBaseAttempt =
+  | Readonly<{
+    cursor: SqlTokenCursor;
+    matched: false;
+  }>
+  | Readonly<{
+    base: ParsedTypeBase;
+    matched: true;
+  }>;
+
+type SqlTypeNameParseAttempt =
+  | Readonly<{
+    cursor: SqlTokenCursor;
+    matched: false;
+  }>
+  | Readonly<{
+    cursor: SqlTokenCursor;
+    matched: true;
+    node: SqlTypeNameNode;
+  }>;
+
+const noTypeBaseMatch = (
+  original: SqlTokenCursor,
+  attempted: SqlTokenCursor,
+): ParsedTypeBaseAttempt => ({
+  cursor: restoreSqlTokenCursorPosition(original, attempted),
+  matched: false,
+});
 
 const isWord = (
   cursor: SqlTokenCursor,
@@ -87,10 +122,10 @@ const identifierAt = (
 const parseGenericType = (
   cursor: SqlTokenCursor,
   context: TypeNameContext,
-): ParsedTypeBase | null => {
+): ParsedTypeBaseAttempt => {
   const first = identifierAt(cursor, 0);
   if (first === null) {
-    return null;
+    return noTypeBaseMatch(cursor, cursor);
   }
   const qualified = isText(cursor, 1, ".");
   if (
@@ -116,7 +151,7 @@ const parseGenericType = (
     ? true
     : isTypeFunctionName(first);
   if (!firstAllowed) {
-    return null;
+    return noTypeBaseMatch(cursor, cursor);
   }
 
   const nameStart = cursor.index;
@@ -161,7 +196,7 @@ const parseGenericType = (
           ),
         )
       ) {
-        return null;
+        return noTypeBaseMatch(cursor, current);
       }
     }
     const parsed = parseModifierList(current);
@@ -169,13 +204,16 @@ const parseGenericType = (
     current = parsed.cursor;
   }
   return {
-    cursor: current,
-    form: "generic",
-    intervalQualifier: null,
-    modifiers,
-    nameParts,
-    nameRange,
-    timeZone: null,
+    base: {
+      cursor: current,
+      form: "generic",
+      intervalQualifier: null,
+      modifiers,
+      nameParts,
+      nameRange,
+      timeZone: null,
+    },
+    matched: true,
   };
 };
 
@@ -230,18 +268,21 @@ const typeBase = (
   modifiers: ReadonlyArray<SqlTypeModifierNode>,
   intervalQualifier: SqlIntervalQualifierNode | null,
   timeZone: SqlTimeZoneNode | null,
-): ParsedTypeBase => ({
-  cursor,
-  form,
-  intervalQualifier,
-  modifiers,
-  nameParts,
-  nameRange: sqlRangeFromTokenIndexes(
-    cursor.kernel,
-    nameStart,
-    nameStart + nameParts.length,
-  ),
-  timeZone,
+): ParsedTypeBaseAttempt => ({
+  base: {
+    cursor,
+    form,
+    intervalQualifier,
+    modifiers,
+    nameParts,
+    nameRange: sqlRangeFromTokenIndexes(
+      cursor.kernel,
+      nameStart,
+      nameStart + nameParts.length,
+    ),
+    timeZone,
+  },
+  matched: true,
 });
 
 const simpleTypeForm = (
@@ -269,11 +310,11 @@ const simpleTypeForm = (
 const parseSpecialType = (
   cursor: SqlTokenCursor,
   context: TypeNameContext,
-): ParsedTypeBase | null => {
+): ParsedTypeBaseAttempt => {
   const first = identifierAt(cursor, 0);
   const word = tokenWord(first ?? undefined);
   if (first === null || word === null || isText(cursor, 1, ".")) {
-    return null;
+    return noTypeBaseMatch(cursor, cursor);
   }
   const nameStart = cursor.index;
 
@@ -432,7 +473,7 @@ const parseSpecialType = (
     );
     if (word === "national") {
       if (!isWord(current, 0, "char") && !isWord(current, 0, "character")) {
-        return null;
+        return noTypeBaseMatch(cursor, current);
       }
       const nationalKind = identifierAt(current, 0);
       if (nationalKind !== null) {
@@ -550,7 +591,7 @@ const parseSpecialType = (
     );
   }
 
-  return null;
+  return noTypeBaseMatch(cursor, cursor);
 };
 
 const parseArrayBounds = (
@@ -662,10 +703,10 @@ const parseArrayBounds = (
   return { bounds, cursor: current };
 };
 
-export const parsePostgreSqlTypeNameAtCursor = (
+const parsePostgreSqlTypeNameAttemptAtCursor = (
   cursor: SqlTokenCursor,
   context: TypeNameContext,
-): SqlTypeParseResult<SqlTypeNameNode> | null => {
+): SqlTypeNameParseAttempt => {
   const startIndex = cursor.index;
   let current = cursor;
   let setOf = false;
@@ -678,11 +719,17 @@ export const parsePostgreSqlTypeNameAtCursor = (
     );
   }
 
-  const special = parseSpecialType(current, context);
-  const base = special ?? parseGenericType(current, context);
-  if (base === null) {
-    return null;
+  const specialAttempt = parseSpecialType(current, context);
+  const baseAttempt = specialAttempt.matched
+    ? specialAttempt
+    : parseGenericType(specialAttempt.cursor, context);
+  if (!baseAttempt.matched) {
+    return {
+      cursor: restoreSqlTokenCursorPosition(cursor, baseAttempt.cursor),
+      matched: false,
+    };
   }
+  const base = baseAttempt.base;
   current = base.cursor;
 
   let arrayBounds: ReadonlyArray<SqlArrayBoundNode> = [];
@@ -699,6 +746,7 @@ export const parsePostgreSqlTypeNameAtCursor = (
   );
   return {
     cursor: current,
+    matched: true,
     node: {
       arrayBounds,
       form: base.form,
@@ -714,29 +762,64 @@ export const parsePostgreSqlTypeNameAtCursor = (
   };
 };
 
+export const parsePostgreSqlTypeNameAtCursor = (
+  cursor: SqlTokenCursor,
+  context: TypeNameContext,
+): SqlTypeParseResult<SqlTypeNameNode> | null => {
+  const attempt = parsePostgreSqlTypeNameAttemptAtCursor(cursor, context);
+  return attempt.matched
+    ? { cursor: attempt.cursor, node: attempt.node }
+    : null;
+};
+
+const typedConstantNoMatch = (
+  original: SqlTokenCursor,
+  attempted: SqlTokenCursor,
+): SqlTypedConstantParseAttempt => ({
+  cursor: restoreSqlTokenCursorPosition(original, attempted),
+  matched: false,
+});
+
 export const parsePostgreSqlTypedConstantAtCursor = (
   cursor: SqlTokenCursor,
-): SqlTypeParseResult<SqlTypedConstantNode> | null => {
-  const parsedType = parsePostgreSqlTypeNameAtCursor(
+): SqlTypedConstantParseAttempt => {
+  const parsedType = parsePostgreSqlTypeNameAttemptAtCursor(
     cursor,
     "typed_constant",
   );
-  if (parsedType === null) {
-    return null;
+  if (!parsedType.matched) {
+    const inspected = parsedType.cursor.workUnits === cursor.workUnits
+      ? inspectSqlTokenCursor(
+        parsedType.cursor,
+        0,
+        "PostgreSQL typed-constant type inspection",
+      ).cursor
+      : parsedType.cursor;
+    return typedConstantNoMatch(cursor, inspected);
   }
-  const value = sqlTokenAt(parsedType.cursor, 0);
-  if (!isStringConstant(value)) {
-    return null;
-  }
-  let current = advanceSqlTokenCursor(
+  const valueInspection = inspectSqlTokenCursor(
     parsedType.cursor,
-    1,
-    "PostgreSQL typed constant value",
+    0,
+    "PostgreSQL typed-constant value inspection",
   );
+  if (!isStringConstant(valueInspection.token)) {
+    return typedConstantNoMatch(cursor, valueInspection.cursor);
+  }
+  const value = valueInspection.token;
+  let current = consumeSqlTokenCursor(
+    valueInspection.cursor,
+    "PostgreSQL typed-constant value",
+  ).cursor;
   let qualifier: SqlIntervalQualifierNode | null = null;
   if (parsedType.node.form === "interval") {
     if (parsedType.node.modifiers.length > 0) {
-      const following = tokenWord(sqlTokenAt(current, 0));
+      const qualifierInspection = inspectSqlTokenCursor(
+        current,
+        0,
+        "PostgreSQL typed-constant interval qualifier inspection",
+      );
+      current = qualifierInspection.cursor;
+      const following = tokenWord(qualifierInspection.token);
       if (following !== null && INTERVAL_FIELDS.has(following)) {
         return throwSqlPolicyParserError(
           "invalid_typed_constant",
@@ -745,10 +828,10 @@ export const parsePostgreSqlTypedConstantAtCursor = (
         );
       }
     } else {
-      const parsedQualifier = parseIntervalQualifier(current);
-      if (parsedQualifier !== null) {
-        qualifier = parsedQualifier.node;
-        current = parsedQualifier.cursor;
+      const qualifierAttempt = parseIntervalQualifierAttempt(current);
+      current = qualifierAttempt.cursor;
+      if (qualifierAttempt.matched) {
+        qualifier = qualifierAttempt.node;
       }
     }
   }
@@ -759,6 +842,7 @@ export const parsePostgreSqlTypedConstantAtCursor = (
   );
   return {
     cursor: current,
+    matched: true,
     node: {
       intervalQualifier: qualifier,
       range,
@@ -841,11 +925,11 @@ export const parsePostgreSqlTypedConstantInfrastructure = (
     "PostgreSQL typed-constant parsing",
   );
   const result = parsePostgreSqlTypedConstantAtCursor(cursor);
-  if (result === null) {
+  if (!result.matched) {
     return throwSqlPolicyParserError(
       "invalid_typed_constant",
       "Expected a complete PostgreSQL 18 typed constant",
-      sqlCursorRange(cursor),
+      sqlCursorRange(result.cursor),
     );
   }
   assertFullyConsumed(result, "PostgreSQL typed constant");


### PR DESCRIPTION
Summary:
- return discriminated typed-constant parse attempts with cumulative cursor work
- add charged INTERVAL qualifier speculation while preserving compatibility APIs and exact errors
- cover rollback, EOF, work limits, qualifier paths, and PostgreSQL syntax commitment

Validation:
- agent-shared lint, 67 tests, and build
- SQL API lint and build
- web lint and production build
- git diff --check