### PR TITLE
Add read cursor lifecycle

### DIFF
--- a/packages/agent-shared/src/sql-policy-read-state.test.ts
+++ b/packages/agent-shared/src/sql-policy-read-state.test.ts
@@ -2,20 +2,34 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { SqlSourceRange } from "./sql-policy-lexer.js";
 import {
+  advanceSqlTokenCursor,
+  consumeSqlTokenCursor,
   createSqlParserKernel,
+  restoreSqlTokenCursorPosition,
   type SqlParserKernel,
   type SqlParserLimits,
+  type SqlTokenCursor,
 } from "./sql-policy-parser-kernel.js";
 import {
   SqlPolicyParserError,
   type SqlPolicyParserErrorCode,
 } from "./sql-policy-parser-model.js";
 import {
+  adoptSqlTokenCursor,
+  advanceSqlReadCursor,
   checkedSqlReadDepth,
+  consumeSqlReadToken,
+  createSqlReadCursor,
   createSqlReadState,
+  enterSqlReadDepth,
+  inspectSqlReadToken,
+  matchingSqlReadDelimiter,
+  narrowSqlReadCursor,
   sqlReadRangeAt,
   sqlReadRangeForSpan,
+  sqlTokenCursorFromReadCursor,
 } from "./sql-policy-read-state.js";
+import { parsePostgreSqlTypedConstantAtCursor } from "./sql-policy-type-parser.js";
 
 const limits = (
   maxSourceCodeUnits: number,
@@ -321,4 +335,516 @@ test("long flat state construction and far range lookup retain graph identity", 
       - `c${String(tokenCount - 2)} c${String(tokenCount - 1)}`.length,
     end: sql.length,
   });
