### PR TITLE
Cut budget backend over to normalized adjustments

### DIFF
--- a/apps/web/src/app/api/budget-adjustments-id-route.test.ts
+++ b/apps/web/src/app/api/budget-adjustments-id-route.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DELETE, PATCH } from "@/app/api/budget-adjustments/[adjustmentId]/route";
+
+const context = {
+  params: Promise.resolve({ adjustmentId: "demo-adjustment-groceries-seasonal" }),
+};
+
+test("demo patch returns the canonical seeded adjustment with the supplied change", async (): Promise<void> => {
+  const response = await PATCH(new Request("http://localhost/api/budget-adjustments/demo-adjustment-groceries-seasonal", {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      cookie: "demo=true",
+    },
+    body: JSON.stringify({ note: "Updated note" }),
+  }), context);
+
+  assert.equal(response.status, 200);
+  const adjustment = await response.json() as Record<string, unknown>;
+  assert.equal(adjustment.adjustmentId, "demo-adjustment-groceries-seasonal");
+  assert.equal(adjustment.direction, "spend");
+  assert.equal(adjustment.category, "Groceries");
+  assert.equal(adjustment.amount, 75);
+  assert.equal(adjustment.note, "Updated note");
+});
+
+test("demo delete returns the delete contract", async (): Promise<void> => {
+  const response = await DELETE(new Request("http://localhost/api/budget-adjustments/demo-adjustment-groceries-seasonal", {
+    method: "DELETE",
+    headers: { cookie: "demo=true" },
+  }), context);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true });
+});
+
+test("demo patch and delete return 404 for an unknown adjustment", async (): Promise<void> => {
+  const unknownContext = {
+    params: Promise.resolve({ adjustmentId: "unknown-adjustment" }),
+  };
+  const patchResponse = await PATCH(new Request("http://localhost/api/budget-adjustments/unknown-adjustment", {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      cookie: "demo=true",
+    },
+    body: JSON.stringify({ amount: 1 }),
+  }), unknownContext);
+  const deleteResponse = await DELETE(new Request("http://localhost/api/budget-adjustments/unknown-adjustment", {
+    method: "DELETE",
+    headers: { cookie: "demo=true" },
+  }), unknownContext);
+
+  assert.equal(patchResponse.status, 404);
+  assert.equal(deleteResponse.status, 404);
+});

--- a/apps/web/src/app/api/budget-adjustments/[adjustmentId]/route.ts
+++ b/apps/web/src/app/api/budget-adjustments/[adjustmentId]/route.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+import { isDemoModeFromRequest } from "@/lib/demoMode";
+import { parseBudgetAdjustmentId, parseBudgetAdjustmentPatchBody } from "@/server/api/budget";
+import { ApiRouteError } from "@/server/api/errors";
+import { handleRoute } from "@/server/api/handleRoute";
+import { parseJsonBody } from "@/server/api/validation";
+import { BudgetAdjustmentNotFoundError, deleteBudgetAdjustment, patchBudgetAdjustment } from "@/server/budget/budgetAdjustments";
+import { deleteDemoBudgetAdjustment, patchDemoBudgetAdjustment } from "@/server/demo/budgetAdjustments";
+import { extractUserId, extractWorkspaceId } from "@/server/userId";
+
+type RouteContext = Readonly<{
+  params: Promise<{
+    adjustmentId: string;
+  }>;
+}>;
+
+const toNotFoundRouteError = (error: unknown): never => {
+  if (error instanceof BudgetAdjustmentNotFoundError) {
+    throw new ApiRouteError(404, error.message);
+  }
+  throw error;
+};
+
+export const PATCH = async (request: Request, context: RouteContext): Promise<Response> =>
+  handleRoute(
+    { route: "/api/budget-adjustments/[adjustmentId]", method: "PATCH", internalErrorMessage: "Budget adjustment update failed" },
+    async (): Promise<Response> => {
+      const { adjustmentId: rawAdjustmentId } = await context.params;
+      const adjustmentId = parseBudgetAdjustmentId(rawAdjustmentId);
+      const body = parseBudgetAdjustmentPatchBody(await parseJsonBody(request, z.unknown()));
+
+      try {
+        if (isDemoModeFromRequest(request)) {
+          return Response.json(patchDemoBudgetAdjustment(adjustmentId, body));
+        }
+
+        const userId = extractUserId(request);
+        const workspaceId = extractWorkspaceId(request);
+        return Response.json(await patchBudgetAdjustment(userId, workspaceId, adjustmentId, body));
+      } catch (error) {
+        return toNotFoundRouteError(error);
+      }
+    },
+  );
+
+export const DELETE = async (request: Request, context: RouteContext): Promise<Response> =>
+  handleRoute(
+    { route: "/api/budget-adjustments/[adjustmentId]", method: "DELETE", internalErrorMessage: "Budget adjustment delete failed" },
+    async (): Promise<Response> => {
+      const { adjustmentId: rawAdjustmentId } = await context.params;
+      const adjustmentId = parseBudgetAdjustmentId(rawAdjustmentId);
+
+      try {
+        if (isDemoModeFromRequest(request)) {
+          deleteDemoBudgetAdjustment(adjustmentId);
+          return Response.json({ ok: true });
+        }
+
+        const userId = extractUserId(request);
+        const workspaceId = extractWorkspaceId(request);
+        await deleteBudgetAdjustment(userId, workspaceId, adjustmentId);
+        return Response.json({ ok: true });
+      } catch (error) {
+        return toNotFoundRouteError(error);
+      }
+    },
+  );

--- a/apps/web/src/app/api/budget-adjustments/route.test.ts
+++ b/apps/web/src/app/api/budget-adjustments/route.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { POST } from "@/app/api/budget-adjustments/route";
+import { getCurrentMonth } from "@/lib/monthUtils";
+
+test("demo create returns a contract-shaped zero adjustment without identity headers", async (): Promise<void> => {
+  const response = await POST(new Request("http://localhost/api/budget-adjustments", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: "demo=true",
+    },
+    body: JSON.stringify({
+      month: getCurrentMonth(),
+      direction: "spend",
+      category: "Groceries",
+      amount: 0,
+      note: null,
+    }),
+  }));
+
+  assert.equal(response.status, 200);
+  const adjustment = await response.json() as Record<string, unknown>;
+  assert.match(adjustment.adjustmentId as string, /^demo-created-spend-/);
+  assert.equal(adjustment.month, getCurrentMonth());
+  assert.equal(adjustment.direction, "spend");
+  assert.equal(adjustment.category, "Groceries");
+  assert.equal(adjustment.amount, 0);
+  assert.equal(adjustment.note, null);
+  assert.equal(typeof adjustment.createdAt, "string");
+  assert.equal(typeof adjustment.updatedAt, "string");
+  assert.deepEqual(Object.keys(adjustment).sort(), [
+    "adjustmentId",
+    "amount",
+    "category",
+    "createdAt",
+    "direction",
+    "month",
+    "note",
+    "updatedAt",
+  ]);
+});

--- a/apps/web/src/app/api/budget-adjustments/route.ts
+++ b/apps/web/src/app/api/budget-adjustments/route.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+import { isDemoModeFromRequest } from "@/lib/demoMode";
+import { parseBudgetAdjustmentCreateBody } from "@/server/api/budget";
+import { handleRoute } from "@/server/api/handleRoute";
+import { parseJsonBody } from "@/server/api/validation";
+import { createBudgetAdjustment } from "@/server/budget/budgetAdjustments";
+import { createDemoBudgetAdjustment } from "@/server/demo/budgetAdjustments";
+import { extractUserId, extractWorkspaceId } from "@/server/userId";
+
+export const POST = async (request: Request): Promise<Response> =>
+  handleRoute(
+    { route: "/api/budget-adjustments", method: "POST", internalErrorMessage: "Budget adjustment create failed" },
+    async (): Promise<Response> => {
+      const body = parseBudgetAdjustmentCreateBody(await parseJsonBody(request, z.unknown()));
+
+      if (isDemoModeFromRequest(request)) {
+        return Response.json(createDemoBudgetAdjustment(body));
+      }
+
+      const userId = extractUserId(request);
+      const workspaceId = extractWorkspaceId(request);
+      return Response.json(await createBudgetAdjustment(userId, workspaceId, body));
+    },
+  );

