### PR TITLE
Add read parser metadata model

### DIFF
--- a/packages/agent-shared/src/sql-policy-read-model.ts
+++ b/packages/agent-shared/src/sql-policy-read-model.ts
@@ -1,0 +1,63 @@
+import type {
+  SqlIdentifierToken,
+  SqlSourceRange,
+} from "./sql-policy-lexer.js";
+import type {
+  SqlTypeNameNode,
+  SqlTypedConstantNode,
+} from "./sql-policy-type-model.js";
+
+export type SqlQueryContext = "nested" | "root" | "root_cte";
+
+export type SqlExpressionSyntaxContext = "cycle" | "expression" | "from";
+
+export type SqlIdentifierPath = ReadonlyArray<SqlIdentifierToken>;
+
+export type SqlCallNode = Readonly<{
+  argumentsRange: SqlSourceRange;
+  context: SqlQueryContext;
+  path: SqlIdentifierPath;
+  queryId: number;
+  range: SqlSourceRange;
+  syntaxContext: SqlExpressionSyntaxContext;
+}>;
+
+export type SqlNestedQueryKind =
+  | "array"
+  | "exists"
+  | "expression"
+  | "in"
+  | "quantified";
+
+export type SqlNestedQueryNode = Readonly<{
+  bodyRange: SqlSourceRange;
+  context: "nested";
+  kind: SqlNestedQueryKind;
+  parentQueryId: number;
+  range: SqlSourceRange;
+  startIndex: number;
+  endIndex: number;
+}>;
+
+export type SqlTypeConstructNode =
+  | Readonly<{
+    context: SqlQueryContext;
+    queryId: number;
+    range: SqlSourceRange;
+    syntax: "cast";
+    typeName: SqlTypeNameNode;
+  }>
+  | Readonly<{
+    context: SqlQueryContext;
+    queryId: number;
+    range: SqlSourceRange;
+    syntax: "literal";
+    typedConstant: SqlTypedConstantNode;
+    typeName: SqlTypeNameNode;
+  }>;
+
+export type SqlExpressionMetadata = Readonly<{
+  calls: ReadonlyArray<SqlCallNode>;
+  nestedQueries: ReadonlyArray<SqlNestedQueryNode>;
+  typeConstructs: ReadonlyArray<SqlTypeConstructNode>;
+}>;


### PR DESCRIPTION
Summary:
- add the immutable read-parser expression metadata vocabulary
- reuse canonical lexer and type-model nodes
- keep runtime parsing, public exports, and later query/relation structures out of scope

Validation:
- agent-shared lint, build, and 84 tests
- SQL API lint and build
- web lint and production build
- git diff whitespace and scope checks
- independent review gate: CLEAN, NO-SPLIT