### PR TITLE
Add SQL expression reader contract

### DIFF
--- a/packages/agent-shared/src/sql-policy-read-expression.ts
+++ b/packages/agent-shared/src/sql-policy-read-expression.ts
@@ -1,0 +1,31 @@
+import type { SqlSourceRange } from "./sql-policy-lexer.js";
+import type {
+  SqlExpressionMetadata,
+  SqlExpressionSyntaxContext,
+  SqlQueryContext,
+} from "./sql-policy-read-model.js";
+import type { SqlReadCursor } from "./sql-policy-read-state.js";
+
+export type SqlExpressionEnvironment = Readonly<{
+  context: SqlQueryContext;
+  queryId: number;
+  syntaxContext: SqlExpressionSyntaxContext;
+}>;
+
+export type SqlExpressionResult = Readonly<{
+  cursor: SqlReadCursor;
+  metadata: SqlExpressionMetadata;
+  range: SqlSourceRange;
+}>;
+
+export type SqlExpressionListResult = Readonly<{
+  count: number;
+  cursor: SqlReadCursor;
+  metadata: SqlExpressionMetadata;
+  range: SqlSourceRange;
+}>;
+
+export type SqlExpressionReader<TResult extends SqlExpressionResult> = (
+  environment: SqlExpressionEnvironment,
+  cursor: SqlReadCursor,
+) => TResult;


### PR DESCRIPTION
## Summary

- add the dormant, type-only SQL expression reader contract
- thread canonical read cursors through expression and list results
- keep query metadata separate from cursor-owned parser state and work

## Validation

- agent-shared lint, build, and 84 tests
- SQL API lint and build
- web lint and production build
- clean mandatory review gate with no P0-P4 findings