+});
+
+test("read cursor creation is frozen, bounded, and starts at delimiter work", (): void => {
+  const emptyState = createSqlReadState(
+    createSqlParserKernel("", limits(10, 10, 4, 10)),
+  );
+  const empty = createSqlReadCursor(emptyState, 0, 0);
+  assert.ok(Object.isFrozen(empty));
+  assert.deepEqual(empty, {
+    depth: 0,
+    endIndex: 0,
+    index: 0,
+    state: emptyState,
+    workUnits: 0,
+  });
+
+  const kernel = createSqlParserKernel(
+    "alpha beta gamma",
+    limits(30, 10, 4, 20),
+  );
+  const state = createSqlReadState(kernel);
+  const bounded = createSqlReadCursor(state, 1, 2);
+  assert.ok(Object.isFrozen(bounded));
+  assert.equal(bounded.state, state);
+  assert.equal(bounded.index, 1);
+  assert.equal(bounded.endIndex, 2);
+  assert.equal(bounded.workUnits, state.delimiterScanWorkUnits);
+  assert.equal(bounded.depth, 0);
+
+  expectParserError(
+    () => {
+      createSqlReadCursor(state, 2, 1);
+    },
+    "internal_invariant",
+    { start: 11, end: 16 },
+    /Invalid SQL token cursor bounds 2\.\.1 for 3 tokens/u,
+  );
+  expectParserError(
+    () => {
+      createSqlReadCursor(state, 0, state.tokenCount + 1);
+    },
+    "internal_invariant",
+    { start: 0, end: 5 },
+    /Invalid SQL token cursor bounds 0\.\.4 for 3 tokens/u,
+  );
+});
+
+test("read inspection, consumption, and advancement preserve exact transitions", (): void => {
+  const kernel = createSqlParserKernel(
+    "alpha beta trailing",
+    limits(30, 10, 4, 20),
+  );
+  const state = createSqlReadState(kernel);
+  const initial = createSqlReadCursor(state, 0, 2);
+  const inspected = inspectSqlReadToken(
+    initial,
+    1,
+    "Inspect bounded beta",
+  );
+  assert.ok(Object.isFrozen(inspected));
+  assert.ok(Object.isFrozen(inspected.cursor));
+  assert.equal(inspected.token, kernel.tokens[1]);
+  assert.deepEqual(inspected.token?.range, { start: 6, end: 10 });
+  assert.equal(inspected.cursor.index, 0);
+  assert.equal(inspected.cursor.endIndex, 2);
+  assert.equal(inspected.cursor.workUnits, initial.workUnits + 1);
+
+  const consumed = consumeSqlReadToken(
+    inspected.cursor,
+    "Consume bounded alpha",
+  );
+  assert.ok(Object.isFrozen(consumed));
+  assert.equal(consumed.token, kernel.tokens[0]);
+  assert.equal(consumed.cursor.index, 1);
+  assert.equal(
+    consumed.cursor.workUnits,
+    inspected.cursor.workUnits + 1,
+  );
+
+  const exhausted = advanceSqlReadCursor(
+    consumed.cursor,
+    1,
+    "Advance to bounded EOF",
+  );
+  assert.equal(exhausted.index, 2);
+  assert.equal(exhausted.endIndex, 2);
+  assert.equal(exhausted.workUnits, consumed.cursor.workUnits + 1);
+  const eof = inspectSqlReadToken(exhausted, 0, "Inspect bounded EOF");
+  assert.equal(eof.token, undefined);
+  assert.equal(eof.cursor.index, 2);
+  assert.equal(eof.cursor.workUnits, exhausted.workUnits + 1);
+  expectParserError(
+    () => {
+      consumeSqlReadToken(eof.cursor, "Consume bounded EOF");
+    },
+    "internal_invariant",
+    { start: 10, end: 10 },
+    /bounded end 2/u,
+  );
+
+  assert.equal(initial.index, 0);
+  assert.equal(initial.workUnits, kernel.delimiters.scanSteps);
+});
+
+test("read work permits the exact maximum and fails on the first excess", (): void => {
+  const kernel = createSqlParserKernel(
+    "alpha beta gamma",
+    limits(30, 10, 4, 5),
+  );
+  const state = createSqlReadState(kernel);
+  const initial = createSqlReadCursor(state, 0, state.tokenCount);
+  const exact = advanceSqlReadCursor(
+    initial,
+    2,
+    "Advance at exact work limit",
+  );
+  assert.equal(exact.index, 2);
+  assert.equal(exact.workUnits, kernel.limits.maxWorkUnits);
+  expectParserError(
+    () => {
+      consumeSqlReadToken(exact, "Consume first excess");
+    },
+    "limit_complexity",
+    { start: 11, end: 16 },
+    /maxWorkUnits=5 at token 2/u,
+  );
+  expectParserError(
+    () => {
+      advanceSqlReadCursor(initial, 3, "Advance through first excess");
+    },
+    "limit_complexity",
+    { start: 11, end: 16 },
+    /maxWorkUnits=5 at token 2/u,
+  );
+
+  const emptyKernel = createSqlParserKernel(
+    "alpha beta",
+    limits(20, 10, 4, 2),
+  );
+  const emptyAtLimit = createSqlReadCursor(
+    createSqlReadState(emptyKernel),
+    0,
+    0,
+  );
+  expectParserError(
+    () => {
+      inspectSqlReadToken(emptyAtLimit, 0, "Inspect exhausted empty range");
+    },
+    "limit_complexity",
+    { start: 0, end: 0 },
+    /maxWorkUnits=2 at token 0/u,
+  );
+});
+
+test("narrowing preserves cumulative work and exact bounded EOF", (): void => {
+  const kernel = createSqlParserKernel(
+    "alpha beta gamma",
+    limits(30, 10, 4, 20),
+  );
+  const state = createSqlReadState(kernel);
+  const advanced = advanceSqlReadCursor(
+    createSqlReadCursor(state, 0, state.tokenCount),
+    1,
+    "Prepare bounded cursor",
+  );
+  const bounded = narrowSqlReadCursor(advanced, 2, "Narrow read cursor");
+  assert.ok(Object.isFrozen(bounded));
+  assert.equal(bounded.index, 1);
+  assert.equal(bounded.endIndex, 2);
+  assert.equal(bounded.workUnits, advanced.workUnits);
+  const atEnd = advanceSqlReadCursor(bounded, 1, "Reach bounded end");
+  const inspected = inspectSqlReadToken(atEnd, 0, "Inspect narrowed EOF");
+  assert.equal(inspected.token, undefined);
+
+  expectParserError(
+    () => {
+      consumeSqlReadToken(inspected.cursor, "Consume narrowed EOF");
+    },
+    "internal_invariant",
+    { start: 10, end: 10 },
+    /bounded end 2/u,
+  );
+  expectParserError(
+    () => {
+      narrowSqlReadCursor(advanced, 0, "Narrow before current index");
+    },
+    "internal_invariant",
+    { start: 6, end: 10 },
+    /safe integer within the current read cursor range 1\.\.3/u,
+  );
+  expectParserError(
+    () => {
+      narrowSqlReadCursor(advanced, Number.NaN, "Narrow with invalid end");
+    },
+    "internal_invariant",
+    { start: 6, end: 10 },
+    /bounded end NaN must be a safe integer/u,
+  );
+  expectParserError(
+    () => {
+      narrowSqlReadCursor(advanced, 4, "Narrow past current end");
+    },
+    "internal_invariant",
+    { start: 6, end: 10 },
+    /current read cursor range 1\.\.3/u,
+  );
+});
+
+test("read depth accepts the maximum at token and bounded EOF positions", (): void => {
+  const kernel = createSqlParserKernel(
+    "alpha beta",
+    limits(20, 10, 2, 20),
+  );
+  const state = createSqlReadState(kernel);
+  const atToken = advanceSqlReadCursor(
+    createSqlReadCursor(state, 0, state.tokenCount),
+    1,
+    "Reach depth token",
+  );
+  const tokenDepthOne = enterSqlReadDepth(atToken, "Token depth");
+  const tokenDepthMax = enterSqlReadDepth(tokenDepthOne, "Token depth");
+  assert.equal(tokenDepthMax.depth, state.limits.maxNestingDepth);
+  assert.equal(tokenDepthMax.workUnits, atToken.workUnits);
+  expectParserError(
+    () => {
+      enterSqlReadDepth(tokenDepthMax, "Token depth");
+    },
+    "limit_nesting",
+    { start: 6, end: 10 },
+    /nesting depth 3 exceeds maxNestingDepth=2/u,
+  );
+
+  const boundedEnd = advanceSqlReadCursor(
+    createSqlReadCursor(state, 0, 1),
+    1,
+    "Reach bounded depth EOF",
+  );
+  const eofDepthOne = enterSqlReadDepth(boundedEnd, "Bounded EOF depth");
+  const eofDepthMax = enterSqlReadDepth(eofDepthOne, "Bounded EOF depth");
+  assert.equal(eofDepthMax.depth, state.limits.maxNestingDepth);
+  assert.equal(eofDepthMax.workUnits, boundedEnd.workUnits);
+  expectParserError(
+    () => {
+      enterSqlReadDepth(eofDepthMax, "Bounded EOF depth");
+    },
+    "limit_nesting",
+    { start: 5, end: 5 },
+    /nesting depth 3 exceeds maxNestingDepth=2/u,
+  );
+});
+
+test("delimiter matching is bounded, opening-only, and charged once", (): void => {
+  const kernel = createSqlParserKernel(
+    "(alpha) trailing",
+    limits(30, 10, 4, 20),
+  );
+  const state = createSqlReadState(kernel);
+  const cursor = createSqlReadCursor(state, 0, 3);
+  const matched = matchingSqlReadDelimiter(cursor, "Match read delimiter");
+  assert.ok(Object.isFrozen(matched));
+  assert.equal(matched.closeIndex, 2);
+  assert.equal(matched.cursor.index, cursor.index);
+  assert.equal(matched.cursor.endIndex, cursor.endIndex);
+  assert.equal(matched.cursor.workUnits, cursor.workUnits + 1);
+
+  const notOpening = advanceSqlReadCursor(
+    cursor,
+    1,
+    "Reach non-opening token",
+  );
+  expectParserError(
+    () => {
+      matchingSqlReadDelimiter(notOpening, "Reject non-opening token");
+    },
+    "internal_invariant",
+    { start: 1, end: 6 },
+    /not an indexed opening SQL delimiter/u,
+  );
+  const excludesClose = narrowSqlReadCursor(
+    cursor,
+    2,
+    "Exclude closing delimiter",
+  );
+  expectParserError(
+    () => {
+      matchingSqlReadDelimiter(excludesClose, "Reject out-of-range close");
+    },
+    "unexpected_token",
+    { start: 0, end: 1 },
+    /closes outside the current parse range/u,
+  );
+});
+
+test("token cursor adapters round-trip typed-constant results without rewinding work", (): void => {
+  const kernel = createSqlParserKernel(
+    "date '2024-01-01' trailing",
+    limits(40, 10, 4, 40),
+  );
+  const state = createSqlReadState(kernel);
+  const initial = enterSqlReadDepth(
+    createSqlReadCursor(state, 0, 2),
+    "Typed-constant read depth",
+  );
+  const delegated = sqlTokenCursorFromReadCursor(
+    initial,
+    "Adapt typed-constant cursor",
+  );
+  assert.ok(Object.isFrozen(delegated));
+  assert.equal(delegated.kernel, kernel);
+  assert.equal(delegated.index, initial.index);
+  assert.equal(delegated.endIndex, initial.endIndex);
+  assert.equal(delegated.workUnits, initial.workUnits);
+  const roundTrip = adoptSqlTokenCursor(
+    initial,
+    delegated,
+    "Round-trip typed-constant cursor",
+  );
+  assert.equal(roundTrip.index, initial.index);
+  assert.equal(roundTrip.workUnits, initial.workUnits);
+  assert.equal(roundTrip.depth, initial.depth);
+
+  const parsed = parsePostgreSqlTypedConstantAtCursor(delegated);
+  assert.equal(parsed.matched, true);
+  if (!parsed.matched) {
+    assert.fail("Expected a date typed constant");
+  }
+  const adopted = adoptSqlTokenCursor(
+    initial,
+    parsed.cursor,
+    "Adopt typed-constant cursor",
+  );
+  assert.equal(adopted.index, 2);
+  assert.equal(adopted.endIndex, initial.endIndex);
+  assert.equal(adopted.workUnits, parsed.cursor.workUnits);
+  assert.ok(adopted.workUnits > initial.workUnits);
+  assert.equal(adopted.depth, initial.depth);
+});
+
+test("cursor adoption rejects kernel, end, work, and read-bound violations", (): void => {
+  const kernel = createSqlParserKernel(
+    "alpha beta gamma",
+    limits(30, 10, 4, 20),
+  );
+  const otherKernel = createSqlParserKernel(
+    "other value here",
+    limits(30, 10, 4, 20),
+  );
+  const state = createSqlReadState(kernel);
+  const parent = advanceSqlReadCursor(
+    createSqlReadCursor(state, 0, state.tokenCount),
+    1,
+    "Prepare adoption parent",
+  );
+  const delegated = sqlTokenCursorFromReadCursor(parent, "Prepare adoption");
+  const cases: ReadonlyArray<Readonly<{
+    cursor: SqlTokenCursor;
+    message: RegExp;
+  }>> = [
+    {
+      cursor: { ...delegated, kernel: otherKernel },
+      message: /different SQL parser kernel/u,
+    },
+    {
+      cursor: { ...delegated, endIndex: delegated.endIndex - 1 },
+      message: /returned cursor end 2 but the read cursor end is 3/u,
+    },
+    {
+      cursor: { ...delegated, index: parent.index - 1 },
+      message: /outside the permitted read cursor range 1\.\.3/u,
+    },
+    {
+      cursor: { ...delegated, index: parent.endIndex + 1 },
+      message: /outside the permitted read cursor range 1\.\.3/u,
+    },
+    {
+      cursor: { ...delegated, workUnits: parent.workUnits - 1 },
+      message: /would rewind read work/u,
+    },
+    {
+      cursor: { ...delegated, workUnits: Number.NaN },
+      message: /workUnits must be a non-negative safe integer/u,
+    },
+    {
+      cursor: {
+        ...delegated,
+        workUnits: kernel.limits.maxWorkUnits + 1,
+      },
+      message: /exceeds maxWorkUnits=20/u,
+    },
+  ];
+
+  for (const invalid of cases) {
+    expectParserError(
+      () => {
+        adoptSqlTokenCursor(parent, invalid.cursor, "Reject returned cursor");
+      },
+      "internal_invariant",
+      { start: 6, end: 10 },
+      invalid.message,
+    );
+  }
+});
+
+test("restored delegated attempts cannot reset the read work budget", (): void => {
+  const kernel = createSqlParserKernel(
+    "only",
+    limits(10, 10, 4, 3),
+  );
+  const state = createSqlReadState(kernel);
+  let cursor = createSqlReadCursor(state, 0, state.tokenCount);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const delegated = sqlTokenCursorFromReadCursor(
+      cursor,
+      `Delegate attempt ${String(attempt + 1)}`,
+    );
+    const consumed = consumeSqlTokenCursor(
+      delegated,
+      `Consume attempt ${String(attempt + 1)}`,
+    );
+    const restored = restoreSqlTokenCursorPosition(
+      delegated,
+      consumed.cursor,
+    );
+    cursor = adoptSqlTokenCursor(
+      cursor,
+      restored,
+      `Adopt attempt ${String(attempt + 1)}`,
+    );
+    assert.equal(cursor.index, 0);
+    assert.equal(
+      cursor.workUnits,
+      kernel.delimiters.scanSteps + attempt + 1,
+    );
+  }
+
+  expectParserError(
+    () => {
+      consumeSqlReadToken(cursor, "Consume after exhausted attempts");
+    },
+    "limit_complexity",
+    { start: 0, end: 4 },
+    /maxWorkUnits=3 at token 0/u,
+  );
+});
+
+test("read cursors retain linear work on long flat and delimiter inputs", {
+  timeout: 3_000,
+}, (): void => {
+  const flatTokenCount = 20_000;
+  const flatSql = Array.from(
+    { length: flatTokenCount },
+    (_value, index): string => `c${String(index)}`,
+  ).join(" ");
+  const flatKernel = createSqlParserKernel(
+    flatSql,
+    limits(
+      flatSql.length,
+      flatTokenCount,
+      4,
+      flatTokenCount * 2 + 1,
+    ),
+  );
+  const flatState = createSqlReadState(flatKernel);
+  const inspected = inspectSqlReadToken(
+    createSqlReadCursor(flatState, 0, flatState.tokenCount),
+    flatTokenCount - 1,
+    "Inspect last flat token",
+  );
+  assert.equal(inspected.token?.text, `c${String(flatTokenCount - 1)}`);
+  const traversed = advanceSqlReadCursor(
+    inspected.cursor,
+    flatTokenCount,
+    "Traverse flat tokens",
+  );
+  assert.equal(traversed.index, flatTokenCount);
+  assert.equal(traversed.workUnits, flatKernel.limits.maxWorkUnits);
+
+  const pairCount = 5_000;
+  const delimiterSql = "()".repeat(pairCount);
+  const delimiterKernel = createSqlParserKernel(
+    delimiterSql,
+    limits(
+      delimiterSql.length,
+      delimiterSql.length,
+      4,
+      delimiterSql.length + pairCount * 3,
+    ),
+  );
+  const delimiterState = createSqlReadState(delimiterKernel);
+  let delimiterCursor = createSqlReadCursor(
+    delimiterState,
+    0,
+    delimiterState.tokenCount,
+  );
+  for (let pair = 0; pair < pairCount; pair++) {
+    const matched = matchingSqlReadDelimiter(
+      delimiterCursor,
+      "Match flat delimiter",
+    );
+    assert.equal(matched.closeIndex, delimiterCursor.index + 1);
+    delimiterCursor = advanceSqlReadCursor(
+      matched.cursor,
+      2,
+      "Advance flat delimiter pair",
+    );
+  }
+  assert.equal(delimiterCursor.index, delimiterState.tokenCount);
+  assert.equal(
+    delimiterCursor.workUnits,
+    delimiterKernel.limits.maxWorkUnits,
+  );
 });

