### PR TITLE
Add exact SQL child cursor resumption

### DIFF
--- a/packages/agent-shared/src/sql-policy-read-state.test.ts
+++ b/packages/agent-shared/src/sql-policy-read-state.test.ts
@@ -25,6 +25,7 @@ import {
   inspectSqlReadToken,
   matchingSqlReadDelimiter,
   narrowSqlReadCursor,
+  resumeEnteredSqlReadCursor,
   resumeSqlReadCursor,
   sqlReadRangeAt,
   sqlReadRangeForSpan,
@@ -56,6 +57,22 @@ const expectParserError = (
   assert.match(error.message, message);
   return true;
 });
+
+type SqlReadCursorRuntimeValue = object | number | null | undefined;
+
+const resumeEnteredSqlReadCursorAtRuntime = (
+  parent: SqlReadCursorRuntimeValue,
+  entered: SqlReadCursorRuntimeValue,
+  returned: SqlReadCursorRuntimeValue,
+  operation: string,
+): void => {
+  Reflect.apply(resumeEnteredSqlReadCursor, null, [
+    parent,
+    entered,
+    returned,
+    operation,
+  ]);
+};
 
 test("read state is a frozen constant-time view of the canonical kernel", (): void => {
   const cases: ReadonlyArray<Readonly<{
@@ -802,6 +819,314 @@ test("read cursor resumption rejects incompatible returned cursors at the parent
     parentRange,
     /workUnits=21 exceeds maxWorkUnits=20/u,
   );
+});
+
+test("entered-child resumption adopts exact progress and restores the parent frame", (): void => {
+  const kernel = createSqlParserKernel(
+    "prefix alpha beta trailing",
+    limits(40, 10, 4, 40),
+  );
+  const state = createSqlReadState(kernel);
+  const parent = narrowSqlReadCursor(
+    enterSqlReadDepth(
+      advanceSqlReadCursor(
+        createSqlReadCursor(state, 0, state.tokenCount),
+        1,
+        "Prepare exact-child parent",
+      ),
+      "Enter exact-child parent depth",
+    ),
+    3,
+    "Bound exact-child parent",
+  );
+  const entered = enterSqlReadDepth(parent, "Enter exact child");
+  const partial = advanceSqlReadCursor(
+    entered,
+    1,
+    "Read exact child prefix",
+  );
+  const parentBefore = { ...parent };
+  const enteredBefore = { ...entered };
+  const partialBefore = { ...partial };
+  const resumedPartial = resumeEnteredSqlReadCursor(
+    parent,
+    entered,
+    partial,
+    "Resume partial exact child",
+  );
+
+  assert.ok(Object.isFrozen(resumedPartial));
+  assert.equal(resumedPartial.state, state);
+  assert.equal(resumedPartial.index, partial.index);
+  assert.equal(resumedPartial.endIndex, parent.endIndex);
+  assert.equal(resumedPartial.workUnits, partial.workUnits);
+  assert.equal(resumedPartial.depth, parent.depth);
+  assert.deepEqual(parent, parentBefore);
+  assert.deepEqual(entered, enteredBefore);
+  assert.deepEqual(partial, partialBefore);
+
+  const atEof = advanceSqlReadCursor(
+    entered,
+    entered.endIndex - entered.index,
+    "Read exact child to EOF",
+  );
+  const resumedEof = resumeEnteredSqlReadCursor(
+    parent,
+    entered,
+    atEof,
+    "Resume exact child at EOF",
+  );
+  assert.equal(resumedEof.index, parent.endIndex);
+  assert.equal(resumedEof.endIndex, parent.endIndex);
+  assert.equal(resumedEof.workUnits, atEof.workUnits);
+  assert.equal(resumedEof.depth, parent.depth);
+
+  const zeroProgress = resumeEnteredSqlReadCursor(
+    parent,
+    entered,
+    entered,
+    "Resume zero-progress exact child",
+  );
+  assert.deepEqual(zeroProgress, parent);
+  assert.notEqual(zeroProgress, parent);
+});
+
+test("entered-child resumption rejects altered returned child state at the entry range", (): void => {
+  const kernel = createSqlParserKernel(
+    "prefix alpha beta gamma trailing",
+    limits(50, 10, 4, 20),
+  );
+  const state = createSqlReadState(kernel);
+  const parent = advanceSqlReadCursor(
+    createSqlReadCursor(state, 0, 4),
+    1,
+    "Prepare returned exact-child checks",
+  );
+  const entered = enterSqlReadDepth(parent, "Enter returned exact child");
+  const equivalentState = createSqlReadState(kernel);
+  const entryRange = { start: 7, end: 12 };
+  const cases: ReadonlyArray<Readonly<{
+    cursor: typeof entered;
+    message: RegExp;
+  }>> = [
+    {
+      cursor: { ...entered, state: equivalentState },
+      message: /returned cursor must use the entered child SQL read state/u,
+    },
+    {
+      cursor: { ...entered, endIndex: entered.endIndex - 1 },
+      message: /returned cursor end 3 must equal the entered child end 4/u,
+    },
+    {
+      cursor: { ...entered, endIndex: entered.endIndex + 1 },
+      message: /returned cursor end 5 must equal the entered child end 4/u,
+    },
+    {
+      cursor: { ...entered, endIndex: Number.NaN },
+      message: /returned cursor end NaN must equal the entered child end 4/u,
+    },
+    {
+      cursor: { ...entered, depth: entered.depth - 1 },
+      message: /returned cursor nesting depth 0 must equal the entered child depth 1/u,
+    },
+    {
+      cursor: { ...entered, depth: entered.depth + 1 },
+      message: /returned cursor nesting depth 2 must equal the entered child depth 1/u,
+    },
+    {
+      cursor: { ...entered, depth: Number.NaN },
+      message: /returned cursor nesting depth NaN must equal the entered child depth 1/u,
+    },
+    {
+      cursor: { ...entered, index: entered.index - 1 },
+      message: /returned cursor index 0 outside the exact entered child range 1\.\.4/u,
+    },
+    {
+      cursor: { ...entered, index: entered.endIndex + 1 },
+      message: /returned cursor index 5 outside the exact entered child range 1\.\.4/u,
+    },
+    {
+      cursor: { ...entered, index: Number.NaN },
+      message: /returned cursor index NaN outside the exact entered child range 1\.\.4/u,
+    },
+    {
+      cursor: { ...entered, workUnits: entered.workUnits - 1 },
+      message: /would rewind entered child work/u,
+    },
+    {
+      cursor: {
+        ...entered,
+        workUnits: state.limits.maxWorkUnits + 1,
+      },
+      message: /workUnits=21 exceeds maxWorkUnits=20/u,
+    },
+  ];
+  const invalidWorkUnits: ReadonlyArray<number> = [
+    Number.NaN,
+    Number.NEGATIVE_INFINITY,
+    Number.POSITIVE_INFINITY,
+    -1,
+    0.5,
+    Number.MAX_SAFE_INTEGER + 1,
+  ];
+
+  for (const invalid of cases) {
+    expectParserError(
+      () => {
+        resumeEnteredSqlReadCursor(
+          parent,
+          entered,
+          invalid.cursor,
+          "Reject altered returned exact child",
+        );
+      },
+      "internal_invariant",
+      entryRange,
+      invalid.message,
+    );
+  }
+  for (const workUnits of invalidWorkUnits) {
+    expectParserError(
+      () => {
+        resumeEnteredSqlReadCursor(
+          parent,
+          entered,
+          { ...entered, workUnits },
+          "Reject invalid returned exact-child work",
+        );
+      },
+      "internal_invariant",
+      entryRange,
+      /returned cursor workUnits must be a non-negative safe integer/u,
+    );
+  }
+});
+
+test("entered-child resumption requires the original one-depth entry transition", (): void => {
+  const kernel = createSqlParserKernel(
+    "prefix alpha beta gamma trailing",
+    limits(50, 10, 4, 30),
+  );
+  const state = createSqlReadState(kernel);
+  const parent = enterSqlReadDepth(
+    advanceSqlReadCursor(
+      createSqlReadCursor(state, 0, 4),
+      1,
+      "Prepare entered exact-child checks",
+    ),
+    "Enter exact-child check parent depth",
+  );
+  const entered = enterSqlReadDepth(parent, "Enter checked exact child");
+  const equivalentState = createSqlReadState(kernel);
+  const entryRange = { start: 7, end: 12 };
+  const cases: ReadonlyArray<Readonly<{
+    cursor: typeof entered;
+    message: RegExp;
+  }>> = [
+    {
+      cursor: { ...entered, state: equivalentState },
+      message: /entered cursor must use the parent SQL read state/u,
+    },
+    {
+      cursor: { ...entered, index: entered.index - 1 },
+      message: /entered cursor index 0 must equal the parent index 1/u,
+    },
+    {
+      cursor: { ...entered, endIndex: entered.endIndex - 1 },
+      message: /entered cursor end 3 must equal the parent end 4/u,
+    },
+    {
+      cursor: { ...entered, workUnits: entered.workUnits + 1 },
+      message: /entered cursor workUnits=7 must equal the parent workUnits=6/u,
+    },
+    {
+      cursor: { ...entered, depth: parent.depth },
+      message: /entered cursor nesting depth 1 must equal parent depth 1 plus one/u,
+    },
+    {
+      cursor: { ...entered, depth: entered.depth + 1 },
+      message: /entered cursor nesting depth 3 must equal parent depth 1 plus one/u,
+    },
+  ];
+
+  for (const invalid of cases) {
+    expectParserError(
+      () => {
+        resumeEnteredSqlReadCursor(
+          parent,
+          invalid.cursor,
+          entered,
+          "Reject malformed entered exact child",
+        );
+      },
+      "internal_invariant",
+      entryRange,
+      invalid.message,
+    );
+  }
+});
+
+test("entered-child resumption rejects malformed cursor roots before dereference", (): void => {
+  const kernel = createSqlParserKernel(
+    "prefix alpha beta trailing",
+    limits(40, 10, 4, 40),
+  );
+  const state = createSqlReadState(kernel);
+  const parent = advanceSqlReadCursor(
+    createSqlReadCursor(state, 0, state.tokenCount),
+    1,
+    "Prepare malformed exact-child roots",
+  );
+  const entered = enterSqlReadDepth(parent, "Enter exact child root check");
+  const entryRange = { start: 7, end: 12 };
+  const malformedRoots: ReadonlyArray<SqlReadCursorRuntimeValue> = [
+    null,
+    undefined,
+    7,
+    [],
+  ];
+
+  for (const malformed of malformedRoots) {
+    expectParserError(
+      () => {
+        resumeEnteredSqlReadCursorAtRuntime(
+          parent,
+          malformed,
+          entered,
+          "Reject malformed entered root",
+        );
+      },
+      "internal_invariant",
+      entryRange,
+      /entered cursor must be a non-null, non-array object/u,
+    );
+    expectParserError(
+      () => {
+        resumeEnteredSqlReadCursorAtRuntime(
+          parent,
+          entered,
+          malformed,
+          "Reject malformed returned root",
+        );
+      },
+      "internal_invariant",
+      entryRange,
+      /returned cursor must be a non-null, non-array object/u,
+    );
+    expectParserError(
+      () => {
+        resumeEnteredSqlReadCursorAtRuntime(
+          malformed,
+          entered,
+          entered,
+          "Reject malformed parent root",
+        );
+      },
+      "internal_invariant",
+      { start: 0, end: 0 },
+      /parent cursor must be a non-null, non-array object/u,
+    );
+  }
 });
 
 test("repeated nested resumption cannot reset cumulative read work", (): void => {

--- a/packages/agent-shared/src/sql-policy-read-state.ts
+++ b/packages/agent-shared/src/sql-policy-read-state.ts
@@ -53,6 +53,23 @@ const sqlReadInvariant = (
   range: SqlSourceRange,
 ): never => throwSqlPolicyParserError("internal_invariant", message, range);
 
+const validateSqlReadCursorObject = (
+  cursor: SqlReadCursor,
+  subject: string,
+  range: SqlSourceRange,
+): void => {
+  if (
+    typeof cursor !== "object"
+    || cursor === null
+    || Array.isArray(cursor)
+  ) {
+    return sqlReadInvariant(
+      `${subject} must be a non-null, non-array object`,
+      range,
+    );
+  }
+};
+
 const checkedNonNegativeSafeInteger = (
   value: number,
   subject: string,
@@ -503,6 +520,127 @@ export const resumeSqlReadCursor = (
     returned.index,
     parent.endIndex,
     adoptedWork.workUnits,
+    parent.depth,
+  );
+};
+
+export const resumeEnteredSqlReadCursor = (
+  parent: SqlReadCursor,
+  entered: SqlReadCursor,
+  returned: SqlReadCursor,
+  operation: string,
+): SqlReadCursor => {
+  validateSqlReadCursorObject(
+    parent,
+    `${operation} parent cursor`,
+    sqlReadRange(0, 0),
+  );
+  const adaptedParent = sqlTokenCursorFromReadCursor(parent, operation);
+  const range = sqlCursorRange(adaptedParent);
+  validateSqlReadCursorObject(
+    entered,
+    `${operation} entered cursor`,
+    range,
+  );
+  if (entered.state !== parent.state) {
+    return sqlReadInvariant(
+      `${operation} entered cursor must use the parent SQL read state`,
+      range,
+    );
+  }
+  if (entered.index !== parent.index) {
+    return sqlReadInvariant(
+      `${operation} entered cursor index ${String(entered.index)} must equal the parent index ${String(parent.index)}`,
+      range,
+    );
+  }
+  if (entered.endIndex !== parent.endIndex) {
+    return sqlReadInvariant(
+      `${operation} entered cursor end ${String(entered.endIndex)} must equal the parent end ${String(parent.endIndex)}`,
+      range,
+    );
+  }
+  if (entered.workUnits !== parent.workUnits) {
+    return sqlReadInvariant(
+      `${operation} entered cursor workUnits=${String(entered.workUnits)} must equal the parent workUnits=${String(parent.workUnits)}`,
+      range,
+    );
+  }
+  const expectedDepth = parent.depth + 1;
+  if (
+    !Number.isSafeInteger(expectedDepth)
+    || expectedDepth > parent.state.limits.maxNestingDepth
+  ) {
+    return sqlReadInvariant(
+      `${operation} cannot resume an entered child from parent nesting depth ${String(parent.depth)} with maxNestingDepth=${String(parent.state.limits.maxNestingDepth)}`,
+      range,
+    );
+  }
+  if (entered.depth !== expectedDepth) {
+    return sqlReadInvariant(
+      `${operation} entered cursor nesting depth ${String(entered.depth)} must equal parent depth ${String(parent.depth)} plus one`,
+      range,
+    );
+  }
+  sqlTokenCursorFromReadCursor(entered, operation);
+
+  validateSqlReadCursorObject(
+    returned,
+    `${operation} returned cursor`,
+    range,
+  );
+  if (returned.state !== parent.state) {
+    return sqlReadInvariant(
+      `${operation} returned cursor must use the entered child SQL read state`,
+      range,
+    );
+  }
+  if (returned.endIndex !== entered.endIndex) {
+    return sqlReadInvariant(
+      `${operation} returned cursor end ${String(returned.endIndex)} must equal the entered child end ${String(entered.endIndex)}`,
+      range,
+    );
+  }
+  if (returned.depth !== entered.depth) {
+    return sqlReadInvariant(
+      `${operation} returned cursor nesting depth ${String(returned.depth)} must equal the entered child depth ${String(entered.depth)}`,
+      range,
+    );
+  }
+  if (
+    !Number.isSafeInteger(returned.index)
+    || returned.index < entered.index
+    || returned.index > entered.endIndex
+  ) {
+    return sqlReadInvariant(
+      `${operation} returned cursor index ${String(returned.index)} outside the exact entered child range ${String(entered.index)}..${String(entered.endIndex)}`,
+      range,
+    );
+  }
+  checkedNonNegativeSafeInteger(
+    returned.workUnits,
+    `${operation} returned cursor workUnits`,
+    range,
+  );
+  if (returned.workUnits < entered.workUnits) {
+    return sqlReadInvariant(
+      `${operation} returned cursor workUnits=${String(returned.workUnits)} would rewind entered child work from ${String(entered.workUnits)}`,
+      range,
+    );
+  }
+  if (returned.workUnits > parent.state.limits.maxWorkUnits) {
+    return sqlReadInvariant(
+      `${operation} returned cursor workUnits=${String(returned.workUnits)} exceeds maxWorkUnits=${String(parent.state.limits.maxWorkUnits)}`,
+      range,
+    );
+  }
+  sqlTokenCursorFromReadCursor(returned, operation);
+
+  return sqlReadCursor(
+    parent.state,
+    returned.index,
+    parent.endIndex,
+    returned.workUnits,
     parent.depth,
   );
 };


### PR DESCRIPTION
## Summary
- add a dormant exact entered-child SQL read cursor resumption helper
- enforce state, depth, bounds, and monotone work invariants without changing generic resume behavior
- add focused success, immutability, malformed cursor, and typed error-range coverage

## Validation
- agent-shared focused tests: 25/25
- agent-shared full tests: 159/159
- agent-shared lint and build
- SQL API tests: 6/6, lint, and build
- web lint and production build
- git diff --check