### PR TITLE
feat(agent-shared): add prefix expression reader contract

### DIFF
--- a/packages/agent-shared/src/sql-policy-read-expression.ts
+++ b/packages/agent-shared/src/sql-policy-read-expression.ts
@@ -25,7 +25,19 @@ export type SqlExpressionListResult = Readonly<{
   range: SqlSourceRange;
 }>;
 
+/** Reads an expression from a cursor already bounded to its exact token span. */
 export type SqlExpressionReader<TResult extends SqlExpressionResult> = (
   environment: SqlExpressionEnvironment,
   cursor: SqlReadCursor,
 ) => TResult;
+
+/**
+ * Reads one complete expression prefix without requiring a guessed end bound.
+ * The returned range and metadata describe only that expression. The returned
+ * cursor keeps the input end bound, points at the first unconsumed token, and
+ * preserves all cumulative work charged while reading the expression.
+ */
+export type SqlExpressionPrefixReader = (
+  environment: SqlExpressionEnvironment,
+  cursor: SqlReadCursor,
+) => SqlExpressionResult;


### PR DESCRIPTION
## Summary
- distinguish prefix-expression parsing from exact-bounded expression parsing
- reuse the existing strict expression result shape
- document cursor bounds, first-unconsumed position, metadata, range, and cumulative work semantics

## Validation
- npm run test --workspace @expense-budget-tracker/agent-shared
- npm run build --workspace @expense-budget-tracker/agent-shared
- npm run lint --workspace expense-budget-tracker-sql-api
- npm run build --workspace expense-budget-tracker-sql-api
- npm run lint --workspace expense-budget-tracker-web
- npm run build --workspace expense-budget-tracker-web