--- a/packages/agent-shared/src/sql-policy-read-state.ts
+++ b/packages/agent-shared/src/sql-policy-read-state.ts
@@ -1,7 +1,16 @@
 import type { SqlSourceRange } from "./sql-policy-lexer.js";
-import type {
-  SqlParserKernel,
-  SqlParserLimits,
+import {
+  advanceSqlTokenCursor,
+  consumeSqlTokenCursor,
+  createSqlTokenCursor,
+  inspectSqlTokenCursor,
+  matchingSqlDelimiterIndexWithinCursor,
+  restoreSqlTokenCursorPosition,
+  sqlCursorRange,
+  type SqlParserKernel,
+  type SqlParserLimits,
+  type SqlParserToken,
+  type SqlTokenCursor,
 } from "./sql-policy-parser-kernel.js";
 import { throwSqlPolicyParserError } from "./sql-policy-parser-model.js";
 
@@ -11,6 +20,29 @@ export type SqlReadState = Readonly<{
   sourceLength: number;
   tokenCount: number;
   delimiterScanWorkUnits: number;
+}>;
+
+export type SqlReadCursor = Readonly<{
+  state: SqlReadState;
+  index: number;
+  endIndex: number;
+  workUnits: number;
+  depth: number;
+}>;
+
+export type SqlReadTokenInspection = Readonly<{
+  cursor: SqlReadCursor;
+  token: SqlParserToken | undefined;
+}>;
+
+export type SqlReadTokenConsumption = Readonly<{
+  cursor: SqlReadCursor;
+  token: SqlParserToken;
+}>;
+
+export type SqlReadDelimiterMatch = Readonly<{
+  closeIndex: number;
+  cursor: SqlReadCursor;
 }>;
 
 const sqlReadRange = (start: number, end: number): SqlSourceRange =>
@@ -81,6 +113,74 @@ const checkedBoundaryIndex = (
     );
   }
   return index;
