### PR TITLE
feat: add budget adjustment presentation foundation

### DIFF
--- a/apps/web/src/ui/tables/budget/BudgetAdjustmentEditor.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetAdjustmentEditor.tsx
@@ -81,7 +81,7 @@ export const BudgetAdjustmentEditor = (
   } = props;
   const { t } = useTranslation();
   const accessibilityId = useId();
-  const rows = controller.getCellRows(location);
+  const rows = controller.getCellRows(location, effectiveAllowlist);
   const categoryOptions = useMemo<ReadonlyArray<string>>(
     () => getBudgetAdjustmentCategoryOptions(categories, effectiveAllowlist),
     [categories, effectiveAllowlist],

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRecovery.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRecovery.ts
@@ -1,0 +1,19 @@
+import type {
+  BudgetAdjustmentFlushOutcome,
+  BudgetAdjustmentRecoveryOutcome,
+  BudgetAdjustmentRowsController,
+} from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
+
+export type { BudgetAdjustmentRecoveryOutcome };
+
+export const isSuccessfulBudgetAdjustmentFlushOutcome = (
+  outcome: BudgetAdjustmentFlushOutcome,
+): boolean => outcome === "saved"
+  || outcome === "unchanged"
+  || outcome === "deleted";
+
+export const recoverBudgetAdjustment = async (
+  controller: BudgetAdjustmentRowsController,
+  adjustmentId: string,
+): Promise<BudgetAdjustmentRecoveryOutcome> =>
+  controller.recoverRow(adjustmentId);

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.test.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.test.ts
@@ -8,6 +8,7 @@ import type {
 import type { BudgetRow } from "@/server/budget/getBudgetGrid";
 import {
   applyBudgetAdjustmentRows,
+  applyBudgetAdjustmentRowsWithProtectedCells,
   budgetAdjustmentNoteFromInput,
   budgetAdjustmentNoteToInput,
   clearBudgetAdjustmentCellInvalidations,
@@ -17,7 +18,10 @@ import {
   getBudgetAdjustmentCellRows,
   getBudgetAdjustmentCellTotal,
   getBudgetAdjustmentRowCellKey,
+  isBudgetAdjustmentCategoryVisible,
+  isBudgetAdjustmentRowVisible,
   isValidBudgetAdjustmentCategory,
+  isValidBudgetAdjustmentNoteInput,
   parseBudgetAdjustmentAmount,
   parseBudgetAdjustmentDraft,
   recordBudgetAdjustmentCellMove,
@@ -157,6 +161,8 @@ test("validates category and note limits by code point", (): void => {
 
   assert.equal(emptyCategory.ok ? null : emptyCategory.error.code, "invalidCategory");
   assert.equal(longNote.ok ? null : longNote.error.code, "invalidNote");
+  assert.equal(isValidBudgetAdjustmentNoteInput("\u{1F680}".repeat(2000)), true);
+  assert.equal(isValidBudgetAdjustmentNoteInput("\u{1F680}".repeat(2001)), false);
 });
 
 test("accepts adjustment editor categories only within the category contract", (): void => {
@@ -179,6 +185,118 @@ test("does not expose masked categories in filtered adjustment options", (): voi
   assert.deepEqual(
     getBudgetAdjustmentCategoryOptions(categories, new Set(["Groceries", "Utilities"])),
     ["Groceries", "Utilities"],
+  );
+  assert.equal(
+    isBudgetAdjustmentCategoryVisible("Unknown", new Set(["Groceries", "Utilities"])),
+    false,
+  );
+});
+
+test("keeps moved drafts private until confirmed and draft categories are both visible", (): void => {
+  const confirmed = createBudgetAdjustmentEditorRow(createAdjustment(
+    "masked-move",
+    47,
+    "2026-07",
+    "spend",
+    "Masked",
+    "private note",
+    "2026-07-01T00:00:00.000Z",
+  ));
+  const moved = replaceBudgetAdjustmentDraft([confirmed], confirmed.adjustmentId, {
+    ...confirmed.draft,
+    category: "Allowed",
+  })[0];
+  const allowlist = new Set(["Allowed"]);
+  const visibleRows = [moved].filter((row): boolean =>
+    isBudgetAdjustmentRowVisible(row, allowlist));
+
+  assert.equal(isBudgetAdjustmentRowVisible(moved, allowlist), false);
+  assert.equal(isBudgetAdjustmentRowVisible(moved, null), true);
+  assert.deepEqual(getBudgetAdjustmentCellRows(
+    visibleRows,
+    "2026-07",
+    "spend",
+    "Allowed",
+    "2026-07",
+  ), []);
+  assert.equal(getBudgetAdjustmentCellTotal(
+    visibleRows,
+    "2026-07",
+    "spend",
+    "Allowed",
+    "2026-07",
+  ), 0);
+  assert.deepEqual(
+    applyBudgetAdjustmentRows(
+      [createBudgetRow("2026-07", "spend", "Allowed", 100, 47)],
+      visibleRows,
+      "2026-07",
+      "2026-07",
+      "2026-07",
+      new Set(),
+    ),
+    [createBudgetRow("2026-07", "spend", "Allowed", 100, 0)],
+  );
+});
+
+test("projects a retained adjustment-only cell only when its category is visible", (): void => {
+  const protectedCell = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Adjustment only",
+  };
+
+  const allProjection = applyBudgetAdjustmentRowsWithProtectedCells(
+    [],
+    [],
+    "2026-07",
+    "2026-07",
+    "2026-07",
+    new Set(),
+    [protectedCell],
+    null,
+  );
+  assert.deepEqual(allProjection, [
+    createBudgetRow("2026-07", "spend", "Adjustment only", 0, 0),
+  ]);
+  assert.deepEqual(
+    applyBudgetAdjustmentRowsWithProtectedCells(
+      [],
+      [],
+      "2026-07",
+      "2026-07",
+      "2026-07",
+      new Set(),
+      [protectedCell],
+      new Set(["Allowed"]),
+    ),
+    [],
+  );
+  assert.deepEqual(
+    applyBudgetAdjustmentRowsWithProtectedCells(
+      [],
+      [],
+      "2026-07",
+      "2026-07",
+      "2026-07",
+      new Set(),
+      [protectedCell],
+      null,
+    ),
+    allProjection,
+  );
+  assert.deepEqual(
+    applyBudgetAdjustmentRowsWithProtectedCells(
+      [],
+      [],
+      "2026-07",
+      "2026-07",
+      "2026-07",
+      new Set(),
+      [],
+      null,
+    ),
+    [],
   );
 });
 

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.ts
@@ -49,6 +49,12 @@ export type BudgetAdjustmentCellMove = Readonly<{
   current: BudgetAdjustmentSnapshot;
 }>;
 
+export type ProtectedBudgetAdjustmentCell = Readonly<{
+  month: string;
+  direction: BudgetAdjustmentDirection;
+  category: string;
+}>;
+
 type BudgetAdjustmentLocation = Readonly<{
   month: string;
   category: string;
@@ -85,12 +91,27 @@ export const isValidBudgetAdjustmentCategory = (category: string): boolean => {
   return length >= 1 && length <= 200;
 };
 
+export const isValidBudgetAdjustmentNoteInput = (noteInput: string): boolean =>
+  Array.from(noteInput).length <= 2000;
+
+export const isBudgetAdjustmentCategoryVisible = (
+  category: string,
+  effectiveAllowlist: ReadonlySet<string> | null,
+): boolean => effectiveAllowlist === null || effectiveAllowlist.has(category);
+
 export const getBudgetAdjustmentCategoryOptions = (
   categories: ReadonlyArray<string>,
   effectiveAllowlist: ReadonlySet<string> | null,
 ): ReadonlyArray<string> => [...new Set(categories.filter((category): boolean =>
   isValidBudgetAdjustmentCategory(category)
-  && (effectiveAllowlist === null || effectiveAllowlist.has(category))))];
+  && isBudgetAdjustmentCategoryVisible(category, effectiveAllowlist)))];
+
+export const isBudgetAdjustmentRowVisible = (
+  row: BudgetAdjustmentEditorRow,
+  effectiveAllowlist: ReadonlySet<string> | null,
+): boolean =>
+  isBudgetAdjustmentCategoryVisible(row.confirmed.category, effectiveAllowlist)
+  && isBudgetAdjustmentCategoryVisible(row.draft.category, effectiveAllowlist);
 
 const isValidDraftLocation = (draft: BudgetAdjustmentDraft, planFrom: string): boolean =>
   MONTH_PATTERN.test(draft.month)
@@ -170,7 +191,7 @@ export const parseBudgetAdjustmentDraft = (
       },
     };
   }
