### PR TITLE
Add budget adjustment row state model

### DIFF
--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.test.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.test.ts
@@ -1,0 +1,479 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  BudgetAdjustment,
+  BudgetAdjustmentDirection,
+} from "@/server/budget/budgetAdjustments";
+import type { BudgetRow } from "@/server/budget/getBudgetGrid";
+import {
+  applyBudgetAdjustmentRows,
+  budgetAdjustmentNoteFromInput,
+  budgetAdjustmentNoteToInput,
+  clearBudgetAdjustmentCellInvalidations,
+  createBudgetAdjustmentEditorRow,
+  getBudgetAdjustmentCellKey,
+  getBudgetAdjustmentCellRows,
+  getBudgetAdjustmentCellTotal,
+  getBudgetAdjustmentRowCellKey,
+  parseBudgetAdjustmentAmount,
+  parseBudgetAdjustmentDraft,
+  recordBudgetAdjustmentCellMove,
+  replaceBudgetAdjustmentDraft,
+  sortBudgetAdjustmentRows,
+  type BudgetAdjustmentDraft,
+  type BudgetAdjustmentEditorRow,
+  type BudgetAdjustmentSnapshot,
+} from "@/ui/tables/budget/budgetAdjustmentRowsState";
+
+const createAdjustment = (
+  adjustmentId: string,
+  amount: number,
+  month: string,
+  direction: BudgetAdjustmentDirection,
+  category: string,
+  note: string | null,
+  createdAt: string,
+): BudgetAdjustment => ({
+  adjustmentId,
+  amount,
+  month,
+  direction,
+  category,
+  note,
+  createdAt,
+  updatedAt: createdAt,
+});
+
+const createBudgetRow = (
+  month: string,
+  direction: string,
+  category: string,
+  plannedBase: number,
+  plannedModifier: number,
+): BudgetRow => ({
+  month,
+  direction,
+  category,
+  plannedBase,
+  plannedModifier,
+  planned: plannedBase + plannedModifier,
+  actual: 0,
+  hasUnconvertible: false,
+});
+
+const requireSnapshot = (
+  draft: BudgetAdjustmentDraft,
+  currentMonth: string,
+): BudgetAdjustmentSnapshot => {
+  const parsed = parseBudgetAdjustmentDraft(draft, currentMonth);
+  if (!parsed.ok) throw new Error(`Expected a valid adjustment draft: ${parsed.error.message}`);
+  return parsed.snapshot;
+};
+
+test("parses blank and signed integer amounts", (): void => {
+  assert.deepEqual(parseBudgetAdjustmentAmount(""), { ok: true, amount: 0 });
+  assert.deepEqual(parseBudgetAdjustmentAmount("   "), { ok: true, amount: 0 });
+  assert.deepEqual(parseBudgetAdjustmentAmount("+42"), { ok: true, amount: 42 });
+  assert.deepEqual(parseBudgetAdjustmentAmount(" -17 "), { ok: true, amount: -17 });
+});
+
+test("rejects decimal, text, and unsafe integer amounts with explicit errors", (): void => {
+  const decimal = parseBudgetAdjustmentAmount("1.5");
+  const text = parseBudgetAdjustmentAmount("twelve");
+  const unsafe = parseBudgetAdjustmentAmount("9007199254740992");
+
+  assert.equal(decimal.ok, false);
+  assert.equal(decimal.ok ? null : decimal.error.code, "invalidAmount");
+  assert.match(decimal.ok ? "" : decimal.error.message, /signed integer or blank/);
+  assert.equal(text.ok, false);
+  assert.equal(text.ok ? null : text.error.code, "invalidAmount");
+  assert.equal(unsafe.ok, false);
+  assert.equal(unsafe.ok ? null : unsafe.error.code, "unsafeAmount");
+  assert.match(unsafe.ok ? "" : unsafe.error.message, /safe integer range/);
+});
+
+test("canonicalizes server and draft notes without losing editable text", (): void => {
+  const nullNote = createBudgetAdjustmentEditorRow(createAdjustment(
+    "null-note",
+    10,
+    "2026-07",
+    "spend",
+    "Groceries",
+    null,
+    "2026-07-01T00:00:00.000Z",
+  ));
+  const emptyNote = createBudgetAdjustmentEditorRow(createAdjustment(
+    "empty-note",
+    10,
+    "2026-07",
+    "spend",
+    "Groceries",
+    "",
+    "2026-07-01T00:00:01.000Z",
+  ));
+
+  assert.equal(budgetAdjustmentNoteToInput(null), "");
+  assert.equal(budgetAdjustmentNoteToInput(""), "");
+  assert.equal(budgetAdjustmentNoteFromInput(""), null);
+  assert.equal(budgetAdjustmentNoteFromInput("Draft text"), "Draft text");
+  assert.equal(nullNote.draft.noteInput, "");
+  assert.equal(nullNote.confirmed.note, null);
+  assert.equal(emptyNote.draft.noteInput, "");
+  assert.equal(emptyNote.confirmed.note, null);
+  assert.equal(requireSnapshot({ ...nullNote.draft, noteInput: "Draft text" }, "2026-07").note, "Draft text");
+});
+
+test("accepts current and future months and rejects past months", (): void => {
+  const draft: BudgetAdjustmentDraft = {
+    amountInput: "0",
+    noteInput: "",
+    month: "2026-07",
+    category: "Groceries",
+  };
+
+  assert.equal(parseBudgetAdjustmentDraft(draft, "2026-07").ok, true);
+  assert.equal(parseBudgetAdjustmentDraft({ ...draft, month: "2026-08" }, "2026-07").ok, true);
+  const past = parseBudgetAdjustmentDraft({ ...draft, month: "2026-06" }, "2026-07");
+  assert.equal(past.ok, false);
+  assert.equal(past.ok ? null : past.error.code, "pastMonth");
+  assert.match(past.ok ? "" : past.error.message, /2026-07 or later/);
+});
+
+test("validates category and note limits by code point", (): void => {
+  const draft: BudgetAdjustmentDraft = {
+    amountInput: "0",
+    noteInput: "",
+    month: "2026-07",
+    category: "Groceries",
+  };
+  const emptyCategory = parseBudgetAdjustmentDraft({ ...draft, category: "" }, "2026-07");
+  const longNote = parseBudgetAdjustmentDraft(
+    { ...draft, noteInput: "\u{1F680}".repeat(2001) },
+    "2026-07",
+  );
+
+  assert.equal(emptyCategory.ok ? null : emptyCategory.error.code, "invalidCategory");
+  assert.equal(longNote.ok ? null : longNote.error.code, "invalidNote");
+});
+
+test("orders rows deterministically and selects an exact cell", (): void => {
+  const laterId = createBudgetAdjustmentEditorRow(createAdjustment(
+    "z-row", 1, "2026-08", "spend", "Dining", null, "2026-07-02T00:00:00.000Z",
+  ));
+  const earlierId = createBudgetAdjustmentEditorRow(createAdjustment(
+    "a-row", 2, "2026-08", "spend", "Dining", null, "2026-07-02T00:00:00.000Z",
+  ));
+  const otherDirection = createBudgetAdjustmentEditorRow(createAdjustment(
+    "income", 3, "2026-08", "income", "Dining", null, "2026-07-01T00:00:00.000Z",
+  ));
+  const earlierMonth = createBudgetAdjustmentEditorRow(createAdjustment(
+    "july", 4, "2026-07", "spend", "Dining", null, "2026-07-03T00:00:00.000Z",
+  ));
+  const input = [laterId, otherDirection, earlierMonth, earlierId];
+
+  assert.deepEqual(
+    sortBudgetAdjustmentRows(input).map((row) => row.adjustmentId),
+    ["july", "income", "a-row", "z-row"],
+  );
+  assert.deepEqual(
+    getBudgetAdjustmentCellRows(input, "2026-08", "spend", "Dining", "2026-07")
+      .map((row) => row.adjustmentId),
+    ["a-row", "z-row"],
+  );
+  assert.deepEqual(input.map((row) => row.adjustmentId), ["z-row", "income", "july", "a-row"]);
+});
+
+test("aggregates multiple, cancelling, and zero-valued rows while keeping zero cells addressable", (): void => {
+  const adjustments = [
+    createAdjustment("first", 25, "2026-07", "spend", "Groceries", null, "2026-07-01T00:00:00.000Z"),
+    createAdjustment("second", -10, "2026-07", "spend", "Groceries", null, "2026-07-01T00:00:01.000Z"),
+    createAdjustment("cancel-a", 5, "2026-07", "spend", "Cancelling", null, "2026-07-01T00:00:02.000Z"),
+    createAdjustment("cancel-b", -5, "2026-07", "spend", "Cancelling", null, "2026-07-01T00:00:03.000Z"),
+    createAdjustment("zero", 0, "2026-07", "spend", "Zero", null, "2026-07-01T00:00:04.000Z"),
+  ].map(createBudgetAdjustmentEditorRow);
+  const budgetRows = [createBudgetRow("2026-07", "spend", "Groceries", 100, 999)];
+
+  const result = applyBudgetAdjustmentRows(
+    budgetRows,
+    adjustments,
+    "2026-07",
+    "2026-07",
+    "2026-07",
+    new Set(),
+  );
+  const byCategory = new Map(result.map((row) => [row.category, row]));
+  assert.equal(byCategory.get("Groceries")?.plannedModifier, 15);
+  assert.equal(byCategory.get("Groceries")?.planned, 115);
+  assert.equal(byCategory.get("Cancelling")?.plannedModifier, 0);
+  assert.equal(byCategory.get("Zero")?.plannedModifier, 0);
+  assert.deepEqual(
+    getBudgetAdjustmentCellRows(adjustments, "2026-07", "spend", "Zero", "2026-07")
+      .map((row) => row.adjustmentId),
+    ["zero"],
+  );
+});
+
+test("does not apply or synthesize adjustments before the explicit plan boundary", (): void => {
+  const historical = createBudgetAdjustmentEditorRow(createAdjustment(
+    "historical", 50, "2026-06", "spend", "Phantom", null, "2026-06-01T00:00:00.000Z",
+  ));
+  const current = createBudgetAdjustmentEditorRow(createAdjustment(
+    "current", 20, "2026-07", "spend", "Current", null, "2026-07-01T00:00:00.000Z",
+  ));
+  const historicalActual: BudgetRow = {
+    ...createBudgetRow("2026-06", "spend", "Existing", 0, 0),
+    actual: 30,
+  };
+
+  const result = applyBudgetAdjustmentRows(
+    [historicalActual],
+    [historical, current],
+    "2026-06",
+    "2026-08",
+    "2026-07",
+    new Set(),
+  );
+
+  assert.equal(result.some((row) => row.month === "2026-06" && row.category === "Phantom"), false);
+  assert.equal(result.some((row) => row.month === "2026-07" && row.category === "Current"), true);
+  assert.deepEqual(result.find((row) => row.category === "Existing"), historicalActual);
+  assert.equal(
+    getBudgetAdjustmentCellTotal([historical], "2026-06", "spend", "Phantom", "2026-07"),
+    0,
+  );
+});
+
+test("keeps invalid draft locations in the confirmed cell without hiding validation errors", (): void => {
+  const source = createBudgetAdjustmentEditorRow(createAdjustment(
+    "invalid-location", 10, "2026-08", "spend", "Confirmed", null, "2026-07-01T00:00:00.000Z",
+  ));
+  const cases: ReadonlyArray<Readonly<{
+    name: string;
+    draft: BudgetAdjustmentDraft;
+    errorCode: "invalidMonth" | "pastMonth" | "invalidCategory";
+  }>> = [
+    {
+      name: "empty month",
+      draft: { ...source.draft, amountInput: "25", month: "", category: "Draft" },
+      errorCode: "invalidMonth",
+    },
+    {
+      name: "malformed month",
+      draft: { ...source.draft, amountInput: "25", month: "2026-13", category: "Draft" },
+      errorCode: "invalidMonth",
+    },
+    {
+      name: "past month",
+      draft: { ...source.draft, amountInput: "25", month: "2026-06", category: "Draft" },
+      errorCode: "pastMonth",
+    },
+    {
+      name: "empty category",
+      draft: { ...source.draft, amountInput: "25", month: "2026-09", category: "" },
+      errorCode: "invalidCategory",
+    },
+    {
+      name: "overlong category",
+      draft: {
+        ...source.draft,
+        amountInput: "25",
+        month: "2026-09",
+        category: "\u{1F600}".repeat(201),
+      },
+      errorCode: "invalidCategory",
+    },
+  ];
+
+  for (const input of cases) {
+    const parsed = parseBudgetAdjustmentDraft(input.draft, "2026-07");
+    assert.equal(parsed.ok ? null : parsed.error.code, input.errorCode, input.name);
+    const rows = replaceBudgetAdjustmentDraft([source], source.adjustmentId, input.draft);
+    assert.equal(
+      getBudgetAdjustmentRowCellKey(rows[0], "2026-07"),
+      getBudgetAdjustmentCellKey("2026-08", "spend", "Confirmed"),
+      input.name,
+    );
+    assert.deepEqual(
+      getBudgetAdjustmentCellRows(rows, "2026-08", "spend", "Confirmed", "2026-07")
+        .map((row) => row.adjustmentId),
+      [source.adjustmentId],
+      input.name,
+    );
+    assert.equal(
+      getBudgetAdjustmentCellTotal(rows, "2026-08", "spend", "Confirmed", "2026-07"),
+      25,
+      input.name,
+    );
+    const budget = applyBudgetAdjustmentRows(
+      [createBudgetRow("2026-08", "spend", "Confirmed", 100, 10)],
+      rows,
+      "2026-07",
+      "2026-09",
+      "2026-07",
+      new Set(),
+    );
+    assert.deepEqual(
+      budget.map((row) => [row.month, row.category, row.planned]),
+      [["2026-08", "Confirmed", 125]],
+      input.name,
+    );
+  }
+  assert.equal(recordBudgetAdjustmentCellMove(
+    new Map(),
+    {
+      direction: source.direction,
+      previous: source.confirmed,
+      current: { ...source.confirmed, month: "", category: "Draft" },
+    },
+    1,
+    "2026-07",
+  ).size, 0);
+});
+
+test("sums safe integer adjustments exactly across unsafe intermediate totals", (): void => {
+  const maximum = Number.MAX_SAFE_INTEGER;
+  const rows = [
+    createAdjustment("maximum", maximum, "2026-07", "spend", "Exact", null, "2026-07-01T00:00:00.000Z"),
+    createAdjustment("two", 2, "2026-07", "spend", "Exact", null, "2026-07-01T00:00:01.000Z"),
+    createAdjustment("cancel", -maximum, "2026-07", "spend", "Exact", null, "2026-07-01T00:00:02.000Z"),
+  ].map(createBudgetAdjustmentEditorRow);
+
+  assert.equal(
+    getBudgetAdjustmentCellTotal(rows, "2026-07", "spend", "Exact", "2026-07"),
+    2,
+  );
+  const budget = applyBudgetAdjustmentRows([], rows, "2026-07", "2026-07", "2026-07", new Set());
+  assert.equal(budget[0].plannedModifier, 2);
+  assert.equal(budget[0].planned, 2);
+});
+
+test("rejects unsafe final adjustment totals and unsafe planned values", (): void => {
+  const maximum = Number.MAX_SAFE_INTEGER;
+  const maximumRow = createBudgetAdjustmentEditorRow(createAdjustment(
+    "maximum", maximum, "2026-07", "spend", "Unsafe", null, "2026-07-01T00:00:00.000Z",
+  ));
+  const oneRow = createBudgetAdjustmentEditorRow(createAdjustment(
+    "one", 1, "2026-07", "spend", "Unsafe", null, "2026-07-01T00:00:01.000Z",
+  ));
+
+  assert.throws(
+    () => getBudgetAdjustmentCellTotal(
+      [maximumRow, oneRow],
+      "2026-07",
+      "spend",
+      "Unsafe",
+      "2026-07",
+    ),
+    /adjustment total.*outside the JavaScript safe integer range/,
+  );
+  assert.throws(
+    () => applyBudgetAdjustmentRows(
+      [createBudgetRow("2026-07", "spend", "Unsafe", maximum, 0)],
+      [oneRow],
+      "2026-07",
+      "2026-07",
+      "2026-07",
+      new Set(),
+    ),
+    /planned value.*outside the JavaScript safe (?:integer|numeric) range/,
+  );
+});
+
+test("moves a row across month and category without mutating source rows", (): void => {
+  const source = createBudgetAdjustmentEditorRow(createAdjustment(
+    "move", 40, "2026-07", "spend", "Groceries", null, "2026-07-01T00:00:00.000Z",
+  ));
+  const adjustmentRows = [source];
+  const budgetRows = [
+    createBudgetRow("2026-07", "spend", "Groceries", 100, 40),
+    createBudgetRow("2026-08", "spend", "Dining", 20, 0),
+  ];
+  const originalBudgetRows = structuredClone(budgetRows);
+  const moved = replaceBudgetAdjustmentDraft(adjustmentRows, source.adjustmentId, {
+    ...source.draft,
+    month: "2026-08",
+    category: "Dining",
+  });
+
+  const result = applyBudgetAdjustmentRows(
+    budgetRows,
+    moved,
+    "2026-07",
+    "2026-08",
+    "2026-07",
+    new Set(),
+  );
+  const sourceCell = result.find((row) => row.month === "2026-07" && row.category === "Groceries");
+  const destinationCell = result.find((row) => row.month === "2026-08" && row.category === "Dining");
+  assert.equal(sourceCell?.plannedModifier, 0);
+  assert.equal(sourceCell?.planned, 100);
+  assert.equal(destinationCell?.plannedModifier, 40);
+  assert.equal(destinationCell?.planned, 60);
+  assert.equal(source.draft.month, "2026-07");
+  assert.equal(source.draft.category, "Groceries");
+  assert.deepEqual(budgetRows, originalBudgetRows);
+});
+
+test("zero-valued move provenance hides the stale source until a fresh-enough range", (): void => {
+  const source = createBudgetAdjustmentEditorRow(createAdjustment(
+    "zero-move", 0, "2026-07", "spend", "Source", null, "2026-07-01T00:00:00.000Z",
+  ));
+  const current = requireSnapshot({
+    ...source.draft,
+    month: "2026-08",
+    category: "Destination",
+  }, "2026-07");
+  const moved = replaceBudgetAdjustmentDraft([source], source.adjustmentId, {
+    ...source.draft,
+    month: current.month,
+    category: current.category,
+  });
+  const originalProvenance = new Map<string, number>();
+  const provenance = recordBudgetAdjustmentCellMove(
+    originalProvenance,
+    { direction: source.direction, previous: source.confirmed, current },
+    5,
+    "2026-07",
+  );
+  const staleBudgetRows = [createBudgetRow("2026-07", "spend", "Source", 0, 0)];
+
+  const result = applyBudgetAdjustmentRows(
+    staleBudgetRows,
+    moved,
+    "2026-07",
+    "2026-08",
+    "2026-07",
+    new Set(provenance.keys()),
+  );
+  assert.equal(result.some((row) => row.month === "2026-07" && row.category === "Source"), false);
+  assert.equal(result.some((row) => row.month === "2026-08" && row.category === "Destination"), true);
+  assert.equal(
+    provenance.get(getBudgetAdjustmentCellKey("2026-07", "spend", "Source")),
+    5,
+  );
+  assert.equal(clearBudgetAdjustmentCellInvalidations(provenance, "2026-07", "2026-07", 4).size, 1);
+  assert.equal(clearBudgetAdjustmentCellInvalidations(provenance, "2026-07", "2026-07", 5).size, 0);
+  assert.equal(originalProvenance.size, 0);
+  assert.equal(provenance.size, 1);
+  assert.equal(source.draft.month, "2026-07");
+});
+
+test("pure helpers reject invalid structural inputs without mutating inputs", (): void => {
+  const row = createBudgetAdjustmentEditorRow(createAdjustment(
+    "keep", 1, "2026-07", "spend", "Groceries", null, "2026-07-01T00:00:00.000Z",
+  ));
+  const rows: ReadonlyArray<BudgetAdjustmentEditorRow> = [row];
+  const provenance = new Map([[getBudgetAdjustmentCellKey("2026-07", "spend", "Groceries"), 2]]);
+
+  assert.throws(
+    () => replaceBudgetAdjustmentDraft(rows, "missing", row.draft),
+    /missing budget adjustment/,
+  );
+  assert.throws(
+    () => clearBudgetAdjustmentCellInvalidations(provenance, "2026-08", "2026-07", 2),
+    /must not be after/,
+  );
+  assert.deepEqual(rows, [row]);
+  assert.equal(provenance.size, 1);
+});

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.ts
@@ -1,0 +1,468 @@
+import type {
+  BudgetAdjustment,
+  BudgetAdjustmentDirection,
+} from "@/server/budget/budgetAdjustments";
+import type { BudgetRow } from "@/server/budget/getBudgetGrid";
+
+const AMOUNT_PATTERN = /^[+-]?\d+$/;
+const MONTH_PATTERN = /^\d{4}-(?:0[1-9]|1[0-2])$/;
+
+export type BudgetAdjustmentSnapshot = Readonly<{
+  amount: number;
+  note: string | null;
+  month: string;
+  category: string;
+}>;
+
+export type BudgetAdjustmentDraft = Readonly<{
+  amountInput: string;
+  noteInput: string;
+  month: string;
+  category: string;
+}>;
+
+export type BudgetAdjustmentEditorRow = Readonly<{
+  adjustmentId: string;
+  direction: BudgetAdjustmentDirection;
+  draft: BudgetAdjustmentDraft;
+  confirmed: BudgetAdjustmentSnapshot;
+  createdAt: string;
+  updatedAt: string;
+}>;
+
+export type BudgetAdjustmentDraftError = Readonly<{
+  code: "invalidAmount" | "unsafeAmount" | "invalidMonth" | "pastMonth" | "invalidCategory" | "invalidNote";
+  message: string;
+}>;
+
+export type ParsedBudgetAdjustmentAmount =
+  | Readonly<{ ok: true; amount: number }>
+  | Readonly<{ ok: false; error: BudgetAdjustmentDraftError }>;
+
+export type ParsedBudgetAdjustmentDraft =
+  | Readonly<{ ok: true; snapshot: BudgetAdjustmentSnapshot }>
+  | Readonly<{ ok: false; error: BudgetAdjustmentDraftError }>;
+
+export type BudgetAdjustmentCellMove = Readonly<{
+  direction: BudgetAdjustmentDirection;
+  previous: BudgetAdjustmentSnapshot;
+  current: BudgetAdjustmentSnapshot;
+}>;
+
+type BudgetAdjustmentLocation = Readonly<{
+  month: string;
+  category: string;
+}>;
+
+const compareText = (left: string, right: string): number => {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+};
+
+const validateMonth = (month: string, context: string): void => {
+  if (!MONTH_PATTERN.test(month)) {
+    throw new RangeError(`${context} must use YYYY-MM with a valid month; received "${month}"`);
+  }
+};
+
+const validateRange = (monthFrom: string, monthTo: string, context: string): void => {
+  validateMonth(monthFrom, `${context} monthFrom`);
+  validateMonth(monthTo, `${context} monthTo`);
+  if (monthFrom > monthTo) {
+    throw new RangeError(`${context} monthFrom "${monthFrom}" must not be after monthTo "${monthTo}"`);
+  }
+};
+
+const validateRevision = (revision: number, context: string): void => {
+  if (!Number.isSafeInteger(revision) || revision < 0) {
+    throw new RangeError(`${context} must be a non-negative safe integer; received ${String(revision)}`);
+  }
+};
+
+const isValidCategory = (category: string): boolean => {
+  const length = Array.from(category).length;
+  return length >= 1 && length <= 200;
+};
+
+const isValidDraftLocation = (draft: BudgetAdjustmentDraft, planFrom: string): boolean =>
+  MONTH_PATTERN.test(draft.month)
+  && draft.month >= planFrom
+  && isValidCategory(draft.category);
+
+const getEffectiveLocation = (
+  row: BudgetAdjustmentEditorRow,
+  planFrom: string,
+): BudgetAdjustmentLocation => isValidDraftLocation(row.draft, planFrom)
+  ? { month: row.draft.month, category: row.draft.category }
+  : { month: row.confirmed.month, category: row.confirmed.category };
+
+export const budgetAdjustmentNoteToInput = (note: string | null): string => note ?? "";
+
+export const budgetAdjustmentNoteFromInput = (noteInput: string): string | null =>
+  noteInput === "" ? null : noteInput;
+
+export const parseBudgetAdjustmentAmount = (
+  amountInput: string,
+): ParsedBudgetAdjustmentAmount => {
+  const value = amountInput.trim();
+  if (value.length === 0) return { ok: true, amount: 0 };
+  if (!AMOUNT_PATTERN.test(value)) {
+    return {
+      ok: false,
+      error: {
+        code: "invalidAmount",
+        message: `Budget adjustment amount "${amountInput}" must be a signed integer or blank`,
+      },
+    };
+  }
+  const amount = Number(value);
+  if (!Number.isSafeInteger(amount)) {
+    return {
+      ok: false,
+      error: {
+        code: "unsafeAmount",
+        message: `Budget adjustment amount "${amountInput}" is outside the safe integer range`,
+      },
+    };
+  }
+  return { ok: true, amount };
+};
+
+export const parseBudgetAdjustmentDraft = (
+  draft: BudgetAdjustmentDraft,
+  currentMonth: string,
+): ParsedBudgetAdjustmentDraft => {
+  validateMonth(currentMonth, "Current month");
+  const amount = parseBudgetAdjustmentAmount(draft.amountInput);
+  if (!amount.ok) return amount;
+  if (!MONTH_PATTERN.test(draft.month)) {
+    return {
+      ok: false,
+      error: {
+        code: "invalidMonth",
+        message: `Budget adjustment month "${draft.month}" must use YYYY-MM with a valid month`,
+      },
+    };
+  }
+  if (draft.month < currentMonth) {
+    return {
+      ok: false,
+      error: {
+        code: "pastMonth",
+        message: `Budget adjustment month "${draft.month}" must be ${currentMonth} or later`,
+      },
+    };
+  }
+  if (!isValidCategory(draft.category)) {
+    return {
+      ok: false,
+      error: {
+        code: "invalidCategory",
+        message: "Budget adjustment category must contain between 1 and 200 characters",
+      },
+    };
+  }
+  if (Array.from(draft.noteInput).length > 2000) {
+    return {
+      ok: false,
+      error: {
+        code: "invalidNote",
+        message: "Budget adjustment note must contain at most 2000 characters",
+      },
+    };
+  }
+  return {
+    ok: true,
+    snapshot: {
+      amount: amount.amount,
+      note: budgetAdjustmentNoteFromInput(draft.noteInput),
+      month: draft.month,
+      category: draft.category,
+    },
+  };
+};
+
+export const createBudgetAdjustmentEditorRow = (
+  adjustment: BudgetAdjustment,
+): BudgetAdjustmentEditorRow => {
+  validateMonth(adjustment.month, `Budget adjustment "${adjustment.adjustmentId}" month`);
+  if (!Number.isSafeInteger(adjustment.amount)) {
+    throw new RangeError(
+      `Budget adjustment "${adjustment.adjustmentId}" amount must be a safe integer; received ${String(adjustment.amount)}`,
+    );
+  }
+  const note = budgetAdjustmentNoteFromInput(budgetAdjustmentNoteToInput(adjustment.note));
+  return {
+    adjustmentId: adjustment.adjustmentId,
+    direction: adjustment.direction,
+    draft: {
+      amountInput: String(adjustment.amount),
+      noteInput: budgetAdjustmentNoteToInput(adjustment.note),
+      month: adjustment.month,
+      category: adjustment.category,
+    },
+    confirmed: {
+      amount: adjustment.amount,
+      note,
+      month: adjustment.month,
+      category: adjustment.category,
+    },
+    createdAt: adjustment.createdAt,
+    updatedAt: adjustment.updatedAt,
+  };
+};
+
+export const sortBudgetAdjustmentRows = (
+  rows: ReadonlyArray<BudgetAdjustmentEditorRow>,
+): ReadonlyArray<BudgetAdjustmentEditorRow> => [...rows].sort((left, right): number =>
+  compareText(left.draft.month, right.draft.month)
+  || compareText(left.direction, right.direction)
+  || compareText(left.draft.category, right.draft.category)
+  || compareText(left.createdAt, right.createdAt)
+  || compareText(left.adjustmentId, right.adjustmentId));
+
+export const getBudgetAdjustmentCellKey = (
+  month: string,
+  direction: BudgetAdjustmentDirection,
+  category: string,
+): string => `${month}\u0000${direction}\u0000${category}`;
+
+export const getBudgetAdjustmentRowCellKey = (
+  row: BudgetAdjustmentEditorRow,
+  planFrom: string,
+): string => {
+  validateMonth(planFrom, "Budget adjustment plan boundary");
+  const location = getEffectiveLocation(row, planFrom);
+  return getBudgetAdjustmentCellKey(location.month, row.direction, location.category);
+};
+
+export const getBudgetAdjustmentCellRows = (
+  rows: ReadonlyArray<BudgetAdjustmentEditorRow>,
+  month: string,
+  direction: BudgetAdjustmentDirection,
+  category: string,
+  planFrom: string,
+): ReadonlyArray<BudgetAdjustmentEditorRow> => {
+  validateMonth(planFrom, "Budget adjustment plan boundary");
+  return sortBudgetAdjustmentRows(rows.filter((row): boolean => {
+    const location = getEffectiveLocation(row, planFrom);
+    return location.month === month
+      && row.direction === direction
+      && location.category === category;
+  }));
+};
+
+export const replaceBudgetAdjustmentDraft = (
+  rows: ReadonlyArray<BudgetAdjustmentEditorRow>,
+  adjustmentId: string,
+  draft: BudgetAdjustmentDraft,
+): ReadonlyArray<BudgetAdjustmentEditorRow> => {
+  if (!rows.some((row) => row.adjustmentId === adjustmentId)) {
+    throw new Error(`Cannot replace draft for missing budget adjustment "${adjustmentId}"`);
+  }
+  return sortBudgetAdjustmentRows(rows.map((row): BudgetAdjustmentEditorRow =>
+    row.adjustmentId === adjustmentId ? { ...row, draft: { ...draft } } : row));
+};
+
+const getOptimisticAmount = (row: BudgetAdjustmentEditorRow): number => {
+  const amount = parseBudgetAdjustmentAmount(row.draft.amountInput);
+  return amount.ok ? amount.amount : row.confirmed.amount;
+};
+
+export const getBudgetAdjustmentCellTotal = (
+  rows: ReadonlyArray<BudgetAdjustmentEditorRow>,
+  month: string,
+  direction: BudgetAdjustmentDirection,
+  category: string,
+  planFrom: string,
+): number => {
+  validateMonth(planFrom, "Budget adjustment plan boundary");
+  if (month < planFrom) return 0;
+  const total = getBudgetAdjustmentCellRows(rows, month, direction, category, planFrom)
+    .reduce((sum, row): bigint => sum + BigInt(getOptimisticAmount(row)), BigInt(0));
+  return toSafeNumber(total, `Budget adjustment total for ${month}/${direction}/${category}`);
+};
+
+type AdjustmentCellTotal = Readonly<{
+  month: string;
+  direction: BudgetAdjustmentDirection;
+  category: string;
+  total: bigint;
+}>;
+
+const toSafeNumber = (value: bigint, context: string): number => {
+  const minimum = BigInt(Number.MIN_SAFE_INTEGER);
+  const maximum = BigInt(Number.MAX_SAFE_INTEGER);
+  if (value < minimum || value > maximum) {
+    throw new RangeError(`${context} is outside the JavaScript safe integer range: ${value.toString()}`);
+  }
+  return Number(value);
+};
+
+const aggregateAdjustmentRows = (
+  rows: ReadonlyArray<BudgetAdjustmentEditorRow>,
+  plannedFrom: string,
+  loadedTo: string,
+  planFrom: string,
+): ReadonlyMap<string, AdjustmentCellTotal> => {
+  const totals = new Map<string, AdjustmentCellTotal>();
+  for (const row of rows) {
+    const location = getEffectiveLocation(row, planFrom);
+    if (location.month < plannedFrom || location.month > loadedTo) continue;
+    const key = getBudgetAdjustmentCellKey(location.month, row.direction, location.category);
+    const previous = totals.get(key);
+    totals.set(key, {
+      month: location.month,
+      direction: row.direction,
+      category: location.category,
+      total: (previous?.total ?? BigInt(0)) + BigInt(getOptimisticAmount(row)),
+    });
+  }
+  return totals;
+};
+
+const addPlannedValue = (
+  plannedBase: number,
+  adjustmentTotal: number,
+  context: string,
+): number => {
+  if (!Number.isFinite(plannedBase) || Math.abs(plannedBase) > Number.MAX_SAFE_INTEGER) {
+    throw new RangeError(`${context} base is outside the JavaScript safe numeric range: ${String(plannedBase)}`);
+  }
+  if (Number.isInteger(plannedBase)) {
+    return toSafeNumber(
+      BigInt(plannedBase) + BigInt(adjustmentTotal),
+      `${context} planned value`,
+    );
+  }
+  const planned = plannedBase + adjustmentTotal;
+  if (!Number.isFinite(planned) || Math.abs(planned) > Number.MAX_SAFE_INTEGER) {
+    throw new RangeError(`${context} planned value is outside the JavaScript safe numeric range: ${String(planned)}`);
+  }
+  return planned;
+};
+
+const sortBudgetRows = (rows: ReadonlyArray<BudgetRow>): ReadonlyArray<BudgetRow> =>
+  [...rows].sort((left, right): number =>
+    compareText(left.month, right.month)
+    || compareText(left.direction, right.direction)
+    || compareText(left.category, right.category));
+
+export const applyBudgetAdjustmentRows = (
+  budgetRows: ReadonlyArray<BudgetRow>,
+  adjustmentRows: ReadonlyArray<BudgetAdjustmentEditorRow>,
+  loadedFrom: string,
+  loadedTo: string,
+  planFrom: string,
+  invalidatedCellKeys: ReadonlySet<string>,
+): ReadonlyArray<BudgetRow> => {
+  validateRange(loadedFrom, loadedTo, "Budget adjustment display range");
+  validateMonth(planFrom, "Budget adjustment plan boundary");
+  const plannedFrom = loadedFrom > planFrom ? loadedFrom : planFrom;
+  const totals = aggregateAdjustmentRows(adjustmentRows, plannedFrom, loadedTo, planFrom);
+  const existingKeys = new Set<string>();
+  const result: Array<BudgetRow> = [];
+
+  for (const row of budgetRows) {
+    if (
+      row.month < loadedFrom
+      || row.month > loadedTo
+      || row.month < plannedFrom
+      || (row.direction !== "income" && row.direction !== "spend")
+    ) {
+      result.push(row);
+      continue;
+    }
+    const key = getBudgetAdjustmentCellKey(row.month, row.direction, row.category);
+    const cellTotal = totals.get(key);
+    const hasNoIndependentValue = row.plannedBase === 0
+      && row.actual === 0
+      && !row.hasUnconvertible;
+    const isStaleAdjustmentOnly = hasNoIndependentValue
+      && cellTotal === undefined
+      && (row.plannedModifier !== 0 || invalidatedCellKeys.has(key));
+    if (isStaleAdjustmentOnly) continue;
+
+    existingKeys.add(key);
+    const plannedModifier = cellTotal === undefined
+      ? 0
+      : toSafeNumber(cellTotal.total, `Budget adjustment total for ${row.month}/${row.direction}/${row.category}`);
+    result.push({
+      ...row,
+      plannedModifier,
+      planned: addPlannedValue(
+        row.plannedBase,
+        plannedModifier,
+        `Budget cell ${row.month}/${row.direction}/${row.category}`,
+      ),
+    });
+  }
+
+  for (const [key, cell] of totals) {
+    if (existingKeys.has(key)) continue;
+    const plannedModifier = toSafeNumber(
+      cell.total,
+      `Budget adjustment total for ${cell.month}/${cell.direction}/${cell.category}`,
+    );
+    result.push({
+      month: cell.month,
+      direction: cell.direction,
+      category: cell.category,
+      plannedBase: 0,
+      plannedModifier,
+      planned: plannedModifier,
+      actual: 0,
+      hasUnconvertible: false,
+    });
+  }
+  return sortBudgetRows(result);
+};
+
+export const recordBudgetAdjustmentCellMove = (
+  current: ReadonlyMap<string, number>,
+  move: BudgetAdjustmentCellMove,
+  mutationRevision: number,
+  planFrom: string,
+): ReadonlyMap<string, number> => {
+  validateRevision(mutationRevision, "Budget adjustment move revision");
+  validateMonth(planFrom, "Budget adjustment plan boundary");
+  const next = new Map(current);
+  const currentLocation = MONTH_PATTERN.test(move.current.month)
+    && move.current.month >= planFrom
+    && isValidCategory(move.current.category)
+    ? move.current
+    : move.previous;
+  if (
+    move.previous.month !== currentLocation.month
+    || move.previous.category !== currentLocation.category
+  ) {
+    next.set(
+      getBudgetAdjustmentCellKey(
+        move.previous.month,
+        move.direction,
+        move.previous.category,
+      ),
+      mutationRevision,
+    );
+  }
+  return next;
+};
+
+export const clearBudgetAdjustmentCellInvalidations = (
+  current: ReadonlyMap<string, number>,
+  monthFrom: string,
+  monthTo: string,
+  rangeRevision: number,
+): ReadonlyMap<string, number> => {
+  validateRange(monthFrom, monthTo, "Budget adjustment invalidation range");
+  validateRevision(rangeRevision, "Budget adjustment range revision");
+  const next = new Map(current);
+  for (const [key, mutationRevision] of current) {
+    const month = key.slice(0, 7);
+    if (month >= monthFrom && month <= monthTo && mutationRevision <= rangeRevision) {
+      next.delete(key);
+    }
+  }
+  return next;
+};


### PR DESCRIPTION
## Summary

- add the immutable budget-adjustment draft/editor-row model
- apply exact, plan-bounded optimistic adjustment aggregation
- preserve confirmed cells for invalid draft locations and track move invalidation

## Validation

- focused tests: 14/14
- existing budget tests: 28/28
- npm run lint
- npm run build