### PR TITLE
Add budget adjustment browser API

### DIFF
--- a/apps/web/src/ui/tables/budget/budgetTableApi.test.ts
+++ b/apps/web/src/ui/tables/budget/budgetTableApi.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BudgetAdjustment } from "@/server/budget/budgetAdjustments";
+import {
+  readBudgetAdjustmentDeleteResponse,
+  readBudgetAdjustmentResponse,
+} from "@/ui/tables/budget/budgetTableApi";
+
+const createAdjustment = (
+  adjustmentId: string,
+  category: string,
+  amount: number,
+  note: string | null,
+): BudgetAdjustment => ({
+  adjustmentId,
+  month: "2026-07",
+  direction: "spend",
+  category,
+  amount,
+  note,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-02T00:00:00.000Z",
+});
+
+const assertInvalidAdjustmentResponse = async (payload: unknown): Promise<void> => {
+  await assert.rejects(
+    readBudgetAdjustmentResponse(Response.json(payload), "Invalid adjustment response"),
+    /returned an invalid response/,
+  );
+};
+
+test("budget adjustment responses accept contract boundaries measured by code point", async (): Promise<void> => {
+  const boundaryAdjustment = createAdjustment(
+    "\u{1F4B0}".repeat(200),
+    "\u{1F600}".repeat(200),
+    Number.MAX_SAFE_INTEGER,
+    "\u{1F680}".repeat(2000),
+  );
+
+  assert.deepEqual(
+    await readBudgetAdjustmentResponse(Response.json(boundaryAdjustment), "Boundary response"),
+    boundaryAdjustment,
+  );
+  assert.equal(
+    (await readBudgetAdjustmentResponse(
+      Response.json({ ...boundaryAdjustment, amount: Number.MIN_SAFE_INTEGER, note: null }),
+      "Minimum amount response",
+    )).amount,
+    Number.MIN_SAFE_INTEGER,
+  );
+});
+
+test("budget adjustment responses enforce strict fields, string bounds, safe integers, and ISO dates", async (): Promise<void> => {
+  const adjustment = createAdjustment("adjustment-1", "Groceries", 0, null);
+
+  await assertInvalidAdjustmentResponse({ ...adjustment, adjustmentId: "" });
+  await assertInvalidAdjustmentResponse({ ...adjustment, adjustmentId: "\u{1F4B0}".repeat(201) });
+  await assertInvalidAdjustmentResponse({ ...adjustment, category: "" });
+  await assertInvalidAdjustmentResponse({ ...adjustment, category: "\u{1F600}".repeat(201) });
+  await assertInvalidAdjustmentResponse({ ...adjustment, note: "\u{1F680}".repeat(2001) });
+  await assertInvalidAdjustmentResponse({ ...adjustment, amount: 0.5 });
+  await assertInvalidAdjustmentResponse({ ...adjustment, amount: Number.MAX_SAFE_INTEGER + 1 });
+  await assertInvalidAdjustmentResponse({ ...adjustment, createdAt: "2026-07-01" });
+  await assertInvalidAdjustmentResponse({ ...adjustment, updatedAt: "not-a-date" });
+  await assertInvalidAdjustmentResponse({ ...adjustment, unexpected: true });
+});
+
+test("budget adjustment responses reject errors and malformed JSON with response context", async (): Promise<void> => {
+  await assert.rejects(
+    readBudgetAdjustmentResponse(
+      new Response("upstream unavailable", { status: 503 }),
+      "Budget adjustment create",
+    ),
+    /Budget adjustment create failed: 503 upstream unavailable/,
+  );
+  await assert.rejects(
+    readBudgetAdjustmentResponse(
+      new Response("not-json", { status: 200 }),
+      "Budget adjustment create",
+    ),
+    /Budget adjustment create returned invalid JSON:.*Response body: not-json/,
+  );
+});
+
+test("budget adjustment delete responses distinguish deleted and already absent outcomes", async (): Promise<void> => {
+  assert.equal(
+    await readBudgetAdjustmentDeleteResponse(Response.json({ ok: true }), "deleted"),
+    "deleted",
+  );
+  assert.equal(
+    await readBudgetAdjustmentDeleteResponse(
+      new Response("{\"error\":\"missing\"}", { status: 404 }),
+      "lost-response",
+    ),
+    "already-absent",
+  );
+});
+
+test("successful budget adjustment delete responses are strictly validated", async (): Promise<void> => {
+  await assert.rejects(
+    readBudgetAdjustmentDeleteResponse(Response.json({ ok: false }), "adjustment-1"),
+    /returned an invalid response/,
+  );
+  await assert.rejects(
+    readBudgetAdjustmentDeleteResponse(Response.json({ ok: true, unexpected: true }), "adjustment-1"),
+    /returned an invalid response/,
+  );
+  await assert.rejects(
+    readBudgetAdjustmentDeleteResponse(
+      new Response("server error", { status: 500 }),
+      "adjustment-1",
+    ),
+    /Budget adjustment adjustment-1 delete failed: 500 server error/,
+  );
+});

