### PR TITLE
Migrate SQL readers to persistent metadata

### DIFF
--- a/packages/agent-shared/src/sql-policy-read-expression.ts
+++ b/packages/agent-shared/src/sql-policy-read-expression.ts
@@ -1,9 +1,9 @@
 import type { SqlSourceRange } from "./sql-policy-lexer.js";
 import type {
-  SqlExpressionMetadata,
   SqlExpressionSyntaxContext,
   SqlQueryContext,
 } from "./sql-policy-read-model.js";
+import type { SqlExpressionMetadataSequence } from "./sql-policy-read-metadata.js";
 import type { SqlReadCursor } from "./sql-policy-read-state.js";
 
 export type SqlExpressionEnvironment = Readonly<{
@@ -14,14 +14,14 @@ export type SqlExpressionEnvironment = Readonly<{
 
 export type SqlExpressionResult = Readonly<{
   cursor: SqlReadCursor;
-  metadata: SqlExpressionMetadata;
+  metadata: SqlExpressionMetadataSequence;
   range: SqlSourceRange;
 }>;
 
 export type SqlExpressionListResult = Readonly<{
   count: number;
   cursor: SqlReadCursor;
-  metadata: SqlExpressionMetadata;
+  metadata: SqlExpressionMetadataSequence;
   range: SqlSourceRange;
 }>;
 

--- a/packages/agent-shared/src/sql-policy-read-frame.test.ts
+++ b/packages/agent-shared/src/sql-policy-read-frame.test.ts
@@ -28,6 +28,15 @@ import type {
   SqlNestedQueryNode,
   SqlTypeConstructNode,
 } from "./sql-policy-read-model.js";
+import {
+  concatSqlExpressionMetadataSequences,
+  emptySqlExpressionMetadataSequence,
+  materializeSqlExpressionMetadataSequence,
+  sqlCallMetadataSequence,
+  sqlNestedQueryMetadataSequence,
+  sqlTypeConstructMetadataSequence,
+  type SqlExpressionMetadataSequence,
+} from "./sql-policy-read-metadata.js";
 import { readSqlWindowFrame } from "./sql-policy-read-frame.js";
 import {
   advanceSqlReadCursor,
@@ -64,6 +73,66 @@ type PrefixReaderHarness = Readonly<{
   snapshot: () => PrefixReaderSnapshot;
 }>;
 
+type CursorContractCase = Readonly<{
+  message: string;
+  mutate: (
+    cursor: SqlReadCursor,
+    foreign: SqlReadCursor,
+  ) => SqlReadCursor;
+}>;
+
+const cursorContractCases = (
+  operation: string,
+  enteredEndIndex: number,
+  enteredDepth: number,
+): ReadonlyArray<CursorContractCase> => Object.freeze([
+  Object.freeze({
+    message: `${operation} returned cursor end ${String(enteredEndIndex - 1)} must equal the entered child end ${String(enteredEndIndex)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      endIndex: cursor.endIndex - 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor end ${String(enteredEndIndex + 1)} must equal the entered child end ${String(enteredEndIndex)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      endIndex: cursor.endIndex + 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor nesting depth ${String(enteredDepth - 1)} must equal the entered child depth ${String(enteredDepth)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      depth: cursor.depth - 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor nesting depth ${String(enteredDepth + 1)} must equal the entered child depth ${String(enteredDepth)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      depth: cursor.depth + 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor must use the entered child SQL read state`,
+    mutate: (
+      cursor: SqlReadCursor,
+      foreign: SqlReadCursor,
+    ): SqlReadCursor => Object.freeze({
+      ...cursor,
+      state: foreign.state,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor workUnits must be a non-negative safe integer; received -1`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      workUnits: -1,
+    }),
+  }),
+]);
+
 type DeterministicDelimiterRead = Readonly<{
   cursor: SqlReadCursor;
   itemCount: number;
@@ -87,11 +156,8 @@ const environment = (queryId: number): SqlExpressionEnvironment => ({
   syntaxContext: "expression",
 });
 
-const emptyMetadata = (): SqlExpressionMetadata => Object.freeze({
-  calls: Object.freeze([]),
-  nestedQueries: Object.freeze([]),
-  typeConstructs: Object.freeze([]),
-});
+const emptyMetadata = (): SqlExpressionMetadataSequence =>
+  emptySqlExpressionMetadataSequence();
 
 const expressionMetadata = (
   expressionEnvironment: SqlExpressionEnvironment,
@@ -99,7 +165,7 @@ const expressionMetadata = (
   range: SqlSourceRange,
   startIndex: number,
   endIndex: number,
-): SqlExpressionMetadata => {
+): SqlExpressionMetadataSequence => {
   if (token === undefined) {
     return emptyMetadata();
   }
@@ -139,11 +205,13 @@ const expressionMetadata = (
     syntax: "cast",
     typeName,
   });
-  return Object.freeze({
-    calls: Object.freeze([call]),
-    nestedQueries: Object.freeze([nestedQuery]),
-    typeConstructs: Object.freeze([typeConstruct]),
-  });
+  return concatSqlExpressionMetadataSequences(
+    concatSqlExpressionMetadataSequences(
+      sqlCallMetadataSequence(call),
+      sqlNestedQueryMetadataSequence(nestedQuery),
+    ),
+    sqlTypeConstructMetadataSequence(typeConstruct),
+  );
 };
 
 const isOpeningDelimiter = (token: SqlParserToken): boolean =>
@@ -674,9 +742,42 @@ const sourceRange = (
 const expressionSql = (
   sql: string,
   result: SqlExpressionResult,
-): ReadonlyArray<string> => result.metadata.calls.map((call) =>
+): ReadonlyArray<string> => materializedMetadata(result).calls.map((call) =>
   sql.slice(call.range.start, call.range.end)
 );
+
+const materializedMetadata = (
+  result: SqlExpressionResult,
+): SqlExpressionMetadata => materializeSqlExpressionMetadataSequence(
+  result.metadata,
+);
+
+const countMetadataConcatNodes = (
+  sequence: SqlExpressionMetadataSequence,
+): number => {
+  const stack: Array<SqlExpressionMetadataSequence> = [sequence];
+  let count = 0;
+  while (stack.length > 0) {
+    const current = stack.pop();
+    assert.notEqual(current, undefined);
+    if (current?.kind === "concat") {
+      count++;
+      stack.push(current.right, current.left);
+    }
+  }
+  return count;
+};
+
+const repeatMetadataSequence = (
+  sequence: SqlExpressionMetadataSequence,
+  count: number,
+): SqlExpressionMetadataSequence => {
+  let repeated = emptySqlExpressionMetadataSequence();
+  for (let index = 0; index < count; index++) {
+    repeated = concatSqlExpressionMetadataSequences(repeated, sequence);
+  }
+  return repeated;
+};
 
 const expectParserError = (
   action: () => unknown,
@@ -973,29 +1074,71 @@ test("ranked bounds enforce PostgreSQL endpoint restrictions", (): void => {
 test("offset metadata stays ordered, exact, and frozen", (): void => {
   const sql = "ROWS BETWEEN alpha + 1 PRECEDING AND beta + 2 FOLLOWING";
   const { harness, result } = readFrame(sql, 58);
+  const metadata = materializedMetadata(result);
 
   assert.equal(harness.snapshot().calls, 2);
   assert.deepEqual(expressionSql(sql, result), ["alpha + 1", "beta + 2"]);
   assert.deepEqual(
-    result.metadata.nestedQueries.map((query) =>
+    metadata.nestedQueries.map((query) =>
       sql.slice(query.range.start, query.range.end)
     ),
     ["alpha + 1", "beta + 2"],
   );
   assert.deepEqual(
-    result.metadata.typeConstructs.map((construct) =>
+    metadata.typeConstructs.map((construct) =>
       sql.slice(construct.range.start, construct.range.end)
     ),
     ["alpha + 1", "beta + 2"],
   );
   assert.equal(Object.isFrozen(result), true);
   assert.equal(Object.isFrozen(result.metadata), true);
-  assert.equal(Object.isFrozen(result.metadata.calls), true);
-  assert.equal(Object.isFrozen(result.metadata.nestedQueries), true);
-  assert.equal(Object.isFrozen(result.metadata.typeConstructs), true);
+  assert.equal(Object.isFrozen(metadata.calls), true);
+  assert.equal(Object.isFrozen(metadata.nestedQueries), true);
+  assert.equal(Object.isFrozen(metadata.typeConstructs), true);
+  assert.equal(countMetadataConcatNodes(result.metadata), 5);
 });
 
-test("bounded parents and deeper prefix cursors resume their exact bound and depth", (): void => {
+test("frame reader preserves canonical empty and deep child sequences", (): void => {
+  const empty = readFrame("ROWS CURRENT ROW", 64).result;
+  assert.equal(empty.metadata, emptySqlExpressionMetadataSequence());
+
+  const deepCount = 20_000;
+  const sql = "ROWS offset_value PRECEDING";
+  const { cursor, kernel } = createReadCursor(
+    sql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const token = kernel.tokens[1];
+  assert.equal(token?.kind, "identifier");
+  assert.ok(token?.kind === "identifier");
+  const range = sourceRange(sql, "offset_value", 0);
+  const deepMetadata = repeatMetadataSequence(
+    expressionMetadata(environment(64), token, range, 1, 2),
+    deepCount,
+  );
+  const reader: SqlExpressionPrefixReader = (
+    expressionEnvironment: SqlExpressionEnvironment,
+    child: SqlReadCursor,
+  ): SqlExpressionResult => Object.freeze({
+    ...readDeterministicExpressionPrefix(expressionEnvironment, child),
+    metadata: deepMetadata,
+  });
+  const baseline = readSqlWindowFrame(
+    environment(64),
+    cursor,
+    readDeterministicExpressionPrefix,
+  );
+  const result = readSqlWindowFrame(environment(64), cursor, reader);
+  const metadata = materializedMetadata(result);
+
+  assert.equal(result.metadata, deepMetadata);
+  assert.equal(metadata.calls.length, deepCount);
+  assert.equal(metadata.nestedQueries.length, deepCount);
+  assert.equal(metadata.typeConstructs.length, deepCount);
+  assert.equal(result.cursor.workUnits, baseline.cursor.workUnits);
+});
+
+test("bounded parents and exact prefix cursors resume their bound and depth", (): void => {
   const sql = "prefix ROWS offset_value PRECEDING EXCLUDE TIES trailing";
   const kernel = createSqlParserKernel(sql, DEFAULT_SQL_PARSER_LIMITS);
   const state = createSqlReadState(kernel);
@@ -1007,23 +1150,10 @@ test("bounded parents and deeper prefix cursors resume their exact bound and dep
     "Enter deeper bounded frame parent",
   );
   const harness = createPrefixReaderHarness();
-  const deeperReader: SqlExpressionPrefixReader = (
-    expressionEnvironment: SqlExpressionEnvironment,
-    cursor: SqlReadCursor,
-  ): SqlExpressionResult => {
-    const result = harness.reader(expressionEnvironment, cursor);
-    return Object.freeze({
-      ...result,
-      cursor: enterSqlReadDepth(
-        result.cursor,
-        "Enter deeper returned prefix cursor",
-      ),
-    });
-  };
   const result = readSqlWindowFrame(
     environment(59),
     parent,
-    deeperReader,
+    harness.reader,
   );
   const invocation = harness.snapshot().invocations[0];
 
@@ -1059,6 +1189,39 @@ test("empty prefix results fail as cursor-contract invariants", (): void => {
     sourceRange(sql, "value", 0),
     "Window frame offset prefix reader returned an empty expression",
   );
+});
+
+test("frame offset collaborators must preserve the entered cursor", (): void => {
+  const sql = "ROWS value PRECEDING";
+  const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const foreign = createReadCursor("other", DEFAULT_SQL_PARSER_LIMITS).cursor;
+  const cases = cursorContractCases(
+    "Resume window frame offset expression",
+    3,
+    1,
+  );
+
+  for (const current of cases) {
+    const reader: SqlExpressionPrefixReader = (
+      expressionEnvironment: SqlExpressionEnvironment,
+      child: SqlReadCursor,
+    ): SqlExpressionResult => {
+      const result = readDeterministicExpressionPrefix(
+        expressionEnvironment,
+        child,
+      );
+      return Object.freeze({
+        ...result,
+        cursor: current.mutate(result.cursor, foreign),
+      });
+    };
+    expectParserError(
+      () => readSqlWindowFrame(environment(65), cursor, reader),
+      "internal_invariant",
+      sourceRange(sql, "value", 0),
+      current.message,
+    );
+  }
 });
 
 test("frame and collaborator nesting fail at the exact opening token", (): void => {

--- a/packages/agent-shared/src/sql-policy-read-frame.ts
+++ b/packages/agent-shared/src/sql-policy-read-frame.ts
@@ -7,11 +7,16 @@ import type {
   SqlExpressionPrefixReader,
   SqlExpressionResult,
 } from "./sql-policy-read-expression.js";
-import type { SqlExpressionMetadata } from "./sql-policy-read-model.js";
+import {
+  concatSqlExpressionMetadataSequences,
+  emptySqlExpressionMetadataSequence,
+  type SqlExpressionMetadataSequence,
+} from "./sql-policy-read-metadata.js";
 import {
   consumeSqlReadToken,
   enterSqlReadDepth,
   inspectSqlReadToken,
+  resumeEnteredSqlReadCursor,
   resumeSqlReadCursor,
   sqlReadRangeForSpan,
   sqlTokenCursorFromReadCursor,
@@ -30,7 +35,7 @@ type SqlWindowFrameBoundRank = 0 | 1 | 2 | 3 | 4;
 type SqlWindowFrameBound = Readonly<{
   cursor: SqlReadCursor;
   kind: SqlWindowFrameBoundKind;
-  metadata: SqlExpressionMetadata;
+  metadata: SqlExpressionMetadataSequence;
   range: SqlSourceRange;
   rank: SqlWindowFrameBoundRank;
 }>;
@@ -39,27 +44,6 @@ type SqlWindowFrameSpecialBoundRead = Readonly<{
   bound: SqlWindowFrameBound | null;
   cursor: SqlReadCursor;
 }>;
-
-const emptyExpressionMetadata = (): SqlExpressionMetadata => Object.freeze({
-  calls: Object.freeze([]),
-  nestedQueries: Object.freeze([]),
-  typeConstructs: Object.freeze([]),
-});
-
-const mergeExpressionMetadata = (
-  first: SqlExpressionMetadata,
-  second: SqlExpressionMetadata,
-): SqlExpressionMetadata => Object.freeze({
-  calls: Object.freeze([...first.calls, ...second.calls]),
-  nestedQueries: Object.freeze([
-    ...first.nestedQueries,
-    ...second.nestedQueries,
-  ]),
-  typeConstructs: Object.freeze([
-    ...first.typeConstructs,
-    ...second.typeConstructs,
-  ]),
-});
 
 const readCursorRange = (
   cursor: SqlReadCursor,
@@ -108,7 +92,7 @@ const consumeRequiredWord = (
 const windowFrameBound = (
   initial: SqlReadCursor,
   cursor: SqlReadCursor,
-  metadata: SqlExpressionMetadata,
+  metadata: SqlExpressionMetadataSequence,
   kind: SqlWindowFrameBoundKind,
   rank: SqlWindowFrameBoundRank,
 ): SqlWindowFrameBound => Object.freeze({
@@ -152,7 +136,7 @@ const readSpecialWindowFrameBound = (
       bound: windowFrameBound(
         initial,
         completed,
-        emptyExpressionMetadata(),
+        emptySqlExpressionMetadataSequence(),
         "current_row",
         2,
       ),
@@ -175,7 +159,7 @@ const readSpecialWindowFrameBound = (
       bound: windowFrameBound(
         initial,
         completed,
-        emptyExpressionMetadata(),
+        emptySqlExpressionMetadataSequence(),
         secondWord === "preceding"
           ? "unbounded_preceding"
           : "unbounded_following",
@@ -198,8 +182,9 @@ const readOffsetWindowFrameBound = (
     "Enter window frame offset expression",
   );
   const expression = readExpressionPrefix(environment, nested);
-  const resumed = resumeSqlReadCursor(
+  const resumed = resumeEnteredSqlReadCursor(
     cursor,
+    nested,
     expression.cursor,
     "Resume window frame offset expression",
   );
@@ -480,8 +465,11 @@ export const readSqlWindowFrame = (
   return Object.freeze({
     cursor: current,
     metadata: end === null
-      ? mergeExpressionMetadata(start.metadata, emptyExpressionMetadata())
-      : mergeExpressionMetadata(start.metadata, end.metadata),
+      ? concatSqlExpressionMetadataSequences(
+        start.metadata,
+        emptySqlExpressionMetadataSequence(),
+      )
+      : concatSqlExpressionMetadataSequences(start.metadata, end.metadata),
     range: sqlReadRangeForSpan(initial.state, initial.index, current.index),
   });
 };

--- a/packages/agent-shared/src/sql-policy-read-sort.test.ts
+++ b/packages/agent-shared/src/sql-policy-read-sort.test.ts
@@ -29,6 +29,15 @@ import type {
   SqlNestedQueryNode,
   SqlTypeConstructNode,
 } from "./sql-policy-read-model.js";
+import {
+  concatSqlExpressionMetadataSequences,
+  emptySqlExpressionMetadataSequence,
+  materializeSqlExpressionMetadataSequence,
+  sqlCallMetadataSequence,
+  sqlNestedQueryMetadataSequence,
+  sqlTypeConstructMetadataSequence,
+  type SqlExpressionMetadataSequence,
+} from "./sql-policy-read-metadata.js";
 import type { SqlTypeNameNode } from "./sql-policy-type-model.js";
 import {
   advanceSqlReadCursor,
@@ -70,6 +79,66 @@ type PrefixReaderHarness = Readonly<{
   snapshot: () => PrefixReaderSnapshot;
 }>;
 
+type CursorContractCase = Readonly<{
+  message: string;
+  mutate: (
+    cursor: SqlReadCursor,
+    foreign: SqlReadCursor,
+  ) => SqlReadCursor;
+}>;
+
+const cursorContractCases = (
+  operation: string,
+  enteredEndIndex: number,
+  enteredDepth: number,
+): ReadonlyArray<CursorContractCase> => Object.freeze([
+  Object.freeze({
+    message: `${operation} returned cursor end ${String(enteredEndIndex - 1)} must equal the entered child end ${String(enteredEndIndex)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      endIndex: cursor.endIndex - 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor end ${String(enteredEndIndex + 1)} must equal the entered child end ${String(enteredEndIndex)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      endIndex: cursor.endIndex + 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor nesting depth ${String(enteredDepth - 1)} must equal the entered child depth ${String(enteredDepth)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      depth: cursor.depth - 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor nesting depth ${String(enteredDepth + 1)} must equal the entered child depth ${String(enteredDepth)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      depth: cursor.depth + 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor must use the entered child SQL read state`,
+    mutate: (
+      cursor: SqlReadCursor,
+      foreign: SqlReadCursor,
+    ): SqlReadCursor => Object.freeze({
+      ...cursor,
+      state: foreign.state,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor workUnits must be a non-negative safe integer; received -1`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      workUnits: -1,
+    }),
+  }),
+]);
+
 const limits = (
   maxSourceCodeUnits: number,
   maxTokens: number,
@@ -88,18 +157,14 @@ const environment = (queryId: number): SqlExpressionEnvironment => ({
   syntaxContext: "expression",
 });
 
-const emptyMetadata = (): SqlExpressionMetadata => Object.freeze({
-  calls: Object.freeze([]),
-  nestedQueries: Object.freeze([]),
-  typeConstructs: Object.freeze([]),
-});
+const emptyMetadata = (): SqlExpressionMetadataSequence =>
+  emptySqlExpressionMetadataSequence();
 
-const callMetadata = (
+const callNode = (
   expressionEnvironment: SqlExpressionEnvironment,
   token: SqlIdentifierToken,
   range: SqlSourceRange,
-): SqlExpressionMetadata => {
-  const call: SqlCallNode = Object.freeze({
+): SqlCallNode => Object.freeze({
     argumentsRange: range,
     context: expressionEnvironment.context,
     path: Object.freeze([token]),
@@ -107,12 +172,14 @@ const callMetadata = (
     range,
     syntaxContext: expressionEnvironment.syntaxContext,
   });
-  return Object.freeze({
-    calls: Object.freeze([call]),
-    nestedQueries: Object.freeze([]),
-    typeConstructs: Object.freeze([]),
-  });
-};
+
+const callMetadata = (
+  expressionEnvironment: SqlExpressionEnvironment,
+  token: SqlIdentifierToken,
+  range: SqlSourceRange,
+): SqlExpressionMetadataSequence => sqlCallMetadataSequence(
+  callNode(expressionEnvironment, token, range),
+);
 
 const readMinimalExpression: SqlExpressionReader<SqlExpressionResult> = (
   expressionEnvironment: SqlExpressionEnvironment,
@@ -155,11 +222,11 @@ const readRichMetadataExpression: SqlExpressionReader<SqlExpressionResult> = (
   cursor: SqlReadCursor,
 ): SqlExpressionResult => {
   const result = readMinimalExpression(expressionEnvironment, cursor);
-  const call = result.metadata.calls[0];
-  const name = call?.path[0];
-  if (call === undefined || name === undefined) {
+  const name = cursor.state.kernel.tokens[cursor.index];
+  if (name?.kind !== "identifier") {
     return result;
   }
+  const call = callNode(expressionEnvironment, name, result.range);
   const sql = cursor.state.kernel.sql.slice(
     result.range.start,
     result.range.end,
@@ -194,11 +261,13 @@ const readRichMetadataExpression: SqlExpressionReader<SqlExpressionResult> = (
   });
   return Object.freeze({
     ...result,
-    metadata: Object.freeze({
-      calls: result.metadata.calls,
-      nestedQueries: Object.freeze([nestedQuery]),
-      typeConstructs: Object.freeze([typeConstruct]),
-    }),
+    metadata: concatSqlExpressionMetadataSequences(
+      concatSqlExpressionMetadataSequences(
+        sqlCallMetadataSequence(call),
+        sqlNestedQueryMetadataSequence(nestedQuery),
+      ),
+      sqlTypeConstructMetadataSequence(typeConstruct),
+    ),
   });
 };
 
@@ -452,15 +521,12 @@ const prefixExpressionMetadata = (
   cursor: SqlReadCursor,
   endIndex: number,
   range: SqlSourceRange,
-): SqlExpressionMetadata => {
+): SqlExpressionMetadataSequence => {
   const token = cursor.state.kernel.tokens[cursor.index];
   if (token?.kind !== "identifier") {
     return emptyMetadata();
   }
-  const call = callMetadata(expressionEnvironment, token, range).calls[0];
-  if (call === undefined) {
-    return emptyMetadata();
-  }
+  const call = callNode(expressionEnvironment, token, range);
   const nestedQuery: SqlNestedQueryNode = Object.freeze({
     bodyRange: range,
     context: "nested",
@@ -489,11 +555,13 @@ const prefixExpressionMetadata = (
     syntax: "cast",
     typeName,
   });
-  return Object.freeze({
-    calls: Object.freeze([call]),
-    nestedQueries: Object.freeze([nestedQuery]),
-    typeConstructs: Object.freeze([typeConstruct]),
-  });
+  return concatSqlExpressionMetadataSequences(
+    concatSqlExpressionMetadataSequences(
+      sqlCallMetadataSequence(call),
+      sqlNestedQueryMetadataSequence(nestedQuery),
+    ),
+    sqlTypeConstructMetadataSequence(typeConstruct),
+  );
 };
 
 const readDeterministicExpressionPrefix = (
@@ -594,9 +662,42 @@ const createReadCursor = (
 
 const normalizedCalls = (
   result: SqlExpressionResult,
-): ReadonlyArray<string> => result.metadata.calls.map((call) =>
+): ReadonlyArray<string> => materializedMetadata(result).calls.map((call) =>
   call.path.map((part) => part.untruncatedNormalized).join(".")
 );
+
+const materializedMetadata = (
+  result: SqlExpressionResult,
+): SqlExpressionMetadata => materializeSqlExpressionMetadataSequence(
+  result.metadata,
+);
+
+const countMetadataConcatNodes = (
+  sequence: SqlExpressionMetadataSequence,
+): number => {
+  const stack: Array<SqlExpressionMetadataSequence> = [sequence];
+  let count = 0;
+  while (stack.length > 0) {
+    const current = stack.pop();
+    assert.notEqual(current, undefined);
+    if (current?.kind === "concat") {
+      count++;
+      stack.push(current.right, current.left);
+    }
+  }
+  return count;
+};
+
+const repeatMetadataSequence = (
+  sequence: SqlExpressionMetadataSequence,
+  count: number,
+): SqlExpressionMetadataSequence => {
+  let repeated = emptySqlExpressionMetadataSequence();
+  for (let index = 0; index < count; index++) {
+    repeated = concatSqlExpressionMetadataSequences(repeated, sequence);
+  }
+  return repeated;
+};
 
 const sourceRange = (
   sql: string,
@@ -666,7 +767,7 @@ test("ORDER BY reads expressions, direction, USING, and NULLS suffixes", (): voi
     "delta",
   ]);
   assert.deepEqual(
-    result.metadata.calls.map((call) => sql.slice(
+    materializedMetadata(result).calls.map((call) => sql.slice(
       call.range.start,
       call.range.end,
     )),
@@ -685,7 +786,7 @@ test("ORDER BY keeps contextual NULLS identifiers inside expressions", (): void 
 
   assert.deepEqual(normalizedCalls(result), ["nulls", "nulls", "value"]);
   assert.deepEqual(
-    result.metadata.calls.map((call) => sql.slice(
+    materializedMetadata(result).calls.map((call) => sql.slice(
       call.range.start,
       call.range.end,
     )),
@@ -738,7 +839,7 @@ test("ORDER BY keeps contextual direction words inside expressions", (): void =>
       readMinimalExpression,
     );
     assert.deepEqual(
-      result.metadata.calls.map((call) => expected.sql.slice(
+      materializedMetadata(result).calls.map((call) => expected.sql.slice(
         call.range.start,
         call.range.end,
       )),
@@ -883,7 +984,7 @@ test("ORDER BY ignores nested commas and suffix keywords", (): void => {
 
   assert.deepEqual(normalizedCalls(result), ["outer_fn", "array_value"]);
   assert.deepEqual(
-    result.metadata.calls.map((call) => sql.slice(
+    materializedMetadata(result).calls.map((call) => sql.slice(
       call.range.start,
       call.range.end,
     )),
@@ -1128,20 +1229,109 @@ test("ORDER BY preserves every child metadata collection in order", (): void => 
   const expected = ["first", "second", "third"];
 
   assert.deepEqual(normalizedCalls(result), expected);
-  assert.equal(result.metadata.nestedQueries.length, expected.length);
-  assert.equal(result.metadata.typeConstructs.length, expected.length);
+  const metadata = materializedMetadata(result);
+  assert.equal(metadata.nestedQueries.length, expected.length);
+  assert.equal(metadata.typeConstructs.length, expected.length);
   assert.deepEqual(
-    result.metadata.typeConstructs.map((construct) =>
+    metadata.nestedQueries.map((query) => sql.slice(
+      query.range.start,
+      query.range.end,
+    )),
+    expected,
+  );
+  assert.deepEqual(
+    metadata.typeConstructs.map((construct) =>
       construct.typeName.nameParts[0]?.untruncatedNormalized
     ),
     expected,
   );
-  assert.equal(Object.isFrozen(result.metadata.calls), true);
-  assert.equal(Object.isFrozen(result.metadata.nestedQueries), true);
-  assert.equal(Object.isFrozen(result.metadata.typeConstructs), true);
+  assert.equal(Object.isFrozen(metadata.calls), true);
+  assert.equal(Object.isFrozen(metadata.nestedQueries), true);
+  assert.equal(Object.isFrozen(metadata.typeConstructs), true);
+  assert.equal(countMetadataConcatNodes(result.metadata), 8);
 });
 
-test("bounded parent cursors and deeper child cursors resume exactly", (): void => {
+test("sort readers preserve canonical empty and deep child sequences", (): void => {
+  const emptyExact = createReadCursor("1", DEFAULT_SQL_PARSER_LIMITS);
+  const emptyExactResult = readSqlSortList(
+    environment(36),
+    emptyExact.cursor,
+    readMinimalExpression,
+  );
+  assert.equal(
+    emptyExactResult.metadata,
+    emptySqlExpressionMetadataSequence(),
+  );
+
+  const emptyPrefix = createReadCursor("1 RANGE", DEFAULT_SQL_PARSER_LIMITS);
+  const emptyPrefixResult = readSqlSortListPrefix(
+    environment(36),
+    emptyPrefix.cursor,
+    readDeterministicExpressionPrefix,
+  );
+  assert.equal(
+    emptyPrefixResult.metadata,
+    emptySqlExpressionMetadataSequence(),
+  );
+
+  const deepCount = 20_000;
+  const exact = createReadCursor("alpha", DEFAULT_SQL_PARSER_LIMITS);
+  const token = exact.kernel.tokens[0];
+  assert.equal(token?.kind, "identifier");
+  assert.ok(token?.kind === "identifier");
+  const range = sqlReadRangeForSpan(exact.cursor.state, 0, 1);
+  const deepMetadata = repeatMetadataSequence(
+    callMetadata(environment(36), token, range),
+    deepCount,
+  );
+  const exactReader: SqlExpressionReader<SqlExpressionResult> = (
+    expressionEnvironment: SqlExpressionEnvironment,
+    child: SqlReadCursor,
+  ): SqlExpressionResult => Object.freeze({
+    ...readMinimalExpression(expressionEnvironment, child),
+    metadata: deepMetadata,
+  });
+  const exactBaseline = readSqlSortList(
+    environment(36),
+    exact.cursor,
+    readMinimalExpression,
+  );
+  const exactResult = readSqlSortList(
+    environment(36),
+    exact.cursor,
+    exactReader,
+  );
+  assert.equal(exactResult.metadata, deepMetadata);
+  assert.equal(materializedMetadata(exactResult).calls.length, deepCount);
+  assert.equal(exactResult.cursor.workUnits, exactBaseline.cursor.workUnits);
+
+  const prefix = createReadCursor(
+    "alpha RANGE",
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const prefixReader: SqlExpressionPrefixReader = (
+    expressionEnvironment: SqlExpressionEnvironment,
+    child: SqlReadCursor,
+  ): SqlExpressionResult => Object.freeze({
+    ...readDeterministicExpressionPrefix(expressionEnvironment, child),
+    metadata: deepMetadata,
+  });
+  const prefixBaseline = readSqlSortListPrefix(
+    environment(36),
+    prefix.cursor,
+    readDeterministicExpressionPrefix,
+  );
+  const prefixResult = readSqlSortListPrefix(
+    environment(36),
+    prefix.cursor,
+    prefixReader,
+  );
+  assert.equal(prefixResult.metadata, deepMetadata);
+  assert.equal(materializedMetadata(prefixResult).calls.length, deepCount);
+  assert.equal(prefixResult.cursor.workUnits, prefixBaseline.cursor.workUnits);
+});
+
+test("bounded parent cursors and exact child cursors resume exactly", (): void => {
   const sql = "prefix alpha DESC trailing";
   const kernel = createSqlParserKernel(sql, DEFAULT_SQL_PARSER_LIMITS);
   const state = createSqlReadState(kernel);
@@ -1149,17 +1339,10 @@ test("bounded parent cursors and deeper child cursors resume exactly", (): void 
     createSqlReadCursor(state, 1, kernel.tokens.length - 1),
     "Enter bounded test parent",
   );
-  const deeperReader: SqlExpressionReader<SqlExpressionResult> = (
-    expressionEnvironment: SqlExpressionEnvironment,
-    cursor: SqlReadCursor,
-  ): SqlExpressionResult => readMinimalExpression(
-    expressionEnvironment,
-    enterSqlReadDepth(cursor, "Enter deterministic child depth"),
-  );
   const result = readSqlSortList(
     environment(41),
     parent,
-    deeperReader,
+    readMinimalExpression,
   );
 
   assert.equal(result.cursor.state, parent.state);
@@ -1266,6 +1449,36 @@ test("expression collaborators must consume their exact bounded span", (): void 
   );
 });
 
+test("exact ORDER BY collaborators must preserve the entered cursor", (): void => {
+  const sql = "alpha DESC";
+  const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const foreign = createReadCursor("other", DEFAULT_SQL_PARSER_LIMITS).cursor;
+  const cases = cursorContractCases(
+    "Resume ORDER BY expression result",
+    1,
+    1,
+  );
+
+  for (const current of cases) {
+    const reader: SqlExpressionReader<SqlExpressionResult> = (
+      expressionEnvironment: SqlExpressionEnvironment,
+      child: SqlReadCursor,
+    ): SqlExpressionResult => {
+      const result = readMinimalExpression(expressionEnvironment, child);
+      return Object.freeze({
+        ...result,
+        cursor: current.mutate(result.cursor, foreign),
+      });
+    };
+    expectParserError(
+      () => readSqlSortList(environment(46), cursor, reader),
+      "internal_invariant",
+      sourceRange(sql, "alpha", 0),
+      current.message,
+    );
+  }
+});
+
 test("runtime work accepts the exact maximum and fails at first excess", (): void => {
   const sql = "value";
   const ample = createReadCursor(
@@ -1319,7 +1532,8 @@ test("large ORDER BY metadata aggregation remains ordered and iterative", (): vo
     readMinimalExpression,
   );
 
-  assert.equal(result.metadata.calls.length, count);
+  assert.equal(materializedMetadata(result).calls.length, count);
+  assert.equal(countMetadataConcatNodes(result.metadata), count - 1);
   assert.equal(normalizedCalls(result)[0], "item_0");
   assert.equal(normalizedCalls(result).at(-1), `item_${String(count - 1)}`);
   assert.equal(result.cursor.index, cursor.endIndex);
@@ -1367,7 +1581,7 @@ test("prefix ORDER BY reads every suffix form and leaves caller terminators", ()
       "qualified",
     ], terminator);
     assert.deepEqual(
-      result.metadata.calls.map((call) => sql.slice(
+      materializedMetadata(result).calls.map((call) => sql.slice(
         call.range.start,
         call.range.end,
       )),
@@ -1435,7 +1649,7 @@ test("prefix ORDER BY leaves contextual words to the expression grammar", (): vo
       expected.sql,
     );
     assert.deepEqual(
-      result.metadata.calls.map((call) => expected.sql.slice(
+      materializedMetadata(result).calls.map((call) => expected.sql.slice(
         call.range.start,
         call.range.end,
       )),
@@ -1467,6 +1681,7 @@ test("prefix ORDER BY preserves nested quoted expressions, metadata, bounds, and
   );
   const snapshot = harness.snapshot();
   const rangeTerminator = sourceRange(sql, "RANGE", 0);
+  const metadata = materializedMetadata(result);
 
   assert.equal(result.cursor.state, parent.state);
   assert.equal(result.cursor.index, tokenIndexForRange(kernel, rangeTerminator));
@@ -1477,17 +1692,17 @@ test("prefix ORDER BY preserves nested quoted expressions, metadata, bounds, and
     end: sourceRange(sql, "LAST", 0).end,
   });
   assert.deepEqual(
-    result.metadata.calls.map((call) => sql.slice(
+    metadata.calls.map((call) => sql.slice(
       call.range.start,
       call.range.end,
     )),
     [expression, "beta"],
   );
-  assert.equal(result.metadata.nestedQueries.length, 2);
-  assert.equal(result.metadata.typeConstructs.length, 2);
-  assert.equal(Object.isFrozen(result.metadata.calls), true);
-  assert.equal(Object.isFrozen(result.metadata.nestedQueries), true);
-  assert.equal(Object.isFrozen(result.metadata.typeConstructs), true);
+  assert.equal(metadata.nestedQueries.length, 2);
+  assert.equal(metadata.typeConstructs.length, 2);
+  assert.equal(Object.isFrozen(metadata.calls), true);
+  assert.equal(Object.isFrozen(metadata.nestedQueries), true);
+  assert.equal(Object.isFrozen(metadata.typeConstructs), true);
   assert.equal(snapshot.calls, 2);
   assert.deepEqual(
     snapshot.invocations.map((invocation) => invocation.depth),
@@ -1598,6 +1813,54 @@ test("prefix ORDER BY rejects empty items and strict incomplete expressions prec
     );
     assert.equal(harness.snapshot().calls, 1, invalid.sql);
   }
+});
+
+test("prefix ORDER BY collaborators must preserve the entered cursor", (): void => {
+  const sql = "alpha RANGE";
+  const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const foreign = createReadCursor("other", DEFAULT_SQL_PARSER_LIMITS).cursor;
+  const cases = cursorContractCases(
+    "Resume ORDER BY expression prefix",
+    2,
+    1,
+  );
+
+  for (const current of cases) {
+    const reader: SqlExpressionPrefixReader = (
+      expressionEnvironment: SqlExpressionEnvironment,
+      child: SqlReadCursor,
+    ): SqlExpressionResult => {
+      const result = readDeterministicExpressionPrefix(
+        expressionEnvironment,
+        child,
+      );
+      return Object.freeze({
+        ...result,
+        cursor: current.mutate(result.cursor, foreign),
+      });
+    };
+    expectParserError(
+      () => readSqlSortListPrefix(environment(59), cursor, reader),
+      "internal_invariant",
+      sourceRange(sql, "alpha", 0),
+      current.message,
+    );
+  }
+
+  const emptyReader: SqlExpressionPrefixReader = (
+    _expressionEnvironment: SqlExpressionEnvironment,
+    child: SqlReadCursor,
+  ): SqlExpressionResult => Object.freeze({
+    cursor: child,
+    metadata: emptyMetadata(),
+    range: sqlReadRangeForSpan(child.state, child.index, child.index),
+  });
+  expectParserError(
+    () => readSqlSortListPrefix(environment(59), cursor, emptyReader),
+    "internal_invariant",
+    sourceRange(sql, "alpha", 0),
+    "ORDER BY expression prefix reader returned an empty expression",
+  );
 });
 
 test("prefix ORDER BY validates direct and qualified PostgreSQL all_Op spellings", (): void => {
@@ -1717,7 +1980,8 @@ test("prefix ORDER BY uses one collaborator call per item and linear transitions
   assert.equal(collaboratorTransitions, count * 4);
   assert.equal(sortTransitions, count * 5 - 1);
   assert.equal(totalTransitions, count * 9 - 1);
-  assert.equal(result.metadata.calls.length, count);
+  assert.equal(materializedMetadata(result).calls.length, count);
+  assert.equal(countMetadataConcatNodes(result.metadata), count * 3 - 1);
   assert.equal(normalizedCalls(result)[0], "item_0");
   assert.equal(normalizedCalls(result).at(-1), `item_${String(count - 1)}`);
   assert.equal(

--- a/packages/agent-shared/src/sql-policy-read-sort.ts
+++ b/packages/agent-shared/src/sql-policy-read-sort.ts
@@ -15,12 +15,11 @@ import type {
   SqlExpressionReader,
   SqlExpressionResult,
 } from "./sql-policy-read-expression.js";
-import type {
-  SqlCallNode,
-  SqlExpressionMetadata,
-  SqlNestedQueryNode,
-  SqlTypeConstructNode,
-} from "./sql-policy-read-model.js";
+import {
+  concatSqlExpressionMetadataSequences,
+  emptySqlExpressionMetadataSequence,
+  type SqlExpressionMetadataSequence,
+} from "./sql-policy-read-metadata.js";
 import {
   adoptSqlTokenCursor,
   advanceSqlReadCursor,
@@ -29,17 +28,12 @@ import {
   inspectSqlReadToken,
   matchingSqlReadDelimiter,
   narrowSqlReadCursor,
+  resumeEnteredSqlReadCursor,
   resumeSqlReadCursor,
   sqlReadRangeForSpan,
   sqlTokenCursorFromReadCursor,
   type SqlReadCursor,
 } from "./sql-policy-read-state.js";
-
-type SqlMetadataAccumulator = {
-  calls: Array<SqlCallNode>;
-  nestedQueries: Array<SqlNestedQueryNode>;
-  typeConstructs: Array<SqlTypeConstructNode>;
-};
 
 type SqlReadProbe = Readonly<{
   cursor: SqlReadCursor;
@@ -48,37 +42,8 @@ type SqlReadProbe = Readonly<{
 
 type SqlSortExpressionRead = Readonly<{
   cursor: SqlReadCursor;
-  metadata: SqlExpressionMetadata;
+  metadata: SqlExpressionMetadataSequence;
 }>;
-
-const metadataAccumulator = (): SqlMetadataAccumulator => ({
-  calls: [],
-  nestedQueries: [],
-  typeConstructs: [],
-});
-
-const appendExpressionMetadata = (
-  target: SqlMetadataAccumulator,
-  metadata: SqlExpressionMetadata,
-): void => {
-  for (const call of metadata.calls) {
-    target.calls.push(call);
-  }
-  for (const nestedQuery of metadata.nestedQueries) {
-    target.nestedQueries.push(nestedQuery);
-  }
-  for (const typeConstruct of metadata.typeConstructs) {
-    target.typeConstructs.push(typeConstruct);
-  }
-};
-
-const expressionMetadata = (
-  accumulator: SqlMetadataAccumulator,
-): SqlExpressionMetadata => Object.freeze({
-  calls: Object.freeze(accumulator.calls),
-  nestedQueries: Object.freeze(accumulator.nestedQueries),
-  typeConstructs: Object.freeze(accumulator.typeConstructs),
-});
 
 const readCursorRange = (
   cursor: SqlReadCursor,
@@ -265,7 +230,8 @@ const readExactSqlExpression = (
   );
   const nested = enterSqlReadDepth(bounded, `Enter ${subject}`);
   const result = reader(environment, nested);
-  const completedChild = resumeSqlReadCursor(
+  const completedChild = resumeEnteredSqlReadCursor(
+    bounded,
     nested,
     result.cursor,
     `Resume ${subject} result`,
@@ -299,8 +265,9 @@ const readPrefixSqlExpression = (
     "Enter ORDER BY expression prefix",
   );
   const result = reader(environment, nested);
-  const resumed = resumeSqlReadCursor(
+  const resumed = resumeEnteredSqlReadCursor(
     cursor,
+    nested,
     result.cursor,
     "Resume ORDER BY expression prefix",
   );
@@ -319,10 +286,10 @@ const readPrefixSqlExpression = (
 const expressionResult = (
   initial: SqlReadCursor,
   cursor: SqlReadCursor,
-  metadata: SqlMetadataAccumulator,
+  metadata: SqlExpressionMetadataSequence,
 ): SqlExpressionResult => Object.freeze({
   cursor,
-  metadata: expressionMetadata(metadata),
+  metadata,
   range: sqlReadRangeForSpan(
     initial.state,
     initial.index,
@@ -616,7 +583,7 @@ export const readSqlSortList = (
   readExpression: SqlExpressionReader<SqlExpressionResult>,
 ): SqlExpressionResult => {
   const initial = cursor;
-  const metadata = metadataAccumulator();
+  let metadata = emptySqlExpressionMetadataSequence();
   let current = cursor;
   let itemCount = 0;
 
@@ -646,7 +613,10 @@ export const readSqlSortList = (
       readExpression,
       "ORDER BY expression",
     );
-    appendExpressionMetadata(metadata, expression.metadata);
+    metadata = concatSqlExpressionMetadataSequences(
+      metadata,
+      expression.metadata,
+    );
     current = expression.cursor;
     itemCount++;
 
@@ -695,7 +665,7 @@ export const readSqlSortListPrefix = (
   readExpressionPrefix: SqlExpressionPrefixReader,
 ): SqlExpressionResult => {
   const initial = cursor;
-  const metadata = metadataAccumulator();
+  let metadata = emptySqlExpressionMetadataSequence();
   let current = cursor;
   const first = inspectCurrentSqlReadToken(
     current,
@@ -712,7 +682,10 @@ export const readSqlSortListPrefix = (
       current,
       readExpressionPrefix,
     );
-    appendExpressionMetadata(metadata, expression.metadata);
+    metadata = concatSqlExpressionMetadataSequences(
+      metadata,
+      expression.metadata,
+    );
     current = expression.cursor;
 
     const suffix = readSortItemSuffix(current);

--- a/packages/agent-shared/src/sql-policy-read-window.test.ts
+++ b/packages/agent-shared/src/sql-policy-read-window.test.ts
@@ -29,6 +29,15 @@ import type {
   SqlTypeConstructNode,
 } from "./sql-policy-read-model.js";
 import {
+  concatSqlExpressionMetadataSequences,
+  emptySqlExpressionMetadataSequence,
+  materializeSqlExpressionMetadataSequence,
+  sqlCallMetadataSequence,
+  sqlNestedQueryMetadataSequence,
+  sqlTypeConstructMetadataSequence,
+  type SqlExpressionMetadataSequence,
+} from "./sql-policy-read-metadata.js";
+import {
   advanceSqlReadCursor,
   consumeSqlReadToken,
   createSqlReadCursor,
@@ -66,6 +75,66 @@ type PrefixReaderHarness = Readonly<{
   snapshot: () => PrefixReaderSnapshot;
 }>;
 
+type CursorContractCase = Readonly<{
+  message: string;
+  mutate: (
+    cursor: SqlReadCursor,
+    foreign: SqlReadCursor,
+  ) => SqlReadCursor;
+}>;
+
+const cursorContractCases = (
+  operation: string,
+  enteredEndIndex: number,
+  enteredDepth: number,
+): ReadonlyArray<CursorContractCase> => Object.freeze([
+  Object.freeze({
+    message: `${operation} returned cursor end ${String(enteredEndIndex - 1)} must equal the entered child end ${String(enteredEndIndex)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      endIndex: cursor.endIndex - 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor end ${String(enteredEndIndex + 1)} must equal the entered child end ${String(enteredEndIndex)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      endIndex: cursor.endIndex + 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor nesting depth ${String(enteredDepth - 1)} must equal the entered child depth ${String(enteredDepth)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      depth: cursor.depth - 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor nesting depth ${String(enteredDepth + 1)} must equal the entered child depth ${String(enteredDepth)}`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      depth: cursor.depth + 1,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor must use the entered child SQL read state`,
+    mutate: (
+      cursor: SqlReadCursor,
+      foreign: SqlReadCursor,
+    ): SqlReadCursor => Object.freeze({
+      ...cursor,
+      state: foreign.state,
+    }),
+  }),
+  Object.freeze({
+    message: `${operation} returned cursor workUnits must be a non-negative safe integer; received -1`,
+    mutate: (cursor: SqlReadCursor): SqlReadCursor => Object.freeze({
+      ...cursor,
+      workUnits: -1,
+    }),
+  }),
+]);
+
 const limits = (
   maxSourceCodeUnits: number,
   maxTokens: number,
@@ -84,11 +153,8 @@ const environment = (queryId: number): SqlExpressionEnvironment => ({
   syntaxContext: "expression",
 });
 
-const emptyMetadata = (): SqlExpressionMetadata => Object.freeze({
-  calls: Object.freeze([]),
-  nestedQueries: Object.freeze([]),
-  typeConstructs: Object.freeze([]),
-});
+const emptyMetadata = (): SqlExpressionMetadataSequence =>
+  emptySqlExpressionMetadataSequence();
 
 const callMetadata = (
   expressionEnvironment: SqlExpressionEnvironment,
@@ -97,7 +163,7 @@ const callMetadata = (
   startIndex: number,
   endIndex: number,
   sql: string,
-): SqlExpressionMetadata => {
+): SqlExpressionMetadataSequence => {
   const call: SqlCallNode = Object.freeze({
     argumentsRange: range,
     context: expressionEnvironment.context,
@@ -134,11 +200,13 @@ const callMetadata = (
     syntax: "cast",
     typeName,
   });
-  return Object.freeze({
-    calls: Object.freeze([call]),
-    nestedQueries: Object.freeze([nestedQuery]),
-    typeConstructs: Object.freeze([typeConstruct]),
-  });
+  return concatSqlExpressionMetadataSequences(
+    concatSqlExpressionMetadataSequences(
+      sqlCallMetadataSequence(call),
+      sqlNestedQueryMetadataSequence(nestedQuery),
+    ),
+    sqlTypeConstructMetadataSequence(typeConstruct),
+  );
 };
 
 const deterministicPrefixError = (
@@ -482,9 +550,42 @@ const readWindow = (
 const expressionSql = (
   sql: string,
   result: SqlExpressionResult,
-): ReadonlyArray<string> => result.metadata.calls.map((call) =>
+): ReadonlyArray<string> => materializedMetadata(result).calls.map((call) =>
   sql.slice(call.range.start, call.range.end)
 );
+
+const materializedMetadata = (
+  result: SqlExpressionResult,
+): SqlExpressionMetadata => materializeSqlExpressionMetadataSequence(
+  result.metadata,
+);
+
+const countMetadataConcatNodes = (
+  sequence: SqlExpressionMetadataSequence,
+): number => {
+  const stack: Array<SqlExpressionMetadataSequence> = [sequence];
+  let count = 0;
+  while (stack.length > 0) {
+    const current = stack.pop();
+    assert.notEqual(current, undefined);
+    if (current?.kind === "concat") {
+      count++;
+      stack.push(current.right, current.left);
+    }
+  }
+  return count;
+};
+
+const repeatMetadataSequence = (
+  sequence: SqlExpressionMetadataSequence,
+  count: number,
+): SqlExpressionMetadataSequence => {
+  let repeated = emptySqlExpressionMetadataSequence();
+  for (let index = 0; index < count; index++) {
+    repeated = concatSqlExpressionMetadataSequences(repeated, sequence);
+  }
+  return repeated;
+};
 
 const sourceRange = (
   sql: string,
@@ -795,6 +896,7 @@ test("bounded parents preserve exact offsets, depth, metadata, and cumulative wo
     "offset_one",
   ];
   const snapshot = harness.snapshot();
+  const metadata = materializedMetadata(result);
 
   assert.equal(result.cursor.state, parent.state);
   assert.equal(result.cursor.index, parent.endIndex);
@@ -805,11 +907,26 @@ test("bounded parents preserve exact offsets, depth, metadata, and cumulative wo
     end: sourceRange(sql, "PRECEDING", 0).end,
   });
   assert.deepEqual(expressionSql(sql, result), expectedExpressions);
-  assert.equal(result.metadata.nestedQueries.length, expectedExpressions.length);
-  assert.equal(result.metadata.typeConstructs.length, expectedExpressions.length);
-  assert.equal(Object.isFrozen(result.metadata.calls), true);
-  assert.equal(Object.isFrozen(result.metadata.nestedQueries), true);
-  assert.equal(Object.isFrozen(result.metadata.typeConstructs), true);
+  assert.equal(metadata.nestedQueries.length, expectedExpressions.length);
+  assert.equal(metadata.typeConstructs.length, expectedExpressions.length);
+  assert.deepEqual(
+    metadata.nestedQueries.map((query) => sql.slice(
+      query.range.start,
+      query.range.end,
+    )),
+    expectedExpressions,
+  );
+  assert.deepEqual(
+    metadata.typeConstructs.map((construct) => sql.slice(
+      construct.range.start,
+      construct.range.end,
+    )),
+    expectedExpressions,
+  );
+  assert.equal(Object.isFrozen(metadata.calls), true);
+  assert.equal(Object.isFrozen(metadata.nestedQueries), true);
+  assert.equal(Object.isFrozen(metadata.typeConstructs), true);
+  assert.equal(countMetadataConcatNodes(result.metadata), 11);
   assert.deepEqual(
     snapshot.invocations.map((invocation) => invocation.depth),
     expectedExpressions.map(() => parent.depth + 1),
@@ -819,6 +936,46 @@ test("bounded parents preserve exact offsets, depth, metadata, and cumulative wo
     expectedExpressions.map(() => parent.endIndex),
   );
   assert.equal(result.cursor.workUnits > parent.workUnits, true);
+});
+
+test("window reader preserves canonical empty and deep child sequences", (): void => {
+  const empty = readWindow("", 73).result;
+  assert.equal(empty.metadata, emptySqlExpressionMetadataSequence());
+
+  const deepCount = 20_000;
+  const sql = "PARTITION BY item";
+  const { cursor, kernel } = createReadCursor(
+    sql,
+    DEFAULT_SQL_PARSER_LIMITS,
+  );
+  const token = kernel.tokens[2];
+  assert.equal(token?.kind, "identifier");
+  assert.ok(token?.kind === "identifier");
+  const range = sourceRange(sql, "item", 0);
+  const deepMetadata = repeatMetadataSequence(
+    callMetadata(environment(73), token, range, 2, 3, "item"),
+    deepCount,
+  );
+  const reader: SqlExpressionPrefixReader = (
+    expressionEnvironment: SqlExpressionEnvironment,
+    child: SqlReadCursor,
+  ): SqlExpressionResult => Object.freeze({
+    ...readDeterministicExpressionPrefix(expressionEnvironment, child),
+    metadata: deepMetadata,
+  });
+  const baseline = readSqlWindowSpecification(
+    environment(73),
+    cursor,
+    readDeterministicExpressionPrefix,
+  );
+  const result = readSqlWindowSpecification(environment(73), cursor, reader);
+  const metadata = materializedMetadata(result);
+
+  assert.equal(result.metadata, deepMetadata);
+  assert.equal(metadata.calls.length, deepCount);
+  assert.equal(metadata.nestedQueries.length, deepCount);
+  assert.equal(metadata.typeConstructs.length, deepCount);
+  assert.equal(result.cursor.workUnits, baseline.cursor.workUnits);
 });
 
 test("PARTITION BY delegates each expression exactly once with monotone cursors", (): void => {
@@ -903,6 +1060,39 @@ test("empty partition collaborator results fail as cursor invariants", (): void 
   );
 });
 
+test("partition collaborators must preserve the entered cursor", (): void => {
+  const sql = "PARTITION BY value";
+  const { cursor } = createReadCursor(sql, DEFAULT_SQL_PARSER_LIMITS);
+  const foreign = createReadCursor("other", DEFAULT_SQL_PARSER_LIMITS).cursor;
+  const cases = cursorContractCases(
+    "Resume PARTITION BY expression prefix",
+    3,
+    1,
+  );
+
+  for (const current of cases) {
+    const reader: SqlExpressionPrefixReader = (
+      expressionEnvironment: SqlExpressionEnvironment,
+      child: SqlReadCursor,
+    ): SqlExpressionResult => {
+      const result = readDeterministicExpressionPrefix(
+        expressionEnvironment,
+        child,
+      );
+      return Object.freeze({
+        ...result,
+        cursor: current.mutate(result.cursor, foreign),
+      });
+    };
+    expectParserError(
+      () => readSqlWindowSpecification(environment(74), cursor, reader),
+      "internal_invariant",
+      sourceRange(sql, "value", 0),
+      current.message,
+    );
+  }
+});
+
 test("large partition lists retain ordered metadata and linear cursor work", (): void => {
   const count = 2_000;
   const sql = `PARTITION BY ${Array.from(
@@ -924,7 +1114,8 @@ test("large partition lists retain ordered metadata and linear cursor work", ():
 
   assert.equal(snapshot.calls, count);
   assert.equal(snapshot.invocations.length, count);
-  assert.equal(result.metadata.calls.length, count);
+  assert.equal(materializedMetadata(result).calls.length, count);
+  assert.equal(countMetadataConcatNodes(result.metadata), count * 3 - 1);
   assert.equal(expressionSql(sql, result)[0], "item_0");
   assert.equal(expressionSql(sql, result).at(-1), `item_${String(count - 1)}`);
   assert.equal(result.cursor.index, result.cursor.endIndex);

--- a/packages/agent-shared/src/sql-policy-read-window.ts
+++ b/packages/agent-shared/src/sql-policy-read-window.ts
@@ -13,29 +13,23 @@ import type {
   SqlExpressionPrefixReader,
   SqlExpressionResult,
 } from "./sql-policy-read-expression.js";
-import type {
-  SqlCallNode,
-  SqlExpressionMetadata,
-  SqlNestedQueryNode,
-  SqlTypeConstructNode,
-} from "./sql-policy-read-model.js";
+import {
+  concatSqlExpressionMetadataSequences,
+  emptySqlExpressionMetadataSequence,
+  type SqlExpressionMetadataSequence,
+} from "./sql-policy-read-metadata.js";
 import { readSqlWindowFrame } from "./sql-policy-read-frame.js";
 import { readSqlSortListPrefix } from "./sql-policy-read-sort.js";
 import {
   consumeSqlReadToken,
   enterSqlReadDepth,
   inspectSqlReadToken,
+  resumeEnteredSqlReadCursor,
   resumeSqlReadCursor,
   sqlReadRangeForSpan,
   sqlTokenCursorFromReadCursor,
   type SqlReadCursor,
 } from "./sql-policy-read-state.js";
-
-type SqlMetadataAccumulator = {
-  calls: Array<SqlCallNode>;
-  nestedQueries: Array<SqlNestedQueryNode>;
-  typeConstructs: Array<SqlTypeConstructNode>;
-};
 
 type SqlReadProbe = Readonly<{
   cursor: SqlReadCursor;
@@ -44,37 +38,8 @@ type SqlReadProbe = Readonly<{
 
 type SqlPartitionExpressionRead = Readonly<{
   cursor: SqlReadCursor;
-  metadata: SqlExpressionMetadata;
+  metadata: SqlExpressionMetadataSequence;
 }>;
-
-const metadataAccumulator = (): SqlMetadataAccumulator => ({
-  calls: [],
-  nestedQueries: [],
-  typeConstructs: [],
-});
-
-const appendExpressionMetadata = (
-  target: SqlMetadataAccumulator,
-  metadata: SqlExpressionMetadata,
-): void => {
-  for (const call of metadata.calls) {
-    target.calls.push(call);
-  }
-  for (const nestedQuery of metadata.nestedQueries) {
-    target.nestedQueries.push(nestedQuery);
-  }
-  for (const typeConstruct of metadata.typeConstructs) {
-    target.typeConstructs.push(typeConstruct);
-  }
-};
-
-const expressionMetadata = (
-  accumulator: SqlMetadataAccumulator,
-): SqlExpressionMetadata => Object.freeze({
-  calls: Object.freeze(accumulator.calls),
-  nestedQueries: Object.freeze(accumulator.nestedQueries),
-  typeConstructs: Object.freeze(accumulator.typeConstructs),
-});
 
 const readCursorRange = (
   cursor: SqlReadCursor,
@@ -120,10 +85,10 @@ const isExistingWindowName = (token: SqlParserToken): boolean => {
 const expressionResult = (
   initial: SqlReadCursor,
   cursor: SqlReadCursor,
-  metadata: SqlMetadataAccumulator,
+  metadata: SqlExpressionMetadataSequence,
 ): SqlExpressionResult => Object.freeze({
   cursor,
-  metadata: expressionMetadata(metadata),
+  metadata,
   range: sqlReadRangeForSpan(initial.state, initial.index, cursor.index),
 });
 
@@ -157,8 +122,9 @@ const readPartitionExpression = (
     "Enter PARTITION BY expression prefix",
   );
   const result = readExpressionPrefix(environment, nested);
-  const resumed = resumeSqlReadCursor(
+  const resumed = resumeEnteredSqlReadCursor(
     cursor,
+    nested,
     result.cursor,
     "Resume PARTITION BY expression prefix",
   );
@@ -197,9 +163,9 @@ const readPartitionListPrefix = (
   readExpressionPrefix: SqlExpressionPrefixReader,
 ): Readonly<{
   cursor: SqlReadCursor;
-  metadata: SqlExpressionMetadata;
+  metadata: SqlExpressionMetadataSequence;
 }> => {
-  const metadata = metadataAccumulator();
+  let metadata = emptySqlExpressionMetadataSequence();
   let current = cursor;
   let itemCount = 0;
 
@@ -218,7 +184,10 @@ const readPartitionListPrefix = (
       current,
       readExpressionPrefix,
     );
-    appendExpressionMetadata(metadata, expression.metadata);
+    metadata = concatSqlExpressionMetadataSequences(
+      metadata,
+      expression.metadata,
+    );
     current = expression.cursor;
     itemCount++;
 
@@ -230,7 +199,7 @@ const readPartitionListPrefix = (
     if (separator.token?.text !== ",") {
       return Object.freeze({
         cursor: current,
-        metadata: expressionMetadata(metadata),
+        metadata,
       });
     }
 
@@ -280,7 +249,7 @@ export const readSqlWindowSpecification = (
   readExpressionPrefix: SqlExpressionPrefixReader,
 ): SqlExpressionResult => {
   const initial = cursor;
-  const metadata = metadataAccumulator();
+  let metadata = emptySqlExpressionMetadataSequence();
   let current = cursor;
   let hasPartition = false;
   let hasOrder = false;
@@ -334,7 +303,10 @@ export const readSqlWindowSpecification = (
         current,
         readExpressionPrefix,
       );
-      appendExpressionMetadata(metadata, partition.metadata);
+      metadata = concatSqlExpressionMetadataSequences(
+        metadata,
+        partition.metadata,
+      );
       current = partition.cursor;
       hasPartition = true;
       continue;
@@ -357,7 +329,10 @@ export const readSqlWindowSpecification = (
         current,
         readExpressionPrefix,
       );
-      appendExpressionMetadata(metadata, sorted.metadata);
+      metadata = concatSqlExpressionMetadataSequences(
+        metadata,
+        sorted.metadata,
+      );
       current = resumeSqlReadCursor(
         current,
         sorted.cursor,
@@ -373,7 +348,10 @@ export const readSqlWindowSpecification = (
         current,
         readExpressionPrefix,
       );
-      appendExpressionMetadata(metadata, frame.metadata);
+      metadata = concatSqlExpressionMetadataSequences(
+        metadata,
+        frame.metadata,
+      );
       current = resumeSqlReadCursor(
         current,
         frame.cursor,


### PR DESCRIPTION
## Summary
- migrate dormant expression result metadata to persistent `SqlExpressionMetadataSequence`
- compose sort, frame, and window reader metadata in O(1) and enforce exact entered-child cursor resumption
- add canonical-empty, deep-sequence, structural complexity, source-order, and malicious collaborator coverage

## Validation
- focused sort/frame/window tests: 62/62
- full agent-shared tests: 166/166
- agent-shared typecheck, lint, and build
- SQL API lint/typecheck, registered tests (6/6), and build
- web lint and production build
- `git diff --check`