### PR TITLE
Reconcile budget adjustment mutations

### DIFF
--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsReconciliation.test.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsReconciliation.test.ts
@@ -1,0 +1,402 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BudgetAdjustment, BudgetAdjustmentDirection } from "@/server/budget/budgetAdjustments";
+import {
+  buildBudgetAdjustmentPatch,
+  createBudgetAdjustmentRowsReconciliationState,
+  getBudgetAdjustmentInvalidatedCellKeys,
+  issueBudgetAdjustmentDeleteRequest,
+  issueBudgetAdjustmentPatchRequest,
+  issueBudgetAdjustmentRangeRequest,
+  reconcileBudgetAdjustmentDeleteAcknowledgement,
+  reconcileBudgetAdjustmentDeleteAmbiguousFailure,
+  reconcileBudgetAdjustmentDeleteDefinitiveFailure,
+  reconcileBudgetAdjustmentPatchAcknowledgement,
+  reconcileBudgetAdjustmentPatchAmbiguousFailure,
+  reconcileBudgetAdjustmentPatchDefinitiveFailure,
+  reconcileBudgetAdjustmentRangeFailure,
+  reconcileBudgetAdjustmentRangeResponse,
+  replaceBudgetAdjustmentReconciliationDraft,
+  type BudgetAdjustmentPatchRequest,
+  type BudgetAdjustmentRowsReconciliationState,
+} from "@/ui/tables/budget/budgetAdjustmentRowsReconciliation";
+import { getBudgetAdjustmentCellKey, type BudgetAdjustmentDraft } from "@/ui/tables/budget/budgetAdjustmentRowsState";
+
+const createAdjustment = (adjustmentId: string, amount: number, month: string,
+  direction: BudgetAdjustmentDirection, category: string, note: string | null, updatedDay: number,
+): BudgetAdjustment => ({
+  adjustmentId, amount, month, direction, category, note,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: `2026-07-${String(updatedDay).padStart(2, "0")}T00:00:00.000Z`,
+});
+
+const createDraft = (amountInput: string, month: string, category: string,
+  noteInput: string): BudgetAdjustmentDraft => ({ amountInput, month, category, noteInput });
+
+const editDraft = (state: BudgetAdjustmentRowsReconciliationState,
+  adjustmentId: string, draft: BudgetAdjustmentDraft,
+): BudgetAdjustmentRowsReconciliationState => replaceBudgetAdjustmentReconciliationDraft(state, adjustmentId, draft);
+
+test("patch params are minimal and blank amount parses as zero", (): void => {
+  const adjustment = createAdjustment("minimal", 5, "2026-07", "spend", "Food", null, 1);
+  const initial = createBudgetAdjustmentRowsReconciliationState([adjustment], "2026-07");
+  const edited = editDraft(initial, adjustment.adjustmentId, createDraft("", "2026-08", "Dining", "note"));
+  const issued = issueBudgetAdjustmentPatchRequest(edited, adjustment.adjustmentId);
+  assert.deepEqual(issued.request.params, { amount: 0, note: "note", month: "2026-08", category: "Dining" });
+  assert.deepEqual(buildBudgetAdjustmentPatch(issued.request.requested,
+    { ...issued.request.baseline, amount: 0, note: "note" }), { month: "2026-08", category: "Dining" });
+});
+
+test("raw zero formats survive only while semantically equal to the canonical amount", (): void => {
+  for (const amountInput of ["", "0", "+0", "-0", "00", "+00", "-00", " 0 "]) {
+    const adjustment = createAdjustment("raw-zero", 0, "2026-07", "spend", "Zero", "Old", 1);
+    const initial = createBudgetAdjustmentRowsReconciliationState([adjustment], "2026-07");
+    const edited = editDraft(initial, adjustment.adjustmentId, createDraft(amountInput, "2026-07", "Zero", "New"));
+    const patch = issueBudgetAdjustmentPatchRequest(edited, adjustment.adjustmentId);
+    assert.deepEqual(patch.request.params, { note: "New" });
+    const acknowledged = reconcileBudgetAdjustmentPatchAcknowledgement(patch.state, patch.request,
+      { ...adjustment, note: "New", updatedAt: "2026-07-02T00:00:00.000Z" });
+    assert.equal(acknowledged.state.rows[0].draft.amountInput, amountInput);
+  }
+});
+
+test("a note-only raw-zero race accepts a changed canonical server amount", (): void => {
+  const adjustment = createAdjustment("zero-race", 0, "2026-07", "spend", "Zero", "Old", 1);
+  const initial = createBudgetAdjustmentRowsReconciliationState([adjustment], "2026-07");
+  const requested = editDraft(initial, adjustment.adjustmentId, createDraft("+0", "2026-07", "Zero", "New"));
+  const patch = issueBudgetAdjustmentPatchRequest(requested, adjustment.adjustmentId);
+  const reformatted = editDraft(patch.state, adjustment.adjustmentId, createDraft("00", "2026-07", "Zero", "New"));
+  const acknowledged = reconcileBudgetAdjustmentPatchAcknowledgement(reformatted, patch.request,
+    { ...adjustment, amount: 5, note: "New", updatedAt: "2026-07-02T00:00:00.000Z" },
+  );
+  assert.equal(acknowledged.state.rows[0].confirmed.amount, 5);
+  assert.equal(acknowledged.state.rows[0].draft.amountInput, "5");
+  const noteEdited = editDraft(acknowledged.state, adjustment.adjustmentId, createDraft("5", "2026-07", "Zero", "Again"));
+  assert.deepEqual(issueBudgetAdjustmentPatchRequest(noteEdited, adjustment.adjustmentId).request.params,
+    { note: "Again" });
+});
+
+test("invalid and genuinely newer semantic amount edits remain visible after acknowledgement", (): void => {
+  for (const amountInput of ["invalid", "7"]) {
+    const adjustment = createAdjustment("newer", 0, "2026-07", "spend", "Zero", "Old", 1);
+    const initial = createBudgetAdjustmentRowsReconciliationState([adjustment], "2026-07");
+    const edited = editDraft(initial, adjustment.adjustmentId, createDraft("0", "2026-07", "Zero", "New"));
+    const patch = issueBudgetAdjustmentPatchRequest(edited, adjustment.adjustmentId);
+    const newer = editDraft(patch.state, adjustment.adjustmentId, createDraft(amountInput, "2026-07", "Zero", "New"));
+    const acknowledged = reconcileBudgetAdjustmentPatchAcknowledgement(newer, patch.request,
+      { ...adjustment, amount: 5, note: "New", updatedAt: "2026-07-02T00:00:00.000Z" });
+    assert.equal(acknowledged.state.rows[0].draft.amountInput, amountInput);
+    assert.equal(acknowledged.state.rows[0].confirmed.amount, 5);
+  }
+});
+
+test("patches serialize newer drafts and retire protection after authoritative absence", (): void => {
+  const adjustment = createAdjustment("serial", 0, "2026-07", "spend", "Food", null, 1);
+  const initial = createBudgetAdjustmentRowsReconciliationState([adjustment], "2026-07");
+  const first = issueBudgetAdjustmentPatchRequest(editDraft(initial, adjustment.adjustmentId,
+    createDraft("1", "2026-07", "Food", "")), adjustment.adjustmentId);
+  const newer = editDraft(first.state, adjustment.adjustmentId, createDraft("2", "2026-07", "Food", "local"));
+  assert.throws(() => issueBudgetAdjustmentPatchRequest(newer, adjustment.adjustmentId), /second patch.*pending/);
+  assert.throws(() => issueBudgetAdjustmentDeleteRequest(newer, adjustment.adjustmentId), /patch request is pending/);
+  const acknowledged = reconcileBudgetAdjustmentPatchAcknowledgement(newer, first.request,
+    { ...adjustment, amount: 1, note: "server", updatedAt: "2026-07-02T00:00:00.000Z" },
+  );
+  assert.deepEqual(acknowledged.state.rows[0].draft, createDraft("2", "2026-07", "Food", "local"));
+  assert.deepEqual(issueBudgetAdjustmentPatchRequest(acknowledged.state,
+    adjustment.adjustmentId).request.params, { amount: 2, note: "local" });
+  const range = issueBudgetAdjustmentRangeRequest(acknowledged.state, "2026-07", "2026-07");
+  const hidden = reconcileBudgetAdjustmentRangeResponse(range.state, range.request, []);
+  assert.equal(hidden.confirmedMutationRevisionById.has(adjustment.adjustmentId), false);
+  const reset = editDraft(hidden, adjustment.adjustmentId, createDraft("1", "2026-07", "Food", "server"));
+  assert.deepEqual(reset.rows, []);
+});
+
+test("patch requests and acknowledgements are strict, exact, and repeat-safe", (): void => {
+  const adjustment = createAdjustment("strict", 1, "2026-07", "spend", "Food", null, 1);
+  const initial = createBudgetAdjustmentRowsReconciliationState([adjustment], "2026-07");
+  const patch = issueBudgetAdjustmentPatchRequest(editDraft(initial, adjustment.adjustmentId,
+    createDraft("2", "2026-07", "Food", "")), adjustment.adjustmentId);
+  assert.throws(() => reconcileBudgetAdjustmentPatchAcknowledgement(patch.state,
+    { ...patch.request, params: { amount: 3 } }, { ...adjustment, amount: 2 }), /fields do not match/);
+  assert.throws(() => reconcileBudgetAdjustmentPatchAcknowledgement(patch.state,
+    { ...patch.request, requestId: 99 }, { ...adjustment, amount: 2 }), /not issued/);
+  for (const malformed of [
+    { ...adjustment, amount: 2, note: 4 },
+    { ...adjustment, amount: 2, extra: true },
+    { ...adjustment, amount: 2, updatedAt: "invalid" },
+  ]) {
+    assert.throws(() => reconcileBudgetAdjustmentPatchAcknowledgement(patch.state,
+      patch.request, malformed), /patch acknowledgement is invalid/);
+  }
+  assert.throws(() => reconcileBudgetAdjustmentPatchAcknowledgement(patch.state,
+    patch.request, { ...adjustment, adjustmentId: "other", amount: 2 }), /does not match requested id/);
+  assert.throws(() => reconcileBudgetAdjustmentPatchAcknowledgement(patch.state,
+    patch.request, { ...adjustment, direction: "income", amount: 2 }), /immutable direction/);
+  const accepted = reconcileBudgetAdjustmentPatchAcknowledgement(patch.state, patch.request, { ...adjustment, amount: 2 });
+  const repeated = reconcileBudgetAdjustmentPatchAcknowledgement(accepted.state, patch.request, { ...adjustment, amount: 2 });
+  assert.equal(repeated.outcome, "stale");
+  assert.equal(repeated.state, accepted.state);
+  const deletion = issueBudgetAdjustmentDeleteRequest(accepted.state, adjustment.adjustmentId);
+  const deleted = reconcileBudgetAdjustmentDeleteAcknowledgement(deletion.state, deletion.request, "deleted");
+  const staleAfterDelete = reconcileBudgetAdjustmentPatchAcknowledgement(deleted.state,
+    patch.request, { ...adjustment, amount: 2 });
+  assert.equal(staleAfterDelete.outcome, "stale");
+  assert.deepEqual(staleAfterDelete.state.rows, []);
+});
+
+test("definitive patch failure retries, while ambiguity needs a later authoritative range", (): void => {
+  const adjustment = createAdjustment("failure", 0, "2026-07", "spend", "Food", null, 1);
+  const initial = createBudgetAdjustmentRowsReconciliationState([adjustment], "2026-07");
+  const edited = editDraft(initial, adjustment.adjustmentId, createDraft("1", "2026-07", "Food", ""));
+  const definitiveRequest = issueBudgetAdjustmentPatchRequest(edited, adjustment.adjustmentId);
+  const newer = editDraft(definitiveRequest.state, adjustment.adjustmentId, createDraft("2", "2026-07", "Food", ""));
+  const definitive = reconcileBudgetAdjustmentPatchDefinitiveFailure(newer, definitiveRequest.request);
+  assert.deepEqual(issueBudgetAdjustmentPatchRequest(definitive,
+    adjustment.adjustmentId).request.params, { amount: 2 });
+
+  const ambiguousRequest = issueBudgetAdjustmentPatchRequest(edited, adjustment.adjustmentId);
+  const oldRange = issueBudgetAdjustmentRangeRequest(ambiguousRequest.state, "2026-07", "2026-07");
+  const ambiguous = reconcileBudgetAdjustmentPatchAmbiguousFailure(oldRange.state, ambiguousRequest.request);
+  const stale = reconcileBudgetAdjustmentRangeResponse(ambiguous, oldRange.request, [{ ...adjustment, amount: 1 }]);
+  assert.equal(stale.rows[0].confirmed.amount, 0);
+  assert.throws(() => issueBudgetAdjustmentPatchRequest(stale, adjustment.adjustmentId),
+    /range issued after.*ambiguous failure/);
+  const freshRange = issueBudgetAdjustmentRangeRequest(stale, "2026-07", "2026-07");
+  const refreshed = reconcileBudgetAdjustmentRangeResponse(freshRange.state,
+    freshRange.request, [{ ...adjustment, amount: 1 }]);
+  assert.equal(refreshed.rows[0].confirmed.amount, 1);
+  assert.equal(refreshed.rows[0].draft.amountInput, "1");
+  assert.equal(refreshed.ambiguousRangeRequirementByAdjustmentId.size, 0);
+});
+
+test("ambiguous moves require a found row or accepted source and target coverage", (): void => {
+  const adjustment = createAdjustment("ambiguous-move", 0, "2026-07", "spend", "Source", null, 1);
+  const initial = createBudgetAdjustmentRowsReconciliationState([adjustment], "2026-07");
+  const patch = issueBudgetAdjustmentPatchRequest(editDraft(initial, adjustment.adjustmentId, createDraft("0", "2026-08", "Target", "")), adjustment.adjustmentId);
+  const preFailure = issueBudgetAdjustmentRangeRequest(patch.state, "2026-07", "2026-08");
+  const ambiguous = reconcileBudgetAdjustmentPatchAmbiguousFailure(preFailure.state, patch.request);
+  const target = { ...adjustment, month: "2026-08", category: "Target" };
+  const stale = reconcileBudgetAdjustmentRangeResponse(ambiguous, preFailure.request, [target]);
+  assert.deepEqual([stale.rows[0].confirmed.month, stale.ambiguousRangeRequirementByAdjustmentId.size], ["2026-07", 1]);
+  const sourceOnly = issueBudgetAdjustmentRangeRequest(stale, "2026-07", "2026-07");
+  const unresolved = reconcileBudgetAdjustmentRangeResponse(sourceOnly.state, sourceOnly.request, []);
+  assert.deepEqual(unresolved.rows[0].draft, createDraft("0", "2026-08", "Target", ""));
+  assert.equal(unresolved.ambiguousRangeRequirementByAdjustmentId.size, 1);
+  assert.throws(() => issueBudgetAdjustmentPatchRequest(unresolved, adjustment.adjustmentId), /range issued after.*ambiguous failure/);
+  assert.throws(() => issueBudgetAdjustmentDeleteRequest(unresolved, adjustment.adjustmentId), /Cannot delete.*range issued after.*ambiguous failure/);
+  for (const months of [["2026-07", "2026-08"], ["2026-08", "2026-07"]]) {
+    let split = stale;
+    for (const month of months) {
+      const range = issueBudgetAdjustmentRangeRequest(split, month, month);
+      split = reconcileBudgetAdjustmentRangeResponse(range.state, range.request, []);
+    }
+    assert.deepEqual([split.rows, split.ambiguousRangeRequirementByAdjustmentId.size], [[], 0]);
+  }
+  const targetRange = issueBudgetAdjustmentRangeRequest(unresolved, "2026-08", "2026-08");
+  const found = reconcileBudgetAdjustmentRangeResponse(targetRange.state, targetRange.request, [target]);
+  assert.deepEqual([found.rows[0].confirmed.month, found.ambiguousRangeRequirementByAdjustmentId.size], ["2026-08", 0]);
+  assert.equal(issueBudgetAdjustmentDeleteRequest(found, adjustment.adjustmentId).request.confirmed.month, "2026-08");
+  const combined = issueBudgetAdjustmentRangeRequest(ambiguous, "2026-07", "2026-08");
+  const absent = reconcileBudgetAdjustmentRangeResponse(combined.state, combined.request, []);
+  assert.deepEqual([absent.rows, absent.ambiguousRangeRequirementByAdjustmentId.size], [[], 0]);
+  const olderTarget = issueBudgetAdjustmentRangeRequest(ambiguous, "2026-08", "2026-08");
+  const newerTarget = issueBudgetAdjustmentRangeRequest(olderTarget.state, "2026-08", "2026-08");
+  const newestAbsent = reconcileBudgetAdjustmentRangeResponse(newerTarget.state, newerTarget.request, []);
+  const staleFound = reconcileBudgetAdjustmentRangeResponse(newestAbsent, olderTarget.request, [target]);
+  assert.deepEqual([staleFound.rows[0].confirmed.month, staleFound.ambiguousRangeRequirementByAdjustmentId.size], ["2026-07", 1]);
+});
+
+test("zero and invalid moved drafts provisionally invalidate their confirmed source", (): void => {
+  const adjustment = createAdjustment("provisional", 0, "2026-07", "spend", "Source", null, 1);
+  const initial = createBudgetAdjustmentRowsReconciliationState([adjustment], "2026-07");
+  const sourceKey = getBudgetAdjustmentCellKey("2026-07", "spend", "Source");
+  for (const [amountInput, noteInput] of [["0", ""], ["invalid", ""], ["0", "x".repeat(2001)]]) {
+    const moved = editDraft(initial, adjustment.adjustmentId,
+      createDraft(amountInput, "invalid-month", "", noteInput));
+    assert.equal(getBudgetAdjustmentInvalidatedCellKeys(moved).has(sourceKey), true);
+    assert.equal(moved.cellInvalidationRevisionByKey.size, 0);
+  }
+});
+
+test("confirmed zero moves and both delete outcomes invalidate source cells", (): void => {
+  for (const outcome of ["deleted", "already-absent"] as const) {
+    const move = createAdjustment(`move-${outcome}`, 0, "2026-07", "spend", "Move", null, 1);
+    const remove = createAdjustment(`delete-${outcome}`, 0, "2026-08", "spend", "Delete", null, 1);
+    const initial = createBudgetAdjustmentRowsReconciliationState([remove, move], "2026-07");
+    const patch = issueBudgetAdjustmentPatchRequest(editDraft(initial, move.adjustmentId,
+      createDraft("0", "2026-09", "Target", "")), move.adjustmentId);
+    const moved = reconcileBudgetAdjustmentPatchAcknowledgement(patch.state, patch.request,
+      { ...move, month: "2026-09", category: "Target", updatedAt: "2026-07-02T00:00:00.000Z" },
+    );
+    const deletion = issueBudgetAdjustmentDeleteRequest(moved.state, remove.adjustmentId);
+    assert.throws(() => issueBudgetAdjustmentPatchRequest(deletion.state,
+      remove.adjustmentId), /delete request is pending/);
+    const deleted = reconcileBudgetAdjustmentDeleteAcknowledgement(deletion.state, deletion.request, outcome);
+    assert.equal(deleted.state.deletedMutationRevisionById.has(remove.adjustmentId), false);
+    assert.equal(deleted.state.cellInvalidationRevisionByKey.has(
+      getBudgetAdjustmentCellKey("2026-07", "spend", "Move")), true);
+    assert.equal(deleted.state.cellInvalidationRevisionByKey.has(
+      getBudgetAdjustmentCellKey("2026-08", "spend", "Delete")), true);
+    const repeated = reconcileBudgetAdjustmentDeleteAcknowledgement(deleted.state, deletion.request, outcome);
+    assert.equal(repeated.outcome, "already-applied");
+    assert.equal(repeated.state, deleted.state);
+  }
+});
+
+test("delete failures preserve drafts, permit retry, and mark ambiguity only when needed", (): void => {
+  const adjustment = createAdjustment("delete-retry", 4, "2026-07", "spend", "Food", null, 1);
+  const dirty = editDraft(
+    createBudgetAdjustmentRowsReconciliationState([adjustment], "2026-07"),
+    adjustment.adjustmentId,
+    createDraft("5", "2026-07", "Food", "local"),
+  );
+  const definitiveRequest = issueBudgetAdjustmentDeleteRequest(dirty, adjustment.adjustmentId);
+  const definitive = reconcileBudgetAdjustmentDeleteDefinitiveFailure(
+    definitiveRequest.state, definitiveRequest.request,
+  );
+  assert.deepEqual(definitive.rows[0].draft, dirty.rows[0].draft);
+  assert.doesNotThrow(() => issueBudgetAdjustmentDeleteRequest(definitive, adjustment.adjustmentId));
+  assert.equal(definitive.ambiguousRangeRequirementByAdjustmentId.size, 0);
+
+  const ambiguousRequest = issueBudgetAdjustmentDeleteRequest(dirty, adjustment.adjustmentId);
+  const oldRange = issueBudgetAdjustmentRangeRequest(ambiguousRequest.state, "2026-07", "2026-07");
+  const ambiguous = reconcileBudgetAdjustmentDeleteAmbiguousFailure(oldRange.state, ambiguousRequest.request);
+  const stale = reconcileBudgetAdjustmentRangeResponse(ambiguous, oldRange.request, []);
+  assert.equal(stale.rows.length, 1);
+  assert.throws(() => issueBudgetAdjustmentDeleteRequest(
+    stale, adjustment.adjustmentId,
+  ), /range issued after.*ambiguous failure/);
+  const freshRange = issueBudgetAdjustmentRangeRequest(stale, "2026-07", "2026-07");
+  const absent = reconcileBudgetAdjustmentRangeResponse(freshRange.state, freshRange.request, []);
+  assert.deepEqual(absent.rows, []);
+  assert.equal(absent.ambiguousRangeRequirementByAdjustmentId.size, 0);
+});
+
+test("range ordering owns moves, deletion, and off-range source invalidations", (): void => {
+  const original = createAdjustment("range-row", 0, "2026-07", "spend", "A", null, 1);
+  const movedB = { ...original, month: "2026-08", category: "B" };
+  const movedC = { ...original, month: "2026-09", category: "C" };
+  for (const newerFirst of [false, true]) {
+    const initial = createBudgetAdjustmentRowsReconciliationState([original], "2026-07");
+    const older = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-08");
+    const newer = issueBudgetAdjustmentRangeRequest(older.state, "2026-07", "2026-09");
+    const first = newerFirst
+      ? reconcileBudgetAdjustmentRangeResponse(newer.state, newer.request, [movedC])
+      : reconcileBudgetAdjustmentRangeResponse(newer.state, older.request, [movedB]);
+    const final = newerFirst
+      ? reconcileBudgetAdjustmentRangeResponse(first, older.request, [movedB])
+      : reconcileBudgetAdjustmentRangeResponse(first, newer.request, [movedC]);
+    assert.deepEqual(final.rows.map((row) => [row.confirmed.month, row.confirmed.category]), [
+      ["2026-09", "C"],
+    ]);
+    assert.deepEqual([
+      final.latestMutationRevision,
+      final.confirmedMutationRevisionById.size,
+      final.deletedMutationRevisionById.size,
+    ], [0, 0, 0]);
+  }
+
+  const initial = createBudgetAdjustmentRowsReconciliationState([original], "2026-07");
+  const move = issueBudgetAdjustmentRangeRequest(initial, "2026-08", "2026-08");
+  const moved = reconcileBudgetAdjustmentRangeResponse(move.state, move.request, [movedB]);
+  const sourceKey = getBudgetAdjustmentCellKey("2026-07", "spend", "A");
+  assert.equal(getBudgetAdjustmentInvalidatedCellKeys(moved).has(sourceKey), true);
+  const deletion = issueBudgetAdjustmentRangeRequest(moved, "2026-08", "2026-08");
+  const deleted = reconcileBudgetAdjustmentRangeResponse(deletion.state, deletion.request, []);
+  assert.deepEqual(deleted.rows, []);
+  assert.equal(deleted.latestMutationRevision, 0);
+  const source = issueBudgetAdjustmentRangeRequest(deleted, "2026-07", "2026-07");
+  const cleared = reconcileBudgetAdjustmentRangeResponse(source.state, source.request, []);
+  assert.equal(getBudgetAdjustmentInvalidatedCellKeys(cleared).has(sourceKey), false);
+});
+
+test("stale ranges cannot regress patch/delete, while later source ranges clear invalidations", (): void => {
+  const move = createAdjustment("patched", 0, "2026-07", "spend", "Move", null, 1);
+  const remove = createAdjustment("deleted", 0, "2026-07", "spend", "Delete", null, 1);
+  const initial = createBudgetAdjustmentRowsReconciliationState([remove, move], "2026-07");
+  const staleRange = issueBudgetAdjustmentRangeRequest(initial, "2026-07", "2026-08");
+  const patch = issueBudgetAdjustmentPatchRequest(
+    editDraft(staleRange.state, move.adjustmentId, createDraft("0", "2026-08", "Target", "")),
+    move.adjustmentId,
+  );
+  const pendingRange = issueBudgetAdjustmentRangeRequest(patch.state, "2026-07", "2026-07");
+  const protectedPending = reconcileBudgetAdjustmentRangeResponse(
+    pendingRange.state, pendingRange.request, [{ ...move, amount: 99 }, remove],
+  );
+  assert.equal(protectedPending.rows.find((row) => row.adjustmentId === move.adjustmentId)?.confirmed.amount, 0);
+  const patched = reconcileBudgetAdjustmentPatchAcknowledgement(
+    protectedPending,
+    patch.request,
+    { ...move, month: "2026-08", category: "Target", updatedAt: "2026-07-02T00:00:00.000Z" },
+  );
+  const deletion = issueBudgetAdjustmentDeleteRequest(patched.state, remove.adjustmentId);
+  const deleted = reconcileBudgetAdjustmentDeleteAcknowledgement(
+    deletion.state, deletion.request, "deleted",
+  );
+  assert.equal(deleted.state.deletedMutationRevisionById.has(remove.adjustmentId), true);
+  const failedStale = reconcileBudgetAdjustmentRangeFailure(deleted.state, staleRange.request);
+  assert.equal(failedStale.deletedMutationRevisionById.has(remove.adjustmentId), false);
+  assert.deepEqual(failedStale.rows.map((row) => row.adjustmentId), ["patched"]);
+  const target = { ...move, month: "2026-08", category: "Target" };
+  const targetRange = issueBudgetAdjustmentRangeRequest(deleted.state, "2026-08", "2026-08");
+  const canonical = reconcileBudgetAdjustmentRangeResponse(targetRange.state, targetRange.request, [target]);
+  const stale = reconcileBudgetAdjustmentRangeResponse(canonical, staleRange.request, [move, remove]);
+  assert.deepEqual(stale.rows.map((row) => [row.adjustmentId, row.confirmed.month]), [
+    ["patched", "2026-08"],
+  ]);
+  assert.equal(stale.confirmedMutationRevisionById.has(move.adjustmentId), false);
+  assert.equal(stale.deletedMutationRevisionById.has(remove.adjustmentId), false);
+  const repeated = reconcileBudgetAdjustmentDeleteAcknowledgement(stale, deletion.request, "deleted");
+  assert.equal(repeated.outcome, "already-applied");
+  assert.equal(repeated.state, stale);
+  const emptyRange = issueBudgetAdjustmentRangeRequest(deleted.state, "2026-08", "2026-08");
+  const empty = reconcileBudgetAdjustmentRangeResponse(emptyRange.state, emptyRange.request, []);
+  assert.deepEqual(reconcileBudgetAdjustmentRangeResponse(
+    empty, staleRange.request, [move, remove],
+  ).rows, []);
+  const moveKey = getBudgetAdjustmentCellKey("2026-07", "spend", "Move");
+  const deleteKey = getBudgetAdjustmentCellKey("2026-07", "spend", "Delete");
+  assert.equal(stale.cellInvalidationRevisionByKey.has(moveKey), true);
+  assert.equal(stale.cellInvalidationRevisionByKey.has(deleteKey), true);
+  const sourceRange = issueBudgetAdjustmentRangeRequest(stale, "2026-07", "2026-07");
+  assert.equal(sourceRange.request.mutationRevision, stale.latestMutationRevision);
+  const refreshed = reconcileBudgetAdjustmentRangeResponse(sourceRange.state, sourceRange.request, []);
+  assert.equal(refreshed.cellInvalidationRevisionByKey.has(moveKey), false);
+  assert.equal(refreshed.cellInvalidationRevisionByKey.has(deleteKey), false);
+  assert.equal(refreshed.rows[0].confirmed.month, "2026-08");
+});
+
+test("mutation history is bounded, retains pending requests, and transitions are immutable", (): void => {
+  const pendingRow = createAdjustment("pending", 0, "2026-08", "spend", "B", null, 1);
+  const retryRow = createAdjustment("retry", 0, "2026-07", "income", "A", null, 1);
+  const adjustments = [pendingRow, retryRow];
+  const originalAdjustments = structuredClone(adjustments);
+  const initial = createBudgetAdjustmentRowsReconciliationState(adjustments, "2026-07");
+  const originalRows = structuredClone(initial.rows);
+  const pending = issueBudgetAdjustmentDeleteRequest(initial, pendingRow.adjustmentId);
+  let state = pending.state;
+  const settled: Array<BudgetAdjustmentPatchRequest> = [];
+  for (let index = 1; index <= 12; index += 1) {
+    state = editDraft(state, retryRow.adjustmentId, createDraft(String(index), "2026-07", "A", ""));
+    const issued = issueBudgetAdjustmentPatchRequest(state, retryRow.adjustmentId);
+    settled.push(issued.request);
+    state = reconcileBudgetAdjustmentPatchDefinitiveFailure(issued.state, issued.request);
+  }
+  assert.equal(state.settledMutationRequestIds.size, 8);
+  assert.equal(state.mutationRequestsById.size, 9);
+  assert.equal(state.mutationRequestsById.has(pending.request.requestId), true);
+  assert.throws(
+    () => reconcileBudgetAdjustmentPatchDefinitiveFailure(state, settled[0]),
+    /outside the recent settled request history/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentPatchDefinitiveFailure(state, settled.at(-1)!),
+    /Cannot fail settled/,
+  );
+  assert.deepEqual(state.rows.map((row) => row.adjustmentId), ["retry", "pending"]);
+  assert.deepEqual(adjustments, originalAdjustments);
+  assert.deepEqual(initial.rows, originalRows);
+  assert.equal(initial.latestMutationRequestId, 0);
+  assert.equal(initial.mutationRequestsById.size, 0);
+});

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsReconciliation.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsReconciliation.ts
@@ -1,0 +1,1023 @@
+import type {
+  BudgetAdjustmentDirection,
+  PatchBudgetAdjustmentParams,
+} from "@/server/budget/budgetAdjustments";
+import {
+  issueBudgetAdjustmentRangeRequest as issueRangeRequest,
+  reconcileBudgetAdjustmentRangeFailure as reconcileRangeFailure,
+  reconcileBudgetAdjustmentRangeResponse as reconcileRangeResponse,
+  replaceBudgetAdjustmentRangeDraft,
+  createBudgetAdjustmentRangeReconciliationState,
+  type BudgetAdjustmentRangeDirtyFields,
+  type BudgetAdjustmentRangeReconciliationState,
+  type BudgetAdjustmentRangeRequest as BaseRangeRequest,
+} from "@/ui/tables/budget/budgetAdjustmentRangeReconciliation";
+import {
+  parseBudgetAdjustment,
+  type DeleteBudgetAdjustmentOutcome,
+} from "@/ui/tables/budget/budgetTableApi";
+import {
+  budgetAdjustmentNoteFromInput,
+  budgetAdjustmentNoteToInput,
+  clearBudgetAdjustmentCellInvalidations,
+  createBudgetAdjustmentEditorRow,
+  getBudgetAdjustmentCellKey,
+  parseBudgetAdjustmentAmount,
+  parseBudgetAdjustmentDraft,
+  recordBudgetAdjustmentCellInvalidation,
+  recordBudgetAdjustmentCellMove,
+  sortBudgetAdjustmentRows,
+  type BudgetAdjustmentDraft,
+  type BudgetAdjustmentEditorRow,
+  type BudgetAdjustmentSnapshot,
+} from "@/ui/tables/budget/budgetAdjustmentRowsState";
+
+const MONTH_PATTERN = /^\d{4}-(?:0[1-9]|1[0-2])$/;
+const RECENT_SETTLED_MUTATION_LIMIT = 8;
+
+export type BudgetAdjustmentRangeRequest = Readonly<{
+  kind: "range";
+  requestId: number;
+  monthFrom: string;
+  monthTo: string;
+  mutationRevision: number;
+}>;
+
+export type BudgetAdjustmentPatchRequest = Readonly<{
+  kind: "patch";
+  requestId: number;
+  adjustmentId: string;
+  direction: BudgetAdjustmentDirection;
+  draft: BudgetAdjustmentDraft;
+  requested: BudgetAdjustmentSnapshot;
+  baseline: BudgetAdjustmentSnapshot;
+  params: PatchBudgetAdjustmentParams;
+  mutationRevision: number;
+}>;
+
+export type BudgetAdjustmentDeleteRequest = Readonly<{
+  kind: "delete";
+  requestId: number;
+  adjustmentId: string;
+  direction: BudgetAdjustmentDirection;
+  confirmed: BudgetAdjustmentSnapshot;
+  mutationRevision: number;
+}>;
+
+export type BudgetAdjustmentMutationRequest = BudgetAdjustmentPatchRequest | BudgetAdjustmentDeleteRequest;
+
+export type BudgetAdjustmentReconciliationRequest = BudgetAdjustmentRangeRequest | BudgetAdjustmentMutationRequest;
+
+export type BudgetAdjustmentAmbiguousRangeRequirement = Readonly<{
+  afterRequestId: number;
+  sourceMonth: string;
+  targetMonth: string;
+}>;
+
+export type BudgetAdjustmentRowsReconciliationState =
+  BudgetAdjustmentRangeReconciliationState & Readonly<{
+    planFrom: string;
+    latestMutationRequestId: number;
+    latestMutationRevision: number;
+    confirmedMutationRevisionById: ReadonlyMap<string, number>;
+    deletedMutationRevisionById: ReadonlyMap<string, number>;
+    cellInvalidationRevisionByKey: ReadonlyMap<string, number>;
+    rangeInvalidationRequestIdByCellKey: ReadonlyMap<string, number>;
+    mutationRequestsById: ReadonlyMap<number, BudgetAdjustmentMutationRequest>;
+    settledMutationRequestIds: ReadonlySet<number>;
+    appliedDeleteRequestIds: ReadonlySet<number>;
+    latestPatchRequestIdByAdjustmentId: ReadonlyMap<string, number>;
+    latestDeleteRequestIdByAdjustmentId: ReadonlyMap<string, number>;
+    ambiguousRangeRequirementByAdjustmentId: ReadonlyMap<string, BudgetAdjustmentAmbiguousRangeRequirement>;
+    rangeMutationRevisionByRequestId: ReadonlyMap<number, number>;
+  }>;
+
+export type IssuedBudgetAdjustmentRequest<Request extends BudgetAdjustmentReconciliationRequest> = Readonly<{
+  state: BudgetAdjustmentRowsReconciliationState;
+  request: Request;
+}>;
+
+export type BudgetAdjustmentPatchAcknowledgement = Readonly<{
+  state: BudgetAdjustmentRowsReconciliationState;
+  outcome: "accepted" | "stale";
+}>;
+
+export type BudgetAdjustmentDeleteAcknowledgement = Readonly<{
+  state: BudgetAdjustmentRowsReconciliationState;
+  outcome: "applied" | "already-applied" | "stale";
+}>;
+
+const validateMonth = (month: string, context: string): void => {
+  if (!MONTH_PATTERN.test(month)) {
+    throw new RangeError(`${context} must use YYYY-MM with a valid month; received "${month}"`);
+  }
+};
+
+const validateRequestId = (requestId: number, context: string): void => {
+  if (!Number.isSafeInteger(requestId) || requestId < 1) {
+    throw new RangeError(`${context} must be a positive safe integer; received ${String(requestId)}`);
+  }
+};
+
+const snapshotsEqual = (
+  left: BudgetAdjustmentSnapshot,
+  right: BudgetAdjustmentSnapshot,
+): boolean => Object.keys(left).length === 4
+  && Object.keys(right).length === 4
+  && left.amount === right.amount
+  && left.note === right.note
+  && left.month === right.month
+  && left.category === right.category;
+
+const draftsEqual = (
+  left: BudgetAdjustmentDraft,
+  right: BudgetAdjustmentDraft,
+): boolean => Object.keys(left).length === 4
+  && Object.keys(right).length === 4
+  && left.amountInput === right.amountInput
+  && left.noteInput === right.noteInput
+  && left.month === right.month
+  && left.category === right.category;
+
+const paramsEqual = (
+  left: PatchBudgetAdjustmentParams,
+  right: PatchBudgetAdjustmentParams,
+): boolean => Object.keys(left).length === Object.keys(right).length
+  && left.amount === right.amount
+  && left.note === right.note
+  && left.month === right.month
+  && left.category === right.category;
+
+const mutationRequestsEqual = (
+  left: BudgetAdjustmentMutationRequest,
+  right: BudgetAdjustmentMutationRequest,
+): boolean => {
+  if (
+    left.kind !== right.kind
+    || left.requestId !== right.requestId
+    || left.adjustmentId !== right.adjustmentId
+    || left.direction !== right.direction
+    || left.mutationRevision !== right.mutationRevision
+    || Object.keys(left).length !== Object.keys(right).length
+  ) return false;
+  if (left.kind === "patch" && right.kind === "patch") {
+    return draftsEqual(left.draft, right.draft)
+      && snapshotsEqual(left.requested, right.requested)
+      && snapshotsEqual(left.baseline, right.baseline)
+      && paramsEqual(left.params, right.params);
+  }
+  return left.kind === "delete"
+    && right.kind === "delete"
+    && snapshotsEqual(left.confirmed, right.confirmed);
+};
+
+const getRangeState = (
+  state: BudgetAdjustmentRowsReconciliationState,
+): BudgetAdjustmentRangeReconciliationState => ({
+  rows: state.rows,
+  latestRequestId: state.latestRequestId,
+  acceptedRangeRequestIdByMonth: state.acceptedRangeRequestIdByMonth,
+  rangeProvenanceByAdjustmentId: state.rangeProvenanceByAdjustmentId,
+  dirtyFieldsByAdjustmentId: state.dirtyFieldsByAdjustmentId,
+  requestsById: state.requestsById,
+  settledRequestIds: state.settledRequestIds,
+});
+
+const replaceRangeState = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  rangeState: BudgetAdjustmentRangeReconciliationState,
+): BudgetAdjustmentRowsReconciliationState => ({ ...state, ...rangeState });
+
+const getNextMutationRequestId = (
+  state: BudgetAdjustmentRowsReconciliationState,
+): number => {
+  if (!Number.isSafeInteger(state.latestMutationRequestId) || state.latestMutationRequestId < 0) {
+    throw new RangeError(
+      `Cannot issue budget adjustment mutation: latest request id must be a non-negative safe integer; received ${String(state.latestMutationRequestId)}`,
+    );
+  }
+  if (state.latestMutationRequestId === Number.MAX_SAFE_INTEGER) {
+    throw new RangeError("Cannot issue another budget adjustment mutation: request id limit reached");
+  }
+  return state.latestMutationRequestId + 1;
+};
+
+const getNextMutationRevision = (
+  state: BudgetAdjustmentRowsReconciliationState,
+): number => {
+  if (!Number.isSafeInteger(state.latestMutationRevision) || state.latestMutationRevision < 0) {
+    throw new RangeError(
+      `Cannot confirm budget adjustment mutation: latest revision must be a non-negative safe integer; received ${String(state.latestMutationRevision)}`,
+    );
+  }
+  if (state.latestMutationRevision === Number.MAX_SAFE_INTEGER) {
+    throw new RangeError("Cannot confirm budget adjustment mutation: revision limit reached");
+  }
+  return state.latestMutationRevision + 1;
+};
+
+const requireRow = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  adjustmentId: string,
+  operation: string,
+): BudgetAdjustmentEditorRow => {
+  const row = state.rows.find((candidate) => candidate.adjustmentId === adjustmentId);
+  if (row === undefined) {
+    throw new Error(`Cannot ${operation} missing budget adjustment "${adjustmentId}"`);
+  }
+  return row;
+};
+
+const addMutationRequest = <Request extends BudgetAdjustmentMutationRequest>(
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: Request,
+): BudgetAdjustmentRowsReconciliationState => {
+  const mutationRequestsById = new Map(state.mutationRequestsById);
+  mutationRequestsById.set(request.requestId, request);
+  return { ...state, latestMutationRequestId: request.requestId, mutationRequestsById };
+};
+
+const pruneMutationLifecycle = (
+  state: BudgetAdjustmentRowsReconciliationState,
+): BudgetAdjustmentRowsReconciliationState => {
+  const pendingRangeRevisions = [...state.requestsById]
+    .filter(([requestId]): boolean => !state.settledRequestIds.has(requestId))
+    .map(([requestId]): number => {
+      const revision = state.rangeMutationRevisionByRequestId.get(requestId);
+      if (revision === undefined) {
+        throw new Error(`Cannot prune mutation lifecycle: pending range request ${requestId} has no captured mutation revision`);
+      }
+      return revision;
+    });
+  const deletedMutationRevisionById = new Map(state.deletedMutationRevisionById);
+  for (const [adjustmentId, revision] of deletedMutationRevisionById) {
+    if (pendingRangeRevisions.every((pendingRevision) => pendingRevision >= revision)) {
+      deletedMutationRevisionById.delete(adjustmentId);
+    }
+  }
+  const appliedDeleteRequestIds = new Set([...state.appliedDeleteRequestIds]
+    .filter((requestId): boolean => state.mutationRequestsById.has(requestId)));
+  if (deletedMutationRevisionById.size === state.deletedMutationRevisionById.size
+    && appliedDeleteRequestIds.size === state.appliedDeleteRequestIds.size) return state;
+  return { ...state, deletedMutationRevisionById, appliedDeleteRequestIds };
+};
+
+const settleMutationRequest = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  requestId: number,
+): BudgetAdjustmentRowsReconciliationState => {
+  if (state.settledMutationRequestIds.has(requestId)) return state;
+  const mutationRequestsById = new Map(state.mutationRequestsById);
+  const settledMutationRequestIds = new Set(state.settledMutationRequestIds);
+  settledMutationRequestIds.add(requestId);
+  while (settledMutationRequestIds.size > RECENT_SETTLED_MUTATION_LIMIT) {
+    const expiredRequestId = Math.min(...settledMutationRequestIds);
+    settledMutationRequestIds.delete(expiredRequestId);
+    mutationRequestsById.delete(expiredRequestId);
+  }
+  return pruneMutationLifecycle({ ...state, mutationRequestsById, settledMutationRequestIds });
+};
+
+const requireMutationRequest = <Kind extends BudgetAdjustmentMutationRequest["kind"]>(
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: Extract<BudgetAdjustmentMutationRequest, Readonly<{ kind: Kind }>>,
+  kind: Kind,
+): Extract<BudgetAdjustmentMutationRequest, Readonly<{ kind: Kind }>> => {
+  validateRequestId(request.requestId, `Budget adjustment ${kind} request id`);
+  const stored = state.mutationRequestsById.get(request.requestId);
+  if (stored === undefined) {
+    const reason = request.requestId <= state.latestMutationRequestId
+      ? "it fell outside the recent settled request history"
+      : "the request was not issued by this state";
+    throw new Error(`Cannot acknowledge budget adjustment ${kind} request ${request.requestId}: ${reason}`);
+  }
+  if (stored.kind !== kind) {
+    throw new Error(
+      `Cannot acknowledge budget adjustment ${kind} request ${request.requestId}: it was issued as ${stored.kind}`,
+    );
+  }
+  if (!mutationRequestsEqual(stored, request)) {
+    throw new Error(
+      `Cannot acknowledge budget adjustment ${kind} request ${request.requestId}: request fields do not match the issued request`,
+    );
+  }
+  return stored as Extract<BudgetAdjustmentMutationRequest, Readonly<{ kind: Kind }>>;
+};
+
+const getDirtyFields = (
+  row: BudgetAdjustmentEditorRow,
+): BudgetAdjustmentRangeDirtyFields => {
+  const amount = parseBudgetAdjustmentAmount(row.draft.amountInput);
+  return {
+    amount: !amount.ok || amount.amount !== row.confirmed.amount,
+    note: budgetAdjustmentNoteFromInput(row.draft.noteInput) !== row.confirmed.note,
+    month: row.draft.month !== row.confirmed.month,
+    category: row.draft.category !== row.confirmed.category,
+  };
+};
+
+const hasDirtyFields = (fields: BudgetAdjustmentRangeDirtyFields): boolean =>
+  fields.amount || fields.note || fields.month || fields.category;
+
+const replaceDirtyFields = (
+  current: ReadonlyMap<string, BudgetAdjustmentRangeDirtyFields>,
+  row: BudgetAdjustmentEditorRow,
+): ReadonlyMap<string, BudgetAdjustmentRangeDirtyFields> => {
+  const next = new Map(current);
+  const fields = getDirtyFields(row);
+  if (hasDirtyFields(fields)) next.set(row.adjustmentId, fields);
+  else next.delete(row.adjustmentId);
+  return next;
+};
+
+const enumerateMonths = (monthFrom: string, monthTo: string): ReadonlyArray<string> => {
+  const months: Array<string> = [];
+  let current = monthFrom;
+  while (true) {
+    months.push(current);
+    if (current === monthTo) return months;
+    const year = Number(current.slice(0, 4));
+    const month = Number(current.slice(5, 7));
+    current = month === 12
+      ? `${String(year + 1).padStart(4, "0")}-01`
+      : `${current.slice(0, 5)}${String(month + 1).padStart(2, "0")}`;
+  }
+};
+
+export const createBudgetAdjustmentRowsReconciliationState = (
+  adjustments: ReadonlyArray<unknown>,
+  planFrom: string,
+): BudgetAdjustmentRowsReconciliationState => {
+  validateMonth(planFrom, "Budget adjustment plan boundary");
+  return {
+    ...createBudgetAdjustmentRangeReconciliationState(adjustments),
+    planFrom,
+    latestMutationRequestId: 0,
+    latestMutationRevision: 0,
+    confirmedMutationRevisionById: new Map(),
+    deletedMutationRevisionById: new Map(),
+    cellInvalidationRevisionByKey: new Map(),
+    rangeInvalidationRequestIdByCellKey: new Map(),
+    mutationRequestsById: new Map(),
+    settledMutationRequestIds: new Set(),
+    appliedDeleteRequestIds: new Set(),
+    latestPatchRequestIdByAdjustmentId: new Map(),
+    latestDeleteRequestIdByAdjustmentId: new Map(),
+    ambiguousRangeRequirementByAdjustmentId: new Map(),
+    rangeMutationRevisionByRequestId: new Map(),
+  };
+};
+
+export const replaceBudgetAdjustmentReconciliationDraft = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  adjustmentId: string,
+  draft: BudgetAdjustmentDraft,
+): BudgetAdjustmentRowsReconciliationState => replaceRangeState(
+  state,
+  replaceBudgetAdjustmentRangeDraft(
+    getRangeState(state),
+    adjustmentId,
+    { ...draft },
+  ),
+);
+
+export const getBudgetAdjustmentInvalidatedCellKeys = (
+  state: BudgetAdjustmentRowsReconciliationState,
+): ReadonlySet<string> => {
+  const keys = new Set([
+    ...state.cellInvalidationRevisionByKey.keys(),
+    ...state.rangeInvalidationRequestIdByCellKey.keys(),
+  ]);
+  for (const row of state.rows) {
+    if (
+      row.draft.month !== row.confirmed.month
+      || row.draft.category !== row.confirmed.category
+    ) {
+      keys.add(getBudgetAdjustmentCellKey(
+        row.confirmed.month,
+        row.direction,
+        row.confirmed.category,
+      ));
+    }
+  }
+  return keys;
+};
+
+export const issueBudgetAdjustmentRangeRequest = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  monthFrom: string,
+  monthTo: string,
+): IssuedBudgetAdjustmentRequest<BudgetAdjustmentRangeRequest> => {
+  const issued = issueRangeRequest(getRangeState(state), monthFrom, monthTo);
+  const rangeMutationRevisionByRequestId = new Map(state.rangeMutationRevisionByRequestId);
+  rangeMutationRevisionByRequestId.set(issued.request.requestId, state.latestMutationRevision);
+  return {
+    state: {
+      ...replaceRangeState(state, issued.state),
+      rangeMutationRevisionByRequestId,
+    },
+    request: {
+      kind: "range",
+      ...issued.request,
+      mutationRevision: state.latestMutationRevision,
+    },
+  };
+};
+
+const requireRangeRequest = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentRangeRequest,
+): BaseRangeRequest => {
+  validateRequestId(request.requestId, "Budget adjustment range request id");
+  if (request.kind !== "range" || Object.keys(request).length !== 5) {
+    throw new Error(`Cannot acknowledge budget adjustment range request ${request.requestId}: invalid request shape`);
+  }
+  const revision = state.rangeMutationRevisionByRequestId.get(request.requestId);
+  if (revision === undefined) {
+    const reason = request.requestId <= state.latestRequestId
+      ? "it fell outside the recent settled request history"
+      : "the request was not issued by this state";
+    throw new Error(`Cannot acknowledge budget adjustment range request ${request.requestId}: ${reason}`);
+  }
+  if (revision !== request.mutationRevision) {
+    throw new Error(
+      `Cannot acknowledge budget adjustment range request ${request.requestId}: mutation revision does not match the issued request`,
+    );
+  }
+  return {
+    requestId: request.requestId,
+    monthFrom: request.monthFrom,
+    monthTo: request.monthTo,
+  };
+};
+
+const pruneRangeRevisionHistory = (
+  current: ReadonlyMap<number, number>,
+  rangeState: BudgetAdjustmentRangeReconciliationState,
+): ReadonlyMap<number, number> => new Map([...current]
+  .filter(([requestId]): boolean => rangeState.requestsById.has(requestId)));
+
+export const reconcileBudgetAdjustmentRangeFailure = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentRangeRequest,
+): BudgetAdjustmentRowsReconciliationState => {
+  const failed = reconcileRangeFailure(getRangeState(state), requireRangeRequest(state, request));
+  return pruneMutationLifecycle({
+    ...replaceRangeState(state, failed),
+    rangeMutationRevisionByRequestId: pruneRangeRevisionHistory(
+      state.rangeMutationRevisionByRequestId,
+      failed,
+    ),
+  });
+};
+
+export const buildBudgetAdjustmentPatch = (
+  requested: BudgetAdjustmentSnapshot,
+  baseline: BudgetAdjustmentSnapshot,
+): PatchBudgetAdjustmentParams => {
+  const params: {
+    amount?: number;
+    note?: string | null;
+    month?: string;
+    category?: string;
+  } = {};
+  if (requested.amount !== baseline.amount) params.amount = requested.amount;
+  if (requested.note !== baseline.note) params.note = requested.note;
+  if (requested.month !== baseline.month) params.month = requested.month;
+  if (requested.category !== baseline.category) params.category = requested.category;
+  return params;
+};
+
+const hasPatchFields = (params: PatchBudgetAdjustmentParams): boolean =>
+  params.amount !== undefined
+  || params.note !== undefined
+  || params.month !== undefined
+  || params.category !== undefined;
+
+export const issueBudgetAdjustmentPatchRequest = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  adjustmentId: string,
+): IssuedBudgetAdjustmentRequest<BudgetAdjustmentPatchRequest> => {
+  const row = requireRow(state, adjustmentId, "patch");
+  if (state.latestDeleteRequestIdByAdjustmentId.has(adjustmentId)) {
+    throw new Error(`Cannot patch budget adjustment "${adjustmentId}" while its delete request is pending`);
+  }
+  if (state.latestPatchRequestIdByAdjustmentId.has(adjustmentId)) {
+    throw new Error(`Cannot issue a second patch for budget adjustment "${adjustmentId}" while its patch request is pending`);
+  }
+  if (state.ambiguousRangeRequirementByAdjustmentId.has(adjustmentId)) {
+    throw new Error(
+      `Cannot patch budget adjustment "${adjustmentId}" until a range issued after its ambiguous failure is reconciled`,
+    );
+  }
+  const parsed = parseBudgetAdjustmentDraft(row.draft, state.planFrom);
+  if (!parsed.ok) {
+    throw new Error(`Cannot patch budget adjustment "${adjustmentId}": ${parsed.error.message}`);
+  }
+  const params = buildBudgetAdjustmentPatch(parsed.snapshot, row.confirmed);
+  if (!hasPatchFields(params)) {
+    throw new Error(`Cannot patch budget adjustment "${adjustmentId}" without changed fields`);
+  }
+  const request: BudgetAdjustmentPatchRequest = {
+    kind: "patch",
+    requestId: getNextMutationRequestId(state),
+    adjustmentId,
+    direction: row.direction,
+    draft: { ...row.draft },
+    requested: { ...parsed.snapshot },
+    baseline: { ...row.confirmed },
+    params,
+    mutationRevision: state.latestMutationRevision,
+  };
+  const latestPatchRequestIdByAdjustmentId = new Map(
+    state.latestPatchRequestIdByAdjustmentId,
+  );
+  latestPatchRequestIdByAdjustmentId.set(adjustmentId, request.requestId);
+  return {
+    state: {
+      ...addMutationRequest(state, request),
+      latestPatchRequestIdByAdjustmentId,
+    },
+    request,
+  };
+};
+
+export const issueBudgetAdjustmentDeleteRequest = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  adjustmentId: string,
+): IssuedBudgetAdjustmentRequest<BudgetAdjustmentDeleteRequest> => {
+  const row = requireRow(state, adjustmentId, "delete");
+  if (state.latestPatchRequestIdByAdjustmentId.has(adjustmentId)) {
+    throw new Error(`Cannot delete budget adjustment "${adjustmentId}" while its patch request is pending`);
+  }
+  if (state.latestDeleteRequestIdByAdjustmentId.has(adjustmentId)) {
+    throw new Error(`Cannot issue a second delete for budget adjustment "${adjustmentId}" while its delete request is pending`);
+  }
+  if (state.ambiguousRangeRequirementByAdjustmentId.has(adjustmentId)) {
+    throw new Error(
+      `Cannot delete budget adjustment "${adjustmentId}" until a range issued after its ambiguous failure is reconciled`,
+    );
+  }
+  const request: BudgetAdjustmentDeleteRequest = {
+    kind: "delete",
+    requestId: getNextMutationRequestId(state),
+    adjustmentId,
+    direction: row.direction,
+    confirmed: { ...row.confirmed },
+    mutationRevision: state.latestMutationRevision,
+  };
+  const latestDeleteRequestIdByAdjustmentId = new Map(
+    state.latestDeleteRequestIdByAdjustmentId,
+  );
+  latestDeleteRequestIdByAdjustmentId.set(adjustmentId, request.requestId);
+  return {
+    state: {
+      ...addMutationRequest(state, request),
+      latestDeleteRequestIdByAdjustmentId,
+    },
+    request,
+  };
+};
+
+const getRangeProtectedIds = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentRangeRequest,
+  resolvedAmbiguityIds: ReadonlySet<string>,
+): ReadonlySet<string> => {
+  const ids = new Set<string>();
+  for (const adjustmentId of state.latestPatchRequestIdByAdjustmentId.keys()) ids.add(adjustmentId);
+  for (const adjustmentId of state.latestDeleteRequestIdByAdjustmentId.keys()) ids.add(adjustmentId);
+  for (const [adjustmentId, revision] of state.confirmedMutationRevisionById) {
+    if (revision > request.mutationRevision) ids.add(adjustmentId);
+  }
+  for (const [adjustmentId, revision] of state.deletedMutationRevisionById) {
+    if (revision > request.mutationRevision) ids.add(adjustmentId);
+  }
+  for (const adjustmentId of state.ambiguousRangeRequirementByAdjustmentId.keys()) {
+    if (!resolvedAmbiguityIds.has(adjustmentId)) ids.add(adjustmentId);
+  }
+  return ids;
+};
+
+const restoreProtectedRangeData = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  delegated: BudgetAdjustmentRangeReconciliationState,
+  protectedIds: ReadonlySet<string>,
+): BudgetAdjustmentRangeReconciliationState => {
+  const originalRowsById = new Map(state.rows
+    .filter((row): boolean => protectedIds.has(row.adjustmentId))
+    .map((row): readonly [string, BudgetAdjustmentEditorRow] => [row.adjustmentId, row]));
+  const rows = delegated.rows.filter((row): boolean => !protectedIds.has(row.adjustmentId));
+  rows.push(...originalRowsById.values());
+  const rangeProvenanceByAdjustmentId = new Map(delegated.rangeProvenanceByAdjustmentId);
+  const dirtyFieldsByAdjustmentId = new Map(delegated.dirtyFieldsByAdjustmentId);
+  for (const adjustmentId of protectedIds) {
+    const provenance = state.rangeProvenanceByAdjustmentId.get(adjustmentId);
+    const dirtyFields = state.dirtyFieldsByAdjustmentId.get(adjustmentId);
+    if (provenance === undefined) rangeProvenanceByAdjustmentId.delete(adjustmentId);
+    else rangeProvenanceByAdjustmentId.set(adjustmentId, provenance);
+    if (dirtyFields === undefined) dirtyFieldsByAdjustmentId.delete(adjustmentId);
+    else dirtyFieldsByAdjustmentId.set(adjustmentId, dirtyFields);
+  }
+  return {
+    ...delegated,
+    rows: sortBudgetAdjustmentRows(rows),
+    rangeProvenanceByAdjustmentId,
+    dirtyFieldsByAdjustmentId,
+  };
+};
+
+export const reconcileBudgetAdjustmentRangeResponse = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentRangeRequest,
+  adjustments: ReadonlyArray<unknown>,
+): BudgetAdjustmentRowsReconciliationState => {
+  const delegated = reconcileRangeResponse(
+    getRangeState(state),
+    requireRangeRequest(state, request),
+    adjustments,
+  );
+  const canonicalById = new Map(adjustments.map((input, index): readonly [string, BudgetAdjustmentEditorRow] => {
+    const adjustment = parseBudgetAdjustment(input, `Budget adjustment range response row ${index}`);
+    return [adjustment.adjustmentId, createBudgetAdjustmentEditorRow(adjustment)];
+  }));
+  const acceptedMonths = new Set(enumerateMonths(request.monthFrom, request.monthTo)
+    .filter((month): boolean =>
+      delegated.acceptedRangeRequestIdByMonth.get(month) === request.requestId
+      && (state.acceptedRangeRequestIdByMonth.get(month) ?? 0) < request.requestId));
+  const acceptedCanonicalIds = new Set([...canonicalById]
+    .filter(([, row]): boolean => acceptedMonths.has(row.confirmed.month))
+    .map(([adjustmentId]): string => adjustmentId));
+  const resolvedAmbiguityIds = new Set<string>();
+  for (const [adjustmentId, requirement] of state.ambiguousRangeRequirementByAdjustmentId) {
+    if (
+      (request.requestId > requirement.afterRequestId && acceptedCanonicalIds.has(adjustmentId))
+      || ((delegated.acceptedRangeRequestIdByMonth.get(requirement.sourceMonth) ?? 0)
+          > requirement.afterRequestId
+        && (delegated.acceptedRangeRequestIdByMonth.get(requirement.targetMonth) ?? 0)
+          > requirement.afterRequestId)
+    ) resolvedAmbiguityIds.add(adjustmentId);
+  }
+  const protectedIds = getRangeProtectedIds(state, request, resolvedAmbiguityIds);
+  const restored = restoreProtectedRangeData(state, delegated, protectedIds);
+  let rows = restored.rows;
+  const ambiguousRangeRequirementByAdjustmentId = new Map(
+    state.ambiguousRangeRequirementByAdjustmentId,
+  );
+  const dirtyFieldsByAdjustmentId = new Map(restored.dirtyFieldsByAdjustmentId);
+  for (const adjustmentId of resolvedAmbiguityIds) {
+    if (protectedIds.has(adjustmentId)) continue;
+    ambiguousRangeRequirementByAdjustmentId.delete(adjustmentId);
+    if (!acceptedCanonicalIds.has(adjustmentId)) {
+      rows = rows.filter((row): boolean => row.adjustmentId !== adjustmentId);
+      dirtyFieldsByAdjustmentId.delete(adjustmentId);
+    } else {
+      const refreshed = rows.find((row) => row.adjustmentId === adjustmentId);
+      if (refreshed !== undefined) {
+        const fields = getDirtyFields(refreshed);
+        if (hasDirtyFields(fields)) dirtyFieldsByAdjustmentId.set(adjustmentId, fields);
+        else dirtyFieldsByAdjustmentId.delete(adjustmentId);
+      }
+    }
+  }
+
+  const rowIds = new Set(rows.map((row) => row.adjustmentId));
+  for (const row of state.rows) {
+    if (
+      rowIds.has(row.adjustmentId)
+      || !state.confirmedMutationRevisionById.has(row.adjustmentId)
+      || acceptedMonths.has(row.confirmed.month)
+      || acceptedCanonicalIds.has(row.adjustmentId)
+    ) continue;
+    rows = [...rows, row];
+    rowIds.add(row.adjustmentId);
+  }
+
+  const confirmedMutationRevisionById = new Map(state.confirmedMutationRevisionById);
+  for (const row of state.rows) {
+    const revision = confirmedMutationRevisionById.get(row.adjustmentId);
+    if (revision !== undefined && revision <= request.mutationRevision
+      && acceptedMonths.has(row.confirmed.month) && !protectedIds.has(row.adjustmentId)) {
+      confirmedMutationRevisionById.delete(row.adjustmentId);
+    }
+  }
+
+  let cellInvalidationRevisionByKey = state.cellInvalidationRevisionByKey;
+  const rangeInvalidationRequestIdByCellKey = new Map(
+    state.rangeInvalidationRequestIdByCellKey,
+  );
+  for (const month of acceptedMonths) {
+    cellInvalidationRevisionByKey = clearBudgetAdjustmentCellInvalidations(
+      cellInvalidationRevisionByKey,
+      month,
+      month,
+      request.mutationRevision,
+    );
+    for (const [cellKey, invalidationRequestId] of rangeInvalidationRequestIdByCellKey) {
+      if (cellKey.slice(0, 7) === month && invalidationRequestId < request.requestId) {
+        rangeInvalidationRequestIdByCellKey.delete(cellKey);
+      }
+    }
+  }
+  const rowsById = new Map(rows.map((row): readonly [string, BudgetAdjustmentEditorRow] => [
+    row.adjustmentId,
+    row,
+  ]));
+  for (const previous of state.rows) {
+    const current = rowsById.get(previous.adjustmentId);
+    if (
+      protectedIds.has(previous.adjustmentId)
+      || current === undefined
+      || (previous.confirmed.month === current.confirmed.month
+        && previous.confirmed.category === current.confirmed.category)
+      || acceptedMonths.has(previous.confirmed.month)
+    ) continue;
+    const cellKey = getBudgetAdjustmentCellKey(
+      previous.confirmed.month,
+      previous.direction,
+      previous.confirmed.category,
+    );
+    if ((rangeInvalidationRequestIdByCellKey.get(cellKey) ?? 0) < request.requestId) {
+      rangeInvalidationRequestIdByCellKey.set(cellKey, request.requestId);
+    }
+  }
+  const rangeState: BudgetAdjustmentRangeReconciliationState = {
+    ...restored,
+    rows: sortBudgetAdjustmentRows(rows),
+    dirtyFieldsByAdjustmentId,
+  };
+  return pruneMutationLifecycle({
+    ...replaceRangeState(state, rangeState),
+    confirmedMutationRevisionById,
+    cellInvalidationRevisionByKey,
+    rangeInvalidationRequestIdByCellKey,
+    ambiguousRangeRequirementByAdjustmentId,
+    rangeMutationRevisionByRequestId: pruneRangeRevisionHistory(
+      state.rangeMutationRevisionByRequestId,
+      rangeState,
+    ),
+  });
+};
+
+const rebaseDraftAfterPatch = (
+  row: BudgetAdjustmentEditorRow,
+  request: BudgetAdjustmentPatchRequest,
+  confirmed: BudgetAdjustmentSnapshot,
+): BudgetAdjustmentDraft => {
+  const amount = parseBudgetAdjustmentAmount(row.draft.amountInput);
+  const hasNewerAmount = !amount.ok || amount.amount !== request.requested.amount;
+  return {
+    amountInput: hasNewerAmount
+      ? row.draft.amountInput
+      : amount.amount === confirmed.amount ? row.draft.amountInput : String(confirmed.amount),
+    noteInput: budgetAdjustmentNoteFromInput(row.draft.noteInput) !== request.requested.note
+      ? row.draft.noteInput
+      : budgetAdjustmentNoteToInput(confirmed.note),
+    month: row.draft.month !== request.requested.month ? row.draft.month : confirmed.month,
+    category: row.draft.category !== request.requested.category
+      ? row.draft.category
+      : confirmed.category,
+  };
+};
+
+export const reconcileBudgetAdjustmentPatchAcknowledgement = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentPatchRequest,
+  input: unknown,
+): BudgetAdjustmentPatchAcknowledgement => {
+  const issued = requireMutationRequest(state, request, "patch");
+  const adjustment = parseBudgetAdjustment(input, "Budget adjustment patch acknowledgement");
+  if (adjustment.adjustmentId !== issued.adjustmentId) {
+    throw new Error(
+      `Budget adjustment patch acknowledgement id "${adjustment.adjustmentId}" does not match requested id "${issued.adjustmentId}"`,
+    );
+  }
+  if (adjustment.direction !== issued.direction) {
+    throw new Error(
+      `Budget adjustment patch acknowledgement changed immutable direction for "${issued.adjustmentId}" from ${issued.direction} to ${adjustment.direction}`,
+    );
+  }
+  const isStale = state.settledMutationRequestIds.has(issued.requestId)
+    || state.latestPatchRequestIdByAdjustmentId.get(issued.adjustmentId) !== issued.requestId
+    || (state.confirmedMutationRevisionById.get(issued.adjustmentId) ?? 0) > issued.mutationRevision
+    || (state.deletedMutationRevisionById.get(issued.adjustmentId) ?? 0) > issued.mutationRevision;
+  if (isStale) {
+    return { state: settleMutationRequest(state, issued.requestId), outcome: "stale" };
+  }
+  const row = requireRow(state, issued.adjustmentId, "acknowledge patch for");
+  if (row.direction !== issued.direction || !snapshotsEqual(row.confirmed, issued.baseline)) {
+    throw new Error(
+      `Cannot acknowledge patch for "${issued.adjustmentId}": current confirmed row does not match the request baseline`,
+    );
+  }
+  const canonical = createBudgetAdjustmentEditorRow(adjustment);
+  const reconciled: BudgetAdjustmentEditorRow = {
+    ...canonical,
+    draft: rebaseDraftAfterPatch(row, issued, canonical.confirmed),
+  };
+  const latestMutationRevision = getNextMutationRevision(state);
+  const confirmedMutationRevisionById = new Map(state.confirmedMutationRevisionById);
+  confirmedMutationRevisionById.set(issued.adjustmentId, latestMutationRevision);
+  const deletedMutationRevisionById = new Map(state.deletedMutationRevisionById);
+  deletedMutationRevisionById.delete(issued.adjustmentId);
+  const latestPatchRequestIdByAdjustmentId = new Map(
+    state.latestPatchRequestIdByAdjustmentId,
+  );
+  latestPatchRequestIdByAdjustmentId.delete(issued.adjustmentId);
+  const ambiguousRangeRequirementByAdjustmentId = new Map(
+    state.ambiguousRangeRequirementByAdjustmentId,
+  );
+  ambiguousRangeRequirementByAdjustmentId.delete(issued.adjustmentId);
+  const rows = sortBudgetAdjustmentRows(state.rows.map((candidate): BudgetAdjustmentEditorRow =>
+    candidate.adjustmentId === issued.adjustmentId ? reconciled : candidate));
+  const rangeProvenanceByAdjustmentId = new Map(state.rangeProvenanceByAdjustmentId);
+  if (issued.baseline.month !== canonical.confirmed.month) {
+    rangeProvenanceByAdjustmentId.set(issued.adjustmentId, {
+      direction: issued.direction,
+      presenceRequestIdByMonth: new Map([[canonical.confirmed.month, state.latestRequestId]]),
+      absenceRequestIdByMonth: new Map(), deletedThroughRequestId: null,
+    });
+  }
+  const next = settleMutationRequest({
+    ...state,
+    rows,
+    latestMutationRevision,
+    confirmedMutationRevisionById,
+    deletedMutationRevisionById,
+    rangeProvenanceByAdjustmentId,
+    dirtyFieldsByAdjustmentId: replaceDirtyFields(state.dirtyFieldsByAdjustmentId, reconciled),
+    latestPatchRequestIdByAdjustmentId,
+    ambiguousRangeRequirementByAdjustmentId,
+    cellInvalidationRevisionByKey: recordBudgetAdjustmentCellMove(
+      state.cellInvalidationRevisionByKey,
+      {
+        direction: issued.direction,
+        previous: issued.baseline,
+        current: canonical.confirmed,
+      },
+      latestMutationRevision,
+      state.planFrom,
+    ),
+  }, issued.requestId);
+  return { state: next, outcome: "accepted" };
+};
+
+const settlePatchFailure = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentPatchRequest,
+): BudgetAdjustmentRowsReconciliationState => {
+  const issued = requireMutationRequest(state, request, "patch");
+  if (state.settledMutationRequestIds.has(issued.requestId)) {
+    throw new Error(`Cannot fail settled budget adjustment patch request ${issued.requestId}`);
+  }
+  if (state.latestPatchRequestIdByAdjustmentId.get(issued.adjustmentId) !== issued.requestId) {
+    throw new Error(
+      `Cannot fail budget adjustment patch request ${issued.requestId}: it is not pending for "${issued.adjustmentId}"`,
+    );
+  }
+  const row = requireRow(state, issued.adjustmentId, "fail patch for");
+  if (row.direction !== issued.direction || !snapshotsEqual(row.confirmed, issued.baseline)) {
+    throw new Error(
+      `Cannot fail patch for "${issued.adjustmentId}": current confirmed row does not match the request baseline`,
+    );
+  }
+  const latestPatchRequestIdByAdjustmentId = new Map(
+    state.latestPatchRequestIdByAdjustmentId,
+  );
+  latestPatchRequestIdByAdjustmentId.delete(issued.adjustmentId);
+  return settleMutationRequest({ ...state, latestPatchRequestIdByAdjustmentId }, issued.requestId);
+};
+
+export const reconcileBudgetAdjustmentPatchDefinitiveFailure = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentPatchRequest,
+): BudgetAdjustmentRowsReconciliationState => settlePatchFailure(state, request);
+
+export const reconcileBudgetAdjustmentPatchAmbiguousFailure = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentPatchRequest,
+): BudgetAdjustmentRowsReconciliationState => {
+  const failed = settlePatchFailure(state, request);
+  const ambiguousRangeRequirementByAdjustmentId = new Map(
+    failed.ambiguousRangeRequirementByAdjustmentId,
+  );
+  ambiguousRangeRequirementByAdjustmentId.set(request.adjustmentId, {
+    afterRequestId: state.latestRequestId,
+    sourceMonth: request.baseline.month,
+    targetMonth: request.requested.month,
+  });
+  return { ...failed, ambiguousRangeRequirementByAdjustmentId };
+};
+
+const settleDeleteFailure = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentDeleteRequest,
+): BudgetAdjustmentRowsReconciliationState => {
+  const issued = requireMutationRequest(state, request, "delete");
+  if (state.settledMutationRequestIds.has(issued.requestId)) {
+    throw new Error(`Cannot fail settled budget adjustment delete request ${issued.requestId}`);
+  }
+  if (state.latestDeleteRequestIdByAdjustmentId.get(issued.adjustmentId) !== issued.requestId) {
+    throw new Error(
+      `Cannot fail budget adjustment delete request ${issued.requestId}: it is not pending for "${issued.adjustmentId}"`,
+    );
+  }
+  const row = requireRow(state, issued.adjustmentId, "fail delete for");
+  if (row.direction !== issued.direction || !snapshotsEqual(row.confirmed, issued.confirmed)) {
+    throw new Error(
+      `Cannot fail delete for "${issued.adjustmentId}": current confirmed row does not match the request`,
+    );
+  }
+  const latestDeleteRequestIdByAdjustmentId = new Map(
+    state.latestDeleteRequestIdByAdjustmentId,
+  );
+  latestDeleteRequestIdByAdjustmentId.delete(issued.adjustmentId);
+  return settleMutationRequest({ ...state, latestDeleteRequestIdByAdjustmentId }, issued.requestId);
+};
+
+export const reconcileBudgetAdjustmentDeleteDefinitiveFailure = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentDeleteRequest,
+): BudgetAdjustmentRowsReconciliationState => settleDeleteFailure(state, request);
+
+export const reconcileBudgetAdjustmentDeleteAmbiguousFailure = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentDeleteRequest,
+): BudgetAdjustmentRowsReconciliationState => {
+  const failed = settleDeleteFailure(state, request);
+  const ambiguousRangeRequirementByAdjustmentId = new Map(
+    failed.ambiguousRangeRequirementByAdjustmentId,
+  );
+  ambiguousRangeRequirementByAdjustmentId.set(request.adjustmentId, {
+    afterRequestId: state.latestRequestId,
+    sourceMonth: request.confirmed.month,
+    targetMonth: request.confirmed.month,
+  });
+  return { ...failed, ambiguousRangeRequirementByAdjustmentId };
+};
+
+export const reconcileBudgetAdjustmentDeleteAcknowledgement = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentDeleteRequest,
+  deleteOutcome: DeleteBudgetAdjustmentOutcome,
+): BudgetAdjustmentDeleteAcknowledgement => {
+  const issued = requireMutationRequest(state, request, "delete");
+  if (deleteOutcome !== "deleted" && deleteOutcome !== "already-absent") {
+    throw new Error(
+      `Cannot acknowledge budget adjustment delete request ${issued.requestId}: invalid outcome "${String(deleteOutcome)}"`,
+    );
+  }
+  if (state.settledMutationRequestIds.has(issued.requestId)) {
+    const alreadyApplied = !state.rows.some((row) => row.adjustmentId === issued.adjustmentId)
+      && state.appliedDeleteRequestIds.has(issued.requestId);
+    return { state, outcome: alreadyApplied ? "already-applied" : "stale" };
+  }
+  const isStale = state.latestDeleteRequestIdByAdjustmentId.get(issued.adjustmentId)
+    !== issued.requestId
+    || (state.confirmedMutationRevisionById.get(issued.adjustmentId) ?? 0) > issued.mutationRevision
+    || (state.deletedMutationRevisionById.get(issued.adjustmentId) ?? 0) > issued.mutationRevision;
+  if (isStale) {
+    return { state: settleMutationRequest(state, issued.requestId), outcome: "stale" };
+  }
+  const row = requireRow(state, issued.adjustmentId, "acknowledge delete for");
+  if (row.direction !== issued.direction || !snapshotsEqual(row.confirmed, issued.confirmed)) {
+    throw new Error(
+      `Cannot acknowledge delete for "${issued.adjustmentId}": current confirmed row does not match the request`,
+    );
+  }
+  const latestMutationRevision = getNextMutationRevision(state);
+  const confirmedMutationRevisionById = new Map(state.confirmedMutationRevisionById);
+  confirmedMutationRevisionById.delete(issued.adjustmentId);
+  const deletedMutationRevisionById = new Map(state.deletedMutationRevisionById);
+  deletedMutationRevisionById.set(issued.adjustmentId, latestMutationRevision);
+  const appliedDeleteRequestIds = new Set(state.appliedDeleteRequestIds);
+  appliedDeleteRequestIds.add(issued.requestId);
+  const latestDeleteRequestIdByAdjustmentId = new Map(
+    state.latestDeleteRequestIdByAdjustmentId,
+  );
+  latestDeleteRequestIdByAdjustmentId.delete(issued.adjustmentId);
+  const ambiguousRangeRequirementByAdjustmentId = new Map(
+    state.ambiguousRangeRequirementByAdjustmentId,
+  );
+  ambiguousRangeRequirementByAdjustmentId.delete(issued.adjustmentId);
+  const dirtyFieldsByAdjustmentId = new Map(state.dirtyFieldsByAdjustmentId);
+  dirtyFieldsByAdjustmentId.delete(issued.adjustmentId);
+  const next = settleMutationRequest({
+    ...state,
+    rows: state.rows.filter((candidate): boolean => candidate.adjustmentId !== issued.adjustmentId),
+    latestMutationRevision,
+    confirmedMutationRevisionById,
+    deletedMutationRevisionById,
+    appliedDeleteRequestIds,
+    dirtyFieldsByAdjustmentId,
+    latestDeleteRequestIdByAdjustmentId,
+    ambiguousRangeRequirementByAdjustmentId,
+    cellInvalidationRevisionByKey: recordBudgetAdjustmentCellInvalidation(
+      state.cellInvalidationRevisionByKey,
+      issued.direction,
+      issued.confirmed,
+      latestMutationRevision,
+    ),
+  }, issued.requestId);
+  return { state: next, outcome: "applied" };
+};

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.ts
@@ -449,6 +449,27 @@ export const recordBudgetAdjustmentCellMove = (
   return next;
 };
 