--- a/apps/web/src/ui/tables/budget/budgetTableApi.ts
+++ b/apps/web/src/ui/tables/budget/budgetTableApi.ts
@@ -1,6 +1,67 @@
 import { fetchWithCsrf } from "@/lib/csrf";
 import { buildLiveDataUrl, fetchLiveData } from "@/lib/liveDataFetch";
+import type {
+  BudgetAdjustment,
+  CreateBudgetAdjustmentParams,
+  PatchBudgetAdjustmentParams,
+} from "@/server/budget/budgetAdjustments";
 import type { BudgetGridResult } from "@/server/budget/getBudgetGrid";
+import { z } from "zod";
+
+const hasCodePointLengthBetween = (
+  value: string,
+  minLength: number,
+  maxLength: number,
+): boolean => {
+  const length = Array.from(value).length;
+  return length >= minLength && length <= maxLength;
+};
+
+const budgetAdjustmentSchema: z.ZodType<BudgetAdjustment> = z.object({
+  adjustmentId: z.string().refine((value): boolean => hasCodePointLengthBetween(value, 1, 200)),
+  month: z.string().regex(/^\d{4}-(?:0[1-9]|1[0-2])$/),
+  direction: z.enum(["income", "spend"]),
+  category: z.string().refine((value): boolean => hasCodePointLengthBetween(value, 1, 200)),
+  amount: z.number().safe().int(),
+  note: z.string().refine((value): boolean => hasCodePointLengthBetween(value, 0, 2000)).nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+}).strict();
+
+const deleteBudgetAdjustmentResponseSchema = z.object({ ok: z.literal(true) }).strict();
+
+export type DeleteBudgetAdjustmentOutcome = "deleted" | "already-absent";
+
+const readJsonResponse = async <T>(
+  response: Response,
+  operation: string,
+  schema: z.ZodType<T>,
+): Promise<T> => {
+  const responseBody = await response.text();
+  if (!response.ok) {
+    throw new Error(`${operation} failed: ${response.status} ${responseBody}`);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(responseBody) as unknown;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`${operation} returned invalid JSON: ${reason}. Response body: ${responseBody}`);
+  }
+
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error(`${operation} returned an invalid response: ${parsed.error.message}. Response body: ${responseBody}`);
+  }
+  return parsed.data;
+};
+
+export const readBudgetAdjustmentResponse = async (
+  response: Response,
+  operation: string,
+): Promise<BudgetAdjustment> =>
+  readJsonResponse(response, operation, budgetAdjustmentSchema);
 
 /**
  * Reads the budget grid for the current client-visible range.
@@ -60,6 +121,53 @@ export const postBudgetPlanFill = async (params: {
   if (!response.ok) {
     throw new Error(`Budget plan fill failed: ${response.status} ${await response.text()}`);
   }
+};
+
+export const createBudgetAdjustment = async (
+  params: CreateBudgetAdjustmentParams,
+): Promise<BudgetAdjustment> => {
+  const response = await fetchWithCsrf("/api/budget-adjustments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  return readBudgetAdjustmentResponse(response, "Budget adjustment create");
+};
+
+export const patchBudgetAdjustment = async (
+  adjustmentId: string,
+  params: PatchBudgetAdjustmentParams,
+): Promise<BudgetAdjustment> => {
+  const response = await fetchWithCsrf(`/api/budget-adjustments/${encodeURIComponent(adjustmentId)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  return readBudgetAdjustmentResponse(response, `Budget adjustment ${adjustmentId} update`);
+};
+
+export const readBudgetAdjustmentDeleteResponse = async (
+  response: Response,
+  adjustmentId: string,
+): Promise<DeleteBudgetAdjustmentOutcome> => {
+  if (response.status === 404) {
+    return "already-absent";
+  }
+  await readJsonResponse(
+    response,
+    `Budget adjustment ${adjustmentId} delete`,
+    deleteBudgetAdjustmentResponseSchema,
+  );
+  return "deleted";
+};
+
+export const deleteBudgetAdjustment = async (
+  adjustmentId: string,
+): Promise<DeleteBudgetAdjustmentOutcome> => {
+  const response = await fetchWithCsrf(`/api/budget-adjustments/${encodeURIComponent(adjustmentId)}`, {
+    method: "DELETE",
+  });
+  return readBudgetAdjustmentDeleteResponse(response, adjustmentId);
 };
 
 export const fetchComment = async (month: string, direction: string, category: string): Promise<string | null> => {


### PR DESCRIPTION
## Summary

- add typed browser create, partial patch, and idempotent delete helpers for budget adjustments
- strictly validate adjustment and delete responses, including safe integers, ISO timestamps, and Unicode code-point bounds
- add focused response-contract and delete-outcome tests

## Validation

- npx tsx --test src/ui/tables/budget/budgetTableApi.test.ts
- npx tsx --test src/server/api/budget.test.ts src/server/budget/budgetAdjustments.test.ts src/app/api/budget-adjustments/route.test.ts src/app/api/budget-adjustments-id-route.test.ts
- npm run lint (apps/web)
- npm run build (apps/web)
- git diff --check