### PR TITLE
03A3c: add idempotent budget adjustment create contract

### DIFF
--- a/apps/web/src/app/api/budget-adjustments/[adjustmentId]/route.ts
+++ b/apps/web/src/app/api/budget-adjustments/[adjustmentId]/route.ts
@@ -6,7 +6,7 @@ import { ApiRouteError } from "@/server/api/errors";
 import { handleRoute } from "@/server/api/handleRoute";
 import { parseJsonBody } from "@/server/api/validation";
 import { BudgetAdjustmentNotFoundError, deleteBudgetAdjustment, patchBudgetAdjustment } from "@/server/budget/budgetAdjustments";
-import { deleteDemoBudgetAdjustment, patchDemoBudgetAdjustment } from "@/server/demo/budgetAdjustments";
+import { deleteDemoBudgetAdjustment, patchDemoBudgetAdjustment, readDemoBudgetAdjustmentSession, serializeDemoBudgetAdjustmentSessionCookie } from "@/server/demo/budgetAdjustments";
 import { extractUserId, extractWorkspaceId } from "@/server/userId";
 
 type RouteContext = Readonly<{
@@ -32,7 +32,18 @@ export const PATCH = async (request: Request, context: RouteContext): Promise<Re
 
       try {
         if (isDemoModeFromRequest(request)) {
-          return Response.json(patchDemoBudgetAdjustment(adjustmentId, body));
+          const patched = patchDemoBudgetAdjustment(
+            readDemoBudgetAdjustmentSession(request),
+            adjustmentId,
+            body,
+            new Date().toISOString(),
+          );
+          const response = Response.json(patched.adjustment);
+          response.headers.set(
+            "Set-Cookie",
+            serializeDemoBudgetAdjustmentSessionCookie(patched.state),
+          );
+          return response;
         }
 
         const userId = extractUserId(request);
@@ -53,8 +64,16 @@ export const DELETE = async (request: Request, context: RouteContext): Promise<R
 
       try {
         if (isDemoModeFromRequest(request)) {
-          deleteDemoBudgetAdjustment(adjustmentId);
-          return Response.json({ ok: true });
+          const state = deleteDemoBudgetAdjustment(
+            readDemoBudgetAdjustmentSession(request),
+            adjustmentId,
+          );
+          const response = Response.json({ ok: true });
+          response.headers.set(
+            "Set-Cookie",
+            serializeDemoBudgetAdjustmentSessionCookie(state),
+          );
+          return response;
         }
 
         const userId = extractUserId(request);

--- a/apps/web/src/app/api/budget-adjustments/route.test.ts
+++ b/apps/web/src/app/api/budget-adjustments/route.test.ts
@@ -1,28 +1,46 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { DELETE, PATCH } from "@/app/api/budget-adjustments/[adjustmentId]/route";
 import { POST } from "@/app/api/budget-adjustments/route";
+import { GET as GET_BUDGET_GRID } from "@/app/api/budget-grid/route";
 import { getCurrentMonth } from "@/lib/monthUtils";
 
-test("demo create returns a contract-shaped zero adjustment without identity headers", async (): Promise<void> => {
-  const response = await POST(new Request("http://localhost/api/budget-adjustments", {
+const ADJUSTMENT_ID = "2df9496e-76f5-4db6-a4e6-11c7e588a4fb";
+
+const postDemoAdjustment = async (
+  body: Readonly<Record<string, unknown>>,
+  sessionCookie: string | null,
+): Promise<Response> =>
+  POST(new Request("http://localhost/api/budget-adjustments", {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      cookie: "demo=true",
+      cookie: `demo=true${sessionCookie === null ? "" : `; ${sessionCookie}`}`,
     },
-    body: JSON.stringify({
-      month: getCurrentMonth(),
-      direction: "spend",
-      category: "Groceries",
-      amount: 0,
-      note: null,
-    }),
+    body: JSON.stringify(body),
   }));
+
+const getSessionCookie = (response: Response): string => {
+  const header = response.headers.get("set-cookie");
+  assert.ok(header, "Expected demo adjustment session cookie");
+  return header.split(";", 1)[0];
+};
+
+test("demo create uses the client ID and exact retries preserve the authoritative row", async (): Promise<void> => {
+  const body = {
+    adjustmentId: ADJUSTMENT_ID,
+    month: getCurrentMonth(),
+    direction: "spend",
+    category: "Groceries",
+    amount: 0,
+    note: null,
+  } as const;
+  const response = await postDemoAdjustment(body, null);
 
   assert.equal(response.status, 200);
   const adjustment = await response.json() as Record<string, unknown>;
-  assert.match(adjustment.adjustmentId as string, /^demo-created-spend-/);
+  assert.equal(adjustment.adjustmentId, ADJUSTMENT_ID);
   assert.equal(adjustment.month, getCurrentMonth());
   assert.equal(adjustment.direction, "spend");
   assert.equal(adjustment.category, "Groceries");
@@ -40,4 +58,111 @@ test("demo create returns a contract-shaped zero adjustment without identity hea
     "note",
     "updatedAt",
   ]);
+
+  const lostResponseRetry = await postDemoAdjustment(body, null);
+  assert.equal(lostResponseRetry.status, 200);
+  assert.deepEqual(await lostResponseRetry.json(), adjustment);
+
+  const sessionCookie = getSessionCookie(response);
+  const retryResponse = await postDemoAdjustment(body, sessionCookie);
+  assert.equal(retryResponse.status, 200);
+  assert.deepEqual(await retryResponse.json(), adjustment);
+
+  const conflictResponse = await postDemoAdjustment(
+    { ...body, amount: 1 },
+    sessionCookie,
+  );
+  assert.equal(conflictResponse.status, 409);
+  assert.equal(
+    await conflictResponse.text(),
+    `Budget adjustment ID "${ADJUSTMENT_ID}" is already in use`,
+  );
+});
+
+test("demo create rejects malformed client IDs", async (): Promise<void> => {
+  const response = await postDemoAdjustment({
+    adjustmentId: "not-a-uuid",
+    month: getCurrentMonth(),
+    direction: "income",
+    category: "Bonus",
+    amount: 0,
+    note: null,
+  }, null);
+
+  assert.equal(response.status, 400);
+  assert.match(await response.text(), /Expected UUID/);
+});
+
+test("demo session state follows create, range, patch, and delete across requests", async (): Promise<void> => {
+  const adjustmentId = "bbdbb70a-c525-420c-bf01-97675a03d30b";
+  const month = getCurrentMonth();
+  const createdResponse = await postDemoAdjustment({
+    adjustmentId,
+    month,
+    direction: "income",
+    category: "Session bonus",
+    amount: 5,
+    note: null,
+  }, null);
+  const createdCookie = getSessionCookie(createdResponse);
+  const gridUrl = `http://localhost/api/budget-grid?monthFrom=${month}&monthTo=${month}&planFrom=${month}&actualTo=${month}`;
+  const createdGridResponse = await GET_BUDGET_GRID(new Request(gridUrl, {
+    headers: { cookie: `demo=true; ${createdCookie}` },
+  }));
+  const createdGrid = await createdGridResponse.json() as {
+    adjustments: ReadonlyArray<Record<string, unknown>>;
+    rows: ReadonlyArray<Record<string, unknown>>;
+  };
+  assert.equal(
+    createdGrid.adjustments.find((adjustment) =>
+      adjustment.adjustmentId === adjustmentId)?.amount,
+    5,
+  );
+  assert.equal(
+    createdGrid.rows.find((row) => row.category === "Session bonus")?.plannedModifier,
+    5,
+  );
+
+  const context = { params: Promise.resolve({ adjustmentId }) };
+  const patchedResponse = await PATCH(new Request(
+    `http://localhost/api/budget-adjustments/${adjustmentId}`,
+    {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        cookie: `demo=true; ${createdCookie}`,
+      },
+      body: JSON.stringify({ amount: 9 }),
+    },
+  ), context);
+  assert.equal(patchedResponse.status, 200);
+  const patchedCookie = getSessionCookie(patchedResponse);
+  const patchedGridResponse = await GET_BUDGET_GRID(new Request(gridUrl, {
+    headers: { cookie: `demo=true; ${patchedCookie}` },
+  }));
+  const patchedGrid = await patchedGridResponse.json() as {
+    adjustments: ReadonlyArray<Record<string, unknown>>;
+  };
+  assert.equal(
+    patchedGrid.adjustments.find((adjustment) =>
+      adjustment.adjustmentId === adjustmentId)?.amount,
+    9,
+  );
+
+  const deletedResponse = await DELETE(new Request(
+    `http://localhost/api/budget-adjustments/${adjustmentId}`,
+    { method: "DELETE", headers: { cookie: `demo=true; ${patchedCookie}` } },
+  ), context);
+  assert.equal(deletedResponse.status, 200);
+  const deletedCookie = getSessionCookie(deletedResponse);
+  const deletedGridResponse = await GET_BUDGET_GRID(new Request(gridUrl, {
+    headers: { cookie: `demo=true; ${deletedCookie}` },
+  }));
+  const deletedGrid = await deletedGridResponse.json() as {
+    adjustments: ReadonlyArray<Record<string, unknown>>;
+    rows: ReadonlyArray<Record<string, unknown>>;
+  };
+  assert.equal(deletedGrid.adjustments.some((adjustment) =>
+    adjustment.adjustmentId === adjustmentId), false);
+  assert.equal(deletedGrid.rows.some((row) => row.category === "Session bonus"), false);
 });

--- a/apps/web/src/app/api/budget-adjustments/route.ts
+++ b/apps/web/src/app/api/budget-adjustments/route.ts
@@ -2,10 +2,11 @@ import { z } from "zod";
 
 import { isDemoModeFromRequest } from "@/lib/demoMode";
 import { parseBudgetAdjustmentCreateBody } from "@/server/api/budget";
+import { ApiRouteError } from "@/server/api/errors";
 import { handleRoute } from "@/server/api/handleRoute";
 import { parseJsonBody } from "@/server/api/validation";
-import { createBudgetAdjustment } from "@/server/budget/budgetAdjustments";
-import { createDemoBudgetAdjustment } from "@/server/demo/budgetAdjustments";
+import { BudgetAdjustmentConflictError, createBudgetAdjustment } from "@/server/budget/budgetAdjustments";
+import { createDemoBudgetAdjustment, readDemoBudgetAdjustmentSession, serializeDemoBudgetAdjustmentSessionCookie } from "@/server/demo/budgetAdjustments";
 import { extractUserId, extractWorkspaceId } from "@/server/userId";
 
 export const POST = async (request: Request): Promise<Response> =>
@@ -14,12 +15,28 @@ export const POST = async (request: Request): Promise<Response> =>
     async (): Promise<Response> => {
       const body = parseBudgetAdjustmentCreateBody(await parseJsonBody(request, z.unknown()));
 
-      if (isDemoModeFromRequest(request)) {
-        return Response.json(createDemoBudgetAdjustment(body));
-      }
+      try {
+        if (isDemoModeFromRequest(request)) {
+          const created = createDemoBudgetAdjustment(
+            readDemoBudgetAdjustmentSession(request),
+            body,
+          );
+          const response = Response.json(created.adjustment);
+          response.headers.set(
+            "Set-Cookie",
+            serializeDemoBudgetAdjustmentSessionCookie(created.state),
+          );
+          return response;
+        }
 
-      const userId = extractUserId(request);
-      const workspaceId = extractWorkspaceId(request);
-      return Response.json(await createBudgetAdjustment(userId, workspaceId, body));
+        const userId = extractUserId(request);
+        const workspaceId = extractWorkspaceId(request);
+        return Response.json(await createBudgetAdjustment(userId, workspaceId, body));
+      } catch (error) {
+        if (error instanceof BudgetAdjustmentConflictError) {
+          throw new ApiRouteError(409, error.message);
+        }
+        throw error;
+      }
     },
   );

--- a/apps/web/src/app/api/budget-grid/route.ts
+++ b/apps/web/src/app/api/budget-grid/route.ts
@@ -3,6 +3,7 @@ import { parseBudgetGridQuery } from "@/server/api/budget";
 import { handleRoute } from "@/server/api/handleRoute";
 import { jsonNoStore } from "@/server/api/noStore";
 import { getBudgetGrid } from "@/server/budget/getBudgetGrid";
+import { getDemoBudgetAdjustmentsForSession, readDemoBudgetAdjustmentSession } from "@/server/demo/budgetAdjustments";
 import { getDemoBudgetGrid } from "@/server/demo/data";
 import { extractUserId, extractWorkspaceId } from "@/server/userId";
 
@@ -15,7 +16,16 @@ export const GET = async (request: Request): Promise<Response> =>
       const query = parseBudgetGridQuery(new URL(request.url).searchParams);
 
       if (isDemoModeFromRequest(request)) {
-        return jsonNoStore(getDemoBudgetGrid(query.monthFrom, query.monthTo, query.planFrom, query.actualTo));
+        const adjustments = getDemoBudgetAdjustmentsForSession(
+          readDemoBudgetAdjustmentSession(request),
+        );
+        return jsonNoStore(getDemoBudgetGrid(
+          query.monthFrom,
+          query.monthTo,
+          query.planFrom,
+          query.actualTo,
+          adjustments,
+        ));
       }
 
       const userId = extractUserId(request);

--- a/apps/web/src/app/budget/page.tsx
+++ b/apps/web/src/app/budget/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 
+import { DEMO_BUDGET_ADJUSTMENTS_COOKIE } from "@/lib/demoCookies";
 import { offsetMonth, getCurrentMonth } from "@/lib/monthUtils";
 import { isDemoMode } from "@/lib/demoMode";
 import { DEFAULT_USER_SETTINGS } from "@/lib/locale";
@@ -11,6 +12,7 @@ import { getReportCurrency } from "@/server/reportCurrency";
 import { extractUserIdFromHeaders, extractWorkspaceIdFromHeaders } from "@/server/userId";
 import { getFieldHints } from "@/server/transactions/getTransactions";
 import { getUserSettings } from "@/server/userSettings";
+import { getDemoBudgetAdjustmentsForSession, parseDemoBudgetAdjustmentSessionCookie } from "@/server/demo/budgetAdjustments";
 import { getDemoBudgetGrid, getDemoFieldHints } from "@/server/demo/data";
 import { BudgetTable } from "@/ui/tables/budget/BudgetTable";
 import { LoadingIndicator } from "@/ui/LoadingIndicator";
@@ -30,6 +32,12 @@ async function BudgetData() {
   const monthTo = offsetMonth(currentMonth, INITIAL_FUTURE_MONTHS);
 
   if (demo) {
+    const cookieStore = await cookies();
+    const adjustments = getDemoBudgetAdjustmentsForSession(
+      parseDemoBudgetAdjustmentSessionCookie(
+        cookieStore.get(DEMO_BUDGET_ADJUSTMENTS_COOKIE)?.value ?? null,
+      ),
+    );
     const {
       rows,
       conversionWarnings,
@@ -38,7 +46,13 @@ async function BudgetData() {
       monthEndBalancesByLiquidity,
       businessPersonalTransfers,
       hasBusinessAccount,
-    } = getDemoBudgetGrid(monthFrom, monthTo, currentMonth, currentMonth);
+    } = getDemoBudgetGrid(
+      monthFrom,
+      monthTo,
+      currentMonth,
+      currentMonth,
+      adjustments,
+    );
     const hints = getDemoFieldHints();
     return (
       <BudgetTable

--- a/apps/web/src/app/dashboards/page.tsx
+++ b/apps/web/src/app/dashboards/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 
+import { DEMO_BUDGET_ADJUSTMENTS_COOKIE } from "@/lib/demoCookies";
 import { offsetMonth, getCurrentMonth } from "@/lib/monthUtils";
 import { isDemoMode } from "@/lib/demoMode";
 import { DEFAULT_USER_SETTINGS } from "@/lib/locale";
@@ -10,6 +11,7 @@ import { getBudgetGrid } from "@/server/budget/getBudgetGrid";
 import { getReportCurrency } from "@/server/reportCurrency";
 import { extractUserIdFromHeaders, extractWorkspaceIdFromHeaders } from "@/server/userId";
 import { getUserSettings } from "@/server/userSettings";
+import { getDemoBudgetAdjustmentsForSession, parseDemoBudgetAdjustmentSessionCookie } from "@/server/demo/budgetAdjustments";
 import { getDemoBudgetGrid } from "@/server/demo/data";
 import { BudgetStreamDashboard } from "@/ui/charts/BudgetStreamDashboard";
 import { LoadingIndicator } from "@/ui/LoadingIndicator";
@@ -28,7 +30,19 @@ async function BudgetStreamData() {
   const monthTo = currentMonth;
 
   if (demo) {
-    const { rows } = getDemoBudgetGrid(monthFrom, monthTo, currentMonth, currentMonth);
+    const cookieStore = await cookies();
+    const adjustments = getDemoBudgetAdjustmentsForSession(
+      parseDemoBudgetAdjustmentSessionCookie(
+        cookieStore.get(DEMO_BUDGET_ADJUSTMENTS_COOKIE)?.value ?? null,
+      ),
+    );
+    const { rows } = getDemoBudgetGrid(
+      monthFrom,
+      monthTo,
+      currentMonth,
+      currentMonth,
+      adjustments,
+    );
     return (
       <BudgetStreamDashboard
         initialRows={rows}

--- a/apps/web/src/lib/demoCookies.ts
+++ b/apps/web/src/lib/demoCookies.ts
@@ -1,0 +1,2 @@
+export const DEMO_MODE_COOKIE = "demo";
+export const DEMO_BUDGET_ADJUSTMENTS_COOKIE = "demo_budget_adjustments";

--- a/apps/web/src/lib/demoMode.ts
+++ b/apps/web/src/lib/demoMode.ts
@@ -1,15 +1,15 @@
 import { cookies } from "next/headers";
 
-const DEMO_COOKIE = "demo";
+import { DEMO_MODE_COOKIE } from "@/lib/demoCookies";
 
 /** Check if demo mode is active (cookie). For Server Components. */
 export const isDemoMode = async (): Promise<boolean> => {
   const cookieStore = await cookies();
-  return cookieStore.get(DEMO_COOKIE)?.value === "true";
+  return cookieStore.get(DEMO_MODE_COOKIE)?.value === "true";
 };
 
 /** Check if demo mode is active from a raw Request. For API route handlers. */
 export const isDemoModeFromRequest = (request: Request): boolean => {
   const cookieHeader = request.headers.get("cookie") ?? "";
-  return cookieHeader.split(";").some((c) => c.trim() === `${DEMO_COOKIE}=true`);
+  return cookieHeader.split(";").some((c) => c.trim() === `${DEMO_MODE_COOKIE}=true`);
 };

--- a/apps/web/src/server/api/budget.test.ts
+++ b/apps/web/src/server/api/budget.test.ts
@@ -6,6 +6,7 @@ import { parseBudgetAdjustmentCreateBody, parseBudgetAdjustmentId, parseBudgetAd
 import { ApiRouteError } from "@/server/api/errors";
 
 const SAFE_INTEGER_MESSAGE = /JavaScript-safe integer between -9007199254740991 and 9007199254740991, inclusive/;
+const ADJUSTMENT_ID = "6d09f70d-c767-4a43-9ab7-89559af99c41";
 
 const assertBadRequest = (run: () => unknown, message: RegExp): void => {
   assert.throws(
@@ -23,12 +24,14 @@ test("budget adjustment create accepts zero, signed integers, and nullable notes
   const month = getCurrentMonth();
 
   assert.deepEqual(parseBudgetAdjustmentCreateBody({
+    adjustmentId: ADJUSTMENT_ID,
     month,
     direction: "spend",
     category: "Groceries",
     amount: 0,
     note: null,
   }), {
+    adjustmentId: ADJUSTMENT_ID,
     month,
     direction: "spend",
     category: "Groceries",
@@ -37,6 +40,7 @@ test("budget adjustment create accepts zero, signed integers, and nullable notes
   });
 
   assert.equal(parseBudgetAdjustmentCreateBody({
+    adjustmentId: ADJUSTMENT_ID,
     month,
     direction: "income",
     category: "Bonus",
@@ -45,6 +49,7 @@ test("budget adjustment create accepts zero, signed integers, and nullable notes
   }).amount, -125);
 
   assert.equal(parseBudgetAdjustmentCreateBody({
+    adjustmentId: ADJUSTMENT_ID,
     month,
     direction: "income",
     category: "Maximum boundary",
@@ -52,6 +57,7 @@ test("budget adjustment create accepts zero, signed integers, and nullable notes
     note: null,
   }).amount, Number.MAX_SAFE_INTEGER);
   assert.equal(parseBudgetAdjustmentCreateBody({
+    adjustmentId: ADJUSTMENT_ID,
     month,
     direction: "spend",
     category: "Minimum boundary",
@@ -64,6 +70,7 @@ test("budget adjustment category and note limits count Unicode code points", ():
   const category = "\u{1F600}".repeat(200);
   const note = "\u{1F680}".repeat(2000);
   const valid = {
+    adjustmentId: ADJUSTMENT_ID,
     month: getCurrentMonth(),
     direction: "spend",
     category,
@@ -85,6 +92,7 @@ test("budget adjustment category and note limits count Unicode code points", ():
 
 test("budget adjustment create rejects past months, non-integers, and unknown fields", (): void => {
   const valid = {
+    adjustmentId: ADJUSTMENT_ID,
     month: getCurrentMonth(),
     direction: "spend",
     category: "Groceries",
@@ -92,6 +100,10 @@ test("budget adjustment create rejects past months, non-integers, and unknown fi
     note: null,
   } as const;
 
+  assertBadRequest(
+    () => parseBudgetAdjustmentCreateBody({ ...valid, adjustmentId: "not-a-uuid" }),
+    /Expected UUID/,
+  );
   assertBadRequest(
     () => parseBudgetAdjustmentCreateBody({ ...valid, month: offsetMonth(valid.month, -1) }),
     /current or future month/,

--- a/apps/web/src/server/api/budget.ts
+++ b/apps/web/src/server/api/budget.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { getCurrentMonth } from "@/lib/monthUtils";
 import { createBadRequestError } from "@/server/api/errors";
-import { adjustmentIdSchema, budgetAdjustmentNoteSchema, budgetPlanKindSchema, categorySchema, directionSchema, finiteIntegerSchema, finiteNumberSchema, monthSchema, parseRequiredQueryParam, parseWithSchema } from "@/server/api/validation";
+import { adjustmentIdSchema, adjustmentUuidSchema, budgetAdjustmentNoteSchema, budgetPlanKindSchema, categorySchema, directionSchema, finiteIntegerSchema, finiteNumberSchema, monthSchema, parseRequiredQueryParam, parseWithSchema } from "@/server/api/validation";
 import type { CreateBudgetAdjustmentParams, PatchBudgetAdjustmentParams } from "@/server/budget/budgetAdjustments";
 
 type BudgetPlanBody = Readonly<{
@@ -64,6 +64,7 @@ const currentOrFutureMonthSchema = monthSchema.superRefine((value, ctx) => {
 });
 
 const budgetAdjustmentCreateBodySchema = z.object({
+  adjustmentId: adjustmentUuidSchema,
   month: currentOrFutureMonthSchema,
   direction: directionSchema,
   category: categorySchema,

--- a/apps/web/src/server/api/validation.ts
+++ b/apps/web/src/server/api/validation.ts
@@ -10,6 +10,7 @@ import { createBadRequestError, fromZodError } from "@/server/api/errors";
 
 const MONTH_PATTERN = /^\d{4}-(?:0[1-9]|1[0-2])$/;
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const UUID_SCHEMA = z.uuid();
 
 const addCustomIssue = (ctx: RefinementCtx, message: string): void => {
   ctx.addIssue({ code: "custom", message });
@@ -162,6 +163,14 @@ export const entryIdSchema: ZodType<string> = createStringSchema(
 export const adjustmentIdSchema: ZodType<string> = createStringSchema(
   (value: string): boolean => value.length > 0 && value.length <= 200,
   "Invalid adjustmentId. Expected non-empty string (max 200 chars)",
+);
+
+/**
+ * Accept a UUID supplied by a client when creating a budget adjustment.
+ */
+export const adjustmentUuidSchema: ZodType<string> = createStringSchema(
+  (value: string): boolean => UUID_SCHEMA.safeParse(value).success,
+  "Invalid adjustmentId. Expected UUID",
 );
 
 /**

--- a/apps/web/src/server/budget/budgetAdjustments.test.ts
+++ b/apps/web/src/server/budget/budgetAdjustments.test.ts
@@ -1,9 +1,69 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { QueryResult } from "pg";
 
 import { getCurrentMonth, offsetMonth } from "@/lib/monthUtils";
-import { BUDGET_ADJUSTMENTS_DETAIL_QUERY, buildPatchBudgetAdjustmentQuery, mapBudgetAdjustmentRow } from "@/server/budget/budgetAdjustments";
-import { getDemoBudgetGrid } from "@/server/demo/data";
+import { BUDGET_ADJUSTMENT_BY_ID_QUERY, BUDGET_ADJUSTMENTS_DETAIL_QUERY, BudgetAdjustmentConflictError, CREATE_BUDGET_ADJUSTMENT_QUERY, buildPatchBudgetAdjustmentQuery, createBudgetAdjustmentWithQuery, mapBudgetAdjustmentRow, type BudgetAdjustment, type CreateBudgetAdjustmentParams } from "@/server/budget/budgetAdjustments";
+import type { QueryFn } from "@/server/db/contextRunner";
+import { createDemoBudgetAdjustment, EMPTY_DEMO_BUDGET_ADJUSTMENT_SESSION, parseDemoBudgetAdjustmentSessionCookie, serializeDemoBudgetAdjustmentSessionCookie, type DemoBudgetAdjustmentSessionState } from "@/server/demo/budgetAdjustments";
+import { getDemoBudgetAdjustments, getDemoBudgetGrid } from "@/server/demo/data";
+
+const CREATE_PARAMS: CreateBudgetAdjustmentParams = {
+  adjustmentId: "b8e8703c-f57a-456d-a56d-3d05ae8cffcd",
+  month: "2026-08",
+  direction: "spend",
+  category: "Groceries",
+  amount: -20,
+  note: null,
+};
+
+const CREATE_DB_ROW = {
+  adjustment_id: CREATE_PARAMS.adjustmentId,
+  month: CREATE_PARAMS.month,
+  direction: CREATE_PARAMS.direction,
+  category: CREATE_PARAMS.category,
+  amount: CREATE_PARAMS.amount,
+  note: CREATE_PARAMS.note,
+  created_at: new Date("2026-07-20T10:00:00.000Z"),
+  updated_at: new Date("2026-07-20T10:00:00.000Z"),
+} as const;
+
+const createDemoGridAdjustment = (
+  adjustmentId: string,
+  month: string,
+  direction: "income" | "spend",
+  category: string,
+  amount: number,
+): BudgetAdjustment => ({
+  adjustmentId,
+  month,
+  direction,
+  category,
+  amount,
+  note: null,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-01T00:00:00.000Z",
+});
+
+type QueryCall = Readonly<{
+  text: string;
+  params: ReadonlyArray<unknown>;
+}>;
+
+const createQuerySequence = (
+  rowSets: ReadonlyArray<ReadonlyArray<Record<string, unknown>>>,
+): Readonly<{ queryFn: QueryFn; calls: Array<QueryCall> }> => {
+  const calls: Array<QueryCall> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    const rows = rowSets[calls.length];
+    if (rows === undefined) {
+      throw new Error(`Unexpected budget adjustment test query ${calls.length + 1}`);
+    }
+    calls.push({ text, params });
+    return { rows: [...rows], rowCount: rows.length, command: "", oid: 0, fields: [] };
+  };
+  return { queryFn, calls };
+};
 
 test("mapBudgetAdjustmentRow returns the browser contract without workspace or origin", (): void => {
   const createdAt = new Date("2026-07-20T10:00:00.000Z");
@@ -124,6 +184,69 @@ test("mapBudgetAdjustmentRow rejects invalid database values", (): void => {
   );
 });
 
+test("create inserts the client ID and returns a newly inserted row", async (): Promise<void> => {
+  const sequence = createQuerySequence([[CREATE_DB_ROW]]);
+  const adjustment = await createBudgetAdjustmentWithQuery(
+    sequence.queryFn,
+    "workspace-1",
+    CREATE_PARAMS,
+  );
+
+  assert.equal(adjustment.adjustmentId, CREATE_PARAMS.adjustmentId);
+  assert.equal(sequence.calls.length, 1);
+  assert.equal(sequence.calls[0]?.text, CREATE_BUDGET_ADJUSTMENT_QUERY);
+  assert.deepEqual(sequence.calls[0]?.params, [
+    "workspace-1",
+    CREATE_PARAMS.adjustmentId,
+    CREATE_PARAMS.month,
+    CREATE_PARAMS.direction,
+    CREATE_PARAMS.category,
+    CREATE_PARAMS.amount,
+    CREATE_PARAMS.note,
+  ]);
+  assert.match(CREATE_BUDGET_ADJUSTMENT_QUERY, /ON CONFLICT \(adjustment_id\) DO NOTHING/);
+  assert.doesNotMatch(CREATE_BUDGET_ADJUSTMENT_QUERY, /DO UPDATE/);
+});
+
+test("an exact create retry returns the existing row without changing timestamps", async (): Promise<void> => {
+  const sequence = createQuerySequence([[], [CREATE_DB_ROW]]);
+  const adjustment = await createBudgetAdjustmentWithQuery(
+    sequence.queryFn,
+    "workspace-1",
+    CREATE_PARAMS,
+  );
+
+  assert.equal(adjustment.createdAt, CREATE_DB_ROW.created_at.toISOString());
+  assert.equal(adjustment.updatedAt, CREATE_DB_ROW.updated_at.toISOString());
+  assert.equal(sequence.calls[1]?.text, BUDGET_ADJUSTMENT_BY_ID_QUERY);
+  assert.deepEqual(sequence.calls[1]?.params, ["workspace-1", CREATE_PARAMS.adjustmentId]);
+});
+
+test("create conflicts are explicit and do not distinguish hidden from changed rows", async (): Promise<void> => {
+  for (const existingRows of [
+    [{ ...CREATE_DB_ROW, month: "2026-09" }],
+    [{ ...CREATE_DB_ROW, direction: "income" }],
+    [{ ...CREATE_DB_ROW, category: "Dining" }],
+    [{ ...CREATE_DB_ROW, amount: 1 }],
+    [{ ...CREATE_DB_ROW, note: "different" }],
+    [],
+  ]) {
+    const sequence = createQuerySequence([[], existingRows]);
+    await assert.rejects(
+      createBudgetAdjustmentWithQuery(sequence.queryFn, "workspace-1", CREATE_PARAMS),
+      (error: unknown): boolean => {
+        assert.ok(error instanceof BudgetAdjustmentConflictError);
+        assert.equal(
+          error.message,
+          `Budget adjustment ID "${CREATE_PARAMS.adjustmentId}" is already in use`,
+        );
+        assert.doesNotMatch(error.message, /workspace|Groceries|different/);
+        return true;
+      },
+    );
+  }
+});
+
 test("patch query changes only supplied editable columns and scopes by workspace and id", (): void => {
   const query = buildPatchBudgetAdjustmentQuery("workspace-1", "adjustment-1", {
     amount: 0,
@@ -149,10 +272,38 @@ test("detail query is one deterministic workspace and month-range scan", (): voi
   assert.match(BUDGET_ADJUSTMENTS_DETAIL_QUERY, /ORDER BY budget_month, direction, category, created_at, adjustment_id/);
 });
 
+test("demo adjustment session state is validated and bounded without eviction", (): void => {
+  assert.throws(
+    () => parseDemoBudgetAdjustmentSessionCookie("invalid-cookie"),
+    /Invalid demo budget adjustment session cookie/,
+  );
+  let state: DemoBudgetAdjustmentSessionState = EMPTY_DEMO_BUDGET_ADJUSTMENT_SESSION;
+  for (let index = 1; index <= 9; index += 1) {
+    state = createDemoBudgetAdjustment(state, {
+      adjustmentId: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+      month: getCurrentMonth(),
+      direction: "income",
+      category: `Demo ${index}`,
+      amount: index,
+      note: null,
+    }).state;
+  }
+  assert.throws(
+    () => serializeDemoBudgetAdjustmentSessionCookie(state),
+    /supports at most 8 changed rows/,
+  );
+});
+
 test("demo adjustment details exactly match cell modifiers and include adjustment-only cells", (): void => {
   const currentMonth = getCurrentMonth();
   const nextMonth = offsetMonth(currentMonth, 1);
-  const grid = getDemoBudgetGrid(currentMonth, nextMonth, currentMonth, currentMonth);
+  const grid = getDemoBudgetGrid(
+    currentMonth,
+    nextMonth,
+    currentMonth,
+    currentMonth,
+    getDemoBudgetAdjustments(),
+  );
   const sums = new Map<string, number>();
 
   for (const adjustment of grid.adjustments) {
@@ -177,4 +328,73 @@ test("demo adjustment details exactly match cell modifiers and include adjustmen
   assert.equal(adjustmentOnly.plannedBase, 0);
   assert.equal(adjustmentOnly.plannedModifier, 300);
   assert.equal(adjustmentOnly.planned, 300);
+});
+
+test("demo adjustment aggregation preserves categories containing separators", (): void => {
+  const month = getCurrentMonth();
+  const category = "Travel|Weekend";
+  const grid = getDemoBudgetGrid(
+    month,
+    month,
+    month,
+    month,
+    [createDemoGridAdjustment("separator", month, "spend", category, 25)],
+  );
+
+  const row = grid.rows.find((candidate) =>
+    candidate.month === month
+    && candidate.direction === "spend"
+    && candidate.category === category);
+  assert.ok(row);
+  assert.equal(row.plannedModifier, 25);
+  assert.equal(row.planned, 25);
+});
+
+test("demo adjustment aggregation is exact at safe boundaries and rejects overflow", (): void => {
+  const month = getCurrentMonth();
+  const maximum = Number.MAX_SAFE_INTEGER;
+  const exactGrid = getDemoBudgetGrid(
+    month,
+    month,
+    month,
+    month,
+    [
+      createDemoGridAdjustment("maximum", month, "spend", "Exact", maximum),
+      createDemoGridAdjustment("two", month, "spend", "Exact", 2),
+      createDemoGridAdjustment("cancel", month, "spend", "Exact", -maximum),
+      createDemoGridAdjustment("boundary", month, "spend", "Boundary", maximum),
+    ],
+  );
+  assert.equal(
+    exactGrid.rows.find((row) => row.category === "Exact")?.plannedModifier,
+    2,
+  );
+  assert.equal(
+    exactGrid.rows.find((row) => row.category === "Boundary")?.plannedModifier,
+    maximum,
+  );
+
+  assert.throws(
+    () => getDemoBudgetGrid(
+      month,
+      month,
+      month,
+      month,
+      [
+        createDemoGridAdjustment("maximum", month, "spend", "Overflow", maximum),
+        createDemoGridAdjustment("one", month, "spend", "Overflow", 1),
+      ],
+    ),
+    /modifier is outside the JavaScript safe integer range/,
+  );
+  assert.throws(
+    () => getDemoBudgetGrid(
+      month,
+      month,
+      month,
+      month,
+      [createDemoGridAdjustment("planned", month, "income", "Salary", maximum)],
+    ),
+    /planned value is outside the JavaScript safe integer range/,
+  );
 });

--- a/apps/web/src/server/budget/budgetAdjustments.ts
+++ b/apps/web/src/server/budget/budgetAdjustments.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 import { budgetAdjustmentNoteSchema, categorySchema } from "@/server/api/validation";
-import { queryAs } from "@/server/db";
+import { queryAs, withUserContext } from "@/server/db";
+import type { QueryFn } from "@/server/db/contextRunner";
 
 export type BudgetAdjustmentDirection = "income" | "spend";
 
@@ -17,6 +18,7 @@ export type BudgetAdjustment = Readonly<{
 }>;
 
 export type CreateBudgetAdjustmentParams = Readonly<{
+  adjustmentId: string;
   month: string;
   direction: BudgetAdjustmentDirection;
   category: string;
@@ -60,6 +62,7 @@ const RETURNING_BUDGET_ADJUSTMENT = `
 
 export const CREATE_BUDGET_ADJUSTMENT_QUERY = `
   INSERT INTO budget_adjustments (
+    adjustment_id,
     workspace_id,
     budget_month,
     direction,
@@ -67,8 +70,17 @@ export const CREATE_BUDGET_ADJUSTMENT_QUERY = `
     amount,
     note
   )
-  VALUES ($1, to_date($2, 'YYYY-MM'), $3, $4, $5, $6)
+  VALUES ($2, $1, to_date($3, 'YYYY-MM'), $4, $5, $6, $7)
+  ON CONFLICT (adjustment_id) DO NOTHING
   RETURNING ${RETURNING_BUDGET_ADJUSTMENT}
+`;
+
+export const BUDGET_ADJUSTMENT_BY_ID_QUERY = `
+  SELECT
+    ${RETURNING_BUDGET_ADJUSTMENT}
+  FROM budget_adjustments
+  WHERE workspace_id = $1
+    AND adjustment_id = $2
 `;
 
 export const DELETE_BUDGET_ADJUSTMENT_QUERY = `
@@ -92,6 +104,13 @@ export class BudgetAdjustmentNotFoundError extends Error {
   public constructor(adjustmentId: string) {
     super(`Budget adjustment "${adjustmentId}" was not found`);
     this.name = "BudgetAdjustmentNotFoundError";
+  }
+}
+
+export class BudgetAdjustmentConflictError extends Error {
+  public constructor(adjustmentId: string) {
+    super(`Budget adjustment ID "${adjustmentId}" is already in use`);
+    this.name = "BudgetAdjustmentConflictError";
   }
 }
 
@@ -171,6 +190,54 @@ const mapCreatedAdjustment = (rows: ReadonlyArray<unknown>): BudgetAdjustment =>
   return mapBudgetAdjustmentRow(rows[0], "create budget adjustment");
 };
 
+export const budgetAdjustmentMatchesCreateParams = (
+  params: CreateBudgetAdjustmentParams,
+  adjustment: BudgetAdjustment,
+): boolean => params.adjustmentId === adjustment.adjustmentId
+  && params.month === adjustment.month
+  && params.direction === adjustment.direction
+  && params.category === adjustment.category
+  && params.amount === adjustment.amount
+  && params.note === adjustment.note;
+
+export const createBudgetAdjustmentWithQuery = async (
+  queryFn: QueryFn,
+  workspaceId: string,
+  params: CreateBudgetAdjustmentParams,
+): Promise<BudgetAdjustment> => {
+  const inserted = await queryFn(
+    CREATE_BUDGET_ADJUSTMENT_QUERY,
+    [
+      workspaceId,
+      params.adjustmentId,
+      params.month,
+      params.direction,
+      params.category,
+      params.amount,
+      params.note,
+    ],
+  );
+  if (inserted.rows.length > 0) return mapCreatedAdjustment(inserted.rows);
+
+  const existingResult = await queryFn(
+    BUDGET_ADJUSTMENT_BY_ID_QUERY,
+    [workspaceId, params.adjustmentId],
+  );
+  if (existingResult.rows.length === 1) {
+    const existing = mapBudgetAdjustmentRow(
+      existingResult.rows[0],
+      "existing budget adjustment after create conflict",
+    );
+    if (budgetAdjustmentMatchesCreateParams(params, existing)) return existing;
+  } else if (existingResult.rows.length > 1) {
+    throw new Error(
+      `Failed to resolve budget adjustment create conflict for "${params.adjustmentId}": expected at most one visible row, received ${existingResult.rows.length}`,
+    );
+  }
+
+  throw new BudgetAdjustmentConflictError(params.adjustmentId);
+};
+
 const mapExistingAdjustment = (
   rows: ReadonlyArray<unknown>,
   adjustmentId: string,
@@ -190,14 +257,12 @@ export const createBudgetAdjustment = async (
   workspaceId: string,
   params: CreateBudgetAdjustmentParams,
 ): Promise<BudgetAdjustment> => {
-  const result = await queryAs(
+  return withUserContext(
     userId,
     workspaceId,
-    CREATE_BUDGET_ADJUSTMENT_QUERY,
-    [workspaceId, params.month, params.direction, params.category, params.amount, params.note],
+    async (queryFn): Promise<BudgetAdjustment> =>
+      createBudgetAdjustmentWithQuery(queryFn, workspaceId, params),
   );
-
-  return mapCreatedAdjustment(result.rows);
 };
 
 export const patchBudgetAdjustment = async (

--- a/apps/web/src/server/demo/budgetAdjustments.ts
+++ b/apps/web/src/server/demo/budgetAdjustments.ts
@@ -1,25 +1,196 @@
-import { randomUUID } from "node:crypto";
+import { Buffer } from "node:buffer";
 
-import { getCurrentMonth } from "@/lib/monthUtils";
-import { BudgetAdjustmentNotFoundError, type BudgetAdjustment, type CreateBudgetAdjustmentParams, type PatchBudgetAdjustmentParams } from "@/server/budget/budgetAdjustments";
+import { z } from "zod";
+
+import { DEMO_BUDGET_ADJUSTMENTS_COOKIE } from "@/lib/demoCookies";
+import { ApiRouteError } from "@/server/api/errors";
+import { budgetAdjustmentNoteSchema, categorySchema, adjustmentUuidSchema } from "@/server/api/validation";
+import { budgetAdjustmentMatchesCreateParams, BudgetAdjustmentConflictError, BudgetAdjustmentNotFoundError, type BudgetAdjustment, type CreateBudgetAdjustmentParams, type PatchBudgetAdjustmentParams } from "@/server/budget/budgetAdjustments";
 import { getDemoBudgetAdjustments } from "@/server/demo/data";
 
-const DEMO_CREATED_ID_PATTERN = /^demo-created-(income|spend)-[0-9a-f-]{36}$/;
+const MAX_SESSION_ROWS = 8;
+const MAX_SESSION_COOKIE_VALUE_LENGTH = 3000;
 
-const getCreatedDemoDirection = (adjustmentId: string): "income" | "spend" | null => {
-  const match = DEMO_CREATED_ID_PATTERN.exec(adjustmentId);
-  if (match === null) {
-    return null;
+const demoBudgetAdjustmentSchema: z.ZodType<BudgetAdjustment> = z.object({
+  adjustmentId: z.string().min(1).max(200),
+  month: z.string().regex(/^\d{4}-(?:0[1-9]|1[0-2])$/),
+  direction: z.enum(["income", "spend"]),
+  category: categorySchema,
+  amount: z.number().safe().int(),
+  note: budgetAdjustmentNoteSchema,
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+}).strict();
+
+const demoBudgetAdjustmentSessionSchema = z.object({
+  rows: z.array(demoBudgetAdjustmentSchema).max(MAX_SESSION_ROWS),
+  deletedAdjustmentIds: z.array(z.string().min(1).max(200)).max(MAX_SESSION_ROWS),
+}).strict();
+
+export type DemoBudgetAdjustmentSessionState = Readonly<{
+  rows: ReadonlyArray<BudgetAdjustment>;
+  deletedAdjustmentIds: ReadonlyArray<string>;
+}>;
+
+export type DemoBudgetAdjustmentMutation = Readonly<{
+  state: DemoBudgetAdjustmentSessionState;
+  adjustment: BudgetAdjustment;
+}>;
+
+export const EMPTY_DEMO_BUDGET_ADJUSTMENT_SESSION: DemoBudgetAdjustmentSessionState = {
+  rows: [],
+  deletedAdjustmentIds: [],
+};
+
+const compareAdjustments = (left: BudgetAdjustment, right: BudgetAdjustment): number =>
+  left.month.localeCompare(right.month)
+  || left.direction.localeCompare(right.direction)
+  || left.category.localeCompare(right.category)
+  || left.createdAt.localeCompare(right.createdAt)
+  || left.adjustmentId.localeCompare(right.adjustmentId);
+
+const validateSessionIds = (state: DemoBudgetAdjustmentSessionState): void => {
+  const rowIds = new Set<string>();
+  for (const row of state.rows) {
+    if (rowIds.has(row.adjustmentId)) {
+      throw new ApiRouteError(
+        400,
+        "Invalid demo budget adjustment session: duplicate row ID. Leave Demo mode to reset it.",
+      );
+    }
+    rowIds.add(row.adjustmentId);
   }
-  return match[1] as "income" | "spend";
+  const deletedIds = new Set<string>();
+  for (const adjustmentId of state.deletedAdjustmentIds) {
+    if (deletedIds.has(adjustmentId) || rowIds.has(adjustmentId)) {
+      throw new ApiRouteError(
+        400,
+        "Invalid demo budget adjustment session: conflicting deleted ID. Leave Demo mode to reset it.",
+      );
+    }
+    deletedIds.add(adjustmentId);
+  }
+};
+
+export const parseDemoBudgetAdjustmentSessionCookie = (
+  value: string | null,
+): DemoBudgetAdjustmentSessionState => {
+  if (value === null || value === "") return EMPTY_DEMO_BUDGET_ADJUSTMENT_SESSION;
+
+  let input: unknown;
+  try {
+    input = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as unknown;
+  } catch {
+    throw new ApiRouteError(
+      400,
+      "Invalid demo budget adjustment session cookie. Leave Demo mode to reset it.",
+    );
+  }
+  const parsed = demoBudgetAdjustmentSessionSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new ApiRouteError(
+      400,
+      "Invalid demo budget adjustment session cookie. Leave Demo mode to reset it.",
+    );
+  }
+  const state: DemoBudgetAdjustmentSessionState = {
+    rows: parsed.data.rows,
+    deletedAdjustmentIds: parsed.data.deletedAdjustmentIds,
+  };
+  validateSessionIds(state);
+  return state;
+};
+
+export const readDemoBudgetAdjustmentSession = (
+  request: Request,
+): DemoBudgetAdjustmentSessionState => {
+  const prefix = `${DEMO_BUDGET_ADJUSTMENTS_COOKIE}=`;
+  const cookie = (request.headers.get("cookie") ?? "")
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+  return parseDemoBudgetAdjustmentSessionCookie(
+    cookie === undefined ? null : cookie.slice(prefix.length),
+  );
+};
+
+export const serializeDemoBudgetAdjustmentSessionCookie = (
+  state: DemoBudgetAdjustmentSessionState,
+): string => {
+  if (state.rows.length > MAX_SESSION_ROWS
+    || state.deletedAdjustmentIds.length > MAX_SESSION_ROWS) {
+    throw new ApiRouteError(
+      409,
+      `Demo budget adjustment session supports at most ${MAX_SESSION_ROWS} changed rows. Delete an adjustment or leave Demo mode to reset it.`,
+    );
+  }
+  validateSessionIds(state);
+  const parsed = demoBudgetAdjustmentSessionSchema.safeParse(state);
+  if (!parsed.success) {
+    throw new Error(`Cannot serialize invalid demo budget adjustment session: ${parsed.error.message}`);
+  }
+  if (state.rows.length === 0 && state.deletedAdjustmentIds.length === 0) {
+    return `${DEMO_BUDGET_ADJUSTMENTS_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`;
+  }
+  const value = Buffer.from(JSON.stringify(parsed.data), "utf8").toString("base64url");
+  if (value.length > MAX_SESSION_COOKIE_VALUE_LENGTH) {
+    throw new ApiRouteError(
+      409,
+      "Demo budget adjustment session is full. Shorten notes, delete an adjustment, or leave Demo mode to reset it.",
+    );
+  }
+  return `${DEMO_BUDGET_ADJUSTMENTS_COOKIE}=${value}; Path=/; SameSite=Lax`;
+};
+
+export const getDemoBudgetAdjustmentsForSession = (
+  state: DemoBudgetAdjustmentSessionState,
+): ReadonlyArray<BudgetAdjustment> => {
+  const deletedIds = new Set(state.deletedAdjustmentIds);
+  const byId = new Map(getDemoBudgetAdjustments()
+    .filter((adjustment) => !deletedIds.has(adjustment.adjustmentId))
+    .map((adjustment): readonly [string, BudgetAdjustment] => [
+      adjustment.adjustmentId,
+      adjustment,
+    ]));
+  for (const adjustment of state.rows) byId.set(adjustment.adjustmentId, adjustment);
+  return [...byId.values()].sort(compareAdjustments);
+};
+
+const replaceSessionRow = (
+  state: DemoBudgetAdjustmentSessionState,
+  adjustment: BudgetAdjustment,
+): DemoBudgetAdjustmentSessionState => ({
+  rows: [...state.rows.filter((row) => row.adjustmentId !== adjustment.adjustmentId), adjustment]
+    .sort(compareAdjustments),
+  deletedAdjustmentIds: state.deletedAdjustmentIds.filter((adjustmentId) =>
+    adjustmentId !== adjustment.adjustmentId),
+});
+
+const getDeterministicCreateTimestamp = (adjustmentId: string): string => {
+  const parsed = adjustmentUuidSchema.safeParse(adjustmentId);
+  if (!parsed.success) {
+    throw new Error(`Cannot create demo budget adjustment with non-UUID ID "${adjustmentId}"`);
+  }
+  const secondsAfterEpoch = Number.parseInt(adjustmentId.slice(0, 8), 16);
+  return new Date(Date.UTC(2000, 0, 1) + secondsAfterEpoch * 1000).toISOString();
 };
 
 export const createDemoBudgetAdjustment = (
+  state: DemoBudgetAdjustmentSessionState,
   params: CreateBudgetAdjustmentParams,
-): BudgetAdjustment => {
-  const timestamp = new Date().toISOString();
-  return {
-    adjustmentId: `demo-created-${params.direction}-${randomUUID()}`,
+): DemoBudgetAdjustmentMutation => {
+  const existing = getDemoBudgetAdjustmentsForSession(state).find((adjustment) =>
+    adjustment.adjustmentId === params.adjustmentId);
+  if (existing !== undefined) {
+    if (budgetAdjustmentMatchesCreateParams(params, existing)) {
+      return { state, adjustment: existing };
+    }
+    throw new BudgetAdjustmentConflictError(params.adjustmentId);
+  }
+
+  const timestamp = getDeterministicCreateTimestamp(params.adjustmentId);
+  const adjustment: BudgetAdjustment = {
+    adjustmentId: params.adjustmentId,
     month: params.month,
     direction: params.direction,
     category: params.category,
@@ -28,36 +199,46 @@ export const createDemoBudgetAdjustment = (
     createdAt: timestamp,
     updatedAt: timestamp,
   };
+  return { state: replaceSessionRow(state, adjustment), adjustment };
 };
 
 export const patchDemoBudgetAdjustment = (
+  state: DemoBudgetAdjustmentSessionState,
   adjustmentId: string,
   params: PatchBudgetAdjustmentParams,
-): BudgetAdjustment => {
-  const existing = getDemoBudgetAdjustments().find((adjustment) =>
+  updatedAt: string,
+): DemoBudgetAdjustmentMutation => {
+  const existing = getDemoBudgetAdjustmentsForSession(state).find((adjustment) =>
     adjustment.adjustmentId === adjustmentId);
-  const createdDirection = getCreatedDemoDirection(adjustmentId);
-  if (existing === undefined && createdDirection === null) {
-    throw new BudgetAdjustmentNotFoundError(adjustmentId);
-  }
+  if (existing === undefined) throw new BudgetAdjustmentNotFoundError(adjustmentId);
 
-  const timestamp = new Date().toISOString();
-  return {
+  const adjustment: BudgetAdjustment = {
     adjustmentId,
-    month: params.month ?? existing?.month ?? getCurrentMonth(),
-    direction: existing?.direction ?? createdDirection as "income" | "spend",
-    category: params.category ?? existing?.category ?? "Demo adjustment",
-    amount: params.amount ?? existing?.amount ?? 0,
-    note: params.note !== undefined ? params.note : existing?.note ?? null,
-    createdAt: existing?.createdAt ?? timestamp,
-    updatedAt: timestamp,
+    month: params.month ?? existing.month,
+    direction: existing.direction,
+    category: params.category ?? existing.category,
+    amount: params.amount ?? existing.amount,
+    note: params.note !== undefined ? params.note : existing.note,
+    createdAt: existing.createdAt,
+    updatedAt,
   };
+  return { state: replaceSessionRow(state, adjustment), adjustment };
 };
 
-export const deleteDemoBudgetAdjustment = (adjustmentId: string): void => {
-  const exists = getDemoBudgetAdjustments().some((adjustment) =>
+export const deleteDemoBudgetAdjustment = (
+  state: DemoBudgetAdjustmentSessionState,
+  adjustmentId: string,
+): DemoBudgetAdjustmentSessionState => {
+  const existing = getDemoBudgetAdjustmentsForSession(state).find((adjustment) =>
     adjustment.adjustmentId === adjustmentId);
-  if (!exists && getCreatedDemoDirection(adjustmentId) === null) {
-    throw new BudgetAdjustmentNotFoundError(adjustmentId);
-  }
+  if (existing === undefined) throw new BudgetAdjustmentNotFoundError(adjustmentId);
+
+  const isSeeded = getDemoBudgetAdjustments().some((adjustment) =>
+    adjustment.adjustmentId === adjustmentId);
+  return {
+    rows: state.rows.filter((adjustment) => adjustment.adjustmentId !== adjustmentId),
+    deletedAdjustmentIds: isSeeded
+      ? [...state.deletedAdjustmentIds, adjustmentId].sort()
+      : [...state.deletedAdjustmentIds],
+  };
 };

--- a/apps/web/src/server/demo/data.ts
+++ b/apps/web/src/server/demo/data.ts
@@ -13,7 +13,7 @@ import {
 
 import type { AccountSuggestion } from "@/server/accounts/getAccountSuggestions";
 import type { AccountRow, BalancesSummaryResult, CurrencyTotal } from "@/server/balances/getBalancesSummary";
-import type { BudgetAdjustment } from "@/server/budget/budgetAdjustments";
+import type { BudgetAdjustment, BudgetAdjustmentDirection } from "@/server/budget/budgetAdjustments";
 import type { BudgetGridResult, BudgetRow } from "@/server/budget/getBudgetGrid";
 import type { CommentedCell } from "@/server/budget/getCommentedCells";
 import type { FxBreakdownResult, FxBreakdownRow } from "@/server/budget/getFxBreakdown";
@@ -217,7 +217,6 @@ type DemoData = Readonly<{
   accounts: ReadonlyArray<AccountRow>;
   totals: ReadonlyArray<CurrencyTotal>;
   budgetRows: ReadonlyArray<BudgetRow>;
-  budgetAdjustments: ReadonlyArray<BudgetAdjustment>;
   monthEndBalances: Readonly<Record<string, number>>;
   monthEndBalancesByLiquidity: Readonly<Record<string, Readonly<Record<string, number>>>>;
   businessPersonalTransfers: Readonly<Record<string, Readonly<{ actual: number; hasUnconvertible: boolean }>>>;
@@ -348,12 +347,6 @@ const generate = (): DemoData => {
 
   // Budget rows (past months with actuals + future months plan-only)
   const allBudgetMonths = [...pastMonths, ...Array.from({ length: FUTURE_MONTHS }, (_, i) => offsetMonth(now, i + 1))];
-  const budgetAdjustments = getDemoBudgetAdjustments();
-  const adjustmentTotals = new Map<string, number>();
-  for (const adjustment of budgetAdjustments) {
-    const key = `${adjustment.month}|${adjustment.direction}|${adjustment.category}`;
-    adjustmentTotals.set(key, (adjustmentTotals.get(key) ?? 0) + adjustment.amount);
-  }
   const budgetRows: Array<BudgetRow> = [];
   for (const month of allBudgetMonths) {
     const isPast = month <= now;
@@ -361,29 +354,11 @@ const generate = (): DemoData => {
       const key = `${month}|${bp.direction}|${bp.category}`;
       const raw = actuals.get(key) ?? 0;
       const actual = bp.direction === "spend" ? -raw : raw;
-      const plannedModifier = adjustmentTotals.get(key) ?? 0;
-      if (bp.planned === 0 && plannedModifier === 0 && actual === 0) continue;
+      if (bp.planned === 0 && actual === 0) continue;
       budgetRows.push({
         month, direction: bp.direction, category: bp.category,
-        plannedBase: bp.planned, plannedModifier, planned: bp.planned + plannedModifier,
+        plannedBase: bp.planned, plannedModifier: 0, planned: bp.planned,
         actual: isPast ? round2(actual) : 0, hasUnconvertible: false,
-      });
-    }
-    for (const [key, plannedModifier] of adjustmentTotals) {
-      const [adjustmentMonth, direction, category] = key.split("|");
-      if (adjustmentMonth !== month || budgetRows.some((row) =>
-        row.month === month && row.direction === direction && row.category === category)) {
-        continue;
-      }
-      budgetRows.push({
-        month,
-        direction,
-        category,
-        plannedBase: 0,
-        plannedModifier,
-        planned: plannedModifier,
-        actual: 0,
-        hasUnconvertible: false,
       });
     }
     budgetRows.push({
@@ -400,7 +375,6 @@ const generate = (): DemoData => {
     accounts,
     totals,
     budgetRows,
-    budgetAdjustments,
     monthEndBalances: monthEndBal,
     monthEndBalancesByLiquidity: monthEndBalByLiq,
     businessPersonalTransfers,
@@ -636,17 +610,106 @@ export const getDemoFieldHints = (): FieldHints => {
 // Budget grid
 // ---------------------------------------------------------------------------
 
+type DemoAdjustmentCellTotal = Readonly<{
+  month: string;
+  direction: BudgetAdjustmentDirection;
+  category: string;
+  total: bigint;
+}>;
+
+const getDemoAdjustmentCellKey = (
+  month: string,
+  direction: string,
+  category: string,
+): string => JSON.stringify([month, direction, category]);
+
+const toSafeDemoBudgetInteger = (value: bigint, context: string): number => {
+  const minimum = BigInt(Number.MIN_SAFE_INTEGER);
+  const maximum = BigInt(Number.MAX_SAFE_INTEGER);
+  if (value < minimum || value > maximum) {
+    throw new RangeError(`${context} is outside the JavaScript safe integer range: ${value.toString()}`);
+  }
+  return Number(value);
+};
+
+const addDemoPlannedValue = (
+  plannedBase: number,
+  plannedModifier: number,
+  context: string,
+): number => {
+  if (!Number.isFinite(plannedBase) || Math.abs(plannedBase) > Number.MAX_SAFE_INTEGER) {
+    throw new RangeError(`${context} base is outside the JavaScript safe numeric range: ${String(plannedBase)}`);
+  }
+  if (Number.isInteger(plannedBase)) {
+    return toSafeDemoBudgetInteger(
+      BigInt(plannedBase) + BigInt(plannedModifier),
+      `${context} planned value`,
+    );
+  }
+  const planned = plannedBase + plannedModifier;
+  if (!Number.isFinite(planned) || Math.abs(planned) > Number.MAX_SAFE_INTEGER) {
+    throw new RangeError(`${context} planned value is outside the JavaScript safe numeric range: ${String(planned)}`);
+  }
+  return planned;
+};
+
 export const getDemoBudgetGrid = (
   monthFrom: string,
   monthTo: string,
   _planFrom: string,
   _actualTo: string,
+  adjustments: ReadonlyArray<BudgetAdjustment>,
 ): BudgetGridResult => {
-  const { budgetRows, budgetAdjustments, monthEndBalances, monthEndBalancesByLiquidity, businessPersonalTransfers, hasBusinessAccount } = generate();
+  const { budgetRows, monthEndBalances, monthEndBalancesByLiquidity, businessPersonalTransfers, hasBusinessAccount } = generate();
   const months = new Set(generateMonthRange(monthFrom, monthTo));
+  const adjustmentTotals = new Map<string, DemoAdjustmentCellTotal>();
+  for (const adjustment of adjustments) {
+    if (!months.has(adjustment.month)) continue;
+    const key = getDemoAdjustmentCellKey(
+      adjustment.month,
+      adjustment.direction,
+      adjustment.category,
+    );
+    const previous = adjustmentTotals.get(key);
+    adjustmentTotals.set(key, {
+      month: adjustment.month,
+      direction: adjustment.direction,
+      category: adjustment.category,
+      total: (previous?.total ?? BigInt(0)) + BigInt(adjustment.amount),
+    });
+  }
+  const rows = budgetRows
+    .filter((row) => months.has(row.month))
+    .map((row): BudgetRow => {
+      if (row.direction === "transfer") return row;
+      const key = getDemoAdjustmentCellKey(row.month, row.direction, row.category);
+      const total = adjustmentTotals.get(key)?.total ?? BigInt(0);
+      const context = `Demo budget adjustment for ${row.month}/${row.direction}/${row.category}`;
+      const plannedModifier = toSafeDemoBudgetInteger(total, `${context} modifier`);
+      adjustmentTotals.delete(key);
+      return {
+        ...row,
+        plannedModifier,
+        planned: addDemoPlannedValue(row.plannedBase, plannedModifier, context),
+      };
+    });
+  for (const { month, direction, category, total } of adjustmentTotals.values()) {
+    const context = `Demo budget adjustment for ${month}/${direction}/${category}`;
+    const plannedModifier = toSafeDemoBudgetInteger(total, `${context} modifier`);
+    rows.push({
+      month,
+      direction,
+      category,
+      plannedBase: 0,
+      plannedModifier,
+      planned: plannedModifier,
+      actual: 0,
+      hasUnconvertible: false,
+    });
+  }
   return {
-    rows: budgetRows.filter((r) => months.has(r.month)),
-    adjustments: budgetAdjustments.filter((adjustment) => months.has(adjustment.month)),
+    rows,
+    adjustments: adjustments.filter((adjustment) => months.has(adjustment.month)),
     conversionWarnings: [],
     cumulativeBefore: { incomeActual: 0, spendActual: 0, transferActual: 0 },
     monthEndBalances,

--- a/apps/web/src/ui/ModeToggle.tsx
+++ b/apps/web/src/ui/ModeToggle.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
+import { DEMO_BUDGET_ADJUSTMENTS_COOKIE } from "@/lib/demoCookies";
 import { useFilteredMode } from "@/ui/FilteredModeProvider";
 
 import styles from "./Controls.module.css";
@@ -32,6 +33,7 @@ export const ModeToggle = (props: Props): ReactElement => {
       // Leaving demo mode — store target mode in localStorage before reload
       localStorage.setItem("expense-tracker-visibility-mode", target);
       document.cookie = "demo=; path=/; max-age=0";
+      document.cookie = `${DEMO_BUDGET_ADJUSTMENTS_COOKIE}=; path=/; max-age=0`;
       window.location.reload();
       return;
     }

--- a/apps/web/src/ui/tables/budget/budgetTableApi.test.ts
+++ b/apps/web/src/ui/tables/budget/budgetTableApi.test.ts
@@ -1,11 +1,25 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import type { BudgetAdjustment } from "@/server/budget/budgetAdjustments";
+import type { BudgetAdjustment, CreateBudgetAdjustmentParams } from "@/server/budget/budgetAdjustments";
 import {
+  createBudgetAdjustment,
+  deleteBudgetAdjustment,
+  patchBudgetAdjustment,
+  readBudgetAdjustmentCreateResponse,
   readBudgetAdjustmentDeleteResponse,
   readBudgetAdjustmentResponse,
+  serializeBudgetAdjustmentCreateParams,
 } from "@/ui/tables/budget/budgetTableApi";
+
+const CREATE_PARAMS: CreateBudgetAdjustmentParams = {
+  adjustmentId: "5bd6592b-45e8-4c25-b37e-72b96591f54a",
+  month: "2026-07",
+  direction: "spend",
+  category: "Groceries",
+  amount: 0,
+  note: null,
+};
 
 const createAdjustment = (
   adjustmentId: string,
@@ -83,6 +97,44 @@ test("budget adjustment responses reject errors and malformed JSON with response
   );
 });
 
+test("budget adjustment create serialization includes the final UUID and only contract fields", (): void => {
+  assert.deepEqual(JSON.parse(serializeBudgetAdjustmentCreateParams(CREATE_PARAMS)), CREATE_PARAMS);
+  assert.throws(
+    () => serializeBudgetAdjustmentCreateParams({
+      ...CREATE_PARAMS,
+      adjustmentId: "temporary-row-1",
+    }),
+    /must be a UUID/,
+  );
+});
+
+test("budget adjustment create responses require the requested ID and direction", async (): Promise<void> => {
+  const adjustment = createAdjustment(
+    CREATE_PARAMS.adjustmentId,
+    CREATE_PARAMS.category,
+    CREATE_PARAMS.amount,
+    CREATE_PARAMS.note,
+  );
+  assert.deepEqual(
+    await readBudgetAdjustmentCreateResponse(Response.json(adjustment), CREATE_PARAMS),
+    adjustment,
+  );
+  await assert.rejects(
+    readBudgetAdjustmentCreateResponse(
+      Response.json({ ...adjustment, adjustmentId: "73838d3d-bdce-41a4-ac3e-60349776ca55" }),
+      CREATE_PARAMS,
+    ),
+    /does not match requested id/,
+  );
+  await assert.rejects(
+    readBudgetAdjustmentCreateResponse(
+      Response.json({ ...adjustment, direction: "income" }),
+      CREATE_PARAMS,
+    ),
+    /changed immutable direction/,
+  );
+});
+
 test("budget adjustment delete responses distinguish deleted and already absent outcomes", async (): Promise<void> => {
   assert.equal(
     await readBudgetAdjustmentDeleteResponse(Response.json({ ok: true }), "deleted"),
@@ -113,4 +165,187 @@ test("successful budget adjustment delete responses are strictly validated", asy
     ),
     /Budget adjustment adjustment-1 delete failed: 500 server error/,
   );
+});
+
+test("demo create, patch, and delete wait for the same cross-tab Web Lock", async (): Promise<void> => {
+  type PendingFetch = Readonly<{
+    input: RequestInfo | URL;
+    init: RequestInit | undefined;
+    resolve: (response: Response) => void;
+  }>;
+  type PendingLock = Readonly<{
+    name: string;
+    acquire: () => void;
+  }>;
+
+  const originalFetch = globalThis.fetch;
+  const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const pending: Array<PendingFetch> = [];
+  const pendingLocks: Array<PendingLock> = [];
+  const requirePendingFetch = (index: number): PendingFetch => {
+    const request = pending[index];
+    assert.ok(request, `Expected pending fetch ${index}`);
+    return request;
+  };
+  const acquirePendingLock = (index: number): void => {
+    const lock = pendingLocks[index];
+    assert.ok(lock, `Expected pending Web Lock ${index}`);
+    lock.acquire();
+  };
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token; demo=true" },
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      locks: {
+        request: <T>(name: string, callback: () => Promise<T>): Promise<T> =>
+          new Promise<T>((resolve, reject): void => {
+            pendingLocks.push({
+              name,
+              acquire: (): void => {
+                void callback().then(resolve, reject);
+              },
+            });
+          }),
+      },
+    },
+  });
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
+    new Promise((resolve): void => {
+      pending.push({ input, init, resolve });
+    })) as typeof fetch;
+
+  try {
+    const createPromise = createBudgetAdjustment(CREATE_PARAMS);
+    const patchPromise = patchBudgetAdjustment(CREATE_PARAMS.adjustmentId, { amount: 7 });
+    const deletePromise = deleteBudgetAdjustment(CREATE_PARAMS.adjustmentId);
+
+    assert.deepEqual(
+      pendingLocks.map((lock) => lock.name),
+      [
+        "demo-budget-adjustment-session-cookie-mutation",
+        "demo-budget-adjustment-session-cookie-mutation",
+        "demo-budget-adjustment-session-cookie-mutation",
+      ],
+    );
+    assert.equal(pending.length, 0);
+    acquirePendingLock(0);
+    assert.equal(pending.length, 1);
+    const createRequest = requirePendingFetch(0);
+    assert.equal(String(createRequest.input), "/api/budget-adjustments");
+    assert.equal(createRequest.init?.method, "POST");
+    createRequest.resolve(Response.json(createAdjustment(
+      CREATE_PARAMS.adjustmentId,
+      CREATE_PARAMS.category,
+      CREATE_PARAMS.amount,
+      CREATE_PARAMS.note,
+    )));
+    await createPromise;
+
+    acquirePendingLock(1);
+    assert.equal(pending.length, 2);
+    const patchRequest = requirePendingFetch(1);
+    assert.equal(
+      String(patchRequest.input),
+      `/api/budget-adjustments/${CREATE_PARAMS.adjustmentId}`,
+    );
+    assert.equal(patchRequest.init?.method, "PATCH");
+    patchRequest.resolve(Response.json(createAdjustment(
+      CREATE_PARAMS.adjustmentId,
+      CREATE_PARAMS.category,
+      7,
+      CREATE_PARAMS.note,
+    )));
+    assert.equal((await patchPromise).amount, 7);
+
+    acquirePendingLock(2);
+    assert.equal(pending.length, 3);
+    const deleteRequest = requirePendingFetch(2);
+    assert.equal(
+      String(deleteRequest.input),
+      `/api/budget-adjustments/${CREATE_PARAMS.adjustmentId}`,
+    );
+    assert.equal(deleteRequest.init?.method, "DELETE");
+    deleteRequest.resolve(Response.json({ ok: true }));
+    assert.equal(await deletePromise, "deleted");
+
+    document.cookie = "__Host-csrf=test-token";
+    const nonDemoCreatePromise = createBudgetAdjustment(CREATE_PARAMS);
+    const nonDemoPatchPromise = patchBudgetAdjustment(CREATE_PARAMS.adjustmentId, { amount: 8 });
+    const nonDemoDeletePromise = deleteBudgetAdjustment(CREATE_PARAMS.adjustmentId);
+    assert.equal(pendingLocks.length, 3);
+    assert.equal(pending.length, 6);
+    requirePendingFetch(3).resolve(Response.json(createAdjustment(
+      CREATE_PARAMS.adjustmentId,
+      CREATE_PARAMS.category,
+      CREATE_PARAMS.amount,
+      CREATE_PARAMS.note,
+    )));
+    requirePendingFetch(4).resolve(Response.json(createAdjustment(
+      CREATE_PARAMS.adjustmentId,
+      CREATE_PARAMS.category,
+      8,
+      CREATE_PARAMS.note,
+    )));
+    requirePendingFetch(5).resolve(Response.json({ ok: true }));
+    await Promise.all([
+      nonDemoCreatePromise,
+      nonDemoPatchPromise,
+      nonDemoDeletePromise,
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (documentDescriptor === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", documentDescriptor);
+    }
+    if (navigatorDescriptor === undefined) {
+      Reflect.deleteProperty(globalThis, "navigator");
+    } else {
+      Object.defineProperty(globalThis, "navigator", navigatorDescriptor);
+    }
+  }
+});
+
+test("demo mutations fail explicitly when Web Locks are unavailable", async (): Promise<void> => {
+  const originalFetch = globalThis.fetch;
+  const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  let fetchCalled = false;
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token; demo=true" },
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  globalThis.fetch = ((): Promise<Response> => {
+    fetchCalled = true;
+    return Promise.reject(new Error("Unexpected fetch"));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(
+      createBudgetAdjustment(CREATE_PARAMS),
+      /does not support the Web Locks API required to serialize changes across tabs/,
+    );
+    assert.equal(fetchCalled, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (documentDescriptor === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", documentDescriptor);
+    }
+    if (navigatorDescriptor === undefined) {
+      Reflect.deleteProperty(globalThis, "navigator");
+    } else {
+      Object.defineProperty(globalThis, "navigator", navigatorDescriptor);
+    }
+  }
 });

--- a/apps/web/src/ui/tables/budget/budgetTableApi.ts
+++ b/apps/web/src/ui/tables/budget/budgetTableApi.ts
@@ -1,4 +1,5 @@
 import { fetchWithCsrf } from "@/lib/csrf";
+import { DEMO_MODE_COOKIE } from "@/lib/demoCookies";
 import { buildLiveDataUrl, fetchLiveData } from "@/lib/liveDataFetch";
 import type {
   BudgetAdjustment,
@@ -33,6 +34,36 @@ const budgetAdjustmentSchema: z.ZodType<BudgetAdjustment> = z.object({
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 }).strict();
+
+const budgetAdjustmentUuidSchema = z.uuid();
+const DEMO_BUDGET_ADJUSTMENT_MUTATION_LOCK = "demo-budget-adjustment-session-cookie-mutation";
+
+const runBudgetAdjustmentMutation = <T>(
+  mutation: () => Promise<T>,
+): Promise<T> => {
+  const isDemoMode = typeof document !== "undefined"
+    && document.cookie.split(";").some((part): boolean =>
+      part.trim() === `${DEMO_MODE_COOKIE}=true`);
+  if (!isDemoMode) return mutation();
+
+  if (typeof navigator === "undefined" || navigator.locks === undefined) {
+    return Promise.reject(new Error(
+      "Cannot mutate demo budget adjustments: this browser does not support the Web Locks API required to serialize changes across tabs",
+    ));
+  }
+  return navigator.locks.request(
+    DEMO_BUDGET_ADJUSTMENT_MUTATION_LOCK,
+    mutation,
+  );
+};
+
+export const parseBudgetAdjustmentUuid = (input: unknown, context: string): string => {
+  const parsed = budgetAdjustmentUuidSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new Error(`${context} must be a UUID: ${parsed.error.message}`);
+  }
+  return parsed.data;
+};
 
 export const parseBudgetAdjustment = (input: unknown, context: string): BudgetAdjustment => {
   const parsed = budgetAdjustmentSchema.safeParse(input);
@@ -76,6 +107,41 @@ export const readBudgetAdjustmentResponse = async (
   operation: string,
 ): Promise<BudgetAdjustment> =>
   readJsonResponse(response, operation, budgetAdjustmentSchema);
+
+export const readBudgetAdjustmentCreateResponse = async (
+  response: Response,
+  params: CreateBudgetAdjustmentParams,
+): Promise<BudgetAdjustment> => {
+  const adjustment = await readBudgetAdjustmentResponse(
+    response,
+    `Budget adjustment ${params.adjustmentId} create`,
+  );
+  if (adjustment.adjustmentId !== params.adjustmentId) {
+    throw new Error(
+      `Budget adjustment create response id "${adjustment.adjustmentId}" does not match requested id "${params.adjustmentId}"`,
+    );
+  }
+  if (adjustment.direction !== params.direction) {
+    throw new Error(
+      `Budget adjustment create response changed immutable direction for "${params.adjustmentId}" from ${params.direction} to ${adjustment.direction}`,
+    );
+  }
+  return adjustment;
+};
+
+export const serializeBudgetAdjustmentCreateParams = (
+  params: CreateBudgetAdjustmentParams,
+): string => JSON.stringify({
+  adjustmentId: parseBudgetAdjustmentUuid(
+    params.adjustmentId,
+    "Budget adjustment create adjustmentId",
+  ),
+  month: params.month,
+  direction: params.direction,
+  category: params.category,
+  amount: params.amount,
+  note: params.note,
+});
 
 /**
  * Reads the budget grid for the current client-visible range.
@@ -139,26 +205,30 @@ export const postBudgetPlanFill = async (params: {
 
 export const createBudgetAdjustment = async (
   params: CreateBudgetAdjustmentParams,
-): Promise<BudgetAdjustment> => {
-  const response = await fetchWithCsrf("/api/budget-adjustments", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(params),
-  });
-  return readBudgetAdjustmentResponse(response, "Budget adjustment create");
-};
+): Promise<BudgetAdjustment> => runBudgetAdjustmentMutation(
+  async (): Promise<BudgetAdjustment> => {
+    const response = await fetchWithCsrf("/api/budget-adjustments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: serializeBudgetAdjustmentCreateParams(params),
+    });
+    return readBudgetAdjustmentCreateResponse(response, params);
+  },
+);
 
 export const patchBudgetAdjustment = async (
   adjustmentId: string,
   params: PatchBudgetAdjustmentParams,
-): Promise<BudgetAdjustment> => {
-  const response = await fetchWithCsrf(`/api/budget-adjustments/${encodeURIComponent(adjustmentId)}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(params),
-  });
-  return readBudgetAdjustmentResponse(response, `Budget adjustment ${adjustmentId} update`);
-};
+): Promise<BudgetAdjustment> => runBudgetAdjustmentMutation(
+  async (): Promise<BudgetAdjustment> => {
+    const response = await fetchWithCsrf(`/api/budget-adjustments/${encodeURIComponent(adjustmentId)}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+    });
+    return readBudgetAdjustmentResponse(response, `Budget adjustment ${adjustmentId} update`);
+  },
+);
 
 export const readBudgetAdjustmentDeleteResponse = async (
   response: Response,
@@ -177,12 +247,14 @@ export const readBudgetAdjustmentDeleteResponse = async (
 
 export const deleteBudgetAdjustment = async (
   adjustmentId: string,
-): Promise<DeleteBudgetAdjustmentOutcome> => {
-  const response = await fetchWithCsrf(`/api/budget-adjustments/${encodeURIComponent(adjustmentId)}`, {
-    method: "DELETE",
-  });
-  return readBudgetAdjustmentDeleteResponse(response, adjustmentId);
-};
+): Promise<DeleteBudgetAdjustmentOutcome> => runBudgetAdjustmentMutation(
+  async (): Promise<DeleteBudgetAdjustmentOutcome> => {
+    const response = await fetchWithCsrf(`/api/budget-adjustments/${encodeURIComponent(adjustmentId)}`, {
+      method: "DELETE",
+    });
+    return readBudgetAdjustmentDeleteResponse(response, adjustmentId);
+  },
+);
 
 export const fetchComment = async (month: string, direction: string, category: string): Promise<string | null> => {
   const params = new URLSearchParams({ month, direction, category });

--- a/db/migrations/0056_budget_adjustment_client_ids.sql
+++ b/db/migrations/0056_budget_adjustment_client_ids.sql
@@ -1,0 +1,128 @@
+-- Allow the trusted web application to persist client-generated adjustment IDs
+-- without broadening table access or exposing budget adjustments to SQL clients.
+
+SET LOCAL lock_timeout = '30s';
+
+GRANT INSERT (adjustment_id)
+  ON TABLE public.budget_adjustments
+  TO app;
+
+DO $$
+DECLARE
+  v_column_name NAME;
+  v_has_privilege BOOLEAN;
+  v_privilege_name TEXT;
+  v_rls_enabled BOOLEAN;
+  v_rls_forced BOOLEAN;
+BEGIN
+  SELECT relation.relrowsecurity, relation.relforcerowsecurity
+    INTO v_rls_enabled, v_rls_forced
+    FROM pg_catalog.pg_class AS relation
+    WHERE relation.oid = 'public.budget_adjustments'::regclass;
+
+  IF NOT v_rls_enabled OR NOT v_rls_forced THEN
+    RAISE EXCEPTION
+      'budget adjustment client ID grant invariant failed: row-level security must remain enabled and forced';
+  END IF;
+
+  IF NOT pg_catalog.has_column_privilege(
+    'app',
+    'public.budget_adjustments',
+    'adjustment_id',
+    'INSERT'
+  )
+  THEN
+    RAISE EXCEPTION
+      'budget adjustment client ID grant invariant failed: app must have INSERT privilege on adjustment_id';
+  END IF;
+
+  IF pg_catalog.has_table_privilege(
+    'app',
+    'public.budget_adjustments',
+    'INSERT'
+  )
+  THEN
+    RAISE EXCEPTION
+      'budget adjustment client ID grant invariant failed: app must not have table-level INSERT privilege';
+  END IF;
+
+  FOREACH v_privilege_name IN ARRAY ARRAY[
+    'SELECT',
+    'INSERT',
+    'UPDATE',
+    'DELETE',
+    'TRUNCATE',
+    'REFERENCES',
+    'TRIGGER',
+    'MAINTAIN'
+  ]
+  LOOP
+    IF pg_catalog.has_table_privilege(
+      'api_sql_executor',
+      'public.budget_adjustments',
+      v_privilege_name
+    )
+    THEN
+      RAISE EXCEPTION
+        'budget adjustment client ID grant invariant failed: api_sql_executor has unexpected table-level % privilege',
+        v_privilege_name;
+    END IF;
+  END LOOP;
+
+  FOR v_column_name IN
+    SELECT attribute.attname
+    FROM pg_catalog.pg_attribute AS attribute
+    WHERE attribute.attrelid = 'public.budget_adjustments'::regclass
+      AND attribute.attnum > 0
+      AND NOT attribute.attisdropped
+    ORDER BY attribute.attnum
+  LOOP
+    v_has_privilege := pg_catalog.has_column_privilege(
+      'app',
+      'public.budget_adjustments',
+      v_column_name,
+      'INSERT'
+    );
+    IF v_has_privilege IS DISTINCT FROM (
+      v_column_name = ANY(ARRAY[
+        'adjustment_id'::NAME,
+        'workspace_id'::NAME,
+        'budget_month'::NAME,
+        'direction'::NAME,
+        'category'::NAME,
+        'amount'::NAME,
+        'note'::NAME
+      ])
+    )
+    THEN
+      RAISE EXCEPTION
+        'budget adjustment client ID grant invariant failed: app has unexpected INSERT privilege state % on column %',
+        v_has_privilege,
+        v_column_name;
+    END IF;
+
+    FOREACH v_privilege_name IN ARRAY ARRAY[
+      'SELECT',
+      'INSERT',
+      'UPDATE',
+      'REFERENCES'
+    ]
+    LOOP
+      IF pg_catalog.has_column_privilege(
+        'api_sql_executor',
+        'public.budget_adjustments',
+        v_column_name,
+        v_privilege_name
+      )
+      THEN
+        RAISE EXCEPTION
+          'budget adjustment client ID grant invariant failed: api_sql_executor has unexpected % privilege on column %',
+          v_privilege_name,
+          v_column_name;
+      END IF;
+    END LOOP;
+  END LOOP;
+END;
+$$;
+
+SET LOCAL lock_timeout = '0';


### PR DESCRIPTION
## Summary
- accept client-supplied UUIDs and make normalized budget adjustment create idempotent with safe conflicts
- add the grants-only adjustment_id migration while preserving RLS and SQL executor isolation
- keep demo adjustment state bounded and session-scoped, with cross-tab Web Lock serialization
- add strict browser create serialization and response validation

## Validation
- 86 budget-related tests passed
- npm run lint
- npm run build
- git diff --check