### PR TITLE
Integrate normalized budget adjustments into React table state

### DIFF
--- a/apps/web/src/app/budget/page.tsx
+++ b/apps/web/src/app/budget/page.tsx
@@ -40,6 +40,7 @@ async function BudgetData() {
     );
     const {
       rows,
+      adjustments: initialAdjustments,
       conversionWarnings,
       cumulativeBefore,
       monthEndBalances,
@@ -57,6 +58,7 @@ async function BudgetData() {
     return (
       <BudgetTable
         rows={rows}
+        adjustments={initialAdjustments}
         conversionWarnings={conversionWarnings}
         cumulativeBefore={cumulativeBefore}
         monthEndBalances={monthEndBalances}
@@ -78,6 +80,7 @@ async function BudgetData() {
 
   const [{
     rows,
+    adjustments,
     conversionWarnings,
     cumulativeBefore,
     monthEndBalances,
@@ -93,6 +96,7 @@ async function BudgetData() {
   return (
     <BudgetTable
       rows={rows}
+      adjustments={adjustments}
       conversionWarnings={conversionWarnings}
       cumulativeBefore={cumulativeBefore}
       monthEndBalances={monthEndBalances}

--- a/apps/web/src/ui/tables/budget/controller/useBudgetAdjustmentRowsController.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetAdjustmentRowsController.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import type { BudgetAdjustment } from "@/server/budget/budgetAdjustments";
+import {
+  createBudgetAdjustment,
+  deleteBudgetAdjustment,
+  fetchBudgetRange,
+  patchBudgetAdjustment,
+} from "@/ui/tables/budget/budgetTableApi";
+import {
+  createBudgetAdjustmentRowsController,
+  type BudgetAdjustmentRowsController,
+  type BudgetAdjustmentRowsControllerRuntime,
+} from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
+
+const AUTOSAVE_DELAY_MS = 600;
+
+type UseBudgetAdjustmentRowsControllerParams = Readonly<{
+  adjustments: ReadonlyArray<BudgetAdjustment>;
+  planFrom: string;
+  actualTo: string;
+  refreshToken: string;
+  invalidateYears: (years: ReadonlySet<string>) => void;
+}>;
+
+export const useBudgetAdjustmentRowsController = ({
+  adjustments,
+  planFrom,
+  actualTo,
+  refreshToken,
+  invalidateYears,
+}: UseBudgetAdjustmentRowsControllerParams): BudgetAdjustmentRowsController => {
+  const currentRequestRef = useRef({
+    planFrom,
+    actualTo,
+    refreshToken,
+    invalidateYears,
+  });
+  currentRequestRef.current = {
+    planFrom,
+    actualTo,
+    refreshToken,
+    invalidateYears,
+  };
+  const runtimeRef = useRef<BudgetAdjustmentRowsControllerRuntime | null>(null);
+
+  if (runtimeRef.current === null) {
+    runtimeRef.current = createBudgetAdjustmentRowsController({
+      initialAdjustments: adjustments,
+      planFrom,
+      autosaveDelayMs: AUTOSAVE_DELAY_MS,
+      createAdjustment: (params) => createBudgetAdjustment(params),
+      patchAdjustment: (adjustmentId, params) =>
+        patchBudgetAdjustment(adjustmentId, params),
+      deleteAdjustment: (adjustmentId) => deleteBudgetAdjustment(adjustmentId),
+      fetchRange: (monthFrom, monthTo) => {
+        const current = currentRequestRef.current;
+        return fetchBudgetRange(
+          monthFrom,
+          monthTo,
+          current.planFrom,
+          current.actualTo,
+          current.refreshToken,
+        );
+      },
+      generateAdjustmentId: (): string => crypto.randomUUID(),
+      schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+      cancelScheduled: (handle) => clearTimeout(handle),
+      invalidateYears: (years) => currentRequestRef.current.invalidateYears(years),
+    });
+  }
+
+  const runtime = runtimeRef.current;
+  const state = useSyncExternalStore(
+    runtime.subscribe,
+    runtime.getSnapshot,
+    runtime.getSnapshot,
+  );
+
+  useEffect(() => {
+    runtime.activate();
+    return (): void => runtime.dispose();
+  }, [runtime]);
+
+  return { ...state, ...runtime.commands };
+};

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableController.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableController.ts
@@ -5,6 +5,7 @@ import type { RefObject } from "react";
 import { useFilteredMode } from "@/ui/FilteredModeProvider";
 import { useCommentPresence } from "@/ui/hooks/useCommentPresence";
 import type { FieldHints } from "@/server/transactions/getTransactions";
+import type { BudgetAdjustment } from "@/server/budget/budgetAdjustments";
 import type { BudgetRow, BusinessPersonalTransferCell, ConversionWarning, CumulativeBefore } from "@/server/budget/getBudgetGrid";
 import { getCurrentMonth, getYear } from "@/lib/monthUtils";
 import type {
@@ -19,9 +20,12 @@ import { useBudgetTableDerivedState } from "@/ui/tables/budget/controller/useBud
 import { useBudgetTableRangeState } from "@/ui/tables/budget/controller/useBudgetTableRangeState";
 import { useBudgetTableViewport } from "@/ui/tables/budget/controller/useBudgetTableViewport";
 import { useBudgetTableYearTotals } from "@/ui/tables/budget/controller/useBudgetTableYearTotals";
+import { useBudgetAdjustmentRowsController } from "@/ui/tables/budget/controller/useBudgetAdjustmentRowsController";
+import type { BudgetAdjustmentRowsController } from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
 
 export type BudgetTableProps = Readonly<{
   rows: ReadonlyArray<BudgetRow>;
+  adjustments: ReadonlyArray<BudgetAdjustment>;
   conversionWarnings: ReadonlyArray<ConversionWarning>;
   cumulativeBefore: CumulativeBefore;
   monthEndBalances: Readonly<Record<string, number>>;
@@ -60,6 +64,7 @@ export type BudgetTableController = Readonly<{
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
   commentedCells: ReadonlySet<string>;
   pendingSaves: number;
+  budgetAdjustments: BudgetAdjustmentRowsController;
   isLoadingLeft: boolean;
   isLoadingRight: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
@@ -112,9 +117,24 @@ export const useBudgetTableController = (
   const currentMonth = useMemo(() => getCurrentMonth(), []);
   const currentYear = useMemo(() => getYear(currentMonth), [currentMonth]);
   const resetYearTotalsRef = useRef<() => void>(() => undefined);
+  const invalidateYearTotalsRef = useRef<(years: ReadonlySet<string>) => void>(
+    () => undefined,
+  );
   const handleVisibleRangeRefreshStart = useCallback((): void => {
     resetYearTotalsRef.current();
   }, []);
+
+  const invalidateAdjustmentYears = useCallback((years: ReadonlySet<string>): void => {
+    invalidateYearTotalsRef.current(years);
+  }, []);
+
+  const budgetAdjustments = useBudgetAdjustmentRowsController({
+    adjustments: props.adjustments,
+    planFrom: currentMonth,
+    actualTo: currentMonth,
+    refreshToken: props.refreshToken,
+    invalidateYears: invalidateAdjustmentYears,
+  });
 
   const rangeState = useBudgetTableRangeState({
     rows: props.rows,
@@ -125,14 +145,14 @@ export const useBudgetTableController = (
     monthEndBalancesByLiquidity: props.monthEndBalancesByLiquidity,
     businessPersonalTransfers: props.businessPersonalTransfers,
     hasBusinessAccount: props.hasBusinessAccount,
-    currentMonth,
     refreshToken: props.refreshToken,
     fetchCommentRange,
     reloadCommentRange,
     onVisibleRangeRefreshStart: handleVisibleRangeRefreshStart,
+    loadBudgetRange: budgetAdjustments.loadRange,
   });
 
-  const { yearComputed, resetYearTotals } = useBudgetTableYearTotals({
+  const { yearComputed, invalidateYearTotals, resetYearTotals } = useBudgetTableYearTotals({
     loadedFrom: rangeState.loadedFrom,
     loadedTo: rangeState.loadedTo,
     currentMonth,
@@ -140,16 +160,31 @@ export const useBudgetTableController = (
     refreshToken: props.refreshToken,
   });
   resetYearTotalsRef.current = resetYearTotals;
+  invalidateYearTotalsRef.current = invalidateYearTotals;
+
+  const rowsWithAdjustments = useMemo<ReadonlyArray<BudgetRow>>(
+    () => budgetAdjustments.applyToBudgetRows(
+      rangeState.allRows,
+      rangeState.loadedFrom,
+      rangeState.loadedTo,
+    ),
+    [
+      budgetAdjustments,
+      rangeState.allRows,
+      rangeState.loadedFrom,
+      rangeState.loadedTo,
+    ],
+  );
 
   const viewportState = useBudgetTableViewport({
     currentMonth,
-    pendingSaves: rangeState.pendingSaves,
+    pendingSaves: rangeState.pendingSaves + budgetAdjustments.pendingMutationCount,
     onReachLeft: rangeState.loadLeft,
     onReachRight: rangeState.loadRight,
   });
 
   const derivedState = useBudgetTableDerivedState({
-    allRows: rangeState.allRows,
+    allRows: rowsWithAdjustments,
     loadedFrom: rangeState.loadedFrom,
     loadedTo: rangeState.loadedTo,
     cumBefore: rangeState.cumBefore,
@@ -207,7 +242,8 @@ export const useBudgetTableController = (
     projectedLiqBalances: derivedState.projectedLiqBalances,
     yearComputed,
     commentedCells,
-    pendingSaves: rangeState.pendingSaves,
+    pendingSaves: rangeState.pendingSaves + budgetAdjustments.pendingMutationCount,
+    budgetAdjustments,
     isLoadingLeft: rangeState.isLoadingLeft,
     isLoadingRight: rangeState.isLoadingRight,
     scrollRef: viewportState.scrollRef,

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
@@ -7,7 +7,7 @@ import {
   adjustCumulativeBeforeForPrependedRows,
   getTargetFillMonths,
 } from "@/ui/tables/budget/budgetTableLogic";
-import { fetchBudgetRange } from "@/ui/tables/budget/budgetTableApi";
+import type { BudgetAdjustmentRangeLoadOutcome } from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
 import { logBudgetTableError } from "@/ui/tables/budget/table/logBudgetTableError";
 
 const BATCH_SIZE = 6;
@@ -21,11 +21,14 @@ type UseBudgetTableRangeStateParams = Readonly<{
   monthEndBalancesByLiquidity: Readonly<Record<string, Readonly<Record<string, number>>>>;
   businessPersonalTransfers: Readonly<Record<string, BusinessPersonalTransferCell>>;
   hasBusinessAccount: boolean;
-  currentMonth: string;
   refreshToken: string;
   fetchCommentRange: (monthFrom: string, monthTo: string) => void;
   reloadCommentRange: (monthFrom: string, monthTo: string) => void;
   onVisibleRangeRefreshStart: () => void;
+  loadBudgetRange: (
+    monthFrom: string,
+    monthTo: string,
+  ) => Promise<BudgetAdjustmentRangeLoadOutcome>;
 }>;
 
 export type BudgetTableRangeState = Readonly<{
@@ -162,11 +165,11 @@ export const useBudgetTableRangeState = ({
   monthEndBalancesByLiquidity,
   businessPersonalTransfers: initialBusinessPersonalTransfers,
   hasBusinessAccount: initialHasBusinessAccount,
-  currentMonth,
   refreshToken,
   fetchCommentRange,
   reloadCommentRange,
   onVisibleRangeRefreshStart,
+  loadBudgetRange,
 }: UseBudgetTableRangeStateParams): BudgetTableRangeState => {
   const [allRows, setAllRows] = useState<ReadonlyArray<BudgetRow>>(rows);
   const [loadedFrom, setLoadedFrom] = useState<string>(initialMonthFrom);
@@ -196,13 +199,15 @@ export const useBudgetTableRangeState = ({
     onVisibleRangeRefreshStart();
 
     try {
-      const result = await fetchBudgetRange(loadedFrom, loadedTo, currentMonth, currentMonth, refreshToken);
+      const outcome = await loadBudgetRange(loadedFrom, loadedTo);
+      if (outcome.status === "superseded") return;
+      const result = outcome.result;
       applyFetchedBudgetResult(setAllRows, setCumBefore, setMeb, setMebByLiq, setBusinessPersonalTransfers, setHasBusinessAccount, result);
       reloadCommentRange(loadedFrom, loadedTo);
     } catch (error) {
       logBudgetTableError("visible range refresh", error);
     }
-  }, [currentMonth, loadedFrom, loadedTo, onVisibleRangeRefreshStart, refreshToken, reloadCommentRange]);
+  }, [loadBudgetRange, loadedFrom, loadedTo, onVisibleRangeRefreshStart, refreshToken, reloadCommentRange]);
 
   useEffect(() => {
     if (!initialRefreshHandledRef.current) {
@@ -248,7 +253,9 @@ export const useBudgetTableRangeState = ({
     const newFrom = offsetMonth(loadedFrom, -BATCH_SIZE);
 
     try {
-      const result = await fetchBudgetRange(newFrom, newTo, currentMonth, currentMonth, refreshToken);
+      const outcome = await loadBudgetRange(newFrom, newTo);
+      if (outcome.status === "superseded") return;
+      const result = outcome.result;
       const prependedRows = result.rows;
       setAllRows((previous) => [...prependedRows, ...previous]);
       setCumBefore((previous) => adjustCumulativeBeforeForPrependedRows(previous, prependedRows));
@@ -264,7 +271,7 @@ export const useBudgetTableRangeState = ({
       isLoadingLeftRef.current = false;
       setIsLoadingLeft(false);
     }
-  }, [currentMonth, fetchCommentRange, loadedFrom, refreshToken]);
+  }, [fetchCommentRange, loadBudgetRange, loadedFrom]);
 
   const loadRight = useCallback(async (): Promise<void> => {
     if (isLoadingRightRef.current) {
@@ -278,7 +285,9 @@ export const useBudgetTableRangeState = ({
     const newTo = offsetMonth(loadedTo, BATCH_SIZE);
 
     try {
-      const result = await fetchBudgetRange(newFrom, newTo, currentMonth, currentMonth, refreshToken);
+      const outcome = await loadBudgetRange(newFrom, newTo);
+      if (outcome.status === "superseded") return;
+      const result = outcome.result;
       setAllRows((previous) => [...previous, ...result.rows]);
       setLoadedTo(newTo);
       setMeb((previous) => ({ ...previous, ...result.monthEndBalances }));
@@ -292,7 +301,7 @@ export const useBudgetTableRangeState = ({
       isLoadingRightRef.current = false;
       setIsLoadingRight(false);
     }
-  }, [currentMonth, fetchCommentRange, loadedTo, refreshToken]);
+  }, [fetchCommentRange, loadBudgetRange, loadedTo]);
 
   return {
     allRows,


### PR DESCRIPTION
Summary: add the React lifecycle adapter for the normalized adjustment controller; route range loads through the accepted/superseded contract; project optimistic normalized adjustments once onto loaded budget rows for both live and demo modes. Validation: 119 compatible budget tests passed; npm run lint passed; npm run build passed; git diff --check passed.