### PR TITLE
Add budget adjustment range reconciliation

### DIFF
--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRangeReconciliation.test.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRangeReconciliation.test.ts
@@ -1,0 +1,756 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  BudgetAdjustment,
+  BudgetAdjustmentDirection,
+} from "@/server/budget/budgetAdjustments";
+import {
+  createBudgetAdjustmentRangeReconciliationState,
+  issueBudgetAdjustmentRangeRequest,
+  reconcileBudgetAdjustmentRangeFailure,
+  reconcileBudgetAdjustmentRangeResponse,
+  replaceBudgetAdjustmentRangeDraft,
+  type BudgetAdjustmentRangeProvenance,
+  type BudgetAdjustmentRangeReconciliationState,
+  type BudgetAdjustmentRangeRequest,
+} from "@/ui/tables/budget/budgetAdjustmentRangeReconciliation";
+import type { BudgetAdjustmentDraft } from "@/ui/tables/budget/budgetAdjustmentRowsState";
+
+const createAdjustment = (
+  adjustmentId: string,
+  amount: number,
+  month: string,
+  direction: BudgetAdjustmentDirection,
+  category: string,
+  note: string | null,
+  updatedDay: number,
+): BudgetAdjustment => ({
+  adjustmentId,
+  amount,
+  month,
+  direction,
+  category,
+  note,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: `2026-07-${String(updatedDay).padStart(2, "0")}T00:00:00.000Z`,
+});
+
+const createDraft = (
+  amountInput: string,
+  noteInput: string,
+  month: string,
+  category: string,
+): BudgetAdjustmentDraft => ({ amountInput, noteInput, month, category });
+
+const replaceDraft = (
+  state: BudgetAdjustmentRangeReconciliationState,
+  adjustmentId: string,
+  draft: BudgetAdjustmentDraft,
+): BudgetAdjustmentRangeReconciliationState =>
+  replaceBudgetAdjustmentRangeDraft(state, adjustmentId, draft);
+
+type MoveThenDeleteScenario = Readonly<{
+  adjustment: BudgetAdjustment;
+  state: BudgetAdjustmentRangeReconciliationState;
+  julyRequest: BudgetAdjustmentRangeRequest;
+  augustMoveRequest: BudgetAdjustmentRangeRequest;
+  augustDeleteRequest: BudgetAdjustmentRangeRequest;
+}>;
+
+const createMoveThenDeleteScenario = (): MoveThenDeleteScenario => {
+  const adjustment = createAdjustment("move-delete", 10, "2026-07", "spend", "A", null, 1);
+  const initial = createBudgetAdjustmentRangeReconciliationState([]);
+  const july = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-07");
+  const augustMove = issueBudgetAdjustmentRangeRequest(july.state, "2026-08", "2026-08");
+  const augustDelete = issueBudgetAdjustmentRangeRequest(
+    augustMove.state,
+    "2026-08",
+    "2026-08",
+  );
+  return {
+    adjustment,
+    state: augustDelete.state,
+    julyRequest: july.request,
+    augustMoveRequest: augustMove.request,
+    augustDeleteRequest: augustDelete.request,
+  };
+};
+
+const getExpectedMoveThenDeleteProvenance = (
+  scenario: MoveThenDeleteScenario,
+): BudgetAdjustmentRangeProvenance => ({
+  direction: "spend",
+  presenceRequestIdByMonth: new Map([
+    ["2026-07", scenario.julyRequest.requestId],
+    ["2026-08", scenario.augustMoveRequest.requestId],
+  ]),
+  absenceRequestIdByMonth: new Map([
+    ["2026-08", scenario.augustDeleteRequest.requestId],
+  ]),
+  deletedThroughRequestId: scenario.augustMoveRequest.requestId,
+});
+
+test("a newer same-month response applies A to B to C when the older response arrives first", (): void => {
+  const adjustment = createAdjustment("move", 10, "2026-07", "spend", "A", null, 1);
+  const initial = createBudgetAdjustmentRangeReconciliationState([adjustment]);
+  const first = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-07");
+  const second = issueBudgetAdjustmentRangeRequest(first.state, "2026-07", "2026-07");
+
+  const afterFirst = reconcileBudgetAdjustmentRangeResponse(second.state, first.request, [
+    { ...adjustment, category: "B", updatedAt: "2026-07-02T00:00:00.000Z" },
+  ]);
+  const final = reconcileBudgetAdjustmentRangeResponse(afterFirst, second.request, [
+    { ...adjustment, category: "C", updatedAt: "2026-07-03T00:00:00.000Z" },
+  ]);
+
+  assert.equal(afterFirst.rows[0].confirmed.category, "B");
+  assert.equal(final.rows[0].confirmed.category, "C");
+  assert.equal(final.rows[0].draft.category, "C");
+});
+
+test("an older same-month response cannot regress A to C back to B when it arrives last", (): void => {
+  const adjustment = createAdjustment("move", 10, "2026-07", "spend", "A", null, 1);
+  const initial = createBudgetAdjustmentRangeReconciliationState([adjustment]);
+  const first = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-07");
+  const second = issueBudgetAdjustmentRangeRequest(first.state, "2026-07", "2026-07");
+
+  const afterSecond = reconcileBudgetAdjustmentRangeResponse(second.state, second.request, [
+    { ...adjustment, category: "C", updatedAt: "2026-07-03T00:00:00.000Z" },
+  ]);
+  const final = reconcileBudgetAdjustmentRangeResponse(afterSecond, first.request, [
+    { ...adjustment, category: "B", updatedAt: "2026-07-02T00:00:00.000Z" },
+  ]);
+
+  assert.equal(afterSecond.rows[0].confirmed.category, "C");
+  assert.equal(final.rows[0].confirmed.category, "C");
+  assert.equal(final.acceptedRangeRequestIdByMonth.get("2026-07"), second.request.requestId);
+});
+
+test("range response order cannot clear local field edits that temporarily match the server", (): void => {
+  const adjustment = createAdjustment(
+    "dirty-order",
+    10,
+    "2026-07",
+    "spend",
+    "Initial category",
+    "Initial note",
+    1,
+  );
+  const initial = createBudgetAdjustmentRangeReconciliationState([adjustment]);
+  const edited = replaceDraft(initial, adjustment.adjustmentId, createDraft(
+    "20",
+    "Local note",
+    "2026-08",
+    "Local category",
+  ));
+  const oldRequest = issueBudgetAdjustmentRangeRequest(edited, "2026-07", "2026-09");
+  const newRequest = issueBudgetAdjustmentRangeRequest(
+    oldRequest.state,
+    "2026-07",
+    "2026-09",
+  );
+  const oldResponse = createAdjustment(
+    adjustment.adjustmentId,
+    20,
+    "2026-08",
+    "spend",
+    "Local category",
+    "Local note",
+    2,
+  );
+  const newResponse = createAdjustment(
+    adjustment.adjustmentId,
+    30,
+    "2026-09",
+    "spend",
+    "Server category",
+    "Server note",
+    3,
+  );
+
+  const afterOld = reconcileBudgetAdjustmentRangeResponse(
+    newRequest.state,
+    oldRequest.request,
+    [oldResponse],
+  );
+  const chronological = reconcileBudgetAdjustmentRangeResponse(
+    afterOld,
+    newRequest.request,
+    [newResponse],
+  );
+  const afterNew = reconcileBudgetAdjustmentRangeResponse(
+    newRequest.state,
+    newRequest.request,
+    [newResponse],
+  );
+  const reversed = reconcileBudgetAdjustmentRangeResponse(
+    afterNew,
+    oldRequest.request,
+    [oldResponse],
+  );
+
+  assert.deepEqual(chronological.rows[0].confirmed, reversed.rows[0].confirmed);
+  assert.deepEqual(chronological.rows[0].draft, reversed.rows[0].draft);
+  assert.deepEqual(chronological.rows[0].confirmed, {
+    amount: 30,
+    note: "Server note",
+    month: "2026-09",
+    category: "Server category",
+  });
+  assert.deepEqual(chronological.rows[0].draft, createDraft(
+    "20",
+    "Local note",
+    "2026-08",
+    "Local category",
+  ));
+  const expectedDirtyFields = {
+    amount: true,
+    note: true,
+    month: true,
+    category: true,
+  };
+  assert.deepEqual(
+    chronological.dirtyFieldsByAdjustmentId.get(adjustment.adjustmentId),
+    expectedDirtyFields,
+  );
+  assert.deepEqual(
+    reversed.dirtyFieldsByAdjustmentId.get(adjustment.adjustmentId),
+    expectedDirtyFields,
+  );
+  const partiallyReverted = replaceDraft(
+    chronological,
+    adjustment.adjustmentId,
+    createDraft("20", "Server note", "2026-09", "Server category"),
+  );
+  assert.deepEqual(partiallyReverted.dirtyFieldsByAdjustmentId.get(adjustment.adjustmentId), {
+    amount: true,
+    note: false,
+    month: false,
+    category: false,
+  });
+  const fullyReverted = replaceDraft(
+    partiallyReverted,
+    adjustment.adjustmentId,
+    createDraft("30", "Server note", "2026-09", "Server category"),
+  );
+  assert.equal(fullyReverted.dirtyFieldsByAdjustmentId.has(adjustment.adjustmentId), false);
+  assert.equal(fullyReverted.rows.length, 1);
+});
+
+test("July to August to deleted stays deleted in chronological response order", (): void => {
+  const scenario = createMoveThenDeleteScenario();
+  const afterJuly = reconcileBudgetAdjustmentRangeResponse(
+    scenario.state,
+    scenario.julyRequest,
+    [scenario.adjustment],
+  );
+  const afterMove = reconcileBudgetAdjustmentRangeResponse(
+    afterJuly,
+    scenario.augustMoveRequest,
+    [{ ...scenario.adjustment, month: "2026-08", category: "B" }],
+  );
+  const final = reconcileBudgetAdjustmentRangeResponse(
+    afterMove,
+    scenario.augustDeleteRequest,
+    [],
+  );
+
+  assert.deepEqual(final.rows, []);
+  assert.deepEqual(
+    final.rangeProvenanceByAdjustmentId.get(scenario.adjustment.adjustmentId),
+    getExpectedMoveThenDeleteProvenance(scenario),
+  );
+});
+
+test("July to August to deleted stays deleted in reversed response order", (): void => {
+  const scenario = createMoveThenDeleteScenario();
+  const afterDelete = reconcileBudgetAdjustmentRangeResponse(
+    scenario.state,
+    scenario.augustDeleteRequest,
+    [],
+  );
+  const afterMove = reconcileBudgetAdjustmentRangeResponse(
+    afterDelete,
+    scenario.augustMoveRequest,
+    [{ ...scenario.adjustment, month: "2026-08", category: "B" }],
+  );
+  assert.deepEqual(
+    afterMove.rangeProvenanceByAdjustmentId.get(scenario.adjustment.adjustmentId),
+    {
+      direction: "spend",
+      presenceRequestIdByMonth: new Map([
+        ["2026-08", scenario.augustMoveRequest.requestId],
+      ]),
+      absenceRequestIdByMonth: new Map([
+        ["2026-08", scenario.augustDeleteRequest.requestId],
+      ]),
+      deletedThroughRequestId: scenario.augustMoveRequest.requestId,
+    },
+  );
+  const final = reconcileBudgetAdjustmentRangeResponse(
+    afterMove,
+    scenario.julyRequest,
+    [scenario.adjustment],
+  );
+
+  assert.deepEqual(final.rows, []);
+  assert.deepEqual(
+    final.rangeProvenanceByAdjustmentId.get(scenario.adjustment.adjustmentId),
+    getExpectedMoveThenDeleteProvenance(scenario),
+  );
+});
+
+test("a non-overlapping source absence and destination move converge in both response orders", (): void => {
+  const adjustment = createAdjustment("non-overlap-move", 10, "2026-07", "spend", "A", null, 1);
+  const initial = createBudgetAdjustmentRangeReconciliationState([adjustment]);
+  const august = issueBudgetAdjustmentRangeRequest(initial, "2026-08", "2026-08");
+  const july = issueBudgetAdjustmentRangeRequest(august.state, "2026-07", "2026-07");
+  const moved = { ...adjustment, month: "2026-08", category: "B" };
+
+  const chronologicalMove = reconcileBudgetAdjustmentRangeResponse(
+    july.state,
+    august.request,
+    [moved],
+  );
+  const chronological = reconcileBudgetAdjustmentRangeResponse(
+    chronologicalMove,
+    july.request,
+    [],
+  );
+  const reversedAbsence = reconcileBudgetAdjustmentRangeResponse(
+    july.state,
+    july.request,
+    [],
+  );
+  const reversed = reconcileBudgetAdjustmentRangeResponse(
+    reversedAbsence,
+    august.request,
+    [moved],
+  );
+
+  assert.deepEqual(reversed.rows, chronological.rows);
+  assert.deepEqual(
+    reversed.rangeProvenanceByAdjustmentId,
+    chronological.rangeProvenanceByAdjustmentId,
+  );
+  assert.deepEqual(reversed.rangeProvenanceByAdjustmentId.get(adjustment.adjustmentId), {
+    direction: "spend",
+    presenceRequestIdByMonth: new Map([
+      ["2026-07", 0],
+      ["2026-08", august.request.requestId],
+    ]),
+    absenceRequestIdByMonth: new Map([
+      ["2026-07", july.request.requestId],
+    ]),
+    deletedThroughRequestId: 0,
+  });
+  assert.deepEqual(reversed.rows.map((row) => row.confirmed), [{
+    amount: 10,
+    note: null,
+    month: "2026-08",
+    category: "B",
+  }]);
+});
+
+test("overlapping ranges accept each month from its newest issued request", (): void => {
+  const initial = createBudgetAdjustmentRangeReconciliationState([]);
+  const first = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-08");
+  const second = issueBudgetAdjustmentRangeRequest(first.state, "2026-08", "2026-09");
+  const afterSecond = reconcileBudgetAdjustmentRangeResponse(second.state, second.request, [
+    createAdjustment("august", 20, "2026-08", "spend", "August", null, 2),
+    createAdjustment("september", 30, "2026-09", "spend", "September", null, 2),
+  ]);
+  const final = reconcileBudgetAdjustmentRangeResponse(afterSecond, first.request, [
+    createAdjustment("july", 10, "2026-07", "spend", "July", null, 1),
+    createAdjustment("august", 11, "2026-08", "spend", "August", null, 1),
+  ]);
+
+  assert.deepEqual(
+    final.rows.map((row) => [row.adjustmentId, row.confirmed.amount]),
+    [["july", 10], ["august", 20], ["september", 30]],
+  );
+  assert.equal(final.acceptedRangeRequestIdByMonth.get("2026-07"), first.request.requestId);
+  assert.equal(final.acceptedRangeRequestIdByMonth.get("2026-08"), second.request.requestId);
+  assert.equal(final.acceptedRangeRequestIdByMonth.get("2026-09"), second.request.requestId);
+});
+
+test("non-overlapping ranges merge regardless of response order", (): void => {
+  const initial = createBudgetAdjustmentRangeReconciliationState([]);
+  const july = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-07");
+  const september = issueBudgetAdjustmentRangeRequest(july.state, "2026-09", "2026-09");
+  const afterSeptember = reconcileBudgetAdjustmentRangeResponse(
+    september.state,
+    september.request,
+    [createAdjustment("september", 30, "2026-09", "income", "Salary", null, 2)],
+  );
+  const final = reconcileBudgetAdjustmentRangeResponse(
+    afterSeptember,
+    july.request,
+    [createAdjustment("july", 10, "2026-07", "spend", "Food", null, 1)],
+  );
+
+  assert.deepEqual(final.rows.map((row) => row.adjustmentId), ["july", "september"]);
+});
+
+test("range refreshes preserve dirty fields and rebase untouched fields", (): void => {
+  const adjustment = createAdjustment(
+    "dirty",
+    10,
+    "2026-07",
+    "spend",
+    "Saved",
+    "Original",
+    1,
+  );
+  const initial = createBudgetAdjustmentRangeReconciliationState([adjustment]);
+  const dirty = replaceDraft(initial, adjustment.adjustmentId, createDraft(
+    "25",
+    "Original",
+    "2026-07",
+    "Local category",
+  ));
+  const range = issueBudgetAdjustmentRangeRequest(dirty, "2026-07", "2026-08");
+  const final = reconcileBudgetAdjustmentRangeResponse(range.state, range.request, [
+    createAdjustment("dirty", 99, "2026-08", "spend", "Server category", "Server note", 2),
+  ]);
+
+  assert.deepEqual(final.rows[0].draft, createDraft(
+    "25",
+    "Server note",
+    "2026-08",
+    "Local category",
+  ));
+  assert.deepEqual(final.rows[0].confirmed, {
+    amount: 99,
+    note: "Server note",
+    month: "2026-08",
+    category: "Server category",
+  });
+});
+
+test("invalid draft fields survive while clean fields still rebase", (): void => {
+  const adjustment = createAdjustment("invalid", 10, "2026-07", "spend", "Saved", null, 1);
+  const initial = createBudgetAdjustmentRangeReconciliationState([adjustment]);
+  const dirty = replaceDraft(initial, adjustment.adjustmentId, createDraft(
+    "not-an-integer",
+    "local note",
+    "2026-07",
+    "Saved",
+  ));
+  const range = issueBudgetAdjustmentRangeRequest(dirty, "2026-07", "2026-07");
+  const final = reconcileBudgetAdjustmentRangeResponse(range.state, range.request, [
+    { ...adjustment, amount: 99, category: "Server", updatedAt: "2026-07-02T00:00:00.000Z" },
+  ]);
+
+  assert.deepEqual(
+    final.rows[0].draft,
+    createDraft("not-an-integer", "local note", "2026-07", "Server"),
+  );
+  assert.equal(final.rows[0].confirmed.amount, 99);
+  assert.equal(final.rows[0].confirmed.category, "Server");
+});
+
+test("an absent clean row is removed without discarding an absent dirty row", (): void => {
+  const clean = createAdjustment("clean", 10, "2026-07", "spend", "Clean", null, 1);
+  const dirty = createAdjustment("dirty", 20, "2026-07", "spend", "Dirty", null, 1);
+  const initial = createBudgetAdjustmentRangeReconciliationState([clean, dirty]);
+  const edited = replaceDraft(
+    initial,
+    dirty.adjustmentId,
+    createDraft("invalid", "", "2026-07", "Dirty"),
+  );
+  const range = issueBudgetAdjustmentRangeRequest(edited, "2026-07", "2026-07");
+  const final = reconcileBudgetAdjustmentRangeResponse(range.state, range.request, []);
+
+  assert.deepEqual(final.rows.map((row) => row.adjustmentId), ["dirty"]);
+  assert.equal(final.rows[0].draft.amountInput, "invalid");
+  assert.deepEqual(final.dirtyFieldsByAdjustmentId.get(dirty.adjustmentId), {
+    amount: true,
+    note: false,
+    month: false,
+    category: false,
+  });
+  const reverted = replaceDraft(
+    final,
+    dirty.adjustmentId,
+    createDraft("20", "", "2026-07", "Dirty"),
+  );
+  assert.deepEqual(reverted.rows, []);
+  assert.equal(reverted.dirtyFieldsByAdjustmentId.has(dirty.adjustmentId), false);
+});
+
+test("semantically equal blank, signed, zero, and formatted amounts retain raw input", (): void => {
+  const cases: ReadonlyArray<readonly [string, number]> = [
+    ["", 0],
+    ["   ", 0],
+    ["+0", 0],
+    ["-0", 0],
+    ["00", 0],
+    [" 0 ", 0],
+    ["+10", 10],
+    ["010", 10],
+    [" 10 ", 10],
+    ["-10", -10],
+  ];
+
+  for (const [amountInput, canonicalAmount] of cases) {
+    const adjustment = createAdjustment(
+      `raw-${amountInput || "blank"}`,
+      canonicalAmount,
+      "2026-07",
+      "spend",
+      "Raw",
+      "Old",
+      1,
+    );
+    const initial = createBudgetAdjustmentRangeReconciliationState([adjustment]);
+    const edited = replaceDraft(
+      initial,
+      adjustment.adjustmentId,
+      createDraft(amountInput, "Old", "2026-07", "Raw"),
+    );
+    const unchangedRange = issueBudgetAdjustmentRangeRequest(edited, "2026-07", "2026-07");
+    const unchanged = reconcileBudgetAdjustmentRangeResponse(
+      unchangedRange.state,
+      unchangedRange.request,
+      [{ ...adjustment, note: "Server" }],
+    );
+    assert.equal(unchanged.rows[0].draft.amountInput, amountInput);
+    assert.equal(unchanged.rows[0].draft.noteInput, "Server");
+
+    const changedRange = issueBudgetAdjustmentRangeRequest(unchanged, "2026-07", "2026-07");
+    const changed = reconcileBudgetAdjustmentRangeResponse(
+      changedRange.state,
+      changedRange.request,
+      [{ ...adjustment, amount: canonicalAmount + 1, note: "Later" }],
+    );
+    assert.equal(changed.rows[0].draft.amountInput, String(canonicalAmount + 1));
+  }
+});
+
+test("initial and range rows use the strict browser adjustment contract", (): void => {
+  const adjustment = createAdjustment("strict", 0, "2026-07", "spend", "Strict", null, 1);
+  assert.throws(
+    () => createBudgetAdjustmentRangeReconciliationState([{ ...adjustment, adjustmentId: "" }]),
+    /Initial budget adjustment[\s\S]*adjustmentId[\s\S]*between 1 and 200/,
+  );
+  assert.throws(
+    () => createBudgetAdjustmentRangeReconciliationState([{ ...adjustment, extra: true }]),
+    /Initial budget adjustment[\s\S]*Unrecognized key/,
+  );
+
+  const initial = createBudgetAdjustmentRangeReconciliationState([adjustment]);
+  const range = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-07");
+  const invalidRows: ReadonlyArray<readonly [unknown, RegExp]> = [
+    [{ ...adjustment, category: undefined }, /category/],
+    [{ ...adjustment, adjustmentId: "x".repeat(201) }, /adjustmentId[\s\S]*between 1 and 200/],
+    [{ ...adjustment, note: 1 }, /note/],
+    [{ ...adjustment, note: "n".repeat(2001) }, /note[\s\S]*at most 2000/],
+    [{ ...adjustment, createdAt: "2026-07-01" }, /createdAt/],
+    [{ ...adjustment, updatedAt: "not-a-timestamp" }, /updatedAt/],
+    [{ ...adjustment, extra: true }, /Unrecognized key/],
+  ];
+  for (const [input, expected] of invalidRows) {
+    assert.throws(
+      () => reconcileBudgetAdjustmentRangeResponse(range.state, range.request, [input]),
+      expected,
+    );
+  }
+});
+
+test("range responses reject out-of-range months, duplicate ids, and direction changes", (): void => {
+  const adjustment = createAdjustment("row", 10, "2026-07", "spend", "Food", null, 1);
+  const initial = createBudgetAdjustmentRangeReconciliationState([adjustment]);
+  const range = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-07");
+
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(range.state, range.request, [
+      { ...adjustment, month: "2026-08" },
+    ]),
+    /outside requested range 2026-07\.\.2026-07/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(
+      range.state,
+      range.request,
+      [adjustment, { ...adjustment }],
+    ),
+    /duplicate id "row"/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(range.state, range.request, [
+      { ...adjustment, direction: "income" },
+    ]),
+    /changed immutable direction.*spend to income/,
+  );
+  const removed = reconcileBudgetAdjustmentRangeResponse(range.state, range.request, []);
+  const refresh = issueBudgetAdjustmentRangeRequest(removed, "2026-07", "2026-07");
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(refresh.state, refresh.request, [
+      { ...adjustment, direction: "income" },
+    ]),
+    /changed immutable direction.*spend to income/,
+  );
+});
+
+test("request acknowledgements reject unknown, mismatched, repeated, and invalid requests", (): void => {
+  const initial = createBudgetAdjustmentRangeReconciliationState([]);
+  assert.throws(
+    () => issueBudgetAdjustmentRangeRequest(initial, "2026-08", "2026-07"),
+    /must not be after/,
+  );
+  assert.throws(
+    () => issueBudgetAdjustmentRangeRequest(
+      { ...initial, latestRequestId: Number.MAX_SAFE_INTEGER },
+      "2026-07",
+      "2026-07",
+    ),
+    /request id limit reached/,
+  );
+  const issued = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-07");
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(issued.state, {
+      ...issued.request,
+      requestId: issued.request.requestId + 1,
+    }, []),
+    /not issued by this state/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(
+      issued.state,
+      { ...issued.request, monthTo: "2026-08" },
+      [],
+    ),
+    /fields do not match the issued request/,
+  );
+  const invalidRequest: BudgetAdjustmentRangeRequest = {
+    requestId: 0,
+    monthFrom: "2026-07",
+    monthTo: "2026-07",
+  };
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(initial, invalidRequest, []),
+    /request id.*positive safe integer/,
+  );
+  const settled = reconcileBudgetAdjustmentRangeResponse(issued.state, issued.request, []);
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(settled, issued.request, []),
+    /more than once/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeFailure(settled, issued.request),
+    /fail settled/,
+  );
+  assert.throws(
+    () => replaceBudgetAdjustmentRangeDraft(
+      initial,
+      "missing",
+      createDraft("0", "", "2026-07", "Missing"),
+    ),
+    /missing budget adjustment/,
+  );
+});
+
+test("range failure settles only the exact network or validation request without accepting data", (): void => {
+  const adjustment = createAdjustment("failure", 10, "2026-07", "spend", "Food", null, 1);
+  const initial = createBudgetAdjustmentRangeReconciliationState([adjustment]);
+  const first = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-07");
+  const pending = issueBudgetAdjustmentRangeRequest(first.state, "2026-08", "2026-08");
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(pending.state, first.request, [
+      { ...adjustment, note: 1 },
+    ]),
+    /range response row 0[\s\S]*note/,
+  );
+  const failed = reconcileBudgetAdjustmentRangeFailure(pending.state, first.request);
+
+  assert.equal(failed.rows, pending.state.rows);
+  assert.equal(
+    failed.acceptedRangeRequestIdByMonth,
+    pending.state.acceptedRangeRequestIdByMonth,
+  );
+  assert.equal(
+    failed.rangeProvenanceByAdjustmentId,
+    pending.state.rangeProvenanceByAdjustmentId,
+  );
+  assert.equal(failed.acceptedRangeRequestIdByMonth.size, 0);
+  assert.equal(failed.requestsById.has(pending.request.requestId), true);
+  assert.equal(failed.settledRequestIds.has(pending.request.requestId), false);
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeFailure(
+      failed,
+      { ...pending.request, monthFrom: "2026-07" },
+    ),
+    /fields do not match the issued request/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeFailure(failed, first.request),
+    /fail settled/,
+  );
+});
+
+test("success and failure history is bounded while every pending request is retained", (): void => {
+  let state = createBudgetAdjustmentRangeReconciliationState([]);
+  const pending = issueBudgetAdjustmentRangeRequest(state, "2026-07", "2026-07");
+  state = pending.state;
+  const succeeded: Array<BudgetAdjustmentRangeRequest> = [];
+  const failed: Array<BudgetAdjustmentRangeRequest> = [];
+  for (let index = 0; index < 12; index += 1) {
+    const issued = issueBudgetAdjustmentRangeRequest(state, "2026-08", "2026-08");
+    if (index % 2 === 0) {
+      succeeded.push(issued.request);
+      state = reconcileBudgetAdjustmentRangeResponse(issued.state, issued.request, []);
+    } else {
+      failed.push(issued.request);
+      state = reconcileBudgetAdjustmentRangeFailure(issued.state, issued.request);
+    }
+  }
+
+  assert.equal(state.settledRequestIds.size, 8);
+  assert.equal(state.requestsById.size, 9);
+  assert.equal(state.requestsById.has(pending.request.requestId), true);
+  assert.equal(state.settledRequestIds.has(pending.request.requestId), false);
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(state, succeeded[0], []),
+    /outside the recent settled request history/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeResponse(state, succeeded.at(-1)!, []),
+    /more than once/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentRangeFailure(state, failed.at(-1)!),
+    /fail settled/,
+  );
+});
+
+test("range transitions sort deterministically without mutating any inputs", (): void => {
+  const adjustments = [
+    createAdjustment("z", 1, "2026-08", "spend", "Same", null, 1),
+    createAdjustment("a", 2, "2026-08", "spend", "Same", null, 1),
+    createAdjustment("income", 3, "2026-07", "income", "Income", null, 1),
+  ];
+  const originalAdjustments = structuredClone(adjustments);
+  const initial = createBudgetAdjustmentRangeReconciliationState(adjustments);
+  const originalRows = structuredClone(initial.rows);
+  const originalProvenance = structuredClone(initial.rangeProvenanceByAdjustmentId);
+  const draft = createDraft("4", "local", "2026-07", "Income");
+  const originalDraft = structuredClone(draft);
+  const edited = replaceDraft(initial, "income", draft);
+  const range = issueBudgetAdjustmentRangeRequest(edited, "2026-07", "2026-08");
+  const response = [...adjustments].reverse();
+  const originalResponse = structuredClone(response);
+  const final = reconcileBudgetAdjustmentRangeResponse(range.state, range.request, response);
+
+  assert.deepEqual(final.rows.map((row) => row.adjustmentId), ["income", "a", "z"]);
+  assert.deepEqual(adjustments, originalAdjustments);
+  assert.deepEqual(response, originalResponse);
+  assert.deepEqual(draft, originalDraft);
+  assert.deepEqual(initial.rows, originalRows);
+  assert.deepEqual(initial.rangeProvenanceByAdjustmentId, originalProvenance);
+  assert.equal(initial.latestRequestId, 0);
+  assert.equal(initial.requestsById.size, 0);
+  assert.equal(edited.requestsById.size, 0);
+  assert.equal(range.state.settledRequestIds.size, 0);
+});

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRangeReconciliation.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRangeReconciliation.ts
@@ -1,0 +1,473 @@
+import type { BudgetAdjustmentDirection } from "@/server/budget/budgetAdjustments";
+import {
+  budgetAdjustmentNoteFromInput,
+  budgetAdjustmentNoteToInput,
+  createBudgetAdjustmentEditorRow,
+  parseBudgetAdjustmentAmount,
+  replaceBudgetAdjustmentDraft,
+  sortBudgetAdjustmentRows,
+  type BudgetAdjustmentDraft,
+  type BudgetAdjustmentEditorRow,
+  type BudgetAdjustmentSnapshot,
+} from "@/ui/tables/budget/budgetAdjustmentRowsState";
+import { parseBudgetAdjustment } from "@/ui/tables/budget/budgetTableApi";
+
+const MONTH_PATTERN = /^\d{4}-(?:0[1-9]|1[0-2])$/;
+const RECENT_SETTLED_REQUEST_LIMIT = 8;
+
+export type BudgetAdjustmentRangeRequest = Readonly<{
+  requestId: number;
+  monthFrom: string;
+  monthTo: string;
+}>;
+
+export type BudgetAdjustmentRangeProvenance = Readonly<{
+  direction: BudgetAdjustmentDirection;
+  presenceRequestIdByMonth: ReadonlyMap<string, number>;
+  absenceRequestIdByMonth: ReadonlyMap<string, number>;
+  deletedThroughRequestId: number | null;
+}>;
+
+export type BudgetAdjustmentRangeDirtyFields = Readonly<{
+  amount: boolean;
+  note: boolean;
+  month: boolean;
+  category: boolean;
+}>;
+
+export type BudgetAdjustmentRangeReconciliationState = Readonly<{
+  rows: ReadonlyArray<BudgetAdjustmentEditorRow>;
+  latestRequestId: number;
+  acceptedRangeRequestIdByMonth: ReadonlyMap<string, number>;
+  rangeProvenanceByAdjustmentId: ReadonlyMap<string, BudgetAdjustmentRangeProvenance>;
+  dirtyFieldsByAdjustmentId: ReadonlyMap<string, BudgetAdjustmentRangeDirtyFields>;
+  requestsById: ReadonlyMap<number, BudgetAdjustmentRangeRequest>;
+  settledRequestIds: ReadonlySet<number>;
+}>;
+
+export type IssuedBudgetAdjustmentRangeRequest = Readonly<{
+  state: BudgetAdjustmentRangeReconciliationState;
+  request: BudgetAdjustmentRangeRequest;
+}>;
+
+const validateMonth = (month: string, context: string): void => {
+  if (!MONTH_PATTERN.test(month)) {
+    throw new RangeError(`${context} must use YYYY-MM with a valid month; received "${month}"`);
+  }
+};
+
+const validateRange = (monthFrom: string, monthTo: string, context: string): void => {
+  validateMonth(monthFrom, `${context} monthFrom`);
+  validateMonth(monthTo, `${context} monthTo`);
+  if (monthFrom > monthTo) {
+    throw new RangeError(`${context} monthFrom "${monthFrom}" must not be after monthTo "${monthTo}"`);
+  }
+};
+
+const validateRequestId = (requestId: number, context: string): void => {
+  if (!Number.isSafeInteger(requestId) || requestId < 1) {
+    throw new RangeError(`${context} must be a positive safe integer; received ${String(requestId)}`);
+  }
+};
+
+const requestsEqual = (
+  left: BudgetAdjustmentRangeRequest,
+  right: BudgetAdjustmentRangeRequest,
+): boolean => left.requestId === right.requestId
+  && left.monthFrom === right.monthFrom
+  && left.monthTo === right.monthTo;
+
+const requireIssuedRequest = (
+  state: BudgetAdjustmentRangeReconciliationState,
+  request: BudgetAdjustmentRangeRequest,
+): BudgetAdjustmentRangeRequest => {
+  validateRequestId(request.requestId, "Budget adjustment range request id");
+  validateRange(request.monthFrom, request.monthTo, "Budget adjustment range acknowledgement");
+  const stored = state.requestsById.get(request.requestId);
+  if (stored === undefined) {
+    const reason = request.requestId <= state.latestRequestId
+      ? "it fell outside the recent settled request history"
+      : "the request was not issued by this state";
+    throw new Error(
+      `Cannot acknowledge budget adjustment range request ${request.requestId}: ${reason}`,
+    );
+  }
+  if (!requestsEqual(stored, request)) {
+    throw new Error(
+      `Cannot acknowledge budget adjustment range request ${request.requestId}: request fields do not match the issued request`,
+    );
+  }
+  return stored;
+};
+
+const getNextRequestId = (state: BudgetAdjustmentRangeReconciliationState): number => {
+  if (!Number.isSafeInteger(state.latestRequestId) || state.latestRequestId < 0) {
+    throw new RangeError(
+      `Cannot issue budget adjustment range request: latest request id must be a non-negative safe integer; received ${String(state.latestRequestId)}`,
+    );
+  }
+  if (state.latestRequestId === Number.MAX_SAFE_INTEGER) {
+    throw new RangeError("Cannot issue another budget adjustment range request: request id limit reached");
+  }
+  return state.latestRequestId + 1;
+};
+
+const settleRequest = (
+  state: BudgetAdjustmentRangeReconciliationState,
+  requestId: number,
+): BudgetAdjustmentRangeReconciliationState => {
+  const requestsById = new Map(state.requestsById);
+  const settledRequestIds = new Set(state.settledRequestIds);
+  settledRequestIds.add(requestId);
+  while (settledRequestIds.size > RECENT_SETTLED_REQUEST_LIMIT) {
+    const expiredRequestId = Math.min(...settledRequestIds);
+    settledRequestIds.delete(expiredRequestId);
+    requestsById.delete(expiredRequestId);
+  }
+  return { ...state, requestsById, settledRequestIds };
+};
+
+const createRangeProvenance = (
+  direction: BudgetAdjustmentDirection,
+): BudgetAdjustmentRangeProvenance => ({
+  direction,
+  presenceRequestIdByMonth: new Map(),
+  absenceRequestIdByMonth: new Map(),
+  deletedThroughRequestId: null,
+});
+
+const advanceDeletionCutoff = (
+  current: number | null,
+  candidate: number,
+): number => current === null || candidate > current ? candidate : current;
+
+const recordRangePresence = (
+  provenance: BudgetAdjustmentRangeProvenance,
+  month: string,
+  requestId: number,
+): BudgetAdjustmentRangeProvenance => {
+  const presenceRequestIdByMonth = new Map(provenance.presenceRequestIdByMonth);
+  const previousRequestId = presenceRequestIdByMonth.get(month);
+  if (previousRequestId === undefined || requestId > previousRequestId) {
+    presenceRequestIdByMonth.set(month, requestId);
+  }
+  const absenceRequestId = provenance.absenceRequestIdByMonth.get(month);
+  const deletedThroughRequestId = absenceRequestId !== undefined && absenceRequestId > requestId
+    ? advanceDeletionCutoff(provenance.deletedThroughRequestId, requestId)
+    : provenance.deletedThroughRequestId;
+  return { ...provenance, presenceRequestIdByMonth, deletedThroughRequestId };
+};
+
+const recordRangeAbsence = (
+  provenance: BudgetAdjustmentRangeProvenance,
+  month: string,
+  requestId: number,
+): BudgetAdjustmentRangeProvenance => {
+  const absenceRequestIdByMonth = new Map(provenance.absenceRequestIdByMonth);
+  const previousRequestId = absenceRequestIdByMonth.get(month);
+  if (previousRequestId === undefined || requestId > previousRequestId) {
+    absenceRequestIdByMonth.set(month, requestId);
+  }
+  const presenceRequestId = provenance.presenceRequestIdByMonth.get(month);
+  const deletedThroughRequestId = presenceRequestId !== undefined && requestId > presenceRequestId
+    ? advanceDeletionCutoff(provenance.deletedThroughRequestId, presenceRequestId)
+    : provenance.deletedThroughRequestId;
+  return { ...provenance, absenceRequestIdByMonth, deletedThroughRequestId };
+};
+
+type LiveRangePresence = Readonly<{
+  requestId: number;
+  month: string;
+}>;
+
+const getLatestLiveRangePresence = (
+  provenance: BudgetAdjustmentRangeProvenance,
+): LiveRangePresence | null => {
+  let latest: LiveRangePresence | null = null;
+  for (const [month, requestId] of provenance.presenceRequestIdByMonth) {
+    const isDeleted = provenance.deletedThroughRequestId !== null
+      && requestId <= provenance.deletedThroughRequestId;
+    const isAbsent = (provenance.absenceRequestIdByMonth.get(month) ?? 0) > requestId;
+    if (isDeleted || isAbsent) continue;
+    if (latest === null || requestId > latest.requestId) latest = { requestId, month };
+  }
+  return latest;
+};
+
+const CLEAN_DIRTY_FIELDS: BudgetAdjustmentRangeDirtyFields = {
+  amount: false,
+  note: false,
+  month: false,
+  category: false,
+};
+
+const getReplacementDirtyFields = (
+  row: BudgetAdjustmentEditorRow,
+  draft: BudgetAdjustmentDraft,
+): BudgetAdjustmentRangeDirtyFields => {
+  const amount = parseBudgetAdjustmentAmount(draft.amountInput);
+  return {
+    amount: !amount.ok || amount.amount !== row.confirmed.amount,
+    note: budgetAdjustmentNoteFromInput(draft.noteInput) !== row.confirmed.note,
+    month: draft.month !== row.confirmed.month,
+    category: draft.category !== row.confirmed.category,
+  };
+};
+
+const hasDirtyFields = (dirtyFields: BudgetAdjustmentRangeDirtyFields): boolean =>
+  dirtyFields.amount
+  || dirtyFields.note
+  || dirtyFields.month
+  || dirtyFields.category;
+
+const rebaseDraft = (
+  row: BudgetAdjustmentEditorRow,
+  confirmed: BudgetAdjustmentSnapshot,
+  dirtyFields: BudgetAdjustmentRangeDirtyFields,
+): BudgetAdjustmentDraft => {
+  return {
+    amountInput: dirtyFields.amount || confirmed.amount === row.confirmed.amount
+      ? row.draft.amountInput
+      : String(confirmed.amount),
+    noteInput: dirtyFields.note || confirmed.note === row.confirmed.note
+      ? row.draft.noteInput
+      : budgetAdjustmentNoteToInput(confirmed.note),
+    month: dirtyFields.month || confirmed.month === row.confirmed.month
+      ? row.draft.month
+      : confirmed.month,
+    category: dirtyFields.category || confirmed.category === row.confirmed.category
+      ? row.draft.category
+      : confirmed.category,
+  };
+};
+
+const enumerateMonths = (monthFrom: string, monthTo: string): ReadonlyArray<string> => {
+  const months: Array<string> = [];
+  let current = monthFrom;
+  while (true) {
+    months.push(current);
+    if (current === monthTo) return months;
+    const year = Number(current.slice(0, 4));
+    const month = Number(current.slice(5, 7));
+    current = month === 12
+      ? `${String(year + 1).padStart(4, "0")}-01`
+      : `${current.slice(0, 5)}${String(month + 1).padStart(2, "0")}`;
+  }
+};
+
+const parseRangeRows = (
+  state: BudgetAdjustmentRangeReconciliationState,
+  request: BudgetAdjustmentRangeRequest,
+  inputs: ReadonlyArray<unknown>,
+): ReadonlyMap<string, BudgetAdjustmentEditorRow> => {
+  const existingById = new Map(
+    state.rows.map((row): readonly [string, BudgetAdjustmentEditorRow] => [row.adjustmentId, row]),
+  );
+  const rowsById = new Map<string, BudgetAdjustmentEditorRow>();
+  for (const [index, input] of inputs.entries()) {
+    const adjustment = parseBudgetAdjustment(input, `Budget adjustment range response row ${index}`);
+    if (adjustment.month < request.monthFrom || adjustment.month > request.monthTo) {
+      throw new RangeError(
+        `Budget adjustment range response row "${adjustment.adjustmentId}" month "${adjustment.month}" is outside requested range ${request.monthFrom}..${request.monthTo}`,
+      );
+    }
+    if (rowsById.has(adjustment.adjustmentId)) {
+      throw new Error(
+        `Budget adjustment range response contains duplicate id "${adjustment.adjustmentId}"`,
+      );
+    }
+    const existingDirection = existingById.get(adjustment.adjustmentId)?.direction
+      ?? state.rangeProvenanceByAdjustmentId.get(adjustment.adjustmentId)?.direction;
+    if (existingDirection !== undefined && existingDirection !== adjustment.direction) {
+      throw new Error(
+        `Budget adjustment range response changed immutable direction for "${adjustment.adjustmentId}" from ${existingDirection} to ${adjustment.direction}`,
+      );
+    }
+    rowsById.set(adjustment.adjustmentId, createBudgetAdjustmentEditorRow(adjustment));
+  }
+  return rowsById;
+};
+
+export const createBudgetAdjustmentRangeReconciliationState = (
+  adjustments: ReadonlyArray<unknown>,
+): BudgetAdjustmentRangeReconciliationState => {
+  const adjustmentIds = new Set<string>();
+  const rows = adjustments.map((input, index): BudgetAdjustmentEditorRow => {
+    const adjustment = parseBudgetAdjustment(input, `Initial budget adjustment at index ${index}`);
+    if (adjustmentIds.has(adjustment.adjustmentId)) {
+      throw new Error(`Initial budget adjustments contain duplicate id "${adjustment.adjustmentId}"`);
+    }
+    adjustmentIds.add(adjustment.adjustmentId);
+    return createBudgetAdjustmentEditorRow(adjustment);
+  });
+  return {
+    rows: sortBudgetAdjustmentRows(rows),
+    latestRequestId: 0,
+    acceptedRangeRequestIdByMonth: new Map(),
+    rangeProvenanceByAdjustmentId: new Map(rows.map((row): readonly [string, BudgetAdjustmentRangeProvenance] => [
+      row.adjustmentId,
+      recordRangePresence(createRangeProvenance(row.direction), row.confirmed.month, 0),
+    ])),
+    dirtyFieldsByAdjustmentId: new Map(),
+    requestsById: new Map(),
+    settledRequestIds: new Set(),
+  };
+};
+
+export const replaceBudgetAdjustmentRangeDraft = (
+  state: BudgetAdjustmentRangeReconciliationState,
+  adjustmentId: string,
+  draft: BudgetAdjustmentDraft,
+): BudgetAdjustmentRangeReconciliationState => {
+  const row = state.rows.find((candidate) => candidate.adjustmentId === adjustmentId);
+  if (row === undefined) {
+    throw new Error(`Cannot replace draft for missing budget adjustment "${adjustmentId}"`);
+  }
+  const provenance = state.rangeProvenanceByAdjustmentId.get(adjustmentId);
+  if (provenance === undefined) {
+    throw new Error(
+      `Cannot replace budget adjustment draft: missing provenance for "${adjustmentId}"`,
+    );
+  }
+  const dirtyFields = getReplacementDirtyFields(row, draft);
+  const dirtyFieldsByAdjustmentId = new Map(state.dirtyFieldsByAdjustmentId);
+  if (hasDirtyFields(dirtyFields)) {
+    dirtyFieldsByAdjustmentId.set(adjustmentId, dirtyFields);
+  } else {
+    dirtyFieldsByAdjustmentId.delete(adjustmentId);
+  }
+  const replacedRows = replaceBudgetAdjustmentDraft(state.rows, adjustmentId, { ...draft });
+  const rows = !hasDirtyFields(dirtyFields) && getLatestLiveRangePresence(provenance) === null
+    ? replacedRows.filter((candidate) => candidate.adjustmentId !== adjustmentId)
+    : replacedRows;
+  return { ...state, rows, dirtyFieldsByAdjustmentId };
+};
+
+export const issueBudgetAdjustmentRangeRequest = (
+  state: BudgetAdjustmentRangeReconciliationState,
+  monthFrom: string,
+  monthTo: string,
+): IssuedBudgetAdjustmentRangeRequest => {
+  validateRange(monthFrom, monthTo, "Budget adjustment range request");
+  const request: BudgetAdjustmentRangeRequest = {
+    requestId: getNextRequestId(state),
+    monthFrom,
+    monthTo,
+  };
+  const requestsById = new Map(state.requestsById);
+  requestsById.set(request.requestId, request);
+  return {
+    request,
+    state: { ...state, latestRequestId: request.requestId, requestsById },
+  };
+};
+
+export const reconcileBudgetAdjustmentRangeFailure = (
+  state: BudgetAdjustmentRangeReconciliationState,
+  request: BudgetAdjustmentRangeRequest,
+): BudgetAdjustmentRangeReconciliationState => {
+  const issued = requireIssuedRequest(state, request);
+  if (state.settledRequestIds.has(issued.requestId)) {
+    throw new Error(`Cannot fail settled budget adjustment range request ${issued.requestId}`);
+  }
+  return settleRequest(state, issued.requestId);
+};
+
+export const reconcileBudgetAdjustmentRangeResponse = (
+  state: BudgetAdjustmentRangeReconciliationState,
+  request: BudgetAdjustmentRangeRequest,
+  adjustments: ReadonlyArray<unknown>,
+): BudgetAdjustmentRangeReconciliationState => {
+  const issued = requireIssuedRequest(state, request);
+  if (state.settledRequestIds.has(issued.requestId)) {
+    throw new Error(`Cannot reconcile budget adjustment range request ${issued.requestId} more than once`);
+  }
+  const canonicalById = parseRangeRows(state, issued, adjustments);
+  const acceptedMonths = enumerateMonths(issued.monthFrom, issued.monthTo)
+    .filter((month): boolean =>
+      (state.acceptedRangeRequestIdByMonth.get(month) ?? 0) < issued.requestId);
+  const acceptedMonthSet = new Set(acceptedMonths);
+  const rangeProvenanceByAdjustmentId = new Map(state.rangeProvenanceByAdjustmentId);
+  for (const [adjustmentId, row] of canonicalById) {
+    let provenance = rangeProvenanceByAdjustmentId.get(adjustmentId)
+      ?? createRangeProvenance(row.direction);
+    provenance = recordRangePresence(provenance, row.confirmed.month, issued.requestId);
+    const acceptedTargetRequestId =
+      state.acceptedRangeRequestIdByMonth.get(row.confirmed.month) ?? 0;
+    if (acceptedTargetRequestId > issued.requestId) {
+      provenance = recordRangeAbsence(
+        provenance,
+        row.confirmed.month,
+        acceptedTargetRequestId,
+      );
+    }
+    rangeProvenanceByAdjustmentId.set(adjustmentId, provenance);
+  }
+
+  for (const [adjustmentId, currentProvenance] of rangeProvenanceByAdjustmentId) {
+    const fetchedMonth = canonicalById.get(adjustmentId)?.confirmed.month;
+    let provenance = currentProvenance;
+    for (const month of acceptedMonths) {
+      if (
+        fetchedMonth !== month
+        && provenance.presenceRequestIdByMonth.has(month)
+      ) {
+        provenance = recordRangeAbsence(provenance, month, issued.requestId);
+      }
+    }
+    rangeProvenanceByAdjustmentId.set(adjustmentId, provenance);
+  }
+
+  const fetchedById = new Map<string, BudgetAdjustmentEditorRow>();
+  for (const [adjustmentId, row] of canonicalById) {
+    const provenance = rangeProvenanceByAdjustmentId.get(adjustmentId);
+    if (provenance === undefined) {
+      throw new Error(
+        `Cannot reconcile budget adjustment range: missing provenance for "${adjustmentId}"`,
+      );
+    }
+    const latestPresence = getLatestLiveRangePresence(provenance);
+    if (
+      acceptedMonthSet.has(row.confirmed.month)
+      && latestPresence?.requestId === issued.requestId
+      && latestPresence.month === row.confirmed.month
+    ) {
+      fetchedById.set(adjustmentId, row);
+    }
+  }
+
+  const rows: Array<BudgetAdjustmentEditorRow> = [];
+  for (const row of state.rows) {
+    const fetched = fetchedById.get(row.adjustmentId);
+    if (fetched !== undefined) {
+      fetchedById.delete(row.adjustmentId);
+      const dirtyFields = state.dirtyFieldsByAdjustmentId.get(row.adjustmentId)
+        ?? CLEAN_DIRTY_FIELDS;
+      rows.push({ ...fetched, draft: rebaseDraft(row, fetched.confirmed, dirtyFields) });
+      continue;
+    }
+    const provenance = rangeProvenanceByAdjustmentId.get(row.adjustmentId);
+    if (provenance === undefined) {
+      throw new Error(
+        `Cannot reconcile budget adjustment range: missing provenance for "${row.adjustmentId}"`,
+      );
+    }
+    const dirtyFields = state.dirtyFieldsByAdjustmentId.get(row.adjustmentId)
+      ?? CLEAN_DIRTY_FIELDS;
+    if (getLatestLiveRangePresence(provenance) !== null || hasDirtyFields(dirtyFields)) {
+      rows.push(row);
+    }
+  }
+  rows.push(...fetchedById.values());
+
+  const acceptedRangeRequestIdByMonth = new Map(state.acceptedRangeRequestIdByMonth);
+  for (const month of acceptedMonths) {
+    acceptedRangeRequestIdByMonth.set(month, issued.requestId);
+  }
+  return settleRequest({
+    ...state,
+    rows: sortBudgetAdjustmentRows(rows),
+    acceptedRangeRequestIdByMonth,
+    rangeProvenanceByAdjustmentId,
+  }, issued.requestId);
+};