--- a/apps/web/src/server/api/budget.test.ts
+++ b/apps/web/src/server/api/budget.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { offsetMonth, getCurrentMonth } from "@/lib/monthUtils";
+import { parseBudgetAdjustmentCreateBody, parseBudgetAdjustmentId, parseBudgetAdjustmentPatchBody, parseBudgetPlanBody } from "@/server/api/budget";
+import { ApiRouteError } from "@/server/api/errors";
+
+const SAFE_INTEGER_MESSAGE = /JavaScript-safe integer between -9007199254740991 and 9007199254740991, inclusive/;
+
+const assertBadRequest = (run: () => unknown, message: RegExp): void => {
+  assert.throws(
+    run,
+    (error: unknown): boolean => {
+      assert.ok(error instanceof ApiRouteError);
+      assert.equal(error.status, 400);
+      assert.match(error.publicMessage, message);
+      return true;
+    },
+  );
+};
+
+test("budget adjustment create accepts zero, signed integers, and nullable notes", (): void => {
+  const month = getCurrentMonth();
+
+  assert.deepEqual(parseBudgetAdjustmentCreateBody({
+    month,
+    direction: "spend",
+    category: "Groceries",
+    amount: 0,
+    note: null,
+  }), {
+    month,
+    direction: "spend",
+    category: "Groceries",
+    amount: 0,
+    note: null,
+  });
+
+  assert.equal(parseBudgetAdjustmentCreateBody({
+    month,
+    direction: "income",
+    category: "Bonus",
+    amount: -125,
+    note: "Correction",
+  }).amount, -125);
+
+  assert.equal(parseBudgetAdjustmentCreateBody({
+    month,
+    direction: "income",
+    category: "Maximum boundary",
+    amount: Number.MAX_SAFE_INTEGER,
+    note: null,
+  }).amount, Number.MAX_SAFE_INTEGER);
+  assert.equal(parseBudgetAdjustmentCreateBody({
+    month,
+    direction: "spend",
+    category: "Minimum boundary",
+    amount: Number.MIN_SAFE_INTEGER,
+    note: null,
+  }).amount, Number.MIN_SAFE_INTEGER);
+});
+
+test("budget adjustment category and note limits count Unicode code points", (): void => {
+  const category = "\u{1F600}".repeat(200);
+  const note = "\u{1F680}".repeat(2000);
+  const valid = {
+    month: getCurrentMonth(),
+    direction: "spend",
+    category,
+    amount: 0,
+    note,
+  } as const;
+
+  assert.deepEqual(parseBudgetAdjustmentCreateBody(valid), valid);
+  assert.deepEqual(parseBudgetAdjustmentPatchBody({ category, note }), { category, note });
+  assertBadRequest(
+    () => parseBudgetAdjustmentCreateBody({ ...valid, category: "\u{1F600}".repeat(201) }),
+    /max 200 chars/,
+  );
+  assertBadRequest(
+    () => parseBudgetAdjustmentCreateBody({ ...valid, note: "\u{1F680}".repeat(2001) }),
+    /max 2000 chars/,
+  );
+});
+
+test("budget adjustment create rejects past months, non-integers, and unknown fields", (): void => {
+  const valid = {
+    month: getCurrentMonth(),
+    direction: "spend",
+    category: "Groceries",
+    amount: 10,
+    note: null,
+  } as const;
+
+  assertBadRequest(
+    () => parseBudgetAdjustmentCreateBody({ ...valid, month: offsetMonth(valid.month, -1) }),
+    /current or future month/,
+  );
+  assertBadRequest(
+    () => parseBudgetAdjustmentCreateBody({ ...valid, amount: 10.5 }),
+    SAFE_INTEGER_MESSAGE,
+  );
+  assertBadRequest(
+    () => parseBudgetAdjustmentCreateBody({ ...valid, amount: Number.MAX_SAFE_INTEGER + 1 }),
+    SAFE_INTEGER_MESSAGE,
+  );
+  assertBadRequest(
+    () => parseBudgetAdjustmentCreateBody({ ...valid, amount: Number.MIN_SAFE_INTEGER - 1 }),
+    SAFE_INTEGER_MESSAGE,
+  );
+  assertBadRequest(
+    () => parseBudgetAdjustmentCreateBody({ ...valid, category: "" }),
+    /non-empty string/,
+  );
+  assertBadRequest(
+    () => parseBudgetAdjustmentCreateBody({ ...valid, workspaceId: "workspace-1" }),
+    /Unrecognized key/,
+  );
+  assertBadRequest(
+    () => parseBudgetAdjustmentCreateBody({ ...valid, origin: "legacy" }),
+    /Unrecognized key/,
+  );
+});
+
+test("budget adjustment patch accepts only editable fields and allows edits without a month", (): void => {
+  assert.deepEqual(parseBudgetAdjustmentPatchBody({ amount: -25 }), { amount: -25 });
+  assert.deepEqual(parseBudgetAdjustmentPatchBody({ note: null }), { note: null });
+  assert.deepEqual(parseBudgetAdjustmentPatchBody({
+    month: offsetMonth(getCurrentMonth(), 1),
+    category: "Dining",
+  }), {
+    month: offsetMonth(getCurrentMonth(), 1),
+    category: "Dining",
+  });
+
+  assertBadRequest(() => parseBudgetAdjustmentPatchBody({}), /at least one editable field/);
+  assertBadRequest(
+    () => parseBudgetAdjustmentPatchBody({ month: offsetMonth(getCurrentMonth(), -1) }),
+    /current or future month/,
+  );
+  assertBadRequest(
+    () => parseBudgetAdjustmentPatchBody({ direction: "income" }),
+    /Unrecognized key/,
+  );
+  assertBadRequest(
+    () => parseBudgetAdjustmentPatchBody({ amount: 1, adjustmentId: "adjustment-1" }),
+    /Unrecognized key/,
+  );
+});
+
+test("budget adjustment notes and ids are bounded", (): void => {
+  assert.equal(parseBudgetAdjustmentId("a".repeat(200)).length, 200);
+  assertBadRequest(() => parseBudgetAdjustmentId(""), /non-empty string/);
+  assertBadRequest(() => parseBudgetAdjustmentId("a".repeat(201)), /max 200 chars/);
+  assertBadRequest(
+    () => parseBudgetAdjustmentPatchBody({ note: "n".repeat(2001) }),
+    /max 2000 chars/,
+  );
+});
+
+test("budget plan accepts Base and rejects Modifier", (): void => {
+  const body = {
+    month: getCurrentMonth(),
+    direction: "spend",
+    category: "Groceries",
+    plannedValue: 400,
+  } as const;
+
+  assert.equal(parseBudgetPlanBody({ ...body, kind: "base" }).kind, "base");
+  assertBadRequest(() => parseBudgetPlanBody({ ...body, kind: "modifier" }), /Expected 'base'/);
+});

--- a/apps/web/src/server/api/budget.ts
+++ b/apps/web/src/server/api/budget.ts
@@ -1,13 +1,15 @@
 import { z } from "zod";
 
+import { getCurrentMonth } from "@/lib/monthUtils";
 import { createBadRequestError } from "@/server/api/errors";
-import { budgetPlanKindSchema, categorySchema, directionSchema, finiteNumberSchema, monthSchema, parseRequiredQueryParam, parseWithSchema } from "@/server/api/validation";
+import { adjustmentIdSchema, budgetAdjustmentNoteSchema, budgetPlanKindSchema, categorySchema, directionSchema, finiteIntegerSchema, finiteNumberSchema, monthSchema, parseRequiredQueryParam, parseWithSchema } from "@/server/api/validation";
+import type { CreateBudgetAdjustmentParams, PatchBudgetAdjustmentParams } from "@/server/budget/budgetAdjustments";
 
 type BudgetPlanBody = Readonly<{
   month: string;
   direction: "income" | "spend";
   category: string;
-  kind: "base" | "modifier";
+  kind: "base";
   plannedValue: number;
 }>;
 