+export const recordBudgetAdjustmentCellInvalidation = (
+  current: ReadonlyMap<string, number>,
+  direction: BudgetAdjustmentDirection,
+  snapshot: BudgetAdjustmentSnapshot,
+  mutationRevision: number,
+): ReadonlyMap<string, number> => {
+  validateRevision(mutationRevision, "Budget adjustment cell invalidation revision");
+  validateMonth(snapshot.month, "Budget adjustment cell invalidation month");
+  if (!isValidCategory(snapshot.category)) {
+    throw new RangeError(
+      "Budget adjustment cell invalidation category must contain between 1 and 200 characters",
+    );
+  }
+  const next = new Map(current);
+  next.set(
+    getBudgetAdjustmentCellKey(snapshot.month, direction, snapshot.category),
+    mutationRevision,
+  );
+  return next;
+};
+
 export const clearBudgetAdjustmentCellInvalidations = (
   current: ReadonlyMap<string, number>,
   monthFrom: string,


### PR DESCRIPTION
## Summary
- add pure PATCH and DELETE reconciliation for budget adjustment rows
- preserve range ordering while coordinating mutation and ambiguity provenance
- track source-cell invalidation and bounded mutation lifecycle history

## Validation
- focused reconciliation tests: 14/14
- relevant budget tests: 74/74
- npm run lint
- npm run build
- diff, scope, dependency, and whitespace audits