### PR TITLE
Reconcile budget adjustment creates

### DIFF
--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsReconciliation.test.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsReconciliation.test.ts
@@ -3,12 +3,16 @@ import test from "node:test";
 
 import type { BudgetAdjustment, BudgetAdjustmentDirection } from "@/server/budget/budgetAdjustments";
 import {
+  addOptimisticBudgetAdjustmentRow,
   buildBudgetAdjustmentPatch,
   createBudgetAdjustmentRowsReconciliationState,
   getBudgetAdjustmentInvalidatedCellKeys,
+  issueBudgetAdjustmentCreateRequest,
   issueBudgetAdjustmentDeleteRequest,
   issueBudgetAdjustmentPatchRequest,
   issueBudgetAdjustmentRangeRequest,
+  reconcileBudgetAdjustmentCreateAcknowledgement,
+  reconcileBudgetAdjustmentCreateFailure,
   reconcileBudgetAdjustmentDeleteAcknowledgement,
   reconcileBudgetAdjustmentDeleteAmbiguousFailure,
   reconcileBudgetAdjustmentDeleteDefinitiveFailure,
@@ -18,6 +22,7 @@ import {
   reconcileBudgetAdjustmentRangeFailure,
   reconcileBudgetAdjustmentRangeResponse,
   replaceBudgetAdjustmentReconciliationDraft,
+  type BudgetAdjustmentCreateRequest,
   type BudgetAdjustmentPatchRequest,
   type BudgetAdjustmentRowsReconciliationState,
 } from "@/ui/tables/budget/budgetAdjustmentRowsReconciliation";
@@ -37,6 +42,337 @@ const createDraft = (amountInput: string, month: string, category: string,
 const editDraft = (state: BudgetAdjustmentRowsReconciliationState,
   adjustmentId: string, draft: BudgetAdjustmentDraft,
 ): BudgetAdjustmentRowsReconciliationState => replaceBudgetAdjustmentReconciliationDraft(state, adjustmentId, draft);
+
+const createUuid = (index: number): string =>
+  `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+
+test("optimistic create installs a blank final-ID row and issues one immutable request", (): void => {
+  const adjustmentId = createUuid(1);
+  const initial = createBudgetAdjustmentRowsReconciliationState([], "2026-07");
+  const optimistic = addOptimisticBudgetAdjustmentRow(
+    initial,
+    adjustmentId,
+    "2026-07",
+    "spend",
+    "Food",
+  );
+
+  assert.deepEqual(optimistic.rows[0], {
+    adjustmentId,
+    direction: "spend",
+    draft: createDraft("", "2026-07", "Food", ""),
+    confirmed: { amount: 0, note: null, month: "2026-07", category: "Food" },
+    createdAt: "9999-12-31T23:59:59.999Z",
+    updatedAt: "9999-12-31T23:59:59.999Z",
+  });
+  const issued = issueBudgetAdjustmentCreateRequest(optimistic, adjustmentId);
+  assert.deepEqual(initial.rows, []);
+  assert.equal(initial.optimisticCreateByAdjustmentId.size, 0);
+  assert.equal(
+    optimistic.optimisticCreateByAdjustmentId.get(adjustmentId)?.status,
+    "ready",
+  );
+  assert.equal(
+    issued.state.optimisticCreateByAdjustmentId.get(adjustmentId)?.status,
+    "pending",
+  );
+  assert.deepEqual(issued.request.params, {
+    adjustmentId,
+    month: "2026-07",
+    direction: "spend",
+    category: "Food",
+    amount: 0,
+    note: null,
+  });
+  assert.throws(
+    () => issueBudgetAdjustmentCreateRequest(issued.state, adjustmentId),
+    /second create.*pending/,
+  );
+  assert.throws(
+    () => issueBudgetAdjustmentPatchRequest(issued.state, adjustmentId),
+    /until its create request is acknowledged.*pending/,
+  );
+  assert.throws(
+    () => issueBudgetAdjustmentDeleteRequest(issued.state, adjustmentId),
+    /until its create request is acknowledged.*pending/,
+  );
+  assert.throws(
+    () => addOptimisticBudgetAdjustmentRow(initial, "temporary-1", "2026-07", "spend", "Food"),
+    /must be a UUID/,
+  );
+});
+
+test("create acknowledgement preserves newer edits and survives ranges issued before it", (): void => {
+  const adjustmentId = createUuid(2);
+  const optimistic = addOptimisticBudgetAdjustmentRow(
+    createBudgetAdjustmentRowsReconciliationState([], "2026-07"),
+    adjustmentId,
+    "2026-07",
+    "spend",
+    "Food",
+  );
+  const create = issueBudgetAdjustmentCreateRequest(optimistic, adjustmentId);
+  const beforeAcknowledgement = issueBudgetAdjustmentRangeRequest(
+    create.state,
+    "2026-07",
+    "2026-07",
+  );
+  const preservedBefore = reconcileBudgetAdjustmentRangeResponse(
+    beforeAcknowledgement.state,
+    beforeAcknowledgement.request,
+    [],
+  );
+  assert.equal(preservedBefore.rows[0]?.adjustmentId, adjustmentId);
+
+  const staleAfterAcknowledgement = issueBudgetAdjustmentRangeRequest(
+    preservedBefore,
+    "2026-07",
+    "2026-07",
+  );
+  const edited = editDraft(
+    staleAfterAcknowledgement.state,
+    adjustmentId,
+    createDraft("7", "2026-07", "Food", "local"),
+  );
+  const serverRow = createAdjustment(
+    adjustmentId,
+    0,
+    "2026-07",
+    "spend",
+    "Food",
+    null,
+    2,
+  );
+  const acknowledged = reconcileBudgetAdjustmentCreateAcknowledgement(
+    edited,
+    create.request,
+    serverRow,
+  );
+  assert.equal(acknowledged.outcome, "accepted");
+  assert.deepEqual(
+    acknowledged.state.rows[0]?.draft,
+    createDraft("7", "2026-07", "Food", "local"),
+  );
+  assert.equal(acknowledged.state.rows[0]?.confirmed.amount, 0);
+  assert.deepEqual(
+    issueBudgetAdjustmentPatchRequest(acknowledged.state, adjustmentId).request.params,
+    { amount: 7, note: "local" },
+  );
+
+  const stale = reconcileBudgetAdjustmentRangeResponse(
+    acknowledged.state,
+    staleAfterAcknowledgement.request,
+    [{ ...serverRow, amount: 99 }],
+  );
+  assert.equal(stale.rows[0]?.confirmed.amount, 0);
+  assert.equal(stale.rows[0]?.draft.amountInput, "7");
+});
+
+test("a clean acknowledged create is removable only by a later authoritative range", (): void => {
+  const adjustmentId = createUuid(3);
+  const optimistic = addOptimisticBudgetAdjustmentRow(
+    createBudgetAdjustmentRowsReconciliationState([], "2026-07"),
+    adjustmentId,
+    "2026-07",
+    "income",
+    "Bonus",
+  );
+  const create = issueBudgetAdjustmentCreateRequest(optimistic, adjustmentId);
+  const staleRange = issueBudgetAdjustmentRangeRequest(create.state, "2026-07", "2026-07");
+  const serverRow = createAdjustment(
+    adjustmentId,
+    0,
+    "2026-07",
+    "income",
+    "Bonus",
+    null,
+    2,
+  );
+  const acknowledged = reconcileBudgetAdjustmentCreateAcknowledgement(
+    staleRange.state,
+    create.request,
+    serverRow,
+  );
+  const stale = reconcileBudgetAdjustmentRangeResponse(
+    acknowledged.state,
+    staleRange.request,
+    [],
+  );
+  assert.equal(stale.rows.length, 1);
+  const freshRange = issueBudgetAdjustmentRangeRequest(stale, "2026-07", "2026-07");
+  const absent = reconcileBudgetAdjustmentRangeResponse(
+    freshRange.state,
+    freshRange.request,
+    [],
+  );
+  assert.deepEqual(absent.rows, []);
+  assert.equal(absent.confirmedMutationRevisionById.has(adjustmentId), false);
+});
+
+test("failed create retains its exact payload for retry while newer drafts stay local", (): void => {
+  const adjustmentId = createUuid(4);
+  const optimistic = addOptimisticBudgetAdjustmentRow(
+    createBudgetAdjustmentRowsReconciliationState([], "2026-07"),
+    adjustmentId,
+    "2026-07",
+    "spend",
+    "Food",
+  );
+  const first = issueBudgetAdjustmentCreateRequest(optimistic, adjustmentId);
+  const edited = editDraft(
+    first.state,
+    adjustmentId,
+    createDraft("9", "2026-08", "Dining", "newer"),
+  );
+  const failed = reconcileBudgetAdjustmentCreateFailure(edited, first.request);
+  assert.equal(failed.optimisticCreateByAdjustmentId.get(adjustmentId)?.status, "failed");
+  assert.deepEqual(failed.rows[0]?.draft, createDraft("9", "2026-08", "Dining", "newer"));
+  assert.throws(
+    () => issueBudgetAdjustmentDeleteRequest(failed, adjustmentId),
+    /until its create request is acknowledged.*failed/,
+  );
+  const range = issueBudgetAdjustmentRangeRequest(failed, "2026-07", "2026-07");
+  const rangePreserved = reconcileBudgetAdjustmentRangeResponse(range.state, range.request, []);
+  assert.equal(rangePreserved.rows.length, 1);
+
+  const retry = issueBudgetAdjustmentCreateRequest(rangePreserved, adjustmentId);
+  assert.deepEqual(retry.request.params, first.request.params);
+  assert.deepEqual(retry.request.draft, first.request.draft);
+  const serverRow = createAdjustment(
+    adjustmentId,
+    0,
+    "2026-07",
+    "spend",
+    "Food",
+    null,
+    1,
+  );
+  const acknowledged = reconcileBudgetAdjustmentCreateAcknowledgement(
+    retry.state,
+    retry.request,
+    serverRow,
+  );
+  assert.deepEqual(
+    acknowledged.state.rows[0]?.draft,
+    createDraft("9", "2026-08", "Dining", "newer"),
+  );
+  assert.deepEqual(
+    issueBudgetAdjustmentPatchRequest(acknowledged.state, adjustmentId).request.params,
+    { amount: 9, note: "newer", month: "2026-08", category: "Dining" },
+  );
+  assert.equal(
+    reconcileBudgetAdjustmentCreateAcknowledgement(
+      acknowledged.state,
+      first.request,
+      serverRow,
+    ).outcome,
+    "stale",
+  );
+  assert.equal(
+    reconcileBudgetAdjustmentCreateAcknowledgement(
+      acknowledged.state,
+      retry.request,
+      serverRow,
+    ).outcome,
+    "already-applied",
+  );
+});
+
+test("create acknowledgements require exact provenance and strict matching rows", (): void => {
+  const adjustmentId = createUuid(5);
+  const optimistic = addOptimisticBudgetAdjustmentRow(
+    createBudgetAdjustmentRowsReconciliationState([], "2026-07"),
+    adjustmentId,
+    "2026-07",
+    "spend",
+    "Food",
+  );
+  const create = issueBudgetAdjustmentCreateRequest(optimistic, adjustmentId);
+  const serverRow = createAdjustment(adjustmentId, 0, "2026-07", "spend", "Food", null, 1);
+  assert.throws(
+    () => reconcileBudgetAdjustmentCreateAcknowledgement(
+      create.state,
+      { ...create.request, params: { ...create.request.params, amount: 1 } },
+      serverRow,
+    ),
+    /fields do not match/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentCreateAcknowledgement(
+      create.state,
+      create.request,
+      { ...serverRow, adjustmentId: createUuid(6) },
+    ),
+    /does not match requested id/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentCreateAcknowledgement(
+      create.state,
+      create.request,
+      { ...serverRow, direction: "income" },
+    ),
+    /immutable direction/,
+  );
+  assert.throws(
+    () => reconcileBudgetAdjustmentCreateAcknowledgement(
+      create.state,
+      create.request,
+      { ...serverRow, unexpected: true },
+    ),
+    /create acknowledgement is invalid/,
+  );
+});
+
+test("settled create acknowledgement history is bounded", (): void => {
+  let state = createBudgetAdjustmentRowsReconciliationState([], "2026-07");
+  const requests: Array<BudgetAdjustmentCreateRequest> = [];
+  for (let index = 10; index < 22; index += 1) {
+    const adjustmentId = createUuid(index);
+    state = addOptimisticBudgetAdjustmentRow(
+      state,
+      adjustmentId,
+      "2026-07",
+      "income",
+      `Income ${index}`,
+    );
+    const create = issueBudgetAdjustmentCreateRequest(state, adjustmentId);
+    requests.push(create.request);
+    state = reconcileBudgetAdjustmentCreateAcknowledgement(
+      create.state,
+      create.request,
+      createAdjustment(
+        adjustmentId,
+        0,
+        "2026-07",
+        "income",
+        `Income ${index}`,
+        null,
+        1,
+      ),
+    ).state;
+  }
+
+  assert.equal(state.settledMutationRequestIds.size, 8);
+  assert.equal(state.mutationRequestsById.size, 8);
+  assert.equal(state.appliedCreateRequestIds.size, 8);
+  assert.throws(
+    () => reconcileBudgetAdjustmentCreateAcknowledgement(
+      state,
+      requests[0]!,
+      createAdjustment(createUuid(10), 0, "2026-07", "income", "Income 10", null, 1),
+    ),
+    /outside the recent settled request history/,
+  );
+  const latest = requests.at(-1)!;
+  assert.equal(
+    reconcileBudgetAdjustmentCreateAcknowledgement(
+      state,
+      latest,
+      createAdjustment(latest.adjustmentId, 0, "2026-07", "income", "Income 21", null, 1),
+    ).outcome,
+    "already-applied",
+  );
+});
 
 test("patch params are minimal and blank amount parses as zero", (): void => {
   const adjustment = createAdjustment("minimal", 5, "2026-07", "spend", "Food", null, 1);

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsReconciliation.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsReconciliation.ts
@@ -1,5 +1,6 @@
 import type {
   BudgetAdjustmentDirection,
+  CreateBudgetAdjustmentParams,
   PatchBudgetAdjustmentParams,
 } from "@/server/budget/budgetAdjustments";
 import {
@@ -9,11 +10,13 @@ import {
   replaceBudgetAdjustmentRangeDraft,
   createBudgetAdjustmentRangeReconciliationState,
   type BudgetAdjustmentRangeDirtyFields,
+  type BudgetAdjustmentRangeProvenance,
   type BudgetAdjustmentRangeReconciliationState,
   type BudgetAdjustmentRangeRequest as BaseRangeRequest,
 } from "@/ui/tables/budget/budgetAdjustmentRangeReconciliation";
 import {
   parseBudgetAdjustment,
+  parseBudgetAdjustmentUuid,
   type DeleteBudgetAdjustmentOutcome,
 } from "@/ui/tables/budget/budgetTableApi";
 import {
@@ -34,12 +37,23 @@ import {
 
 const MONTH_PATTERN = /^\d{4}-(?:0[1-9]|1[0-2])$/;
 const RECENT_SETTLED_MUTATION_LIMIT = 8;
+const OPTIMISTIC_ROW_TIMESTAMP = "9999-12-31T23:59:59.999Z";
 
 export type BudgetAdjustmentRangeRequest = Readonly<{
   kind: "range";
   requestId: number;
   monthFrom: string;
   monthTo: string;
+  mutationRevision: number;
+}>;
+
+export type BudgetAdjustmentCreateRequest = Readonly<{
+  kind: "create";
+  requestId: number;
+  adjustmentId: string;
+  direction: BudgetAdjustmentDirection;
+  draft: BudgetAdjustmentDraft;
+  params: CreateBudgetAdjustmentParams;
   mutationRevision: number;
 }>;
 
@@ -64,7 +78,10 @@ export type BudgetAdjustmentDeleteRequest = Readonly<{
   mutationRevision: number;
 }>;
 
-export type BudgetAdjustmentMutationRequest = BudgetAdjustmentPatchRequest | BudgetAdjustmentDeleteRequest;
+export type BudgetAdjustmentMutationRequest =
+  BudgetAdjustmentCreateRequest
+  | BudgetAdjustmentPatchRequest
+  | BudgetAdjustmentDeleteRequest;
 
 export type BudgetAdjustmentReconciliationRequest = BudgetAdjustmentRangeRequest | BudgetAdjustmentMutationRequest;
 
@@ -72,6 +89,12 @@ export type BudgetAdjustmentAmbiguousRangeRequirement = Readonly<{
   afterRequestId: number;
   sourceMonth: string;
   targetMonth: string;
+}>;
+
+export type BudgetAdjustmentOptimisticCreate = Readonly<{
+  status: "ready" | "pending" | "failed";
+  draft: BudgetAdjustmentDraft;
+  params: CreateBudgetAdjustmentParams;
 }>;
 
 export type BudgetAdjustmentRowsReconciliationState =
@@ -85,7 +108,10 @@ export type BudgetAdjustmentRowsReconciliationState =
     rangeInvalidationRequestIdByCellKey: ReadonlyMap<string, number>;
     mutationRequestsById: ReadonlyMap<number, BudgetAdjustmentMutationRequest>;
     settledMutationRequestIds: ReadonlySet<number>;
+    appliedCreateRequestIds: ReadonlySet<number>;
     appliedDeleteRequestIds: ReadonlySet<number>;
+    optimisticCreateByAdjustmentId: ReadonlyMap<string, BudgetAdjustmentOptimisticCreate>;
+    latestCreateRequestIdByAdjustmentId: ReadonlyMap<string, number>;
     latestPatchRequestIdByAdjustmentId: ReadonlyMap<string, number>;
     latestDeleteRequestIdByAdjustmentId: ReadonlyMap<string, number>;
     ambiguousRangeRequirementByAdjustmentId: ReadonlyMap<string, BudgetAdjustmentAmbiguousRangeRequirement>;
@@ -100,6 +126,11 @@ export type IssuedBudgetAdjustmentRequest<Request extends BudgetAdjustmentReconc
 export type BudgetAdjustmentPatchAcknowledgement = Readonly<{
   state: BudgetAdjustmentRowsReconciliationState;
   outcome: "accepted" | "stale";
+}>;
+
+export type BudgetAdjustmentCreateAcknowledgement = Readonly<{
+  state: BudgetAdjustmentRowsReconciliationState;
+  outcome: "accepted" | "already-applied" | "stale";
 }>;
 
 export type BudgetAdjustmentDeleteAcknowledgement = Readonly<{
@@ -148,6 +179,18 @@ const paramsEqual = (
   && left.month === right.month
   && left.category === right.category;
 
+const createParamsEqual = (
+  left: CreateBudgetAdjustmentParams,
+  right: CreateBudgetAdjustmentParams,
+): boolean => Object.keys(left).length === 6
+  && Object.keys(right).length === 6
+  && left.adjustmentId === right.adjustmentId
+  && left.month === right.month
+  && left.direction === right.direction
+  && left.category === right.category
+  && left.amount === right.amount
+  && left.note === right.note;
+
 const mutationRequestsEqual = (
   left: BudgetAdjustmentMutationRequest,
   right: BudgetAdjustmentMutationRequest,
@@ -160,6 +203,10 @@ const mutationRequestsEqual = (
     || left.mutationRevision !== right.mutationRevision
     || Object.keys(left).length !== Object.keys(right).length
   ) return false;
+  if (left.kind === "create" && right.kind === "create") {
+    return draftsEqual(left.draft, right.draft)
+      && createParamsEqual(left.params, right.params);
+  }
   if (left.kind === "patch" && right.kind === "patch") {
     return draftsEqual(left.draft, right.draft)
       && snapshotsEqual(left.requested, right.requested)
@@ -257,9 +304,17 @@ const pruneMutationLifecycle = (
   }
   const appliedDeleteRequestIds = new Set([...state.appliedDeleteRequestIds]
     .filter((requestId): boolean => state.mutationRequestsById.has(requestId)));
+  const appliedCreateRequestIds = new Set([...state.appliedCreateRequestIds]
+    .filter((requestId): boolean => state.mutationRequestsById.has(requestId)));
   if (deletedMutationRevisionById.size === state.deletedMutationRevisionById.size
+    && appliedCreateRequestIds.size === state.appliedCreateRequestIds.size
     && appliedDeleteRequestIds.size === state.appliedDeleteRequestIds.size) return state;
-  return { ...state, deletedMutationRevisionById, appliedDeleteRequestIds };
+  return {
+    ...state,
+    deletedMutationRevisionById,
+    appliedCreateRequestIds,
+    appliedDeleteRequestIds,
+  };
 };
 
 const settleMutationRequest = (
@@ -360,11 +415,98 @@ export const createBudgetAdjustmentRowsReconciliationState = (
     rangeInvalidationRequestIdByCellKey: new Map(),
     mutationRequestsById: new Map(),
     settledMutationRequestIds: new Set(),
+    appliedCreateRequestIds: new Set(),
     appliedDeleteRequestIds: new Set(),
+    optimisticCreateByAdjustmentId: new Map(),
+    latestCreateRequestIdByAdjustmentId: new Map(),
     latestPatchRequestIdByAdjustmentId: new Map(),
     latestDeleteRequestIdByAdjustmentId: new Map(),
     ambiguousRangeRequirementByAdjustmentId: new Map(),
     rangeMutationRevisionByRequestId: new Map(),
+  };
+};
+
+const createOptimisticRangeProvenance = (
+  direction: BudgetAdjustmentDirection,
+  month: string,
+  requestId: number,
+): BudgetAdjustmentRangeProvenance => ({
+  direction,
+  presenceRequestIdByMonth: new Map([[month, requestId]]),
+  absenceRequestIdByMonth: new Map(),
+  deletedThroughRequestId: null,
+});
+
+export const addOptimisticBudgetAdjustmentRow = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  adjustmentId: string,
+  month: string,
+  direction: BudgetAdjustmentDirection,
+  category: string,
+): BudgetAdjustmentRowsReconciliationState => {
+  const parsedAdjustmentId = parseBudgetAdjustmentUuid(
+    adjustmentId,
+    "Optimistic budget adjustment ID",
+  );
+  if (direction !== "income" && direction !== "spend") {
+    throw new Error(
+      `Cannot add optimistic budget adjustment "${parsedAdjustmentId}": direction must be income or spend`,
+    );
+  }
+  if (state.rows.some((row) => row.adjustmentId === parsedAdjustmentId)) {
+    throw new Error(
+      `Cannot add optimistic budget adjustment "${parsedAdjustmentId}": the ID already exists`,
+    );
+  }
+
+  const draft: BudgetAdjustmentDraft = {
+    amountInput: "",
+    noteInput: "",
+    month,
+    category,
+  };
+  const parsed = parseBudgetAdjustmentDraft(draft, state.planFrom);
+  if (!parsed.ok) {
+    throw new Error(
+      `Cannot add optimistic budget adjustment "${parsedAdjustmentId}": ${parsed.error.message}`,
+    );
+  }
+  const params: CreateBudgetAdjustmentParams = {
+    adjustmentId: parsedAdjustmentId,
+    month: parsed.snapshot.month,
+    direction,
+    category: parsed.snapshot.category,
+    amount: parsed.snapshot.amount,
+    note: parsed.snapshot.note,
+  };
+  const row: BudgetAdjustmentEditorRow = {
+    adjustmentId: parsedAdjustmentId,
+    direction,
+    draft: { ...draft },
+    confirmed: { ...parsed.snapshot },
+    createdAt: OPTIMISTIC_ROW_TIMESTAMP,
+    updatedAt: OPTIMISTIC_ROW_TIMESTAMP,
+  };
+  const optimisticCreateByAdjustmentId = new Map(
+    state.optimisticCreateByAdjustmentId,
+  );
+  optimisticCreateByAdjustmentId.set(parsedAdjustmentId, {
+    status: "ready",
+    draft: { ...draft },
+    params: { ...params },
+  });
+  const rangeProvenanceByAdjustmentId = new Map(
+    state.rangeProvenanceByAdjustmentId,
+  );
+  rangeProvenanceByAdjustmentId.set(
+    parsedAdjustmentId,
+    createOptimisticRangeProvenance(direction, month, state.latestRequestId),
+  );
+  return {
+    ...state,
+    rows: sortBudgetAdjustmentRows([...state.rows, row]),
+    optimisticCreateByAdjustmentId,
+    rangeProvenanceByAdjustmentId,
   };
 };
 
@@ -471,6 +613,57 @@ export const reconcileBudgetAdjustmentRangeFailure = (
   });
 };
 
+export const issueBudgetAdjustmentCreateRequest = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  adjustmentId: string,
+): IssuedBudgetAdjustmentRequest<BudgetAdjustmentCreateRequest> => {
+  const row = requireRow(state, adjustmentId, "create");
+  const optimistic = state.optimisticCreateByAdjustmentId.get(adjustmentId);
+  if (optimistic === undefined) {
+    throw new Error(
+      `Cannot create budget adjustment "${adjustmentId}": the row is not optimistic`,
+    );
+  }
+  if (optimistic.status === "pending") {
+    throw new Error(
+      `Cannot issue a second create for budget adjustment "${adjustmentId}" while its create request is pending`,
+    );
+  }
+  if (row.direction !== optimistic.params.direction) {
+    throw new Error(
+      `Cannot create budget adjustment "${adjustmentId}": row direction does not match its immutable create payload`,
+    );
+  }
+  const request: BudgetAdjustmentCreateRequest = {
+    kind: "create",
+    requestId: getNextMutationRequestId(state),
+    adjustmentId,
+    direction: row.direction,
+    draft: { ...optimistic.draft },
+    params: { ...optimistic.params },
+    mutationRevision: state.latestMutationRevision,
+  };
+  const optimisticCreateByAdjustmentId = new Map(
+    state.optimisticCreateByAdjustmentId,
+  );
+  optimisticCreateByAdjustmentId.set(adjustmentId, {
+    ...optimistic,
+    status: "pending",
+  });
+  const latestCreateRequestIdByAdjustmentId = new Map(
+    state.latestCreateRequestIdByAdjustmentId,
+  );
+  latestCreateRequestIdByAdjustmentId.set(adjustmentId, request.requestId);
+  return {
+    state: {
+      ...addMutationRequest(state, request),
+      optimisticCreateByAdjustmentId,
+      latestCreateRequestIdByAdjustmentId,
+    },
+    request,
+  };
+};
+
 export const buildBudgetAdjustmentPatch = (
   requested: BudgetAdjustmentSnapshot,
   baseline: BudgetAdjustmentSnapshot,
@@ -499,6 +692,12 @@ export const issueBudgetAdjustmentPatchRequest = (
   adjustmentId: string,
 ): IssuedBudgetAdjustmentRequest<BudgetAdjustmentPatchRequest> => {
   const row = requireRow(state, adjustmentId, "patch");
+  const optimisticCreate = state.optimisticCreateByAdjustmentId.get(adjustmentId);
+  if (optimisticCreate !== undefined) {
+    throw new Error(
+      `Cannot patch budget adjustment "${adjustmentId}" until its create request is acknowledged; create status is ${optimisticCreate.status}`,
+    );
+  }
   if (state.latestDeleteRequestIdByAdjustmentId.has(adjustmentId)) {
     throw new Error(`Cannot patch budget adjustment "${adjustmentId}" while its delete request is pending`);
   }
@@ -547,6 +746,12 @@ export const issueBudgetAdjustmentDeleteRequest = (
   adjustmentId: string,
 ): IssuedBudgetAdjustmentRequest<BudgetAdjustmentDeleteRequest> => {
   const row = requireRow(state, adjustmentId, "delete");
+  const optimisticCreate = state.optimisticCreateByAdjustmentId.get(adjustmentId);
+  if (optimisticCreate !== undefined) {
+    throw new Error(
+      `Cannot delete budget adjustment "${adjustmentId}" until its create request is acknowledged; create status is ${optimisticCreate.status}`,
+    );
+  }
   if (state.latestPatchRequestIdByAdjustmentId.has(adjustmentId)) {
     throw new Error(`Cannot delete budget adjustment "${adjustmentId}" while its patch request is pending`);
   }
@@ -585,6 +790,7 @@ const getRangeProtectedIds = (
   resolvedAmbiguityIds: ReadonlySet<string>,
 ): ReadonlySet<string> => {
   const ids = new Set<string>();
+  for (const adjustmentId of state.optimisticCreateByAdjustmentId.keys()) ids.add(adjustmentId);
   for (const adjustmentId of state.latestPatchRequestIdByAdjustmentId.keys()) ids.add(adjustmentId);
   for (const adjustmentId of state.latestDeleteRequestIdByAdjustmentId.keys()) ids.add(adjustmentId);
   for (const [adjustmentId, revision] of state.confirmedMutationRevisionById) {
@@ -757,6 +963,182 @@ export const reconcileBudgetAdjustmentRangeResponse = (
       rangeState,
     ),
   });
+};
+
+const rebaseDraftAfterCreate = (
+  row: BudgetAdjustmentEditorRow,
+  request: BudgetAdjustmentCreateRequest,
+  confirmed: BudgetAdjustmentSnapshot,
+): BudgetAdjustmentDraft => {
+  const amount = parseBudgetAdjustmentAmount(row.draft.amountInput);
+  const hasNewerAmount = !amount.ok || amount.amount !== request.params.amount;
+  return {
+    amountInput: hasNewerAmount
+      ? row.draft.amountInput
+      : request.params.amount === confirmed.amount
+        ? row.draft.amountInput
+        : String(confirmed.amount),
+    noteInput: budgetAdjustmentNoteFromInput(row.draft.noteInput) !== request.params.note
+      ? row.draft.noteInput
+      : budgetAdjustmentNoteToInput(confirmed.note),
+    month: row.draft.month !== request.params.month ? row.draft.month : confirmed.month,
+    category: row.draft.category !== request.params.category
+      ? row.draft.category
+      : confirmed.category,
+  };
+};
+
+export const reconcileBudgetAdjustmentCreateAcknowledgement = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentCreateRequest,
+  input: unknown,
+): BudgetAdjustmentCreateAcknowledgement => {
+  const issued = requireMutationRequest(state, request, "create");
+  const adjustment = parseBudgetAdjustment(input, "Budget adjustment create acknowledgement");
+  if (adjustment.adjustmentId !== issued.adjustmentId) {
+    throw new Error(
+      `Budget adjustment create acknowledgement id "${adjustment.adjustmentId}" does not match requested id "${issued.adjustmentId}"`,
+    );
+  }
+  if (adjustment.direction !== issued.direction) {
+    throw new Error(
+      `Budget adjustment create acknowledgement changed immutable direction for "${issued.adjustmentId}" from ${issued.direction} to ${adjustment.direction}`,
+    );
+  }
+  if (state.settledMutationRequestIds.has(issued.requestId)) {
+    const alreadyApplied = state.appliedCreateRequestIds.has(issued.requestId)
+      && state.rows.some((row) => row.adjustmentId === issued.adjustmentId);
+    return { state, outcome: alreadyApplied ? "already-applied" : "stale" };
+  }
+  const isStale = state.latestCreateRequestIdByAdjustmentId.get(issued.adjustmentId)
+    !== issued.requestId
+    || (state.confirmedMutationRevisionById.get(issued.adjustmentId) ?? 0)
+      > issued.mutationRevision
+    || (state.deletedMutationRevisionById.get(issued.adjustmentId) ?? 0)
+      > issued.mutationRevision;
+  if (isStale) {
+    return { state: settleMutationRequest(state, issued.requestId), outcome: "stale" };
+  }
+  const optimistic = state.optimisticCreateByAdjustmentId.get(issued.adjustmentId);
+  if (
+    optimistic === undefined
+    || optimistic.status !== "pending"
+    || !draftsEqual(optimistic.draft, issued.draft)
+    || !createParamsEqual(optimistic.params, issued.params)
+  ) {
+    throw new Error(
+      `Cannot acknowledge create for "${issued.adjustmentId}": optimistic create state does not match the request`,
+    );
+  }
+  const row = requireRow(state, issued.adjustmentId, "acknowledge create for");
+  if (row.direction !== issued.direction) {
+    throw new Error(
+      `Cannot acknowledge create for "${issued.adjustmentId}": row direction does not match the request`,
+    );
+  }
+
+  const canonical = createBudgetAdjustmentEditorRow(adjustment);
+  const reconciled: BudgetAdjustmentEditorRow = {
+    ...canonical,
+    draft: rebaseDraftAfterCreate(row, issued, canonical.confirmed),
+  };
+  const latestMutationRevision = getNextMutationRevision(state);
+  const confirmedMutationRevisionById = new Map(state.confirmedMutationRevisionById);
+  confirmedMutationRevisionById.set(issued.adjustmentId, latestMutationRevision);
+  const deletedMutationRevisionById = new Map(state.deletedMutationRevisionById);
+  deletedMutationRevisionById.delete(issued.adjustmentId);
+  const appliedCreateRequestIds = new Set(state.appliedCreateRequestIds);
+  appliedCreateRequestIds.add(issued.requestId);
+  const optimisticCreateByAdjustmentId = new Map(
+    state.optimisticCreateByAdjustmentId,
+  );
+  optimisticCreateByAdjustmentId.delete(issued.adjustmentId);
+  const latestCreateRequestIdByAdjustmentId = new Map(
+    state.latestCreateRequestIdByAdjustmentId,
+  );
+  latestCreateRequestIdByAdjustmentId.delete(issued.adjustmentId);
+  const rows = sortBudgetAdjustmentRows(state.rows.map((candidate): BudgetAdjustmentEditorRow =>
+    candidate.adjustmentId === issued.adjustmentId ? reconciled : candidate));
+  const rangeProvenanceByAdjustmentId = new Map(state.rangeProvenanceByAdjustmentId);
+  rangeProvenanceByAdjustmentId.set(
+    issued.adjustmentId,
+    createOptimisticRangeProvenance(
+      issued.direction,
+      canonical.confirmed.month,
+      state.latestRequestId,
+    ),
+  );
+  const next = settleMutationRequest({
+    ...state,
+    rows,
+    latestMutationRevision,
+    confirmedMutationRevisionById,
+    deletedMutationRevisionById,
+    appliedCreateRequestIds,
+    optimisticCreateByAdjustmentId,
+    latestCreateRequestIdByAdjustmentId,
+    rangeProvenanceByAdjustmentId,
+    dirtyFieldsByAdjustmentId: replaceDirtyFields(
+      state.dirtyFieldsByAdjustmentId,
+      reconciled,
+    ),
+    cellInvalidationRevisionByKey: recordBudgetAdjustmentCellInvalidation(
+      state.cellInvalidationRevisionByKey,
+      issued.direction,
+      canonical.confirmed,
+      latestMutationRevision,
+    ),
+  }, issued.requestId);
+  return { state: next, outcome: "accepted" };
+};
+
+export const reconcileBudgetAdjustmentCreateFailure = (
+  state: BudgetAdjustmentRowsReconciliationState,
+  request: BudgetAdjustmentCreateRequest,
+): BudgetAdjustmentRowsReconciliationState => {
+  const issued = requireMutationRequest(state, request, "create");
+  if (state.settledMutationRequestIds.has(issued.requestId)) {
+    throw new Error(`Cannot fail settled budget adjustment create request ${issued.requestId}`);
+  }
+  if (state.latestCreateRequestIdByAdjustmentId.get(issued.adjustmentId)
+    !== issued.requestId) {
+    throw new Error(
+      `Cannot fail budget adjustment create request ${issued.requestId}: it is not pending for "${issued.adjustmentId}"`,
+    );
+  }
+  const optimistic = state.optimisticCreateByAdjustmentId.get(issued.adjustmentId);
+  if (
+    optimistic === undefined
+    || optimistic.status !== "pending"
+    || !draftsEqual(optimistic.draft, issued.draft)
+    || !createParamsEqual(optimistic.params, issued.params)
+  ) {
+    throw new Error(
+      `Cannot fail create for "${issued.adjustmentId}": optimistic create state does not match the request`,
+    );
+  }
+  const row = requireRow(state, issued.adjustmentId, "fail create for");
+  if (row.direction !== issued.direction) {
+    throw new Error(
+      `Cannot fail create for "${issued.adjustmentId}": row direction does not match the request`,
+    );
+  }
+  const optimisticCreateByAdjustmentId = new Map(
+    state.optimisticCreateByAdjustmentId,
+  );
+  optimisticCreateByAdjustmentId.set(issued.adjustmentId, {
+    ...optimistic,
+    status: "failed",
+  });
+  const latestCreateRequestIdByAdjustmentId = new Map(
+    state.latestCreateRequestIdByAdjustmentId,
+  );
+  latestCreateRequestIdByAdjustmentId.delete(issued.adjustmentId);
+  return settleMutationRequest({
+    ...state,
+    optimisticCreateByAdjustmentId,
+    latestCreateRequestIdByAdjustmentId,
+  }, issued.requestId);
 };
 
 const rebaseDraftAfterPatch = (


### PR DESCRIPTION
## Summary
- add optimistic budget-adjustment create state using the final client UUID
- preserve exact retry payloads and newer local drafts across acknowledgements and failures
- integrate create lifecycle with range, patch, delete, ordering, invalidation, and bounded request history

## Validation
- focused reconciliation tests: 20/20
- full budget-related tests: 92/92
- npm run lint
- npm run build
- git diff --check