@@ -55,6 +57,30 @@ const budgetPlanBodySchema = z.object({
   plannedValue: finiteNumberSchema("plannedValue"),
 });
 
+const currentOrFutureMonthSchema = monthSchema.superRefine((value, ctx) => {
+  if (value < getCurrentMonth()) {
+    ctx.addIssue({ code: "custom", message: "Invalid month. Expected current or future month" });
+  }
+});
+
+const budgetAdjustmentCreateBodySchema = z.object({
+  month: currentOrFutureMonthSchema,
+  direction: directionSchema,
+  category: categorySchema,
+  amount: finiteIntegerSchema("amount"),
+  note: budgetAdjustmentNoteSchema,
+}).strict();
+
+const budgetAdjustmentPatchBodySchema = z.object({
+  amount: finiteIntegerSchema("amount").optional(),
+  note: budgetAdjustmentNoteSchema.optional(),
+  month: currentOrFutureMonthSchema.optional(),
+  category: categorySchema.optional(),
+}).strict().refine(
+  (value): boolean => Object.keys(value).length > 0,
+  { message: "Budget adjustment patch must include at least one editable field" },
+);
+
 const fromMonthSchema = z.unknown().superRefine((value, ctx) => {
   if (typeof value !== "string") {
     ctx.addIssue({ code: "custom", message: "Invalid fromMonth format. Expected YYYY-MM" });
@@ -98,6 +124,24 @@ export const parseBudgetPlanBody = (input: unknown): BudgetPlanBody =>
  */
 export const parseBudgetPlanFillBody = (input: unknown): BudgetPlanFillBody =>
   parseWithSchema(input, budgetPlanFillBodySchema);
+
+/**
+ * Validate the POST /api/budget-adjustments request body.
+ */
+export const parseBudgetAdjustmentCreateBody = (input: unknown): CreateBudgetAdjustmentParams =>
+  parseWithSchema(input, budgetAdjustmentCreateBodySchema);
+
+/**
+ * Validate the PATCH /api/budget-adjustments/[adjustmentId] request body.
+ */
+export const parseBudgetAdjustmentPatchBody = (input: unknown): PatchBudgetAdjustmentParams =>
+  parseWithSchema(input, budgetAdjustmentPatchBodySchema);
+
+/**
+ * Validate a budget adjustment route identifier.
+ */
+export const parseBudgetAdjustmentId = (input: unknown): string =>
+  parseWithSchema(input, adjustmentIdSchema);
 
 /**
  * Validate the GET /api/budget-comment query string.

--- a/apps/web/src/server/api/validation.ts
+++ b/apps/web/src/server/api/validation.ts
@@ -35,6 +35,15 @@ const createNullableStringSchema = (
     }
   }).transform((value): string | null => value as string | null);
 
+const hasCodePointLengthBetween = (
+  value: string,
+  minLength: number,
+  maxLength: number,
+): boolean => {
+  const length = Array.from(value).length;
+  return length >= minLength && length <= maxLength;
+};
+
 /**
  * Accept a calendar month string in YYYY-MM form.
  */
@@ -68,12 +77,12 @@ export const directionSchema: ZodType<"income" | "spend"> = createStringSchema(
 ) as ZodType<"income" | "spend">;
 
 /**
- * Accept a budget line kind: base or modifier.
+ * Accept the only writable budget line kind: base.
  */
-export const budgetPlanKindSchema: ZodType<"base" | "modifier"> = createStringSchema(
-  (value: string): boolean => value === "base" || value === "modifier",
-  "Invalid kind. Expected 'base' or 'modifier'",
-) as ZodType<"base" | "modifier">;
+export const budgetPlanKindSchema: ZodType<"base"> = createStringSchema(
+  (value: string): boolean => value === "base",
+  "Invalid kind. Expected 'base'",
+) as ZodType<"base">;
 
 /**
  * Accept a transaction kind: income, spend, or transfer.
@@ -87,8 +96,16 @@ export const transactionKindSchema: ZodType<"income" | "spend" | "transfer"> = c
  * Accept a non-empty category string up to 200 characters.
  */
 export const categorySchema: ZodType<string> = createStringSchema(
-  (value: string): boolean => value.length > 0 && value.length <= 200,
+  (value: string): boolean => hasCodePointLengthBetween(value, 1, 200),
   "Invalid category. Expected non-empty string (max 200 chars)",
+);
+
+/**
+ * Accept a nullable budget adjustment note up to 2000 Unicode code points.
+ */
+export const budgetAdjustmentNoteSchema: ZodType<string | null> = createNullableStringSchema(
+  (value: string): boolean => hasCodePointLengthBetween(value, 0, 2000),
+  "Invalid note. Expected string (max 2000 chars) or null",
 );
 
 /**
@@ -140,6 +157,14 @@ export const entryIdSchema: ZodType<string> = createStringSchema(
 );
 
 /**
+ * Accept a budget adjustment identifier string up to 200 characters.
+ */
+export const adjustmentIdSchema: ZodType<string> = createStringSchema(
+  (value: string): boolean => value.length > 0 && value.length <= 200,
+  "Invalid adjustmentId. Expected non-empty string (max 200 chars)",
+);
+
+/**
  * Accept an event identifier string up to 200 characters.
  */
 export const eventIdSchema: ZodType<string> = createStringSchema(
@@ -154,6 +179,16 @@ export const finiteNumberSchema = (fieldName: string): ZodType<number> =>
   z.unknown().superRefine((value, ctx) => {
     if (typeof value !== "number" || !Number.isFinite(value)) {
       addCustomIssue(ctx, `Invalid ${fieldName}. Expected finite number`);
+    }
+  }).transform((value): number => value as number);
+
+/**
+ * Accept a JavaScript-safe integer for the named field.
+ */
+export const finiteIntegerSchema = (fieldName: string): ZodType<number> =>
+  z.unknown().superRefine((value, ctx) => {
+    if (typeof value !== "number" || !Number.isFinite(value) || !Number.isSafeInteger(value)) {
+      addCustomIssue(ctx, `Invalid ${fieldName}. Expected a JavaScript-safe integer between ${Number.MIN_SAFE_INTEGER} and ${Number.MAX_SAFE_INTEGER}, inclusive`);
     }
   }).transform((value): number => value as number);
 

--- a/apps/web/src/server/budget/budgetAdjustments.test.ts
+++ b/apps/web/src/server/budget/budgetAdjustments.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getCurrentMonth, offsetMonth } from "@/lib/monthUtils";
+import { BUDGET_ADJUSTMENTS_DETAIL_QUERY, buildPatchBudgetAdjustmentQuery, mapBudgetAdjustmentRow } from "@/server/budget/budgetAdjustments";
+import { getDemoBudgetGrid } from "@/server/demo/data";
+
+test("mapBudgetAdjustmentRow returns the browser contract without workspace or origin", (): void => {
+  const createdAt = new Date("2026-07-20T10:00:00.000Z");
+  const updatedAt = new Date("2026-07-21T11:00:00.000Z");
+  const adjustment = mapBudgetAdjustmentRow({
+    adjustment_id: "adjustment-1",
+    month: "2026-08",
+    direction: "spend",
+    category: "Groceries",
+    amount: -20,
+    note: null,
+    created_at: createdAt,
+    updated_at: updatedAt,
+  }, "test");
+
+  assert.deepEqual(adjustment, {
+    adjustmentId: "adjustment-1",
+    month: "2026-08",
+    direction: "spend",
+    category: "Groceries",
+    amount: -20,
+    note: null,
+    createdAt: createdAt.toISOString(),
+    updatedAt: updatedAt.toISOString(),
+  });
+  assert.equal("workspaceId" in adjustment, false);
+  assert.equal("origin" in adjustment, false);
+});
+
+test("mapBudgetAdjustmentRow accepts JavaScript safe-integer boundaries", (): void => {
+  for (const amount of [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]) {
+    assert.equal(mapBudgetAdjustmentRow({
+      adjustment_id: `adjustment-${amount}`,
+      month: "2026-08",
+      direction: "income",
+      category: "Boundary",
+      amount,
+      note: null,
+      created_at: new Date("2026-07-20T10:00:00.000Z"),
+      updated_at: new Date("2026-07-20T10:00:00.000Z"),
+    }, "boundary test").amount, amount);
+  }
+});
+
+test("mapBudgetAdjustmentRow counts category and note limits in Unicode code points", (): void => {
+  const category = "\u{1F600}".repeat(200);
+  const note = "\u{1F680}".repeat(2000);
+  const validRow = {
+    adjustment_id: "adjustment-unicode-boundary",
+    month: "2026-08",
+    direction: "income",
+    category,
+    amount: 0,
+    note,
+    created_at: new Date("2026-07-20T10:00:00.000Z"),
+    updated_at: new Date("2026-07-20T10:00:00.000Z"),
+  } as const;
+
+  const adjustment = mapBudgetAdjustmentRow(validRow, "Unicode boundary test");
+  assert.equal(adjustment.category, category);
+  assert.equal(adjustment.note, note);
+  assert.throws(
+    () => mapBudgetAdjustmentRow({
+      ...validRow,
+      category: "\u{1F600}".repeat(201),
+    }, "Unicode category overflow test"),
+    /Invalid budget adjustment database row.*category/,
+  );
+  assert.throws(
+    () => mapBudgetAdjustmentRow({
+      ...validRow,
+      note: "\u{1F680}".repeat(2001),
+    }, "Unicode note overflow test"),
+    /Invalid budget adjustment database row.*note/,
+  );
+});
+
+test("mapBudgetAdjustmentRow rejects invalid database values", (): void => {
+  assert.throws(
+    () => mapBudgetAdjustmentRow({
+      adjustment_id: "adjustment-1",
+      month: "2026-08",
+      direction: "spend",
+      category: "Groceries",
+      amount: 1.5,
+      note: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }, "test"),
+    /Invalid budget adjustment database row.*amount/,
+  );
+
+  assert.throws(
+    () => mapBudgetAdjustmentRow({
+      adjustment_id: "adjustment-empty-category",
+      month: "2026-08",
+      direction: "spend",
+      category: "",
+      amount: 1,
+      note: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }, "test"),
+    /Invalid budget adjustment database row.*category/,
+  );
+  assert.throws(
+    () => mapBudgetAdjustmentRow({
+      adjustment_id: "adjustment-unsafe-amount",
+      month: "2026-08",
+      direction: "spend",
+      category: "Groceries",
+      amount: Number.MAX_SAFE_INTEGER + 1,
+      note: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }, "test"),
+    /Invalid budget adjustment database row.*amount/,
+  );
+});
+
+test("patch query changes only supplied editable columns and scopes by workspace and id", (): void => {
+  const query = buildPatchBudgetAdjustmentQuery("workspace-1", "adjustment-1", {
+    amount: 0,
+    note: null,
+    month: "2026-09",
+    category: "Dining",
+  });
+
+  assert.deepEqual(query.params, ["workspace-1", "adjustment-1", 0, null, "2026-09", "Dining"]);
+  assert.match(query.text, /amount = \$3/);
+  assert.match(query.text, /note = \$4/);
+  assert.match(query.text, /budget_month = to_date\(\$5, 'YYYY-MM'\)/);
+  assert.match(query.text, /category = \$6/);
+  assert.match(query.text, /WHERE workspace_id = \$1\s+AND adjustment_id = \$2/);
+  assert.doesNotMatch(query.text, /SET[^]*direction\s*=/);
+  assert.doesNotMatch(query.text, /origin\s*=/);
+});
+
+test("detail query is one deterministic workspace and month-range scan", (): void => {
+  assert.match(BUDGET_ADJUSTMENTS_DETAIL_QUERY, /WHERE workspace_id = \$1/);
+  assert.match(BUDGET_ADJUSTMENTS_DETAIL_QUERY, /budget_month >= to_date\(\$2, 'YYYY-MM'\)/);
+  assert.match(BUDGET_ADJUSTMENTS_DETAIL_QUERY, /budget_month < \(to_date\(\$3, 'YYYY-MM'\) \+ interval '1 month'\)::date/);
+  assert.match(BUDGET_ADJUSTMENTS_DETAIL_QUERY, /ORDER BY budget_month, direction, category, created_at, adjustment_id/);
+});
+
+test("demo adjustment details exactly match cell modifiers and include adjustment-only cells", (): void => {
+  const currentMonth = getCurrentMonth();
+  const nextMonth = offsetMonth(currentMonth, 1);
+  const grid = getDemoBudgetGrid(currentMonth, nextMonth, currentMonth, currentMonth);
+  const sums = new Map<string, number>();
+
+  for (const adjustment of grid.adjustments) {
+    const key = `${adjustment.month}|${adjustment.direction}|${adjustment.category}`;
+    sums.set(key, (sums.get(key) ?? 0) + adjustment.amount);
+  }
+
+  for (const [key, sum] of sums) {
+    const [month, direction, category] = key.split("|");
+    const row = grid.rows.find((candidate) =>
+      candidate.month === month
+      && candidate.direction === direction
+      && candidate.category === category);
+    assert.ok(row, `Missing demo budget row for ${key}`);
+    assert.equal(row.plannedModifier, sum);
+    assert.equal(row.planned, row.plannedBase + sum);
+  }
+
+  const adjustmentOnly = grid.rows.find((row) =>
+    row.month === nextMonth && row.direction === "spend" && row.category === "Travel reserve");
+  assert.ok(adjustmentOnly);
+  assert.equal(adjustmentOnly.plannedBase, 0);
+  assert.equal(adjustmentOnly.plannedModifier, 300);
+  assert.equal(adjustmentOnly.planned, 300);
+});

--- a/apps/web/src/server/budget/budgetAdjustments.ts
+++ b/apps/web/src/server/budget/budgetAdjustments.ts
@@ -1,0 +1,227 @@
+import { z } from "zod";
+
+import { budgetAdjustmentNoteSchema, categorySchema } from "@/server/api/validation";
+import { queryAs } from "@/server/db";
+
+export type BudgetAdjustmentDirection = "income" | "spend";
+
+export type BudgetAdjustment = Readonly<{
+  adjustmentId: string;
+  month: string;
+  direction: BudgetAdjustmentDirection;
+  category: string;
+  amount: number;
+  note: string | null;
+  createdAt: string;
+  updatedAt: string;
+}>;
+
+export type CreateBudgetAdjustmentParams = Readonly<{
+  month: string;
+  direction: BudgetAdjustmentDirection;
+  category: string;
+  amount: number;
+  note: string | null;
+}>;
+
+export type PatchBudgetAdjustmentParams = Readonly<{
+  amount?: number;
+  note?: string | null;
+  month?: string;
+  category?: string;
+}>;
+
+type BudgetAdjustmentQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<unknown>;
+}>;
+
+const budgetAdjustmentDbRowSchema = z.object({
+  adjustment_id: z.string().min(1).max(200),
+  month: z.string().regex(/^\d{4}-(?:0[1-9]|1[0-2])$/),
+  direction: z.enum(["income", "spend"]),
+  category: categorySchema,
+  amount: z.number().finite().int(),
+  note: budgetAdjustmentNoteSchema,
+  created_at: z.date(),
+  updated_at: z.date(),
+}).strict();
+
+const RETURNING_BUDGET_ADJUSTMENT = `
+  adjustment_id,
+  to_char(budget_month, 'YYYY-MM') AS month,
+  direction,
+  category,
+  amount::double precision AS amount,
+  note,
+  created_at,
+  updated_at
+`;
+
+export const CREATE_BUDGET_ADJUSTMENT_QUERY = `
+  INSERT INTO budget_adjustments (
+    workspace_id,
+    budget_month,
+    direction,
+    category,
+    amount,
+    note
+  )
+  VALUES ($1, to_date($2, 'YYYY-MM'), $3, $4, $5, $6)
+  RETURNING ${RETURNING_BUDGET_ADJUSTMENT}
+`;
+
+export const DELETE_BUDGET_ADJUSTMENT_QUERY = `
+  DELETE FROM budget_adjustments
+  WHERE workspace_id = $1
+    AND adjustment_id = $2
+  RETURNING ${RETURNING_BUDGET_ADJUSTMENT}
+`;
+
+export const BUDGET_ADJUSTMENTS_DETAIL_QUERY = `
+  SELECT
+    ${RETURNING_BUDGET_ADJUSTMENT}
+  FROM budget_adjustments
+  WHERE workspace_id = $1
+    AND budget_month >= to_date($2, 'YYYY-MM')
+    AND budget_month < (to_date($3, 'YYYY-MM') + interval '1 month')::date
+  ORDER BY budget_month, direction, category, created_at, adjustment_id
+`;
+
+export class BudgetAdjustmentNotFoundError extends Error {
+  public constructor(adjustmentId: string) {
+    super(`Budget adjustment "${adjustmentId}" was not found`);
+    this.name = "BudgetAdjustmentNotFoundError";
+  }
+}
+
+export const mapBudgetAdjustmentRow = (row: unknown, context: string): BudgetAdjustment => {
+  const result = budgetAdjustmentDbRowSchema.safeParse(row);
+  if (!result.success) {
+    const details = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "row"}: ${issue.message}`)
+      .join("; ");
+    throw new Error(`Invalid budget adjustment database row from ${context}: ${details}`);
+  }
+
+  return {
+    adjustmentId: result.data.adjustment_id,
+    month: result.data.month,
+    direction: result.data.direction,
+    category: result.data.category,
+    amount: result.data.amount,
+    note: result.data.note,
+    createdAt: result.data.created_at.toISOString(),
+    updatedAt: result.data.updated_at.toISOString(),
+  };
+};
+
+export const mapBudgetAdjustmentRows = (
+  rows: ReadonlyArray<unknown>,
+  context: string,
+): ReadonlyArray<BudgetAdjustment> =>
+  rows.map((row, rowIndex): BudgetAdjustment =>
+    mapBudgetAdjustmentRow(row, `${context} row ${rowIndex}`));
+
+export const buildPatchBudgetAdjustmentQuery = (
+  workspaceId: string,
+  adjustmentId: string,
+  params: PatchBudgetAdjustmentParams,
+): BudgetAdjustmentQuery => {
+  const setClauses: Array<string> = [];
+  const queryParams: Array<unknown> = [workspaceId, adjustmentId];
+
+  if (params.amount !== undefined) {
+    queryParams.push(params.amount);
+    setClauses.push(`amount = $${queryParams.length}`);
+  }
+  if (params.note !== undefined) {
+    queryParams.push(params.note);
+    setClauses.push(`note = $${queryParams.length}`);
+  }
+  if (params.month !== undefined) {
+    queryParams.push(params.month);
+    setClauses.push(`budget_month = to_date($${queryParams.length}, 'YYYY-MM')`);
+  }
+  if (params.category !== undefined) {
+    queryParams.push(params.category);
+    setClauses.push(`category = $${queryParams.length}`);
+  }
+
+  if (setClauses.length === 0) {
+    throw new Error("Cannot patch budget adjustment without at least one editable field");
+  }
+
+  return {
+    text: `
+      UPDATE budget_adjustments
+      SET ${setClauses.join(", ")}
+      WHERE workspace_id = $1
+        AND adjustment_id = $2
+      RETURNING ${RETURNING_BUDGET_ADJUSTMENT}
+    `,
+    params: queryParams,
+  };
+};
+
+const mapCreatedAdjustment = (rows: ReadonlyArray<unknown>): BudgetAdjustment => {
+  if (rows.length !== 1) {
+    throw new Error(`Failed to create budget adjustment: expected one returned row, received ${rows.length}`);
+  }
+  return mapBudgetAdjustmentRow(rows[0], "create budget adjustment");
+};
+
+const mapExistingAdjustment = (
+  rows: ReadonlyArray<unknown>,
+  adjustmentId: string,
+  operation: string,
+): BudgetAdjustment => {
+  if (rows.length === 0) {
+    throw new BudgetAdjustmentNotFoundError(adjustmentId);
+  }
+  if (rows.length !== 1) {
+    throw new Error(`Failed to ${operation} budget adjustment "${adjustmentId}": expected one returned row, received ${rows.length}`);
+  }
+  return mapBudgetAdjustmentRow(rows[0], `${operation} budget adjustment`);
+};
+
+export const createBudgetAdjustment = async (
+  userId: string,
+  workspaceId: string,
+  params: CreateBudgetAdjustmentParams,
+): Promise<BudgetAdjustment> => {
+  const result = await queryAs(
+    userId,
+    workspaceId,
+    CREATE_BUDGET_ADJUSTMENT_QUERY,
+    [workspaceId, params.month, params.direction, params.category, params.amount, params.note],
+  );
+
+  return mapCreatedAdjustment(result.rows);
+};
+
+export const patchBudgetAdjustment = async (
+  userId: string,
+  workspaceId: string,
+  adjustmentId: string,
+  params: PatchBudgetAdjustmentParams,
+): Promise<BudgetAdjustment> => {
+  const patchQuery = buildPatchBudgetAdjustmentQuery(workspaceId, adjustmentId, params);
+  const result = await queryAs(userId, workspaceId, patchQuery.text, patchQuery.params);
+  return mapExistingAdjustment(result.rows, adjustmentId, "patch");
+};
+
+export const deleteBudgetAdjustment = async (
+  userId: string,
+  workspaceId: string,
+  adjustmentId: string,
+): Promise<BudgetAdjustment> => {
+  const result = await queryAs(
+    userId,
+    workspaceId,
+    DELETE_BUDGET_ADJUSTMENT_QUERY,
+    [workspaceId, adjustmentId],
+  );
+
+  return mapExistingAdjustment(result.rows, adjustmentId, "delete");
+};

--- a/apps/web/src/server/budget/getBudgetGrid.ts
+++ b/apps/web/src/server/budget/getBudgetGrid.ts
@@ -1,18 +1,20 @@
 /**
  * Budget grid assembly for the budget dashboard.
  *
- * Runs six queries in true parallel (separate DB connections via queryAs):
- * 1. QUERY — planned (base + modifier) vs actual per month/direction/category,
- *    with FX conversion via exact-date joins on fx_rates_daily. Plan uses
- *    last-write-wins on inserted_at.
- * 2. CUMULATIVE_BALANCE — actual income/spend/transfer totals before the loaded
+ * Runs seven queries in true parallel (separate DB connections via queryAs):
+ * 1. QUERY — planned Base plus grouped normalized adjustments vs actual per
+ *    month/direction/category, with FX conversion via exact-date joins on
+ *    fx_rates_daily. Base uses last-write-wins on inserted_at.
+ * 2. BUDGET_ADJUSTMENTS_DETAIL_QUERY — normalized adjustment rows for the
+ *    loaded month range.
+ * 3. CUMULATIVE_BALANCE — actual income/spend/transfer totals before the loaded
  *    range, used as the Balance row starting point.
- * 3. WARNINGS — currencies missing exchange rates.
- * 4. MONTH_END_BALANCES — mark-to-market portfolio balance at each month-end,
+ * 4. WARNINGS — currencies missing exchange rates.
+ * 5. MONTH_END_BALANCES — mark-to-market portfolio balance at each month-end,
  *    used to anchor the Balance row and derive FX adjustments.
- * 5. BUSINESS_PERSONAL_TRANSFER — net transfer amount on the personal side of
+ * 6. BUSINESS_PERSONAL_TRANSFER — net transfer amount on the personal side of
  *    events crossing explicitly business and personal accounts.
- * 6. HAS_BUSINESS_ACCOUNT — whether the workspace has any explicit business
+ * 7. HAS_BUSINESS_ACCOUNT — whether the workspace has any explicit business
  *    account classification, used to show or hide the derived row.
  *
  * Performance notes:
@@ -26,6 +28,7 @@
  *   connection, serializing all queries despite Promise.all.
  */
 import { queryAs } from "@/server/db";
+import { BUDGET_ADJUSTMENTS_DETAIL_QUERY, mapBudgetAdjustmentRows, type BudgetAdjustment } from "@/server/budget/budgetAdjustments";
 import { getLatestFxCalendarDate } from "@/server/fxRates";
 import { getReportCurrency } from "@/server/reportCurrency";
 
@@ -65,6 +68,7 @@ export type BusinessPersonalTransferCell = Readonly<{
 
 export type BudgetGridResult = Readonly<{
   rows: ReadonlyArray<BudgetRow>;
+  adjustments: ReadonlyArray<BudgetAdjustment>;
   conversionWarnings: ReadonlyArray<ConversionWarning>;
   cumulativeBefore: CumulativeBefore;
   /**
@@ -91,27 +95,49 @@ export type BudgetGridResult = Readonly<{
 }>;
 
 export const QUERY = `
-  WITH latest_plans AS (
+  WITH latest_base_plans AS (
     SELECT
-      budget_month, direction, category, kind, planned_value,
+      budget_month, direction, category, planned_value,
       ROW_NUMBER() OVER (
-        PARTITION BY budget_month, direction, category, kind
+        PARTITION BY budget_month, direction, category
         ORDER BY inserted_at DESC
       ) AS rn
     FROM budget_lines
-    WHERE budget_month >= GREATEST(to_date($4, 'YYYY-MM'), to_date($2, 'YYYY-MM'))
+    WHERE kind = 'base'
+      AND budget_month >= GREATEST(to_date($4, 'YYYY-MM'), to_date($2, 'YYYY-MM'))
       AND budget_month < to_date($3, 'YYYY-MM') + interval '1 month'
   ),
-  planned AS (
+  planned_base AS (
     SELECT
       to_char(budget_month, 'YYYY-MM') AS month,
       direction,
       category,
-      COALESCE(MAX(CASE WHEN kind = 'base' THEN planned_value::double precision END), 0) AS planned_base,
-      COALESCE(MAX(CASE WHEN kind = 'modifier' THEN planned_value::double precision END), 0) AS planned_modifier
-    FROM latest_plans
+      planned_value::double precision AS planned_base
+    FROM latest_base_plans
     WHERE rn = 1
+  ),
+  adjustments AS (
+    SELECT
+      to_char(budget_month, 'YYYY-MM') AS month,
+      direction,
+      category,
+      SUM(amount)::double precision AS planned_modifier
+    FROM budget_adjustments
+    WHERE workspace_id = current_setting('app.workspace_id', true)
+      AND budget_month >= GREATEST(to_date($4, 'YYYY-MM'), to_date($2, 'YYYY-MM'))
+      AND budget_month < (to_date($3, 'YYYY-MM') + interval '1 month')::date
     GROUP BY 1, 2, 3
+  ),
+  planned AS (
+    SELECT
+      COALESCE(base.month, adjustment.month) AS month,
+      COALESCE(base.direction, adjustment.direction) AS direction,
+      COALESCE(base.category, adjustment.category) AS category,
+      COALESCE(base.planned_base, 0) AS planned_base,
+      COALESCE(adjustment.planned_modifier, 0) AS planned_modifier
+    FROM planned_base base
+    FULL OUTER JOIN adjustments adjustment
+      USING (month, direction, category)
   ),
   actual AS (
     SELECT
@@ -214,7 +240,7 @@ const WARNINGS_QUERY = `
     FROM fx_rates_daily
   ),
   data_currencies AS (
-    SELECT DISTINCT currency FROM budget_lines
+    SELECT DISTINCT currency FROM budget_lines WHERE kind = 'base'
     UNION
     SELECT DISTINCT currency FROM ledger_entries
   ),
@@ -370,12 +396,13 @@ export const getBudgetGrid = async (userId: string, workspaceId: string, monthFr
   ]);
 
   // Each queryAs acquires its own connection from the pool and sets RLS context
-  // independently, so Promise.all runs all 4 queries on separate connections
+  // independently, so Promise.all runs all 7 queries on separate connections
   // in true DB-level parallel. The old withUserContext shared one connection,
   // which serialized all queries despite Promise.all (a single pg.Client can
   // only execute one query at a time).
   const [
     rowsResult,
+    adjustmentsResult,
     warningResult,
     cumulativeResult,
     balanceResult,
@@ -383,6 +410,7 @@ export const getBudgetGrid = async (userId: string, workspaceId: string, monthFr
     hasBusinessAccountResult,
   ] = await Promise.all([
     queryAs(userId, workspaceId, QUERY, [reportCurrency, monthFrom, monthTo, planFrom, actualTo]),
+    queryAs(userId, workspaceId, BUDGET_ADJUSTMENTS_DETAIL_QUERY, [workspaceId, monthFrom, monthTo]),
     queryAs(userId, workspaceId, WARNINGS_QUERY, [reportCurrency]),
     queryAs(userId, workspaceId, CUMULATIVE_BALANCE_QUERY, [reportCurrency, monthFrom]),
     queryAs(userId, workspaceId, MONTH_END_BALANCES_QUERY, [reportCurrency, monthFrom, actualTo, latestFxCalendarDate]),
@@ -427,6 +455,7 @@ export const getBudgetGrid = async (userId: string, workspaceId: string, monthFr
       actual: Number(row.actual),
       hasUnconvertible: row.has_unconvertible,
     })),
+    adjustments: mapBudgetAdjustmentRows(adjustmentsResult.rows, "budget grid adjustment details"),
     conversionWarnings: warningResult.rows.map((row: { currency: string }) => ({
       currency: row.currency,
       reason: `No exchange rates available for ${row.currency}`,

--- a/apps/web/src/server/budget/insertBudgetPlan.ts
+++ b/apps/web/src/server/budget/insertBudgetPlan.ts
@@ -8,7 +8,7 @@
 import { queryAs } from "@/server/db";
 import { getReportCurrency } from "@/server/reportCurrency";
 
-type BudgetLineKind = "base" | "modifier";
+type BudgetLineKind = "base";
 
 type InsertBudgetPlanParams = Readonly<{
   month: string;

--- a/apps/web/src/server/demo/budgetAdjustments.ts
+++ b/apps/web/src/server/demo/budgetAdjustments.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+
+import { getCurrentMonth } from "@/lib/monthUtils";
+import { BudgetAdjustmentNotFoundError, type BudgetAdjustment, type CreateBudgetAdjustmentParams, type PatchBudgetAdjustmentParams } from "@/server/budget/budgetAdjustments";
+import { getDemoBudgetAdjustments } from "@/server/demo/data";
+
+const DEMO_CREATED_ID_PATTERN = /^demo-created-(income|spend)-[0-9a-f-]{36}$/;
+
+const getCreatedDemoDirection = (adjustmentId: string): "income" | "spend" | null => {
+  const match = DEMO_CREATED_ID_PATTERN.exec(adjustmentId);
+  if (match === null) {
+    return null;
+  }
+  return match[1] as "income" | "spend";
+};
+
+export const createDemoBudgetAdjustment = (
+  params: CreateBudgetAdjustmentParams,
+): BudgetAdjustment => {
+  const timestamp = new Date().toISOString();
+  return {
+    adjustmentId: `demo-created-${params.direction}-${randomUUID()}`,
+    month: params.month,
+    direction: params.direction,
+    category: params.category,
+    amount: params.amount,
+    note: params.note,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+};
+
+export const patchDemoBudgetAdjustment = (
+  adjustmentId: string,
+  params: PatchBudgetAdjustmentParams,
+): BudgetAdjustment => {
+  const existing = getDemoBudgetAdjustments().find((adjustment) =>
+    adjustment.adjustmentId === adjustmentId);
+  const createdDirection = getCreatedDemoDirection(adjustmentId);
+  if (existing === undefined && createdDirection === null) {
+    throw new BudgetAdjustmentNotFoundError(adjustmentId);
+  }
+
+  const timestamp = new Date().toISOString();
+  return {
+    adjustmentId,
+    month: params.month ?? existing?.month ?? getCurrentMonth(),
+    direction: existing?.direction ?? createdDirection as "income" | "spend",
+    category: params.category ?? existing?.category ?? "Demo adjustment",
+    amount: params.amount ?? existing?.amount ?? 0,
+    note: params.note !== undefined ? params.note : existing?.note ?? null,
+    createdAt: existing?.createdAt ?? timestamp,
+    updatedAt: timestamp,
+  };
+};
+
+export const deleteDemoBudgetAdjustment = (adjustmentId: string): void => {
+  const exists = getDemoBudgetAdjustments().some((adjustment) =>
+    adjustment.adjustmentId === adjustmentId);
+  if (!exists && getCreatedDemoDirection(adjustmentId) === null) {
+    throw new BudgetAdjustmentNotFoundError(adjustmentId);
+  }
+};

--- a/apps/web/src/server/demo/data.ts
+++ b/apps/web/src/server/demo/data.ts
@@ -13,6 +13,7 @@ import {
 
 import type { AccountSuggestion } from "@/server/accounts/getAccountSuggestions";
 import type { AccountRow, BalancesSummaryResult, CurrencyTotal } from "@/server/balances/getBalancesSummary";
+import type { BudgetAdjustment } from "@/server/budget/budgetAdjustments";
 import type { BudgetGridResult, BudgetRow } from "@/server/budget/getBudgetGrid";
 import type { CommentedCell } from "@/server/budget/getCommentedCells";
 import type { FxBreakdownResult, FxBreakdownRow } from "@/server/budget/getFxBreakdown";
@@ -107,6 +108,44 @@ const BUDGET_PLAN: ReadonlyArray<Readonly<{ direction: string; category: string;
   { direction: "spend",  category: "Adjustment",       planned: 0 },
 ];
 
+const DEMO_ADJUSTMENT_TEMPLATES: ReadonlyArray<Readonly<{
+  adjustmentId: string;
+  monthOffset: number;
+  direction: "income" | "spend";
+  category: string;
+  amount: number;
+  note: string | null;
+  createdDay: number;
+}>> = [
+  {
+    adjustmentId: "demo-adjustment-groceries-seasonal",
+    monthOffset: 0,
+    direction: "spend",
+    category: "Groceries",
+    amount: 75,
+    note: "Seasonal groceries",
+    createdDay: 2,
+  },
+  {
+    adjustmentId: "demo-adjustment-groceries-discount",
+    monthOffset: 0,
+    direction: "spend",
+    category: "Groceries",
+    amount: -25,
+    note: null,
+    createdDay: 3,
+  },
+  {
+    adjustmentId: "demo-adjustment-travel-reserve",
+    monthOffset: 1,
+    direction: "spend",
+    category: "Travel reserve",
+    amount: 300,
+    note: "Weekend trip",
+    createdDay: 4,
+  },
+];
+
 const ACCOUNT_CURRENCIES: Readonly<Record<string, string>> = {
   "checking-usd": "USD", "checking-eur": "EUR", "checking-gbp": "GBP", "savings-usd": "USD",
 };
@@ -132,6 +171,31 @@ const vary = (month: string, idx: number, range: number): number =>
 
 const round2 = (n: number): number => Math.round(n * 100) / 100;
 
+export const getDemoBudgetAdjustments = (): ReadonlyArray<BudgetAdjustment> => {
+  const currentMonth = getCurrentMonth();
+  return DEMO_ADJUSTMENT_TEMPLATES
+    .map((template): BudgetAdjustment => {
+      const month = offsetMonth(currentMonth, template.monthOffset);
+      const timestamp = `${month}-${String(template.createdDay).padStart(2, "0")}T09:00:00.000Z`;
+      return {
+        adjustmentId: template.adjustmentId,
+        month,
+        direction: template.direction,
+        category: template.category,
+        amount: template.amount,
+        note: template.note,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+    })
+    .sort((left, right): number =>
+      left.month.localeCompare(right.month)
+      || left.direction.localeCompare(right.direction)
+      || left.category.localeCompare(right.category)
+      || left.createdAt.localeCompare(right.createdAt)
+      || left.adjustmentId.localeCompare(right.adjustmentId));
+};
+
 const noteFor = (category: string, monthAbbr: string): string | null => {
   if (category === "Salary") return `${monthAbbr} salary`;
   if (category === "Rent") return `${monthAbbr} rent`;
@@ -153,6 +217,7 @@ type DemoData = Readonly<{
   accounts: ReadonlyArray<AccountRow>;
   totals: ReadonlyArray<CurrencyTotal>;
   budgetRows: ReadonlyArray<BudgetRow>;
+  budgetAdjustments: ReadonlyArray<BudgetAdjustment>;
   monthEndBalances: Readonly<Record<string, number>>;
   monthEndBalancesByLiquidity: Readonly<Record<string, Readonly<Record<string, number>>>>;
   businessPersonalTransfers: Readonly<Record<string, Readonly<{ actual: number; hasUnconvertible: boolean }>>>;
@@ -283,6 +348,12 @@ const generate = (): DemoData => {
 
   // Budget rows (past months with actuals + future months plan-only)
   const allBudgetMonths = [...pastMonths, ...Array.from({ length: FUTURE_MONTHS }, (_, i) => offsetMonth(now, i + 1))];
+  const budgetAdjustments = getDemoBudgetAdjustments();
+  const adjustmentTotals = new Map<string, number>();
+  for (const adjustment of budgetAdjustments) {
+    const key = `${adjustment.month}|${adjustment.direction}|${adjustment.category}`;
+    adjustmentTotals.set(key, (adjustmentTotals.get(key) ?? 0) + adjustment.amount);
+  }
   const budgetRows: Array<BudgetRow> = [];
   for (const month of allBudgetMonths) {
     const isPast = month <= now;
@@ -290,11 +361,29 @@ const generate = (): DemoData => {
       const key = `${month}|${bp.direction}|${bp.category}`;
       const raw = actuals.get(key) ?? 0;
       const actual = bp.direction === "spend" ? -raw : raw;
-      if (bp.planned === 0 && actual === 0) continue;
+      const plannedModifier = adjustmentTotals.get(key) ?? 0;
+      if (bp.planned === 0 && plannedModifier === 0 && actual === 0) continue;
       budgetRows.push({
         month, direction: bp.direction, category: bp.category,
-        plannedBase: bp.planned, plannedModifier: 0, planned: bp.planned,
+        plannedBase: bp.planned, plannedModifier, planned: bp.planned + plannedModifier,
         actual: isPast ? round2(actual) : 0, hasUnconvertible: false,
+      });
+    }
+    for (const [key, plannedModifier] of adjustmentTotals) {
+      const [adjustmentMonth, direction, category] = key.split("|");
+      if (adjustmentMonth !== month || budgetRows.some((row) =>
+        row.month === month && row.direction === direction && row.category === category)) {
+        continue;
+      }
+      budgetRows.push({
+        month,
+        direction,
+        category,
+        plannedBase: 0,
+        plannedModifier,
+        planned: plannedModifier,
+        actual: 0,
+        hasUnconvertible: false,
       });
     }
     budgetRows.push({
@@ -311,6 +400,7 @@ const generate = (): DemoData => {
     accounts,
     totals,
     budgetRows,
+    budgetAdjustments,
     monthEndBalances: monthEndBal,
     monthEndBalancesByLiquidity: monthEndBalByLiq,
     businessPersonalTransfers,
@@ -552,10 +642,11 @@ export const getDemoBudgetGrid = (
   _planFrom: string,
   _actualTo: string,
 ): BudgetGridResult => {
-  const { budgetRows, monthEndBalances, monthEndBalancesByLiquidity, businessPersonalTransfers, hasBusinessAccount } = generate();
+  const { budgetRows, budgetAdjustments, monthEndBalances, monthEndBalancesByLiquidity, businessPersonalTransfers, hasBusinessAccount } = generate();
   const months = new Set(generateMonthRange(monthFrom, monthTo));
   return {
     rows: budgetRows.filter((r) => months.has(r.month)),
+    adjustments: budgetAdjustments.filter((adjustment) => months.has(adjustment.month)),
     conversionWarnings: [],
     cumulativeBefore: { incomeActual: 0, spendActual: 0, transferActual: 0 },
     monthEndBalances,

--- a/db/migrations/0055_budget_adjustments_browser_contract.sql
+++ b/db/migrations/0055_budget_adjustments_browser_contract.sql
@@ -1,0 +1,93 @@
+-- Align persisted budget adjustments with the browser contract without
+-- rewriting any existing row. Fail with the first actionable mismatch before
+-- replacing the validated constraints.
+
+SET LOCAL lock_timeout = '30s';
+
+LOCK TABLE public.budget_adjustments IN ACCESS EXCLUSIVE MODE;
+
+-- Forced RLS also applies to a NOSUPERUSER/NOBYPASSRLS table owner. Install a
+-- transaction-scoped policy so the preflight inspects every workspace.
+DO $$
+BEGIN
+  EXECUTE pg_catalog.format(
+    'CREATE POLICY budget_adjustments_0055_migration_read
+       ON public.budget_adjustments
+       FOR SELECT
+       TO %I
+       USING (true)',
+    current_user
+  );
+END;
+$$;
+
+DO $$
+DECLARE
+  v_invalid RECORD;
+BEGIN
+  SELECT
+    adjustment.adjustment_id,
+    adjustment.workspace_id,
+    adjustment.category
+    INTO v_invalid
+    FROM public.budget_adjustments AS adjustment
+    WHERE char_length(adjustment.category) NOT BETWEEN 1 AND 200
+    ORDER BY adjustment.workspace_id, adjustment.adjustment_id
+    LIMIT 1;
+
+  IF FOUND THEN
+    RAISE EXCEPTION
+      'budget_adjustments browser contract precondition failed: adjustment % in workspace % has category length %; set a non-empty category of at most 200 characters before retrying migration 0055',
+      v_invalid.adjustment_id,
+      v_invalid.workspace_id,
+      char_length(v_invalid.category);
+  END IF;
+
+  SELECT
+    adjustment.adjustment_id,
+    adjustment.workspace_id,
+    adjustment.amount
+    INTO v_invalid
+    FROM public.budget_adjustments AS adjustment
+    WHERE adjustment.amount NOT BETWEEN
+      (-9007199254740991)::NUMERIC
+      AND 9007199254740991::NUMERIC
+    ORDER BY adjustment.workspace_id, adjustment.adjustment_id
+    LIMIT 1;
+
+  IF FOUND THEN
+    RAISE EXCEPTION
+      'budget_adjustments browser contract precondition failed: adjustment % in workspace % has amount %, outside the JavaScript safe-integer range [-9007199254740991, 9007199254740991]; correct the amount before retrying migration 0055',
+      v_invalid.adjustment_id,
+      v_invalid.workspace_id,
+      v_invalid.amount;
+  END IF;
+END;
+$$;
+
+DROP POLICY budget_adjustments_0055_migration_read
+  ON public.budget_adjustments;
+
+ALTER TABLE public.budget_adjustments
+  DROP CONSTRAINT budget_adjustments_category_check;
+ALTER TABLE public.budget_adjustments
+  ADD CONSTRAINT budget_adjustments_category_check
+  CHECK (char_length(category) BETWEEN 1 AND 200);
+
+ALTER TABLE public.budget_adjustments
+  DROP CONSTRAINT budget_adjustments_amount_check;
+ALTER TABLE public.budget_adjustments
+  ADD CONSTRAINT budget_adjustments_amount_check
+  CHECK (
+    amount NOT IN (
+      'NaN'::NUMERIC,
+      'Infinity'::NUMERIC,
+      '-Infinity'::NUMERIC
+    )
+    AND amount = pg_catalog.trunc(amount)
+    AND amount BETWEEN
+      (-9007199254740991)::NUMERIC
+      AND 9007199254740991::NUMERIC
+  );
+
+SET LOCAL lock_timeout = '0';

--- a/db/tests/0055_budget_adjustments_browser_contract.sql
+++ b/db/tests/0055_budget_adjustments_browser_contract.sql
@@ -1,0 +1,118 @@
+BEGIN;
+
+DO $$
+DECLARE
+  v_rejected BOOLEAN;
+BEGIN
+  INSERT INTO public.budget_adjustments (
+    workspace_id,
+    budget_month,
+    direction,
+    category,
+    amount,
+    note
+  ) VALUES
+    ('local', date_trunc('month', CURRENT_DATE)::DATE, 'income', 'A', -9007199254740991, NULL),
+    ('local', date_trunc('month', CURRENT_DATE)::DATE, 'spend', repeat('C', 200), 9007199254740991, 'Boundary'),
+    (
+      'local',
+      date_trunc('month', CURRENT_DATE)::DATE,
+      'income',
+      repeat(chr(128512), 200),
+      0,
+      repeat(chr(128640), 2000)
+    );
+
+  v_rejected := FALSE;
+  BEGIN
+    INSERT INTO public.budget_adjustments (
+      workspace_id, budget_month, direction, category, amount, note
+    ) VALUES (
+      'local', date_trunc('month', CURRENT_DATE)::DATE, 'income', '', 0, NULL
+    );
+  EXCEPTION
+    WHEN check_violation THEN
+      v_rejected := TRUE;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION
+      'budget_adjustments schema test failed: empty category was accepted';
+  END IF;
+
+  v_rejected := FALSE;
+  BEGIN
+    INSERT INTO public.budget_adjustments (
+      workspace_id, budget_month, direction, category, amount, note
+    ) VALUES (
+      'local',
+      date_trunc('month', CURRENT_DATE)::DATE,
+      'income',
+      repeat(chr(128512), 201),
+      0,
+      NULL
+    );
+  EXCEPTION
+    WHEN check_violation THEN
+      v_rejected := TRUE;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION
+      'budget_adjustments schema test failed: category above 200 Unicode code points was accepted';
+  END IF;
+
+  v_rejected := FALSE;
+  BEGIN
+    INSERT INTO public.budget_adjustments (
+      workspace_id, budget_month, direction, category, amount, note
+    ) VALUES (
+      'local',
+      date_trunc('month', CURRENT_DATE)::DATE,
+      'income',
+      'Unicode note overflow',
+      0,
+      repeat(chr(128640), 2001)
+    );
+  EXCEPTION
+    WHEN check_violation THEN
+      v_rejected := TRUE;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION
+      'budget_adjustments schema test failed: note above 2000 Unicode code points was accepted';
+  END IF;
+
+  v_rejected := FALSE;
+  BEGIN
+    INSERT INTO public.budget_adjustments (
+      workspace_id, budget_month, direction, category, amount, note
+    ) VALUES (
+      'local', date_trunc('month', CURRENT_DATE)::DATE, 'income', 'Too positive', 9007199254740992, NULL
+    );
+  EXCEPTION
+    WHEN check_violation THEN
+      v_rejected := TRUE;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION
+      'budget_adjustments schema test failed: amount above Number.MAX_SAFE_INTEGER was accepted';
+  END IF;
+
+  v_rejected := FALSE;
+  BEGIN
+    INSERT INTO public.budget_adjustments (
+      workspace_id, budget_month, direction, category, amount, note
+    ) VALUES (
+      'local', date_trunc('month', CURRENT_DATE)::DATE, 'spend', 'Too negative', -9007199254740992, NULL
+    );
+  EXCEPTION
+    WHEN check_violation THEN
+      v_rejected := TRUE;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION
+      'budget_adjustments schema test failed: amount below Number.MIN_SAFE_INTEGER was accepted';
+  END IF;
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- read budget adjustments exclusively from the normalized workspace-scoped table
- add strict create, patch, and hard-delete routes with canonical browser responses
- keep budget plans and Fill Months Base-only while preserving grid and demo semantics
- enforce JavaScript-safe amounts and Unicode code-point string limits in migration 0055

## Validation
- 17 focused backend, route, runtime, and Unicode contract tests
- fresh migrations 0001-0055 plus forced-RLS preflight failure/retry and schema checks
- real two-workspace CRUD/RLS/grid and live HTTP contract checks
- 50,000-row EXPLAIN using the existing bounded range index
- web lint and production build
- tracked and untracked diff checks