-  if (Array.from(draft.noteInput).length > 2000) {
+  if (!isValidBudgetAdjustmentNoteInput(draft.noteInput)) {
     return {
       ok: false,
       error: {
@@ -424,6 +445,60 @@ export const applyBudgetAdjustmentRows = (
     });
   }
   return sortBudgetRows(result);
+};
+
+export const applyBudgetAdjustmentRowsWithProtectedCells = (
+  budgetRows: ReadonlyArray<BudgetRow>,
+  adjustmentRows: ReadonlyArray<BudgetAdjustmentEditorRow>,
+  loadedFrom: string,
+  loadedTo: string,
+  planFrom: string,
+  invalidatedCellKeys: ReadonlySet<string>,
+  protectedCells: ReadonlyArray<ProtectedBudgetAdjustmentCell>,
+  effectiveAllowlist: ReadonlySet<string> | null,
+): ReadonlyArray<BudgetRow> => {
+  const projectedRows = applyBudgetAdjustmentRows(
+    budgetRows,
+    adjustmentRows,
+    loadedFrom,
+    loadedTo,
+    planFrom,
+    invalidatedCellKeys,
+  );
+  const existingKeys = new Set(projectedRows
+    .filter((row): boolean => row.direction === "income" || row.direction === "spend")
+    .map((row): string => getBudgetAdjustmentCellKey(
+      row.month,
+      row.direction as BudgetAdjustmentDirection,
+      row.category,
+    )));
+  const retainedRows = [...projectedRows];
+
+  for (const cell of protectedCells) {
+    if (
+      cell.month < loadedFrom
+      || cell.month > loadedTo
+      || cell.month < planFrom
+      || !isBudgetAdjustmentCategoryVisible(cell.category, effectiveAllowlist)
+    ) {
+      continue;
+    }
+    const key = getBudgetAdjustmentCellKey(cell.month, cell.direction, cell.category);
+    if (existingKeys.has(key)) continue;
+    existingKeys.add(key);
+    retainedRows.push({
+      month: cell.month,
+      direction: cell.direction,
+      category: cell.category,
+      plannedBase: 0,
+      plannedModifier: 0,
+      planned: 0,
+      actual: 0,
+      hasUnconvertible: false,
+    });
+  }
+
+  return sortBudgetRows(retainedRows);
 };
 
 export const recordBudgetAdjustmentCellMove = (

--- a/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.test.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.test.ts
@@ -388,12 +388,12 @@ test("serializes and coalesces one row while allowing another row to save indepe
     month: "2026-12",
     direction: "spend",
     category: "Food",
-  }), 0);
+  }, null), 0);
   assert.equal(harness.runtime.commands.getCellTotal({
     month: "2027-01",
     direction: "spend",
     category: "Dining",
-  }), 3);
+  }, null), 3);
   finalPatch.resolve(applyPatch(first, harness.patchCalls[2]?.params ?? {}));
   assert.equal(await firstFlush, "saved");
   assert.deepEqual(
@@ -515,6 +515,41 @@ test("keeps an ambiguous patch retryable when refresh returns the unchanged row"
   assert.equal(refreshed.errorByAdjustmentId.get(FIRST_ID)?.action, "retry-save");
   assert.equal(await harness.runtime.commands.flushRow(FIRST_ID), "saved");
   assert.equal(harness.runtime.getSnapshot().errorByAdjustmentId.has(FIRST_ID), false);
+});
+
+test("coalesces recovery for one adjustment and publishes shared pending state", async (): Promise<void> => {
+  const initial = createAdjustment(FIRST_ID, 1, "2026-07", "Food", null);
+  const range = createDeferred<BudgetGridResult>();
+  const harness = createHarness([initial]);
+  let patchAttempt = 0;
+  harness.setPatchHandler(async (_adjustmentId, params): Promise<BudgetAdjustment> => {
+    patchAttempt += 1;
+    if (patchAttempt === 1) throw new Error("patch response lost");
+    return applyPatch(initial, params);
+  });
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("2", "2026-07", "Food", ""),
+  );
+  assert.equal(await harness.runtime.commands.flushRow(FIRST_ID), "error");
+  harness.setRangeHandler((_monthFrom, _monthTo) => range.promise);
+
+  const popoverRecovery = harness.runtime.commands.recoverRow(FIRST_ID);
+  const tableRecovery = harness.runtime.commands.recoverRow(FIRST_ID);
+  assert.equal(tableRecovery, popoverRecovery);
+  assert.equal(harness.runtime.getSnapshot().recoveringAdjustmentIds.has(FIRST_ID), true);
+  await settleStart();
+  assert.deepEqual(harness.rangeCalls, [{ monthFrom: "2026-07", monthTo: "2026-07" }]);
+
+  range.resolve(createGrid([initial], []));
+  assert.equal(await popoverRecovery, "recovered");
+  assert.equal(await tableRecovery, "recovered");
+  const snapshot = harness.runtime.getSnapshot();
+  assert.equal(snapshot.recoveringAdjustmentIds.has(FIRST_ID), false);
+  assert.equal(snapshot.errorByAdjustmentId.has(FIRST_ID), false);
+  assert.equal(snapshot.rows[0]?.confirmed.amount, 2);
+  assert.equal(harness.rangeCalls.length, 1);
+  assert.equal(harness.patchCalls.length, 2);
 });
 
 test("reconciles a typed PATCH 404 as authoritative absence", async (): Promise<void> => {
@@ -723,8 +758,10 @@ test("publishes mutation snapshots until unsubscribed and exposes cell selectors
   );
   assert.equal(snapshots.length, 1);
   assert.equal(snapshots[0]?.pendingMutationCount, 1);
-  assert.equal(harness.runtime.commands.getCellRows(location).length, 1);
-  assert.equal(harness.runtime.commands.getCellTotal(location), 2);
+  assert.equal(harness.runtime.commands.getRow(FIRST_ID, null)?.draft.amountInput, "2");
+  assert.equal(harness.runtime.commands.getRow(SECOND_ID, null), null);
+  assert.equal(harness.runtime.commands.getCellRows(location, null).length, 1);
+  assert.equal(harness.runtime.commands.getCellTotal(location, null), 2);
 
   unsubscribe();
   harness.runtime.commands.replaceDraft(
@@ -732,6 +769,188 @@ test("publishes mutation snapshots until unsubscribed and exposes cell selectors
     createDraft("3", "2026-07", "Food", ""),
   );
   assert.equal(snapshots.length, 1);
+});
+
+test("uses one filtered presentation rule for selectors and projected budget rows", (): void => {
+  const harness = createHarness([
+    createAdjustment(FIRST_ID, 47, "2026-07", "Masked", "private note"),
+  ]);
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("47", "2026-07", "Allowed", "private note"),
+  );
+  const allowlist = new Set(["Allowed"]);
+  const destination = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Allowed",
+  };
+  const protectedPrivateCell = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Masked",
+  };
+  const release = harness.runtime.commands.retainCell(
+    "filtered-presentation",
+    protectedPrivateCell,
+  );
+  const budgetRows: ReadonlyArray<BudgetRow> = [{
+    month: "2026-07",
+    direction: "spend",
+    category: "Allowed",
+    plannedBase: 100,
+    plannedModifier: 47,
+    planned: 147,
+    actual: 0,
+    hasUnconvertible: false,
+  }];
+
+  assert.deepEqual(harness.runtime.commands.getCellRows(destination, allowlist), []);
+  assert.equal(harness.runtime.commands.getCellTotal(destination, allowlist), 0);
+  assert.equal(harness.runtime.commands.getRow(FIRST_ID, allowlist), null);
+  assert.equal(
+    harness.runtime.commands.getRow(FIRST_ID, null)?.confirmed.category,
+    "Masked",
+  );
+  assert.deepEqual(
+    harness.runtime.commands.applyToBudgetRows(
+      budgetRows,
+      "2026-07",
+      "2026-07",
+      allowlist,
+    ),
+    [{
+      ...budgetRows[0],
+      plannedModifier: 0,
+      planned: 100,
+    }],
+  );
+  assert.deepEqual(
+    [...harness.runtime.getSnapshot().protectedCellKeys],
+    ["2026-07\u0000spend\u0000Masked"],
+  );
+  assert.equal(harness.runtime.commands.getCellRows(destination, null).length, 1);
+  assert.equal(
+    harness.runtime.commands.applyToBudgetRows(
+      budgetRows,
+      "2026-07",
+      "2026-07",
+      null,
+    ).some((row): boolean => row.category === protectedPrivateCell.category),
+    true,
+  );
+  release();
+});
+
+test("keeps an unknown draft category private in the public row selector", (): void => {
+  const harness = createHarness([
+    createAdjustment(FIRST_ID, 12, "2026-07", "Allowed", null),
+  ]);
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("12", "2026-07", "Unknown", ""),
+  );
+  const allowlist = new Set(["Allowed"]);
+
+  assert.equal(harness.runtime.commands.getRow(FIRST_ID, allowlist), null);
+  assert.equal(
+    harness.runtime.commands.getRow(FIRST_ID, null)?.draft.category,
+    "Unknown",
+  );
+});
+
+test("retains protected adjustment cells by explicit remount-safe owner identity", (): void => {
+  const harness = createHarness([]);
+  const location = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Adjustment only",
+  };
+  const projectedRow: BudgetRow = {
+    month: "2026-07",
+    direction: "spend",
+    category: "Adjustment only",
+    plannedBase: 0,
+    plannedModifier: 0,
+    planned: 0,
+    actual: 0,
+    hasUnconvertible: false,
+  };
+  const releaseFirst = harness.runtime.commands.retainCell("first-editor", location);
+  const releaseSecond = harness.runtime.commands.retainCell("second-editor", location);
+
+  assert.deepEqual(
+    harness.runtime.commands.applyToBudgetRows([], "2026-07", "2026-07", null),
+    [projectedRow],
+  );
+  assert.deepEqual(
+    harness.runtime.commands.applyToBudgetRows(
+      [],
+      "2026-07",
+      "2026-07",
+      new Set(["Allowed"]),
+    ),
+    [],
+  );
+  assert.deepEqual(
+    [...harness.runtime.getSnapshot().protectedCellKeys],
+    ["2026-07\u0000spend\u0000Adjustment only"],
+  );
+  assert.deepEqual(
+    harness.runtime.commands.applyToBudgetRows([], "2026-07", "2026-07", null),
+    [projectedRow],
+  );
+
+  releaseFirst();
+  assert.equal(harness.runtime.getSnapshot().protectedCellKeys.size, 1);
+  releaseFirst();
+  assert.equal(harness.runtime.getSnapshot().protectedCellKeys.size, 1);
+  releaseSecond();
+  assert.equal(harness.runtime.getSnapshot().protectedCellKeys.size, 0);
+
+  const releaseStaleMount = harness.runtime.commands.retainCell("remounted-editor", location);
+  const releaseCurrentMount = harness.runtime.commands.retainCell("remounted-editor", location);
+  releaseStaleMount();
+  assert.equal(harness.runtime.getSnapshot().protectedCellKeys.size, 1);
+  releaseCurrentMount();
+  assert.equal(harness.runtime.getSnapshot().protectedCellKeys.size, 0);
+  assert.deepEqual(
+    harness.runtime.commands.applyToBudgetRows([], "2026-07", "2026-07", null),
+    [],
+  );
+});
+
+test("keeps a protected source cell projected through authoritative range absence", async (): Promise<void> => {
+  const adjustment = createAdjustment(
+    FIRST_ID,
+    12,
+    "2026-07",
+    "Adjustment only",
+    null,
+  );
+  const harness = createHarness([adjustment]);
+  harness.setRangeHandler(async (): Promise<BudgetGridResult> => createGrid([], []));
+  const location = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Adjustment only",
+  };
+  const release = harness.runtime.commands.retainCell("source-editor", location);
+
+  const outcome = await harness.runtime.commands.loadRange("2026-07", "2026-07");
+  assert.equal(outcome.status, "accepted");
+  assert.equal(harness.runtime.commands.getRow(FIRST_ID, null), null);
+  assert.equal(
+    harness.runtime.commands.applyToBudgetRows([], "2026-07", "2026-07", null)
+      .some((row): boolean => row.category === location.category),
+    true,
+  );
+
+  release();
+  assert.deepEqual(
+    harness.runtime.commands.applyToBudgetRows([], "2026-07", "2026-07", null),
+    [],
+  );
 });
 
 test("accepts exact-overlap ranges in response order and supersedes stale results", async (): Promise<void> => {
@@ -950,7 +1169,12 @@ test("projects normalized drafts onto budget rows across the loaded range", (): 
   ];
 
   assert.deepEqual(
-    harness.runtime.commands.applyToBudgetRows(budgetRows, "2026-07", "2026-08"),
+    harness.runtime.commands.applyToBudgetRows(
+      budgetRows,
+      "2026-07",
+      "2026-08",
+      null,
+    ),
     [
       {
         ...budgetRows[0],

--- a/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.ts
@@ -28,13 +28,16 @@ import {
   type BudgetAdjustmentRowsReconciliationState,
 } from "@/ui/tables/budget/budgetAdjustmentRowsReconciliation";
 import {
-  applyBudgetAdjustmentRows,
+  applyBudgetAdjustmentRowsWithProtectedCells,
+  getBudgetAdjustmentCellKey,
   getBudgetAdjustmentCellRows,
   getBudgetAdjustmentCellTotal,
+  isBudgetAdjustmentRowVisible,
   parseBudgetAdjustmentDraft,
   type BudgetAdjustmentDraft,
   type BudgetAdjustmentDraftError,
   type BudgetAdjustmentEditorRow,
+  type ProtectedBudgetAdjustmentCell,
 } from "@/ui/tables/budget/budgetAdjustmentRowsState";
 import {
   BudgetAdjustmentApiError,
@@ -78,6 +81,8 @@ export type BudgetAdjustmentFlushOutcome =
   | "refresh-required"
   | "deleted";
 
+export type BudgetAdjustmentRecoveryOutcome = "recovered" | "unsuccessful";
+
 export type BudgetAdjustmentRangeLoadOutcome =
   | Readonly<{ status: "accepted"; result: BudgetGridResult }>
   | Readonly<{ status: "superseded" }>;
@@ -88,6 +93,8 @@ export type BudgetAdjustmentRowsControllerState = Readonly<{
   validationByAdjustmentId: ReadonlyMap<string, BudgetAdjustmentDraftError>;
   errorByAdjustmentId: ReadonlyMap<string, BudgetAdjustmentRowError>;
   operationByAdjustmentId: ReadonlyMap<string, BudgetAdjustmentRowOperation>;
+  recoveringAdjustmentIds: ReadonlySet<string>;
+  protectedCellKeys: ReadonlySet<string>;
   rangeErrorByKey: ReadonlyMap<string, BudgetAdjustmentRangeError>;
   pendingMutationCount: number;
   pendingRangeCount: number;
@@ -97,15 +104,31 @@ export type BudgetAdjustmentRowsControllerCommands = Readonly<{
   addRow: (location: BudgetAdjustmentCellLocation) => string;
   replaceDraft: (adjustmentId: string, draft: BudgetAdjustmentDraft) => void;
   flushRow: (adjustmentId: string) => Promise<BudgetAdjustmentFlushOutcome>;
+  recoverRow: (adjustmentId: string) => Promise<BudgetAdjustmentRecoveryOutcome>;
   requestDelete: (adjustmentId: string) => Promise<BudgetAdjustmentFlushOutcome>;
   loadRange: (monthFrom: string, monthTo: string) => Promise<BudgetAdjustmentRangeLoadOutcome>;
   refreshRow: (adjustmentId: string) => Promise<BudgetAdjustmentRangeLoadOutcome>;
-  getCellRows: (location: BudgetAdjustmentCellLocation) => ReadonlyArray<BudgetAdjustmentEditorRow>;
-  getCellTotal: (location: BudgetAdjustmentCellLocation) => number;
+  getRow: (
+    adjustmentId: string,
+    effectiveAllowlist: ReadonlySet<string> | null,
+  ) => BudgetAdjustmentEditorRow | null;
+  getCellRows: (
+    location: BudgetAdjustmentCellLocation,
+    effectiveAllowlist: ReadonlySet<string> | null,
+  ) => ReadonlyArray<BudgetAdjustmentEditorRow>;
+  getCellTotal: (
+    location: BudgetAdjustmentCellLocation,
+    effectiveAllowlist: ReadonlySet<string> | null,
+  ) => number;
+  retainCell: (
+    ownerId: string,
+    location: BudgetAdjustmentCellLocation,
+  ) => () => void;
   applyToBudgetRows: (
     budgetRows: ReadonlyArray<BudgetRow>,
     loadedFrom: string,
     loadedTo: string,
+    effectiveAllowlist: ReadonlySet<string> | null,
   ) => ReadonlyArray<BudgetRow>;
 }>;
 
@@ -213,7 +236,12 @@ export const createBudgetAdjustmentRowsController = (
   const suspendedAutosaveIds = new Set<string>();
   const suspendedInvalidationYears = new Set<string>();
   const activeFlushes = new Map<string, Promise<BudgetAdjustmentFlushOutcome>>();
+  const activeRecoveries = new Map<string, Promise<BudgetAdjustmentRecoveryOutcome>>();
   const deleteRequestedIds = new Set<string>();
+  const protectedCellOwners = new Map<string, Readonly<{
+    cell: ProtectedBudgetAdjustmentCell;
+    lease: symbol;
+  }>>();
   let rowErrors = new Map<string, BudgetAdjustmentRowError>();
   let rowOperations = new Map<string, BudgetAdjustmentRowOperation>();
   let rangeFailuresByKey = new Map<string, BudgetAdjustmentRangeFailure>();
@@ -229,6 +257,14 @@ export const createBudgetAdjustmentRowsController = (
     validationByAdjustmentId: buildValidationMap(reconciliation.rows, dependencies.planFrom),
     errorByAdjustmentId: new Map(rowErrors),
     operationByAdjustmentId: new Map(rowOperations),
+    recoveringAdjustmentIds: new Set(activeRecoveries.keys()),
+    protectedCellKeys: new Set([...protectedCellOwners.values()].map(
+      (owner): string => getBudgetAdjustmentCellKey(
+        owner.cell.month,
+        owner.cell.direction,
+        owner.cell.category,
+      ),
+    )),
     rangeErrorByKey: new Map([...rangeFailuresByKey].map(
       ([rangeKey, failure]): readonly [string, BudgetAdjustmentRangeError] =>
         [rangeKey, failure.error],
@@ -701,47 +737,136 @@ export const createBudgetAdjustmentRowsController = (
     return loadRange(monthFrom, monthTo);
   };
 
+  const recoverRow = (
+    adjustmentId: string,
+  ): Promise<BudgetAdjustmentRecoveryOutcome> => {
+    const disposedError = getDisposedError(`recover budget adjustment "${adjustmentId}"`);
+    if (disposedError !== null) return Promise.reject(disposedError);
+    const active = activeRecoveries.get(adjustmentId);
+    if (active !== undefined) return active;
+
+    const promise = Promise.resolve()
+      .then(async (): Promise<BudgetAdjustmentRecoveryOutcome> => {
+        const rowError = rowErrors.get(adjustmentId);
+        if (rowError?.action === "refresh-range") {
+          const rangeOutcome = await refreshRow(adjustmentId);
+          if (rangeOutcome.status !== "accepted") return "unsuccessful";
+          const rowExists = rangeOutcome.result.adjustments.some(
+            (adjustment): boolean => adjustment.adjustmentId === adjustmentId,
+          );
+          if (!rowExists) return "recovered";
+        }
+
+        const flushOutcome = await flushRow(adjustmentId);
+        return flushOutcome === "saved"
+          || flushOutcome === "unchanged"
+          || flushOutcome === "deleted"
+          ? "recovered"
+          : "unsuccessful";
+      })
+      .finally((): void => {
+        if (activeRecoveries.get(adjustmentId) !== promise) return;
+        activeRecoveries.delete(adjustmentId);
+        publish();
+      });
+    activeRecoveries.set(adjustmentId, promise);
+    publish();
+    return promise;
+  };
+
+  const getVisibleRows = (
+    effectiveAllowlist: ReadonlySet<string> | null,
+  ): ReadonlyArray<BudgetAdjustmentEditorRow> => reconciliation.rows.filter(
+    (row): boolean => isBudgetAdjustmentRowVisible(row, effectiveAllowlist),
+  );
+
   const getCellRows = (
     location: BudgetAdjustmentCellLocation,
+    effectiveAllowlist: ReadonlySet<string> | null,
   ): ReadonlyArray<BudgetAdjustmentEditorRow> => getBudgetAdjustmentCellRows(
-    reconciliation.rows,
+    getVisibleRows(effectiveAllowlist),
     location.month,
     location.direction,
     location.category,
     dependencies.planFrom,
   );
 
-  const getCellTotal = (location: BudgetAdjustmentCellLocation): number =>
+  const getRow = (
+    adjustmentId: string,
+    effectiveAllowlist: ReadonlySet<string> | null,
+  ): BudgetAdjustmentEditorRow | null =>
+    getVisibleRows(effectiveAllowlist).find(
+      (row): boolean => row.adjustmentId === adjustmentId,
+    ) ?? null;
+
+  const getCellTotal = (
+    location: BudgetAdjustmentCellLocation,
+    effectiveAllowlist: ReadonlySet<string> | null,
+  ): number =>
     getBudgetAdjustmentCellTotal(
-      reconciliation.rows,
+      getVisibleRows(effectiveAllowlist),
       location.month,
       location.direction,
       location.category,
       dependencies.planFrom,
     );
 
+  const retainCell = (
+    ownerId: string,
+    location: BudgetAdjustmentCellLocation,
+  ): (() => void) => {
+    const disposedError = getDisposedError(
+      `retain budget adjustment cell ${location.month}/${location.direction}/${location.category}`,
+    );
+    if (disposedError !== null) throw disposedError;
+    if (ownerId.length === 0) {
+      throw new RangeError("Budget adjustment cell ownerId must not be empty");
+    }
+
+    const lease = Symbol(ownerId);
+    protectedCellOwners.set(ownerId, {
+      cell: { ...location },
+      lease,
+    });
+    publish();
+
+    return (): void => {
+      if (protectedCellOwners.get(ownerId)?.lease !== lease) return;
+      protectedCellOwners.delete(ownerId);
+      publish();
+    };
+  };
+
   const applyToBudgetRows = (
     budgetRows: ReadonlyArray<BudgetRow>,
     loadedFrom: string,
     loadedTo: string,
-  ): ReadonlyArray<BudgetRow> => applyBudgetAdjustmentRows(
+    effectiveAllowlist: ReadonlySet<string> | null,
+  ): ReadonlyArray<BudgetRow> => applyBudgetAdjustmentRowsWithProtectedCells(
     budgetRows,
-    reconciliation.rows,
+    getVisibleRows(effectiveAllowlist),
     loadedFrom,
     loadedTo,
     dependencies.planFrom,
     getBudgetAdjustmentInvalidatedCellKeys(reconciliation),
+    [...protectedCellOwners.values()].map(
+      (owner): ProtectedBudgetAdjustmentCell => owner.cell,
+    ),
+    effectiveAllowlist,
   );
 
   const commands: BudgetAdjustmentRowsControllerCommands = {
     addRow,
     replaceDraft,
     flushRow,
+    recoverRow,
     requestDelete,
     loadRange,
     refreshRow,
+    getRow,
     getCellRows,
     getCellTotal,
+    retainCell,
     applyToBudgetRows,
   };
 

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableController.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableController.ts
@@ -167,9 +167,11 @@ export const useBudgetTableController = (
       rangeState.allRows,
       rangeState.loadedFrom,
       rangeState.loadedTo,
+      effectiveAllowlist,
     ),
     [
       budgetAdjustments,
+      effectiveAllowlist,
       rangeState.allRows,
       rangeState.loadedFrom,
       rangeState.loadedTo,


### PR DESCRIPTION
## Summary

- apply one privacy-safe visibility rule to adjustment selectors and projections
- add remount-safe protected-cell ownership and filtered projection behavior
- coalesce adjustment recovery and expose shared pending state
- update the two compile-contract call sites without rendered editor wiring

## Validation

- focused controller/state tests: 50/50 passed
- full required suite: 127/127 passed
- npm run lint
- npm run build
- git diff --check
- fresh empty-history review: no P0-P4 findings