+};
+
+const checkedSqlReadStateKernel = (
+  state: SqlReadState,
+  subject: string,
+): SqlParserKernel => {
+  const kernel = state.kernel;
+  const range = sqlReadRange(kernel.sql.length, kernel.sql.length);
+  if (state.limits !== kernel.limits) {
+    return sqlReadInvariant(
+      `${subject} state limits must reference its parser kernel limits`,
+      range,
+    );
+  }
+  if (state.sourceLength !== kernel.sql.length) {
+    return sqlReadInvariant(
+      `${subject} state source length ${String(state.sourceLength)} does not match parser kernel source length ${String(kernel.sql.length)}`,
+      range,
+    );
+  }
+  if (state.tokenCount !== kernel.tokens.length) {
+    return sqlReadInvariant(
+      `${subject} state token count ${String(state.tokenCount)} does not match parser kernel token count ${String(kernel.tokens.length)}`,
+      range,
+    );
+  }
+  if (state.delimiterScanWorkUnits !== kernel.delimiters.scanSteps) {
+    return sqlReadInvariant(
+      `${subject} state delimiter scan work ${String(state.delimiterScanWorkUnits)} does not match parser kernel scanSteps=${String(kernel.delimiters.scanSteps)}`,
+      range,
+    );
+  }
+  return kernel;
+};
+
+const sqlReadCursor = (
+  state: SqlReadState,
+  index: number,
+  endIndex: number,
+  workUnits: number,
+  depth: number,
+): SqlReadCursor => Object.freeze({
+  depth,
+  endIndex,
+  index,
+  state,
+  workUnits,
+});
+
+const checkedSqlReadDepthAtRange = (
+  state: SqlReadState,
+  depth: number,
+  range: SqlSourceRange,
+  subject: string,
+): number => {
+  const checkedDepth = checkedNonNegativeSafeInteger(
+    depth,
+    `${subject} nesting depth`,
+    range,
+  );
+  if (checkedDepth > state.limits.maxNestingDepth) {
+    return throwSqlPolicyParserError(
+      "limit_nesting",
+      `${subject} nesting depth ${String(checkedDepth)} exceeds maxNestingDepth=${String(state.limits.maxNestingDepth)}`,
+      range,
+    );
+  }
+  return checkedDepth;
 };
 
 export const createSqlReadState = (
@@ -182,18 +282,207 @@ export const checkedSqlReadDepth = (
     index,
     `${subject} depth position`,
   );
-  const range = rangeAtUnchecked(state, checkedIndex);
-  const checkedDepth = checkedNonNegativeSafeInteger(
+  return checkedSqlReadDepthAtRange(
+    state,
     depth,
-    `${subject} nesting depth`,
-    range,
+    rangeAtUnchecked(state, checkedIndex),
+    subject,
   );
-  if (checkedDepth > state.limits.maxNestingDepth) {
-    return throwSqlPolicyParserError(
-      "limit_nesting",
-      `${subject} nesting depth ${String(checkedDepth)} exceeds maxNestingDepth=${String(state.limits.maxNestingDepth)}`,
+};
+
+export const createSqlReadCursor = (
+  state: SqlReadState,
+  startIndex: number,
+  endIndex: number,
+): SqlReadCursor => {
+  const kernel = checkedSqlReadStateKernel(state, "SQL read cursor creation");
+  const cursor = createSqlTokenCursor(kernel, startIndex, endIndex);
+  return sqlReadCursor(
+    state,
+    cursor.index,
+    cursor.endIndex,
+    cursor.workUnits,
+    0,
+  );
+};
+
+export const sqlTokenCursorFromReadCursor = (
+  cursor: SqlReadCursor,
+  operation: string,
+): SqlTokenCursor => {
+  const kernel = checkedSqlReadStateKernel(cursor.state, operation);
+  const initial = createSqlTokenCursor(
+    kernel,
+    cursor.index,
+    cursor.endIndex,
+  );
+  const restored = restoreSqlTokenCursorPosition(initial, {
+    ...initial,
+    workUnits: cursor.workUnits,
+  });
+  checkedSqlReadDepthAtRange(
+    cursor.state,
+    cursor.depth,
+    sqlCursorRange(restored),
+    operation,
+  );
+  return Object.freeze(restored);
+};
+
+export const adoptSqlTokenCursor = (
+  cursor: SqlReadCursor,
+  returned: SqlTokenCursor,
+  operation: string,
+): SqlReadCursor => {
+  const parent = sqlTokenCursorFromReadCursor(cursor, operation);
+  const range = sqlCursorRange(parent);
+  if (returned.kernel !== parent.kernel) {
+    return sqlReadInvariant(
+      `${operation} returned a cursor for a different SQL parser kernel`,
       range,
     );
   }
-  return checkedDepth;
+  if (returned.endIndex !== parent.endIndex) {
+    return sqlReadInvariant(
+      `${operation} returned cursor end ${String(returned.endIndex)} but the read cursor end is ${String(parent.endIndex)}`,
+      range,
+    );
+  }
+  if (
+    !Number.isSafeInteger(returned.index)
+    || returned.index < parent.index
+    || returned.index > parent.endIndex
+  ) {
+    return sqlReadInvariant(
+      `${operation} returned cursor index ${String(returned.index)} outside the permitted read cursor range ${String(parent.index)}..${String(parent.endIndex)}`,
+      range,
+    );
+  }
+  checkedNonNegativeSafeInteger(
+    returned.workUnits,
+    `${operation} returned cursor workUnits`,
+    range,
+  );
+  if (returned.workUnits < parent.workUnits) {
+    return sqlReadInvariant(
+      `${operation} returned cursor workUnits=${String(returned.workUnits)} would rewind read work from ${String(parent.workUnits)}`,
+      range,
+    );
+  }
+  const restored = restoreSqlTokenCursorPosition(parent, returned);
+  return sqlReadCursor(
+    cursor.state,
+    returned.index,
+    returned.endIndex,
+    restored.workUnits,
+    cursor.depth,
+  );
+};
+
+export const inspectSqlReadToken = (
+  cursor: SqlReadCursor,
+  offset: number,
+  operation: string,
+): SqlReadTokenInspection => {
+  const inspected = inspectSqlTokenCursor(
+    sqlTokenCursorFromReadCursor(cursor, operation),
+    offset,
+    operation,
+  );
+  return Object.freeze({
+    cursor: adoptSqlTokenCursor(cursor, inspected.cursor, operation),
+    token: inspected.token,
+  });
+};
+
+export const consumeSqlReadToken = (
+  cursor: SqlReadCursor,
+  operation: string,
+): SqlReadTokenConsumption => {
+  const consumed = consumeSqlTokenCursor(
+    sqlTokenCursorFromReadCursor(cursor, operation),
+    operation,
+  );
+  return Object.freeze({
+    cursor: adoptSqlTokenCursor(cursor, consumed.cursor, operation),
+    token: consumed.token,
+  });
+};
+
+export const advanceSqlReadCursor = (
+  cursor: SqlReadCursor,
+  count: number,
+  operation: string,
+): SqlReadCursor => {
+  const advanced = advanceSqlTokenCursor(
+    sqlTokenCursorFromReadCursor(cursor, operation),
+    count,
+    operation,
+  );
+  return adoptSqlTokenCursor(cursor, advanced, operation);
+};
+
+export const narrowSqlReadCursor = (
+  cursor: SqlReadCursor,
+  endIndex: number,
+  operation: string,
+): SqlReadCursor => {
+  const adapted = sqlTokenCursorFromReadCursor(cursor, operation);
+  if (
+    !Number.isSafeInteger(endIndex)
+    || endIndex < cursor.index
+    || endIndex > cursor.endIndex
+  ) {
+    return sqlReadInvariant(
+      `${operation} bounded end ${String(endIndex)} must be a safe integer within the current read cursor range ${String(cursor.index)}..${String(cursor.endIndex)}`,
+      sqlCursorRange(adapted),
+    );
+  }
+  return sqlReadCursor(
+    cursor.state,
+    cursor.index,
+    endIndex,
+    cursor.workUnits,
+    cursor.depth,
+  );
+};
+
+export const enterSqlReadDepth = (
+  cursor: SqlReadCursor,
+  operation: string,
+): SqlReadCursor => {
+  const adapted = sqlTokenCursorFromReadCursor(cursor, operation);
+  const depth = checkedSqlReadDepthAtRange(
+    cursor.state,
+    cursor.depth + 1,
+    sqlCursorRange(adapted),
+    operation,
+  );
+  return sqlReadCursor(
+    cursor.state,
+    cursor.index,
+    cursor.endIndex,
+    cursor.workUnits,
+    depth,
+  );
+};
+
+export const matchingSqlReadDelimiter = (
+  cursor: SqlReadCursor,
+  operation: string,
+): SqlReadDelimiterMatch => {
+  const inspected = inspectSqlTokenCursor(
+    sqlTokenCursorFromReadCursor(cursor, operation),
+    0,
+    operation,
+  );
+  const closeIndex = matchingSqlDelimiterIndexWithinCursor(
+    inspected.cursor,
+    "unexpected_token",
+    operation,
+  );
+  return Object.freeze({
+    closeIndex,
+    cursor: adoptSqlTokenCursor(cursor, inspected.cursor, operation),
+  });
 };


### PR DESCRIPTION
## Summary
- add a frozen bounded read cursor over the canonical parser kernel
- thread charged work, depth, delimiter lookup, and token-cursor adoption without resets
- cover bounded EOF, limits, adapters, repeated attempts, and long-input complexity

## Validation
- npm test --workspace @expense-budget-tracker/agent-shared
- npm run build --workspace @expense-budget-tracker/agent-shared
- npm run lint --workspace expense-budget-tracker-sql-api
- npm run build --workspace expense-budget-tracker-sql-api
- npm run lint --workspace expense-budget-tracker-web
- npm run build --workspace expense-budget-tracker-web

## Review
- NO-SPLIT
- No P0-P4 findings
- CLEAN