--- a/apps/web/src/ui/tables/budget/budgetTableApi.ts
+++ b/apps/web/src/ui/tables/budget/budgetTableApi.ts
@@ -18,15 +18,29 @@ const hasCodePointLengthBetween = (
 };
 
 const budgetAdjustmentSchema: z.ZodType<BudgetAdjustment> = z.object({
-  adjustmentId: z.string().refine((value): boolean => hasCodePointLengthBetween(value, 1, 200)),
+  adjustmentId: z.string().refine((value): boolean => hasCodePointLengthBetween(value, 1, 200), {
+    message: "must contain between 1 and 200 characters",
+  }),
   month: z.string().regex(/^\d{4}-(?:0[1-9]|1[0-2])$/),
   direction: z.enum(["income", "spend"]),
-  category: z.string().refine((value): boolean => hasCodePointLengthBetween(value, 1, 200)),
+  category: z.string().refine((value): boolean => hasCodePointLengthBetween(value, 1, 200), {
+    message: "must contain between 1 and 200 characters",
+  }),
   amount: z.number().safe().int(),
-  note: z.string().refine((value): boolean => hasCodePointLengthBetween(value, 0, 2000)).nullable(),
+  note: z.string().refine((value): boolean => hasCodePointLengthBetween(value, 0, 2000), {
+    message: "must contain at most 2000 characters",
+  }).nullable(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 }).strict();
+
+export const parseBudgetAdjustment = (input: unknown, context: string): BudgetAdjustment => {
+  const parsed = budgetAdjustmentSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new Error(`${context} is invalid: ${parsed.error.message}`);
+  }
+  return parsed.data;
+};
 
 const deleteBudgetAdjustmentResponseSchema = z.object({ ok: z.literal(true) }).strict();
 


### PR DESCRIPTION
## Summary

- add pure range-only budget adjustment reconciliation with strict server-row validation
- preserve request-order provenance, month-scoped absence/deletion evidence, and explicit per-field dirty drafts
- cover out-of-order range, orphan-revert, validation, history, and immutability behavior

## Testing

- relevant budget tests: 60 passed
- npm run lint
- npm run build
- whitespace, scope, dependency, and exact diff scans