### PR TITLE
feat(agent-shared): add cursor-native sort reader

### DIFF
--- a/packages/agent-shared/src/sql-policy-read-sort.test.ts
+++ b/packages/agent-shared/src/sql-policy-read-sort.test.ts
@@ -1,0 +1,890 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  SqlIdentifierToken,
+  SqlSourceRange,
+} from "./sql-policy-lexer.js";
+import {
+  createSqlParserKernel,
+  DEFAULT_SQL_PARSER_LIMITS,
+  type SqlParserKernel,
+  type SqlParserLimits,
+} from "./sql-policy-parser-kernel.js";
+import {
+  SqlPolicyParserError,
+  throwSqlPolicyParserError,
+  type SqlPolicyParserErrorCode,
+} from "./sql-policy-parser-model.js";
+import type {
+  SqlExpressionEnvironment,
+  SqlExpressionReader,
+  SqlExpressionResult,
+} from "./sql-policy-read-expression.js";
+import type {
+  SqlCallNode,
+  SqlExpressionMetadata,
+  SqlNestedQueryNode,
+  SqlTypeConstructNode,
+} from "./sql-policy-read-model.js";
+import type { SqlTypeNameNode } from "./sql-policy-type-model.js";
+import {
+  advanceSqlReadCursor,
+  createSqlReadCursor,
+  createSqlReadState,
+  enterSqlReadDepth,
+  inspectSqlReadToken,
+  sqlReadRangeForSpan,
+  type SqlReadCursor,
+} from "./sql-policy-read-state.js";
+import { readSqlSortList } from "./sql-policy-read-sort.js";
+
+const limits = (
+  maxSourceCodeUnits: number,
+  maxTokens: number,
+  maxNestingDepth: number,
+  maxWorkUnits: number,
+): SqlParserLimits => ({
+  maxNestingDepth,
+  maxSourceCodeUnits,
+  maxTokens,
+  maxWorkUnits,
+});
+
+const environment = (queryId: number): SqlExpressionEnvironment => ({
+  context: "root",
+  queryId,
+  syntaxContext: "expression",
+});
+
+const emptyMetadata = (): SqlExpressionMetadata => Object.freeze({
+  calls: Object.freeze([]),
+  nestedQueries: Object.freeze([]),
+  typeConstructs: Object.freeze([]),
+});
+
+const callMetadata = (
+  expressionEnvironment: SqlExpressionEnvironment,
+  token: SqlIdentifierToken,
+  range: SqlSourceRange,
+): SqlExpressionMetadata => {
+  const call: SqlCallNode = Object.freeze({
+    argumentsRange: range,
+    context: expressionEnvironment.context,
+    path: Object.freeze([token]),
+    queryId: expressionEnvironment.queryId,
+    range,
+    syntaxContext: expressionEnvironment.syntaxContext,
+  });
+  return Object.freeze({
+    calls: Object.freeze([call]),
+    nestedQueries: Object.freeze([]),
+    typeConstructs: Object.freeze([]),
+  });
+};
+
+const readMinimalExpression: SqlExpressionReader<SqlExpressionResult> = (
+  expressionEnvironment: SqlExpressionEnvironment,
+  cursor: SqlReadCursor,
+): SqlExpressionResult => {
+  const startIndex = cursor.index;
+  const inspected = inspectSqlReadToken(
+    cursor,
+    0,
+    "Inspect deterministic test expression",
+  );
+  if (inspected.token === undefined) {
+    return throwSqlPolicyParserError(
+      "unexpected_token",
+      "Deterministic test expression reader requires a token",
+      sqlReadRangeForSpan(cursor.state, startIndex, startIndex),
+    );
+  }
+  const range = sqlReadRangeForSpan(
+    cursor.state,
+    startIndex,
+    cursor.endIndex,
+  );
+  const advanced = advanceSqlReadCursor(
+    inspected.cursor,
+    cursor.endIndex - cursor.index,
+    "Consume deterministic test expression",
+  );
+  return Object.freeze({
+    cursor: advanced,
+    metadata: inspected.token.kind === "identifier"
+      ? callMetadata(expressionEnvironment, inspected.token, range)
+      : emptyMetadata(),
+    range,
+  });
+};
+
+const readRichMetadataExpression: SqlExpressionReader<SqlExpressionResult> = (
+  expressionEnvironment: SqlExpressionEnvironment,
+  cursor: SqlReadCursor,
+): SqlExpressionResult => {
+  const result = readMinimalExpression(expressionEnvironment, cursor);
+  const call = result.metadata.calls[0];
+  const name = call?.path[0];
+  if (call === undefined || name === undefined) {
+    return result;
+  }
+  const sql = cursor.state.kernel.sql.slice(
+    result.range.start,
+    result.range.end,
+  );
+  const nestedQuery: SqlNestedQueryNode = Object.freeze({
+    bodyRange: result.range,
+    context: "nested",
+    endIndex: result.cursor.index,
+    kind: "expression",
+    parentQueryId: expressionEnvironment.queryId,
+    range: result.range,
+    startIndex: cursor.index,
+  });
+  const typeName: SqlTypeNameNode = Object.freeze({
+    arrayBounds: Object.freeze([]),
+    form: "generic",
+    intervalQualifier: null,
+    modifiers: Object.freeze([]),
+    nameParts: Object.freeze([name]),
+    nameRange: name.range,
+    range: result.range,
+    setOf: false,
+    sql,
+    timeZone: null,
+  });
+  const typeConstruct: SqlTypeConstructNode = Object.freeze({
+    context: expressionEnvironment.context,
+    queryId: expressionEnvironment.queryId,
+    range: result.range,
+    syntax: "cast",
+    typeName,
+  });
+  return Object.freeze({
+    ...result,
+    metadata: Object.freeze({
+      calls: result.metadata.calls,
+      nestedQueries: Object.freeze([nestedQuery]),
+      typeConstructs: Object.freeze([typeConstruct]),
+    }),
+  });
+};
+
+const createReadCursor = (
+  sql: string,
+  parserLimits: SqlParserLimits,
+): Readonly<{ cursor: SqlReadCursor; kernel: SqlParserKernel }> => {
+  const kernel = createSqlParserKernel(sql, parserLimits);
+  const state = createSqlReadState(kernel);
+  return Object.freeze({
+    cursor: createSqlReadCursor(state, 0, state.tokenCount),
+    kernel,
+  });
+};
+
+const normalizedCalls = (
+  result: SqlExpressionResult,
+): ReadonlyArray<string> => result.metadata.calls.map((call) =>
+  call.path.map((part) => part.untruncatedNormalized).join(".")
+);
+
+const expectParserError = (
+  action: () => unknown,
+  code: SqlPolicyParserErrorCode,
+  range: SqlSourceRange,
+  message: string,
+): void => assert.throws(action, (error: unknown): boolean => {
+  assert.ok(error instanceof SqlPolicyParserError);
+  assert.equal(error.code, code);
+  assert.deepEqual(error.range, range);
+  assert.equal(error.message, message);
+  return true;
+});
+
+test("ORDER BY reads expressions, direction, USING, and NULLS suffixes", (): void => {
+  const sql = [
+    "alpha DESC NULLS LAST",
+    "beta USING > NULLS FIRST",
+    "qualified USING OPERATOR(pg_catalog.<) NULLS LAST",
+    "gamma ASC",
+    "delta",
+  ].join(", ");
+  const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const result = readSqlSortList(
+    environment(21),
+    cursor,
+    readMinimalExpression,
+  );
+
+  assert.equal(result.cursor.index, cursor.endIndex);
+  assert.equal(result.cursor.endIndex, cursor.endIndex);
+  assert.equal(result.cursor.depth, cursor.depth);
+  assert.equal(result.cursor.state, cursor.state);
+  assert.equal(result.range.start, 0);
+  assert.equal(result.range.end, sql.length);
+  assert.deepEqual(normalizedCalls(result), [
+    "alpha",
+    "beta",
+    "qualified",
+    "gamma",
+    "delta",
+  ]);
+  assert.deepEqual(
+    result.metadata.calls.map((call) => sql.slice(
+      call.range.start,
+      call.range.end,
+    )),
+    ["alpha", "beta", "qualified", "gamma", "delta"],
+  );
+});
+
+test("ORDER BY keeps contextual NULLS identifiers inside expressions", (): void => {
+  const sql = "nulls, nulls DESC, value NULLS FIRST";
+  const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const result = readSqlSortList(
+    environment(25),
+    cursor,
+    readMinimalExpression,
+  );
+
+  assert.deepEqual(normalizedCalls(result), ["nulls", "nulls", "value"]);
+  assert.deepEqual(
+    result.metadata.calls.map((call) => sql.slice(
+      call.range.start,
+      call.range.end,
+    )),
+    ["nulls", "nulls", "value"],
+  );
+});
+
+test("ORDER BY keeps contextual direction words inside expressions", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    expressions: ReadonlyArray<string>;
+    sql: string;
+  }>> = [
+    { expressions: ["ASC"], sql: "ASC" },
+    { expressions: ["DESC"], sql: "DESC" },
+    { expressions: ["USING"], sql: "USING" },
+    {
+      expressions: ["asc", "desc", "using"],
+      sql: "asc, desc, using",
+    },
+    {
+      expressions: ["alpha USING first"],
+      sql: "alpha USING first",
+    },
+    {
+      expressions: ["foo + asc"],
+      sql: "foo + asc DESC",
+    },
+    {
+      expressions: ["foo + desc"],
+      sql: "foo + desc NULLS LAST",
+    },
+    {
+      expressions: ["foo + using"],
+      sql: "foo + using ASC",
+    },
+    {
+      expressions: ["foo + using"],
+      sql: "foo + using NULLS FIRST",
+    },
+  ];
+
+  for (const expected of cases) {
+    const { cursor } = createReadCursor(
+      expected.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const result = readSqlSortList(
+      environment(27),
+      cursor,
+      readMinimalExpression,
+    );
+    assert.deepEqual(
+      result.metadata.calls.map((call) => expected.sql.slice(
+        call.range.start,
+        call.range.end,
+      )),
+      expected.expressions,
+      expected.sql,
+    );
+    assert.equal(result.cursor.index, cursor.endIndex, expected.sql);
+  }
+});
+
+test("ORDER BY recognizes terminal field wildcards before suffixes", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    expression: string;
+    sql: string;
+  }>> = [
+    {
+      expression: "row_value.*",
+      sql: "row_value.* DESC",
+    },
+    {
+      expression: "(row_value).*",
+      sql: "(row_value).* ASC NULLS FIRST",
+    },
+    {
+      expression: "row_value.*",
+      sql: "row_value.* USING < NULLS LAST",
+    },
+    {
+      expression: "row_value.*",
+      sql: "row_value.* NULLS FIRST",
+    },
+    {
+      expression: "(row_value).*",
+      sql: "(row_value).* USING <",
+    },
+  ];
+
+  for (const expected of cases) {
+    const expressions: Array<string> = [];
+    const { cursor } = createReadCursor(
+      expected.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const recordingReader: SqlExpressionReader<SqlExpressionResult> = (
+      expressionEnvironment: SqlExpressionEnvironment,
+      child: SqlReadCursor,
+    ): SqlExpressionResult => {
+      const range = sqlReadRangeForSpan(
+        child.state,
+        child.index,
+        child.endIndex,
+      );
+      expressions.push(expected.sql.slice(range.start, range.end));
+      return readMinimalExpression(expressionEnvironment, child);
+    };
+    const result = readSqlSortList(
+      environment(30),
+      cursor,
+      recordingReader,
+    );
+
+    assert.deepEqual(expressions, [expected.expression], expected.sql);
+    assert.equal(result.cursor.index, cursor.endIndex, expected.sql);
+  }
+});
+
+test("ORDER BY does not confuse multiplication or incomplete dots with field wildcards", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    expression: string;
+    sql: string;
+  }>> = [
+    {
+      expression: "left_value * right_value",
+      sql: "left_value * right_value DESC",
+    },
+    {
+      expression: "left_value * DESC",
+      sql: "left_value * DESC",
+    },
+    {
+      expression: "(left_value) * USING <",
+      sql: "(left_value) * USING <",
+    },
+    {
+      expression: "row_value. DESC",
+      sql: "row_value. DESC",
+    },
+    {
+      expression: ".* ASC",
+      sql: ".* ASC",
+    },
+    {
+      expression: "row_value.*. USING <",
+      sql: "row_value.*. USING <",
+    },
+    {
+      expression: "row_value.* * right_value",
+      sql: "row_value.* * right_value DESC",
+    },
+  ];
+
+  for (const expected of cases) {
+    const expressions: Array<string> = [];
+    const { cursor } = createReadCursor(
+      expected.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    const recordingReader: SqlExpressionReader<SqlExpressionResult> = (
+      expressionEnvironment: SqlExpressionEnvironment,
+      child: SqlReadCursor,
+    ): SqlExpressionResult => {
+      const range = sqlReadRangeForSpan(
+        child.state,
+        child.index,
+        child.endIndex,
+      );
+      expressions.push(expected.sql.slice(range.start, range.end));
+      return readMinimalExpression(expressionEnvironment, child);
+    };
+    const result = readSqlSortList(
+      environment(30),
+      cursor,
+      recordingReader,
+    );
+
+    assert.deepEqual(expressions, [expected.expression], expected.sql);
+    assert.equal(result.cursor.index, cursor.endIndex, expected.sql);
+  }
+});
+
+test("ORDER BY ignores nested commas and suffix keywords", (): void => {
+  const sql = [
+    "outer_fn(inner DESC, other NULLS FIRST) DESC NULLS LAST",
+    "array_value[using, asc, nested(desc)] USING <",
+  ].join(", ");
+  const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const result = readSqlSortList(
+    environment(22),
+    cursor,
+    readMinimalExpression,
+  );
+
+  assert.deepEqual(normalizedCalls(result), ["outer_fn", "array_value"]);
+  assert.deepEqual(
+    result.metadata.calls.map((call) => sql.slice(
+      call.range.start,
+      call.range.end,
+    )),
+    [
+      "outer_fn(inner DESC, other NULLS FIRST)",
+      "array_value[using, asc, nested(desc)]",
+    ],
+  );
+});
+
+test("ORDER BY rejects empty and malformed items at the exact token", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    sql: string;
+    range: SqlSourceRange;
+    message: string;
+  }>> = [
+    {
+      message: "ORDER BY requires at least one expression",
+      range: { start: 0, end: 0 },
+      sql: "",
+    },
+    {
+      message: "ORDER BY item requires an expression before comma",
+      range: { start: 0, end: 1 },
+      sql: ", alpha",
+    },
+    {
+      message: "ORDER BY cannot end with a comma",
+      range: { start: 5, end: 6 },
+      sql: "alpha,",
+    },
+    {
+      message: "ORDER BY item requires an expression before comma",
+      range: { start: 7, end: 8 },
+      sql: "alpha, , beta",
+    },
+    {
+      message: "Expected a comma between ORDER BY items",
+      range: { start: 11, end: 15 },
+      sql: "alpha DESC beta",
+    },
+  ];
+
+  for (const invalid of cases) {
+    const { cursor } = createReadCursor(
+      invalid.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    expectParserError(
+      () => readSqlSortList(
+        environment(23),
+        cursor,
+        readMinimalExpression,
+      ),
+      "unexpected_token",
+      invalid.range,
+      invalid.message,
+    );
+  }
+});
+
+test("ORDER BY rejects missing and misordered suffix components", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    sql: string;
+    range: SqlSourceRange;
+    message: string;
+  }>> = [
+    {
+      message: "ORDER BY NULLS requires FIRST or LAST",
+      range: { start: 16, end: 16 },
+      sql: "alpha DESC NULLS",
+    },
+    {
+      message: "ORDER BY NULLS requires FIRST or LAST",
+      range: { start: 17, end: 23 },
+      sql: "alpha DESC NULLS middle",
+    },
+    {
+      message: "DESC must appear before NULLS ordering in an ORDER BY item",
+      range: { start: 18, end: 22 },
+      sql: "alpha NULLS FIRST DESC",
+    },
+    {
+      message: "ORDER BY item cannot contain more than one ASC, DESC, or USING clause",
+      range: { start: 10, end: 15 },
+      sql: "alpha ASC USING >",
+    },
+    {
+      message: "ORDER BY item cannot contain more than one ASC, DESC, or USING clause",
+      range: { start: 11, end: 14 },
+      sql: "alpha DESC ASC",
+    },
+    {
+      message: "ORDER BY item cannot contain more than one NULLS clause",
+      range: { start: 18, end: 23 },
+      sql: "alpha NULLS FIRST NULLS LAST",
+    },
+  ];
+
+  for (const invalid of cases) {
+    const { cursor } = createReadCursor(
+      invalid.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    expectParserError(
+      () => readSqlSortList(
+        environment(24),
+        cursor,
+        readMinimalExpression,
+      ),
+      "unexpected_token",
+      invalid.range,
+      invalid.message,
+    );
+  }
+});
+
+test("ORDER BY validates qualified OPERATOR names exactly", (): void => {
+  const cases: ReadonlyArray<Readonly<{
+    sql: string;
+    range: SqlSourceRange;
+    message: string;
+  }>> = [
+    {
+      message: "ORDER BY USING OPERATOR requires an opening parenthesis",
+      range: { start: 20, end: 20 },
+      sql: "value USING OPERATOR",
+    },
+    {
+      message: "ORDER BY USING OPERATOR requires an opening parenthesis",
+      range: { start: 20, end: 21 },
+      sql: "value USING OPERATOR[<]",
+    },
+    {
+      message: "ORDER BY USING OPERATOR requires an operator name",
+      range: { start: 21, end: 21 },
+      sql: "value USING OPERATOR()",
+    },
+    {
+      message: "ORDER BY USING OPERATOR qualifier requires a following dot",
+      range: { start: 31, end: 31 },
+      sql: "value USING OPERATOR(pg_catalog)",
+    },
+    {
+      message: "ORDER BY USING OPERATOR requires dot-separated PostgreSQL identifiers followed by an operator name",
+      range: { start: 21, end: 27 },
+      sql: "value USING OPERATOR(select.<)",
+    },
+    {
+      message: "ORDER BY USING OPERATOR cannot contain tokens after the operator name",
+      range: { start: 34, end: 39 },
+      sql: "value USING OPERATOR(pg_catalog.< extra)",
+    },
+  ];
+
+  for (const invalid of cases) {
+    const { cursor } = createReadCursor(
+      invalid.sql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    expectParserError(
+      () => readSqlSortList(
+        environment(26),
+        cursor,
+        readMinimalExpression,
+      ),
+      "unexpected_token",
+      invalid.range,
+      invalid.message,
+    );
+  }
+});
+
+test("ORDER BY rejects operators outside PostgreSQL all_Op", (): void => {
+  const specialOperators: ReadonlyArray<string> = ["::", ":=", "..", "=>"];
+
+  for (const operator of specialOperators) {
+    const directSql = `value USING ${operator}`;
+    const direct = createReadCursor(
+      directSql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    expectParserError(
+      () => readSqlSortList(
+        environment(28),
+        direct.cursor,
+        readMinimalExpression,
+      ),
+      "unexpected_token",
+      { start: 12, end: 14 },
+      `ORDER BY USING requires a PostgreSQL all_Op operator; "${operator}" is reserved syntax`,
+    );
+
+    const qualifiedSql = `value USING OPERATOR(pg_catalog. ${operator})`;
+    const qualified = createReadCursor(
+      qualifiedSql,
+      DEFAULT_SQL_PARSER_LIMITS,
+    );
+    expectParserError(
+      () => readSqlSortList(
+        environment(28),
+        qualified.cursor,
+        readMinimalExpression,
+      ),
+      "unexpected_token",
+      { start: 33, end: 35 },
+      `ORDER BY USING OPERATOR requires a PostgreSQL all_Op operator; "${operator}" is reserved syntax`,
+    );
+  }
+});
+
+test("ORDER BY accepts neighboring PostgreSQL all_Op operators", (): void => {
+  const accepted: ReadonlyArray<string> = [
+    "value USING =",
+    "value USING ->",
+    "value USING ?",
+    "value USING OPERATOR(pg_catalog.=)",
+    "value USING OPERATOR(pg_catalog.->)",
+    "value USING OPERATOR(?)",
+  ];
+
+  for (const sql of accepted) {
+    const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+    const result = readSqlSortList(
+      environment(29),
+      cursor,
+      readMinimalExpression,
+    );
+    assert.equal(result.cursor.index, cursor.endIndex, sql);
+    assert.deepEqual(normalizedCalls(result), ["value"], sql);
+  }
+});
+
+test("ORDER BY preserves every child metadata collection in order", (): void => {
+  const sql = "first, second DESC, third USING >";
+  const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const result = readSqlSortList(
+    environment(35),
+    cursor,
+    readRichMetadataExpression,
+  );
+  const expected = ["first", "second", "third"];
+
+  assert.deepEqual(normalizedCalls(result), expected);
+  assert.equal(result.metadata.nestedQueries.length, expected.length);
+  assert.equal(result.metadata.typeConstructs.length, expected.length);
+  assert.deepEqual(
+    result.metadata.typeConstructs.map((construct) =>
+      construct.typeName.nameParts[0]?.untruncatedNormalized
+    ),
+    expected,
+  );
+  assert.equal(Object.isFrozen(result.metadata.calls), true);
+  assert.equal(Object.isFrozen(result.metadata.nestedQueries), true);
+  assert.equal(Object.isFrozen(result.metadata.typeConstructs), true);
+});
+
+test("bounded parent cursors and deeper child cursors resume exactly", (): void => {
+  const sql = "prefix alpha DESC trailing";
+  const kernel = createSqlParserKernel(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const state = createSqlReadState(kernel);
+  const parent = enterSqlReadDepth(
+    createSqlReadCursor(state, 1, kernel.tokens.length - 1),
+    "Enter bounded test parent",
+  );
+  const deeperReader: SqlExpressionReader<SqlExpressionResult> = (
+    expressionEnvironment: SqlExpressionEnvironment,
+    cursor: SqlReadCursor,
+  ): SqlExpressionResult => readMinimalExpression(
+    expressionEnvironment,
+    enterSqlReadDepth(cursor, "Enter deterministic child depth"),
+  );
+  const result = readSqlSortList(
+    environment(41),
+    parent,
+    deeperReader,
+  );
+
+  assert.equal(result.cursor.state, parent.state);
+  assert.equal(result.cursor.index, parent.endIndex);
+  assert.equal(result.cursor.endIndex, parent.endIndex);
+  assert.equal(result.cursor.depth, parent.depth);
+  assert.equal(result.range.start, 7);
+  assert.equal(result.range.end, 17);
+  assert.equal(result.cursor.workUnits > parent.workUnits, true);
+});
+
+test("delimiter scanning enforces read depth at the opening token", (): void => {
+  const sql = "outer(inner DESC) ASC";
+  const parserLimits = limits(sql.length, 20, 1, 200);
+  const { cursor } = createReadCursor(sql, parserLimits);
+  const nestedParent = enterSqlReadDepth(cursor, "Fill test read depth");
+
+  expectParserError(
+    () => readSqlSortList(
+      environment(42),
+      nestedParent,
+      readMinimalExpression,
+    ),
+    "limit_nesting",
+    { start: 5, end: 6 },
+    "Scan ORDER BY expression nesting nesting depth 2 exceeds maxNestingDepth=1",
+  );
+});
+
+test("qualified OPERATOR enforces delimiter bounds and restores read depth", (): void => {
+  const sql = "value USING OPERATOR(pg_catalog.<)";
+  const boundedKernel = createSqlParserKernel(
+    sql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const boundedState = createSqlReadState(boundedKernel);
+  const bounded = createSqlReadCursor(
+    boundedState,
+    0,
+    boundedKernel.tokens.length - 1,
+  );
+  expectParserError(
+    () => readSqlSortList(
+      environment(47),
+      bounded,
+      readMinimalExpression,
+    ),
+    "unexpected_token",
+    { start: 20, end: 21 },
+    "Match ORDER BY USING OPERATOR parentheses closes outside the current parse range",
+  );
+
+  const depthLimits = limits(sql.length, 20, 1, 200);
+  const { cursor } = createReadCursor(sql, depthLimits);
+  const result = readSqlSortList(
+    environment(47),
+    cursor,
+    readMinimalExpression,
+  );
+  assert.equal(result.cursor.index, cursor.endIndex);
+  assert.equal(result.cursor.endIndex, cursor.endIndex);
+  assert.equal(result.cursor.depth, cursor.depth);
+});
+
+test("qualified OPERATOR reports the low-limit first excess at lookup", (): void => {
+  const sql = "value USING OPERATOR(pg_catalog.<)";
+  const { cursor } = createReadCursor(
+    sql,
+    limits(sql.length, 20, 3, 19),
+  );
+  expectParserError(
+    () => readSqlSortList(
+      environment(48),
+      cursor,
+      readMinimalExpression,
+    ),
+    "limit_complexity",
+    { start: 20, end: 21 },
+    "SQL parser Match ORDER BY USING OPERATOR parentheses exceeded maxWorkUnits=19 at token 3",
+  );
+});
+
+test("expression collaborators must consume their exact bounded span", (): void => {
+  const sql = "alpha DESC";
+  const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const partialReader: SqlExpressionReader<SqlExpressionResult> = (
+    _expressionEnvironment: SqlExpressionEnvironment,
+    child: SqlReadCursor,
+  ): SqlExpressionResult => Object.freeze({
+    cursor: child,
+    metadata: emptyMetadata(),
+    range: sqlReadRangeForSpan(child.state, child.index, child.index),
+  });
+
+  expectParserError(
+    () => readSqlSortList(
+      environment(43),
+      cursor,
+      partialReader,
+    ),
+    "internal_invariant",
+    { start: 0, end: 5 },
+    "ORDER BY expression reader returned cursor 0..1 but the exact expression span ends at token 1",
+  );
+});
+
+test("runtime work accepts the exact maximum and fails at first excess", (): void => {
+  const sql = "value";
+  const ample = createReadCursor(
+    sql,
+    limits(sql.length, 5, 2, 100),
+  );
+  const measured = readSqlSortList(
+    environment(44),
+    ample.cursor,
+    readMinimalExpression,
+  );
+  const exactLimit = measured.cursor.workUnits;
+
+  const exact = createReadCursor(
+    sql,
+    limits(sql.length, 5, 2, exactLimit),
+  );
+  const exactResult = readSqlSortList(
+    environment(44),
+    exact.cursor,
+    readMinimalExpression,
+  );
+  assert.equal(exactResult.cursor.workUnits, exactLimit);
+
+  const firstExcess = createReadCursor(
+    sql,
+    limits(sql.length, 5, 2, exactLimit - 1),
+  );
+  expectParserError(
+    () => readSqlSortList(
+      environment(44),
+      firstExcess.cursor,
+      readMinimalExpression,
+    ),
+    "limit_complexity",
+    { start: sql.length, end: sql.length },
+    `SQL parser Inspect ORDER BY item terminator exceeded maxWorkUnits=${String(exactLimit - 1)} at token 1`,
+  );
+});
+
+test("large ORDER BY metadata aggregation remains ordered and iterative", (): void => {
+  const count = 2_000;
+  const sql = Array.from(
+    { length: count },
+    (_unused, index) => `item_${String(index)}`,
+  ).join(",");
+  const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const result = readSqlSortList(
+    environment(45),
+    cursor,
+    readMinimalExpression,
+  );
+
+  assert.equal(result.metadata.calls.length, count);
+  assert.equal(normalizedCalls(result)[0], "item_0");
+  assert.equal(normalizedCalls(result).at(-1), `item_${String(count - 1)}`);
+  assert.equal(result.cursor.index, cursor.endIndex);
+});

--- a/packages/agent-shared/src/sql-policy-read-sort.ts
+++ b/packages/agent-shared/src/sql-policy-read-sort.ts
@@ -1,0 +1,651 @@
+import type { SqlSourceRange } from "./sql-policy-lexer.js";
+import {
+  isPostgreSqlColId,
+  postgreSqlTokenWord,
+} from "./sql-policy-parser-keywords.js";
+import {
+  restoreSqlTokenCursorPosition,
+  sqlCursorRange,
+  type SqlParserToken,
+} from "./sql-policy-parser-kernel.js";
+import { throwSqlPolicyParserError } from "./sql-policy-parser-model.js";
+import type {
+  SqlExpressionEnvironment,
+  SqlExpressionReader,
+  SqlExpressionResult,
+} from "./sql-policy-read-expression.js";
+import type {
+  SqlCallNode,
+  SqlExpressionMetadata,
+  SqlNestedQueryNode,
+  SqlTypeConstructNode,
+} from "./sql-policy-read-model.js";
+import {
+  adoptSqlTokenCursor,
+  advanceSqlReadCursor,
+  consumeSqlReadToken,
+  enterSqlReadDepth,
+  inspectSqlReadToken,
+  matchingSqlReadDelimiter,
+  narrowSqlReadCursor,
+  resumeSqlReadCursor,
+  sqlReadRangeForSpan,
+  sqlTokenCursorFromReadCursor,
+  type SqlReadCursor,
+} from "./sql-policy-read-state.js";
+
+type SqlMetadataAccumulator = {
+  calls: Array<SqlCallNode>;
+  nestedQueries: Array<SqlNestedQueryNode>;
+  typeConstructs: Array<SqlTypeConstructNode>;
+};
+
+type SqlReadProbe = Readonly<{
+  cursor: SqlReadCursor;
+  token: SqlParserToken | undefined;
+}>;
+
+type SqlExactExpressionRead = Readonly<{
+  cursor: SqlReadCursor;
+  metadata: SqlExpressionMetadata;
+}>;
+
+const metadataAccumulator = (): SqlMetadataAccumulator => ({
+  calls: [],
+  nestedQueries: [],
+  typeConstructs: [],
+});
+
+const appendExpressionMetadata = (
+  target: SqlMetadataAccumulator,
+  metadata: SqlExpressionMetadata,
+): void => {
+  for (const call of metadata.calls) {
+    target.calls.push(call);
+  }
+  for (const nestedQuery of metadata.nestedQueries) {
+    target.nestedQueries.push(nestedQuery);
+  }
+  for (const typeConstruct of metadata.typeConstructs) {
+    target.typeConstructs.push(typeConstruct);
+  }
+};
+
+const expressionMetadata = (
+  accumulator: SqlMetadataAccumulator,
+): SqlExpressionMetadata => Object.freeze({
+  calls: Object.freeze(accumulator.calls),
+  nestedQueries: Object.freeze(accumulator.nestedQueries),
+  typeConstructs: Object.freeze(accumulator.typeConstructs),
+});
+
+const readCursorRange = (
+  cursor: SqlReadCursor,
+  operation: string,
+): SqlSourceRange => sqlCursorRange(
+  sqlTokenCursorFromReadCursor(cursor, operation),
+);
+
+const unexpectedSqlReadToken = (
+  cursor: SqlReadCursor,
+  message: string,
+): never => throwSqlPolicyParserError(
+  "unexpected_token",
+  message,
+  readCursorRange(cursor, "Report SQL sort-reader error"),
+);
+
+const sqlReadInvariant = (
+  cursor: SqlReadCursor,
+  message: string,
+): never => throwSqlPolicyParserError(
+  "internal_invariant",
+  message,
+  readCursorRange(cursor, "Report SQL sort-reader invariant"),
+);
+
+const inspectCurrentSqlReadToken = (
+  cursor: SqlReadCursor,
+  operation: string,
+): SqlReadProbe => inspectSqlReadToken(cursor, 0, operation);
+
+const restoreSqlReadPosition = (
+  original: SqlReadCursor,
+  attempted: SqlReadCursor,
+  operation: string,
+): SqlReadCursor => adoptSqlTokenCursor(
+  original,
+  restoreSqlTokenCursorPosition(
+    sqlTokenCursorFromReadCursor(original, `${operation} original cursor`),
+    sqlTokenCursorFromReadCursor(attempted, `${operation} attempted cursor`),
+  ),
+  operation,
+);
+
+const skipNestedSqlReadDelimiter = (
+  cursor: SqlReadCursor,
+  operation: string,
+): SqlReadCursor => {
+  const nested = enterSqlReadDepth(cursor, `${operation} nesting`);
+  const matched = matchingSqlReadDelimiter(
+    nested,
+    `${operation} delimiter lookup`,
+  );
+  const advanced = advanceSqlReadCursor(
+    matched.cursor,
+    matched.closeIndex - cursor.index + 1,
+    `${operation} delimiter traversal`,
+  );
+  return resumeSqlReadCursor(
+    cursor,
+    advanced,
+    `${operation} delimiter resumption`,
+  );
+};
+
+const isOpeningDelimiter = (token: SqlParserToken): boolean =>
+  token.text === "(" || token.text === "[";
+
+const canPrecedeSortSuffix = (token: SqlParserToken): boolean =>
+  token.kind === "identifier"
+  || token.kind === "numeric"
+  || token.kind === "parameter"
+  || token.kind === "string"
+  || token.text === ")"
+  || token.text === "]";
+
+const isPostgreSqlAllOperator = (token: SqlParserToken): boolean =>
+  token.kind === "operator"
+  && token.text !== "::"
+  && token.text !== ":="
+  && token.text !== ".."
+  && token.text !== "=>";
+
+const isSortDirectionWord = (word: string | null): boolean =>
+  word === "asc"
+  || word === "desc"
+  || word === "using";
+
+const isSortSuffixWord = (word: string | null): boolean =>
+  word === "nulls" || isSortDirectionWord(word);
+
+const inspectNextWord = (
+  cursor: SqlReadCursor,
+  operation: string,
+): Readonly<{ cursor: SqlReadCursor; word: string | null }> => {
+  const inspected = inspectSqlReadToken(cursor, 1, operation);
+  return Object.freeze({
+    cursor: inspected.cursor,
+    word: postgreSqlTokenWord(inspected.token),
+  });
+};
+
+const scanSortExpressionEnd = (
+  cursor: SqlReadCursor,
+): SqlReadCursor => {
+  let current = cursor;
+  let canCompleteFieldWildcard: boolean = false;
+  let canPrecedeSuffix: boolean = false;
+  while (true) {
+    const inspected = inspectCurrentSqlReadToken(
+      current,
+      "Scan ORDER BY expression",
+    );
+    current = inspected.cursor;
+    if (inspected.token === undefined || inspected.token.text === ",") {
+      return current;
+    }
+    if (isOpeningDelimiter(inspected.token)) {
+      current = skipNestedSqlReadDelimiter(
+        current,
+        "Scan ORDER BY expression",
+      );
+      canCompleteFieldWildcard = false;
+      canPrecedeSuffix = true;
+      continue;
+    }
+    const word = postgreSqlTokenWord(inspected.token);
+    if (
+      canPrecedeSuffix
+      && (word === "asc" || word === "desc")
+    ) {
+      return current;
+    }
+    if (canPrecedeSuffix && word === "using") {
+      const operator = inspectSqlReadToken(
+        current,
+        1,
+        "Inspect contextual ORDER BY USING operator",
+      );
+      current = operator.cursor;
+      if (
+        operator.token?.kind === "operator"
+        || postgreSqlTokenWord(operator.token) === "operator"
+      ) {
+        return current;
+      }
+    }
+    if (word === "nulls") {
+      const next = inspectNextWord(
+        current,
+        "Inspect contextual ORDER BY NULLS suffix",
+      );
+      current = next.cursor;
+      if (next.word === "first" || next.word === "last") {
+        return current;
+      }
+    }
+    const isFieldWildcard: boolean = canCompleteFieldWildcard
+      && inspected.token.kind === "operator"
+      && inspected.token.text === "*";
+    canCompleteFieldWildcard = inspected.token.text === "."
+      && canPrecedeSuffix;
+    canPrecedeSuffix = isFieldWildcard
+      || canPrecedeSortSuffix(inspected.token);
+    current = advanceSqlReadCursor(
+      current,
+      1,
+      "Advance ORDER BY expression scan",
+    );
+  }
+};
+
+const readExactSqlExpression = (
+  environment: SqlExpressionEnvironment,
+  cursor: SqlReadCursor,
+  endIndex: number,
+  reader: SqlExpressionReader<SqlExpressionResult>,
+  subject: string,
+): SqlExactExpressionRead => {
+  const bounded = narrowSqlReadCursor(
+    cursor,
+    endIndex,
+    `Bound ${subject}`,
+  );
+  const nested = enterSqlReadDepth(bounded, `Enter ${subject}`);
+  const result = reader(environment, nested);
+  const completedChild = resumeSqlReadCursor(
+    nested,
+    result.cursor,
+    `Resume ${subject} result`,
+  );
+  if (
+    completedChild.index !== endIndex
+    || completedChild.endIndex !== endIndex
+  ) {
+    return sqlReadInvariant(
+      completedChild,
+      `${subject} reader returned cursor ${String(completedChild.index)}..${String(completedChild.endIndex)} but the exact expression span ends at token ${String(endIndex)}`,
+    );
+  }
+  return Object.freeze({
+    cursor: resumeSqlReadCursor(
+      cursor,
+      completedChild,
+      `Resume exact ${subject}`,
+    ),
+    metadata: result.metadata,
+  });
+};
+
+const expressionResult = (
+  initial: SqlReadCursor,
+  cursor: SqlReadCursor,
+  metadata: SqlMetadataAccumulator,
+): SqlExpressionResult => Object.freeze({
+  cursor,
+  metadata: expressionMetadata(metadata),
+  range: sqlReadRangeForSpan(
+    initial.state,
+    initial.index,
+    cursor.index,
+  ),
+});
+
+const emptySortExpressionMessage = (
+  cursor: SqlReadCursor,
+  token: SqlParserToken | undefined,
+  itemCount: number,
+): never => {
+  if (token === undefined && itemCount === 0) {
+    return unexpectedSqlReadToken(
+      cursor,
+      "ORDER BY requires at least one expression",
+    );
+  }
+  if (token?.text === ",") {
+    return unexpectedSqlReadToken(
+      cursor,
+      "ORDER BY item requires an expression before comma",
+    );
+  }
+  const word = postgreSqlTokenWord(token);
+  return unexpectedSqlReadToken(
+    cursor,
+    `ORDER BY item requires an expression before ${word?.toUpperCase() ?? "the item suffix"}`,
+  );
+};
+
+const malformedSortSuffix = (
+  cursor: SqlReadCursor,
+  word: string,
+  direction: "keyword" | "using" | null,
+  hasNulls: boolean,
+): never => {
+  if (word === "nulls") {
+    return unexpectedSqlReadToken(
+      cursor,
+      "ORDER BY item cannot contain more than one NULLS clause",
+    );
+  }
+  if (hasNulls) {
+    return unexpectedSqlReadToken(
+      cursor,
+      `${word.toUpperCase()} must appear before NULLS ordering in an ORDER BY item`,
+    );
+  }
+  if (direction !== null) {
+    return unexpectedSqlReadToken(
+      cursor,
+      "ORDER BY item cannot contain more than one ASC, DESC, or USING clause",
+    );
+  }
+  return unexpectedSqlReadToken(
+    cursor,
+    "Malformed ORDER BY item suffix",
+  );
+};
+
+const readQualifiedSortOperator = (
+  cursor: SqlReadCursor,
+): SqlReadCursor => {
+  let current = consumeSqlReadToken(
+    cursor,
+    "Consume ORDER BY USING OPERATOR",
+  ).cursor;
+  const opening = inspectCurrentSqlReadToken(
+    current,
+    "Inspect ORDER BY USING OPERATOR opening parenthesis",
+  );
+  current = opening.cursor;
+  if (opening.token?.text !== "(") {
+    return unexpectedSqlReadToken(
+      current,
+      "ORDER BY USING OPERATOR requires an opening parenthesis",
+    );
+  }
+
+  const outer = current;
+  const nested = enterSqlReadDepth(
+    outer,
+    "Enter ORDER BY USING OPERATOR name",
+  );
+  const matched = matchingSqlReadDelimiter(
+    nested,
+    "Match ORDER BY USING OPERATOR parentheses",
+  );
+  const afterOpening = consumeSqlReadToken(
+    matched.cursor,
+    "Consume ORDER BY USING OPERATOR opening parenthesis",
+  ).cursor;
+  const innerParent = afterOpening;
+  current = narrowSqlReadCursor(
+    afterOpening,
+    matched.closeIndex,
+    "Bound ORDER BY USING OPERATOR name",
+  );
+
+  while (true) {
+    const part = inspectCurrentSqlReadToken(
+      current,
+      "Inspect ORDER BY USING qualified operator part",
+    );
+    current = part.cursor;
+    if (part.token === undefined) {
+      return unexpectedSqlReadToken(
+        current,
+        "ORDER BY USING OPERATOR requires an operator name",
+      );
+    }
+    if (part.token.kind === "operator") {
+      if (!isPostgreSqlAllOperator(part.token)) {
+        return unexpectedSqlReadToken(
+          current,
+          `ORDER BY USING OPERATOR requires a PostgreSQL all_Op operator; "${part.token.text}" is reserved syntax`,
+        );
+      }
+      current = consumeSqlReadToken(
+        current,
+        "Consume ORDER BY USING qualified operator name",
+      ).cursor;
+      const end = inspectCurrentSqlReadToken(
+        current,
+        "Inspect end of ORDER BY USING qualified operator",
+      );
+      current = end.cursor;
+      if (end.token !== undefined) {
+        return unexpectedSqlReadToken(
+          current,
+          "ORDER BY USING OPERATOR cannot contain tokens after the operator name",
+        );
+      }
+      break;
+    }
+    if (part.token.kind !== "identifier" || !isPostgreSqlColId(part.token)) {
+      return unexpectedSqlReadToken(
+        current,
+        "ORDER BY USING OPERATOR requires dot-separated PostgreSQL identifiers followed by an operator name",
+      );
+    }
+    current = consumeSqlReadToken(
+      current,
+      "Consume ORDER BY USING operator qualifier",
+    ).cursor;
+    const dot = inspectCurrentSqlReadToken(
+      current,
+      "Inspect ORDER BY USING operator qualifier dot",
+    );
+    current = dot.cursor;
+    if (dot.token?.text !== ".") {
+      return unexpectedSqlReadToken(
+        current,
+        "ORDER BY USING OPERATOR qualifier requires a following dot",
+      );
+    }
+    current = consumeSqlReadToken(
+      current,
+      "Consume ORDER BY USING operator qualifier dot",
+    ).cursor;
+  }
+
+  current = resumeSqlReadCursor(
+    innerParent,
+    current,
+    "Resume ORDER BY USING OPERATOR name",
+  );
+  const closing = consumeSqlReadToken(
+    current,
+    "Consume ORDER BY USING OPERATOR closing parenthesis",
+  );
+  if (closing.token.text !== ")") {
+    return sqlReadInvariant(
+      closing.cursor,
+      "ORDER BY USING OPERATOR delimiter lookup did not resume at a closing parenthesis",
+    );
+  }
+  return resumeSqlReadCursor(
+    outer,
+    closing.cursor,
+    "Resume ORDER BY USING OPERATOR parentheses",
+  );
+};
+
+const readSortOperator = (
+  cursor: SqlReadCursor,
+): SqlReadCursor => {
+  const inspected = inspectCurrentSqlReadToken(
+    cursor,
+    "Inspect ORDER BY USING operator",
+  );
+  if (inspected.token?.kind === "operator") {
+    if (!isPostgreSqlAllOperator(inspected.token)) {
+      return unexpectedSqlReadToken(
+        inspected.cursor,
+        `ORDER BY USING requires a PostgreSQL all_Op operator; "${inspected.token.text}" is reserved syntax`,
+      );
+    }
+    return consumeSqlReadToken(
+      inspected.cursor,
+      "Consume ORDER BY USING operator",
+    ).cursor;
+  }
+  if (postgreSqlTokenWord(inspected.token) === "operator") {
+    return readQualifiedSortOperator(inspected.cursor);
+  }
+  return unexpectedSqlReadToken(
+    inspected.cursor,
+    "ORDER BY USING requires an operator",
+  );
+};
+
+export const readSqlSortList = (
+  environment: SqlExpressionEnvironment,
+  cursor: SqlReadCursor,
+  readExpression: SqlExpressionReader<SqlExpressionResult>,
+): SqlExpressionResult => {
+  const initial = cursor;
+  const metadata = metadataAccumulator();
+  let current = cursor;
+  let itemCount = 0;
+
+  while (true) {
+    const itemStart = current;
+    const scanned = scanSortExpressionEnd(itemStart);
+    if (scanned.index === itemStart.index) {
+      const inspected = inspectCurrentSqlReadToken(
+        scanned,
+        "Inspect missing ORDER BY expression",
+      );
+      return emptySortExpressionMessage(
+        inspected.cursor,
+        inspected.token,
+        itemCount,
+      );
+    }
+    const restored = restoreSqlReadPosition(
+      itemStart,
+      scanned,
+      "Restore ORDER BY expression position",
+    );
+    const expression = readExactSqlExpression(
+      environment,
+      restored,
+      scanned.index,
+      readExpression,
+      "ORDER BY expression",
+    );
+    appendExpressionMetadata(metadata, expression.metadata);
+    current = expression.cursor;
+    itemCount++;
+
+    let direction: "keyword" | "using" | null = null;
+    let inspected = inspectCurrentSqlReadToken(
+      current,
+      "Inspect ORDER BY direction",
+    );
+    current = inspected.cursor;
+    let word = postgreSqlTokenWord(inspected.token);
+    if (word === "asc" || word === "desc") {
+      direction = "keyword";
+      current = consumeSqlReadToken(
+        current,
+        "Consume ORDER BY direction",
+      ).cursor;
+    } else if (word === "using") {
+      direction = "using";
+      current = consumeSqlReadToken(
+        current,
+        "Consume ORDER BY USING",
+      ).cursor;
+      current = readSortOperator(current);
+    }
+
+    let hasNulls = false;
+    inspected = inspectCurrentSqlReadToken(
+      current,
+      "Inspect ORDER BY NULLS ordering",
+    );
+    current = inspected.cursor;
+    word = postgreSqlTokenWord(inspected.token);
+    if (word === "nulls") {
+      hasNulls = true;
+      current = consumeSqlReadToken(
+        current,
+        "Consume ORDER BY NULLS",
+      ).cursor;
+      const ordering = inspectCurrentSqlReadToken(
+        current,
+        "Inspect ORDER BY NULLS keyword",
+      );
+      current = ordering.cursor;
+      const orderingWord = postgreSqlTokenWord(ordering.token);
+      if (orderingWord !== "first" && orderingWord !== "last") {
+        return unexpectedSqlReadToken(
+          current,
+          "ORDER BY NULLS requires FIRST or LAST",
+        );
+      }
+      current = consumeSqlReadToken(
+        current,
+        "Consume ORDER BY NULLS keyword",
+      ).cursor;
+    }
+
+    const terminator = inspectCurrentSqlReadToken(
+      current,
+      "Inspect ORDER BY item terminator",
+    );
+    current = terminator.cursor;
+    if (terminator.token === undefined) {
+      return expressionResult(initial, current, metadata);
+    }
+    const terminatorWord = postgreSqlTokenWord(terminator.token);
+    if (isSortSuffixWord(terminatorWord)) {
+      return malformedSortSuffix(
+        current,
+        terminatorWord ?? "suffix",
+        direction,
+        hasNulls,
+      );
+    }
+    if (terminator.token.text !== ",") {
+      return unexpectedSqlReadToken(
+        current,
+        "Expected a comma between ORDER BY items",
+      );
+    }
+    const commaRange = terminator.token.range;
+    current = consumeSqlReadToken(
+      current,
+      "Consume ORDER BY item comma",
+    ).cursor;
+    const next = inspectCurrentSqlReadToken(
+      current,
+      "Inspect expression after ORDER BY comma",
+    );
+    current = next.cursor;
+    if (next.token === undefined) {
+      return throwSqlPolicyParserError(
+        "unexpected_token",
+        "ORDER BY cannot end with a comma",
+        commaRange,
+      );
+    }
+    if (next.token.text === ",") {
+      return unexpectedSqlReadToken(
+        current,
+        "ORDER BY item requires an expression before comma",
+      );
+    }
+  }
+};


### PR DESCRIPTION
## Summary

- add an internal cursor-native PostgreSQL ORDER BY sort-list reader
- support contextual sort suffixes, qualified operators, and terminal field wildcards
- preserve cursor work, bounds, depth, and linear metadata aggregation
- add focused success, failure, work-limit, and resumption coverage

## Validation

- packages/agent-shared: npm test (107 passed)
- packages/agent-shared: npm run build
- apps/sql-api: npm run lint
- apps/sql-api: npm run build
- apps/web: npm run lint
- apps/web: npm run build