### PR TITLE
Add shared table editor lifecycle gates

### DIFF
--- a/apps/web/e2e-local/monetary-input.local-demo.spec.ts
+++ b/apps/web/e2e-local/monetary-input.local-demo.spec.ts
@@ -42,6 +42,36 @@ test("keeps the invalid transaction amount editor as the only active editor", as
   await expect(page.locator('[data-testid^="transaction-amount-input-"]')).toHaveCount(1);
 });
 
+test("reopens a transaction amount editor from its latest committed value", async ({ page, baseURL }) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+  await setDemoCookies(page, baseURL);
+  await page.goto("/transactions", { waitUntil: "domcontentloaded" });
+
+  const amountCell = page.locator('td[data-testid^="transaction-amount-"]').first();
+  await expect(amountCell).toBeVisible({ timeout: 15_000 });
+  const amountCellTestId = await amountCell.getAttribute("data-testid");
+  if (amountCellTestId === null) {
+    throw new Error("Transaction amount cell is missing its stable test ID");
+  }
+  const entryId = amountCellTestId.slice("transaction-amount-".length);
+  const amountInput = page.getByTestId(`transaction-amount-input-${entryId}`);
+
+  await amountCell.click();
+  await amountInput.fill("123");
+  const updateResponsePromise = page.waitForResponse((response): boolean =>
+    response.url().endsWith("/api/transactions/update")
+      && response.request().method() === "POST");
+  await amountInput.press("Enter");
+  const updateResponse = await updateResponsePromise;
+  expect(updateResponse.ok()).toBe(true);
+  await expect(amountInput).toHaveCount(0);
+
+  await amountCell.click();
+  await expect(amountInput).toHaveValue("123");
+});
+
 test("keeps the invalid budget plan popover as the only active popover", async ({ page, baseURL }) => {
   if (baseURL === undefined) {
     throw new Error("Local Demo Playwright baseURL is required");

--- a/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
@@ -130,7 +130,6 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
   const { numberFormat } = useFormat();
   const { t } = useTranslation();
   const editorId = `budget-plan:${month}:${direction}:${category}`;
-  const { requestActivation, releaseActivation } = useTableEditorActivation(editorId);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [baseInput, setBaseInput] = useState<string>("");
   const [modifierInput, setModifierInput] = useState<string>("");
@@ -149,9 +148,9 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
   const originalModifier = useRef<number>(0);
   const originalComment = useRef<string>("");
 
-  const openPopover = (): void => {
-    if (!showData) return;
-    if (!requestActivation()) return;
+  const initializePopover = (): boolean => {
+    const cell = cellRef.current;
+    if (!showData || cell === null) return false;
     const roundedBase = Math.round(plannedBase);
     const roundedModifier = Math.round(plannedModifier);
     setBaseInput(String(roundedBase));
@@ -161,16 +160,14 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     originalBase.current = roundedBase;
     originalModifier.current = roundedModifier;
 
-    const rect = cellRef.current?.getBoundingClientRect();
-    if (rect !== undefined && rect !== null) {
-      setPopoverPos(getPopoverPosition(
-        rect,
-        { width: getViewportPopoverWidth(window.innerWidth), height: 0 },
-        window.innerWidth,
-        window.innerHeight,
-        getDocumentDirection(),
-      ));
-    }
+    const rect = cell.getBoundingClientRect();
+    setPopoverPos(getPopoverPosition(
+      rect,
+      { width: getViewportPopoverWidth(window.innerWidth), height: 0 },
+      window.innerWidth,
+      window.innerHeight,
+      getDocumentDirection(),
+    ));
     setIsOpen(true);
 
     setIsLoadingComment(true);
@@ -184,6 +181,15 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       })
       .catch((error) => console.error(error))
       .finally(() => setIsLoadingComment(false));
+    return true;
+  };
+  const { requestActivation, releaseActivation } = useTableEditorActivation(
+    editorId,
+    initializePopover,
+  );
+
+  const openPopover = (): void => {
+    requestActivation();
   };
 
   const updatePopoverPosition = useCallback((): void => {

--- a/apps/web/src/ui/tables/editable/EditableAmount.tsx
+++ b/apps/web/src/ui/tables/editable/EditableAmount.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement } from "react";
 import { createPortal } from "react-dom";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
@@ -24,7 +24,6 @@ export const EditableAmount = (props: Props): ReactElement => {
   const { numberFormat } = useFormat();
   const { t } = useTranslation();
   const editorId = `transaction-amount:${entryId}`;
-  const { requestActivation, releaseActivation } = useTableEditorActivation(editorId);
 
   const [editing, setEditing] = useState<boolean>(false);
   const [editValue, setEditValue] = useState<string>("");
@@ -32,6 +31,7 @@ export const EditableAmount = (props: Props): ReactElement => {
   const [rect, setRect] = useState<Rect | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const cellRef = useRef<HTMLTableCellElement | null>(null);
+  const editingRef = useRef<boolean>(false);
 
   useEffect(() => {
     if (editing && inputRef.current !== null) {
@@ -40,17 +40,27 @@ export const EditableAmount = (props: Props): ReactElement => {
     }
   }, [editing]);
 
-  const startEditing = (): void => {
-    if (cellRef.current === null) return;
-    if (!requestActivation()) return;
+  const initializeEditing = (): boolean => {
+    if (cellRef.current === null) return false;
     const r = cellRef.current.getBoundingClientRect();
     setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
     setEditValue(String(currentValue));
     setValidationError(null);
+    editingRef.current = true;
     setEditing(true);
+    return true;
+  };
+  const {
+    requestActivation,
+    releaseActivation,
+    registerTransitionGate,
+  } = useTableEditorActivation(editorId, initializeEditing);
+
+  const startEditing = (): void => {
+    requestActivation();
   };
 
-  const commitEdit = (): void => {
+  const commitEdit = useCallback((): boolean => {
     const parsed = parseMonetaryNumberEdit(editValue, currentValue, numberFormat);
     if (!parsed.ok) {
       const message = t("common.invalidNumber");
@@ -59,15 +69,27 @@ export const EditableAmount = (props: Props): ReactElement => {
         inputRef.current.setCustomValidity(message);
         inputRef.current.reportValidity();
       }
-      return;
+      return false;
     }
 
+    editingRef.current = false;
     setEditing(false);
     setRect(null);
     releaseActivation();
-    if (parsed.value === currentValue) return;
-    onAmountCommit(entryId, parsed.value, currentValue);
-  };
+    if (parsed.value !== currentValue) {
+      onAmountCommit(entryId, parsed.value, currentValue);
+    }
+    return true;
+  }, [currentValue, editValue, entryId, numberFormat, onAmountCommit, releaseActivation, t]);
+  const commitEditRef = useRef<() => boolean>(commitEdit);
+  useLayoutEffect((): void => {
+    commitEditRef.current = commitEdit;
+  }, [commitEdit]);
+
+  useEffect(() => registerTransitionGate({
+    isLifecycleUnresolved: (): boolean => editingRef.current,
+    settleLifecycle: (): Promise<boolean> => Promise.resolve(commitEditRef.current()),
+  }), [registerTransitionGate]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === "Enter") {
@@ -77,6 +99,7 @@ export const EditableAmount = (props: Props): ReactElement => {
     if (e.key === "Escape") {
       e.preventDefault();
       e.stopPropagation();
+      editingRef.current = false;
       setEditing(false);
       setRect(null);
       releaseActivation();

--- a/apps/web/src/ui/tables/shared/TableEditorActivationProvider.test.ts
+++ b/apps/web/src/ui/tables/shared/TableEditorActivationProvider.test.ts
@@ -1,0 +1,697 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createTableEditorActivationCoordinator,
+  createTableEditorActivationLease,
+  createTableEditorRegistration,
+  createTableEditorTransitionCoordinator,
+  type TableEditorTransitionGate,
+} from "@/ui/tables/shared/TableEditorActivationProvider";
+
+const SOURCE_EDITOR_ID = "source-editor";
+const DESTINATION_EDITOR_ID = "destination-editor";
+
+type Deferred<T> = Readonly<{
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}>;
+
+type ActivationCoordinator = ReturnType<typeof createTableEditorActivationCoordinator>;
+type ActivationLease = ReturnType<typeof createTableEditorActivationLease>;
+type ActivationLeaseContext = Parameters<typeof createTableEditorActivationLease>[2];
+type Registration = ReturnType<typeof createTableEditorRegistration>;
+type EditorOwner = ReturnType<Registration["mount"]>;
+type RecoveryGate = Parameters<ActivationLease["registerRecoveryGate"]>[0];
+
+type QueuedActivationScenario = Readonly<{
+  activation: ActivationCoordinator;
+  sourceOwner: EditorOwner;
+  destinationOwner: EditorOwner;
+  activatedDestinationIds: Array<string>;
+}>;
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolvePromise: (value: T) => void = (): void => {
+    throw new Error("Deferred resolver was used before initialization");
+  };
+  const promise = new Promise<T>((resolve): void => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: (value: T): void => resolvePromise(value) };
+};
+
+const createMountedOwner = (editorId: string): EditorOwner => (
+  createTableEditorRegistration(editorId).mount((): boolean => true)
+);
+
+const createTransitionCoordinator = (
+  activation: ActivationCoordinator,
+): ReturnType<typeof createTableEditorTransitionCoordinator> => (
+  createTableEditorTransitionCoordinator({
+    begin: activation.beginTransition,
+    commit: activation.commitTransition,
+    cancel: activation.cancelTransition,
+  })
+);
+
+const createActivationLeaseContext = (
+  activation: ActivationCoordinator,
+): ActivationLeaseContext => ({
+  requestActivation: activation.requestActivation,
+  prepareActivationRelease: activation.prepareActivationRelease,
+  cancelActivationRelease: activation.cancelActivationRelease,
+  cancelActivationRequest: activation.cancelActivationRequest,
+  releaseActivation: activation.releaseActivation,
+  registerRecoveryGate: (): (() => void) => (): void => {},
+  registerTransitionGate: (): (() => void) => (): void => {},
+});
+
+const createQueuedActivationScenario = (): QueuedActivationScenario => {
+  const activation = createTableEditorActivationCoordinator();
+  const sourceOwner = createMountedOwner(SOURCE_EDITOR_ID);
+  const destinationOwner = createMountedOwner(DESTINATION_EDITOR_ID);
+  const activatedDestinationIds: Array<string> = [];
+  assert.equal(
+    activation.requestActivation(sourceOwner, (): void => {}),
+    "activated",
+  );
+  activation.prepareActivationRelease(sourceOwner);
+  assert.equal(
+    activation.requestActivation(destinationOwner, (): void => {
+      activatedDestinationIds.push(DESTINATION_EDITOR_ID);
+    }),
+    "queued",
+  );
+  return {
+    activation,
+    sourceOwner,
+    destinationOwner,
+    activatedDestinationIds,
+  };
+};
+
+const getRejection = async (promise: Promise<boolean>): Promise<unknown> => {
+  try {
+    await promise;
+  } catch (error: unknown) {
+    return error;
+  }
+  throw new Error("Expected table editor transition to reject");
+};
+
+const getRequiredMapValue = <Key, Value>(
+  values: ReadonlyMap<Key, Value>,
+  key: Key,
+  description: string,
+): Value => {
+  const value = values.get(key);
+  if (value === undefined) {
+    throw new Error(`Expected ${description} to be registered`);
+  }
+  return value;
+};
+
+test("editor transition succeeds when no lifecycle is unresolved", async (): Promise<void> => {
+  const activation = createTableEditorActivationCoordinator();
+  const coordinator = createTransitionCoordinator(activation);
+  coordinator.registerTransitionGate(createMountedOwner("resolved-editor"), {
+    isLifecycleUnresolved: (): boolean => false,
+    settleLifecycle: (): Promise<boolean> => {
+      throw new Error("Resolved lifecycle must not be settled");
+    },
+  });
+
+  assert.equal(await coordinator.requestEditorTransition(), true);
+});
+
+test("simultaneous editor transition requests share one settlement promise", async (): Promise<void> => {
+  const settlement = createDeferred<boolean>();
+  let settlementCount = 0;
+  const activation = createTableEditorActivationCoordinator();
+  const coordinator = createTransitionCoordinator(activation);
+  coordinator.registerTransitionGate(createMountedOwner("pending-editor"), {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      settlementCount += 1;
+      return settlement.promise;
+    },
+  });
+
+  const firstRequest = coordinator.requestEditorTransition();
+  const secondRequest = coordinator.requestEditorTransition();
+
+  assert.equal(firstRequest, secondRequest);
+  settlement.resolve(true);
+  assert.equal(await firstRequest, true);
+  assert.equal(settlementCount, 1);
+});
+
+test("aggregate failure cancels a successful source release without activating its destination", async (): Promise<void> => {
+  const {
+    activation,
+    sourceOwner,
+    activatedDestinationIds,
+  } = createQueuedActivationScenario();
+  const coordinator = createTransitionCoordinator(activation);
+  let invalidGateSettlementCount = 0;
+  let invalidGateSettles = false;
+  coordinator.registerTransitionGate(sourceOwner, {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      activation.releaseActivation(sourceOwner);
+      return Promise.resolve(true);
+    },
+  });
+  coordinator.registerTransitionGate(createMountedOwner("invalid-editor"), {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      invalidGateSettlementCount += 1;
+      return Promise.resolve(invalidGateSettles);
+    },
+  });
+
+  assert.equal(await coordinator.requestEditorTransition(), false);
+  assert.deepEqual(activatedDestinationIds, []);
+  assert.equal(activation.releaseActivation(sourceOwner), false);
+  assert.deepEqual(activatedDestinationIds, []);
+
+  invalidGateSettles = true;
+  assert.equal(await coordinator.requestEditorTransition(), true);
+  assert.equal(invalidGateSettlementCount, 2);
+  assert.deepEqual(activatedDestinationIds, []);
+});
+
+test("all successful lifecycles commit one deferred destination handoff", async (): Promise<void> => {
+  const {
+    activation,
+    sourceOwner,
+    destinationOwner,
+    activatedDestinationIds,
+  } = createQueuedActivationScenario();
+  const coordinator = createTransitionCoordinator(activation);
+  coordinator.registerTransitionGate(sourceOwner, {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      activation.releaseActivation(sourceOwner);
+      return Promise.resolve(true);
+    },
+  });
+  coordinator.registerTransitionGate(createMountedOwner("second-editor"), {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => Promise.resolve(true),
+  });
+
+  assert.equal(await coordinator.requestEditorTransition(), true);
+  assert.deepEqual(activatedDestinationIds, [DESTINATION_EDITOR_ID]);
+  assert.equal(activation.getActiveOwner(), destinationOwner);
+  assert.equal(activation.releaseActivation(sourceOwner), false);
+  assert.deepEqual(activatedDestinationIds, [DESTINATION_EDITOR_ID]);
+});
+
+test("releasing source generation cannot reactivate while aggregate settlement is pending", async (): Promise<void> => {
+  const {
+    activation,
+    sourceOwner,
+    activatedDestinationIds,
+  } = createQueuedActivationScenario();
+  const sourceReleased = createDeferred<void>();
+  const secondSettlement = createDeferred<boolean>();
+  const coordinator = createTransitionCoordinator(activation);
+  let sourceReactivationCount = 0;
+  coordinator.registerTransitionGate(sourceOwner, {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      activation.releaseActivation(sourceOwner);
+      sourceReleased.resolve(undefined);
+      return Promise.resolve(true);
+    },
+  });
+  coordinator.registerTransitionGate(createMountedOwner("second-editor"), {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => secondSettlement.promise,
+  });
+
+  const transition = coordinator.requestEditorTransition();
+  await sourceReleased.promise;
+  assert.equal(
+    activation.requestActivation(sourceOwner, (): void => {
+      sourceReactivationCount += 1;
+    }),
+    "denied",
+  );
+  assert.equal(sourceReactivationCount, 0);
+  assert.deepEqual(activatedDestinationIds, []);
+
+  secondSettlement.resolve(true);
+  assert.equal(await transition, true);
+  assert.equal(sourceReactivationCount, 0);
+  assert.deepEqual(activatedDestinationIds, [DESTINATION_EDITOR_ID]);
+});
+
+test("old-generation queued initializer stays dead after same-ID remount", (): void => {
+  let oldInitializationCount = 0;
+  let newInitializationCount = 0;
+  const sourceOwner = createMountedOwner(SOURCE_EDITOR_ID);
+  const destinationRegistration = createTableEditorRegistration(DESTINATION_EDITOR_ID);
+  const oldDestinationOwner = destinationRegistration.mount((): boolean => {
+    oldInitializationCount += 1;
+    return true;
+  });
+  const activation = createTableEditorActivationCoordinator();
+  assert.equal(activation.requestActivation(sourceOwner, (): void => {}), "activated");
+  activation.prepareActivationRelease(sourceOwner);
+  assert.equal(
+    activation.requestActivation(oldDestinationOwner, (): void => {
+      if (destinationRegistration.initializeLatest(oldDestinationOwner)) return;
+      activation.releaseActivation(oldDestinationOwner);
+    }),
+    "queued",
+  );
+
+  destinationRegistration.unmount(oldDestinationOwner);
+  const newDestinationOwner = destinationRegistration.mount((): boolean => {
+    newInitializationCount += 1;
+    return true;
+  });
+  assert.notEqual(newDestinationOwner.generation, oldDestinationOwner.generation);
+  assert.equal(activation.releaseActivation(sourceOwner), true);
+  assert.equal(oldInitializationCount, 0);
+  assert.equal(newInitializationCount, 0);
+  assert.equal(activation.getActiveOwner(), null);
+  assert.equal(destinationRegistration.initializeLatest(newDestinationOwner), true);
+  assert.equal(newInitializationCount, 1);
+});
+
+test("old-generation cleanup cannot release newer same-ID ownership", (): void => {
+  const registration = createTableEditorRegistration(SOURCE_EDITOR_ID);
+  const oldOwner = registration.mount((): boolean => true);
+  const activation = createTableEditorActivationCoordinator();
+  assert.equal(activation.requestActivation(oldOwner, (): void => {}), "activated");
+  registration.unmount(oldOwner);
+  assert.equal(activation.releaseActivation(oldOwner), false);
+
+  const newOwner = registration.mount((): boolean => true);
+  assert.equal(activation.requestActivation(newOwner, (): void => {}), "activated");
+  activation.cancelActivationRequest(oldOwner);
+  activation.cancelActivationRelease(oldOwner);
+  assert.equal(activation.releaseActivation(oldOwner), false);
+  assert.equal(activation.getActiveOwner(), newOwner);
+});
+
+test("throwing immediate initializer releases only its captured owner", (): void => {
+  const expectedError = new Error("Immediate initialization failed");
+  const activation = createTableEditorActivationCoordinator();
+  const registration = createTableEditorRegistration("throwing-editor");
+  const oldOwner = registration.mount((): boolean => {
+    throw expectedError;
+  });
+  const oldLease = createTableEditorActivationLease(
+    registration,
+    oldOwner,
+    createActivationLeaseContext(activation),
+  );
+  let thrownError: unknown = null;
+
+  try {
+    oldLease.requestActivation();
+  } catch (error: unknown) {
+    thrownError = error;
+  }
+
+  assert.equal(thrownError, expectedError);
+  assert.equal(activation.getActiveOwner(), null);
+  registration.unmount(oldOwner);
+  const newOwner = registration.mount((): boolean => true);
+  const newLease = createTableEditorActivationLease(
+    registration,
+    newOwner,
+    createActivationLeaseContext(activation),
+  );
+  assert.equal(newLease.requestActivation(), "activated");
+  assert.equal(oldLease.releaseActivation(), false);
+  assert.equal(activation.getActiveOwner(), newOwner);
+});
+
+test("throwing queued initializer releases its owner during transition commit", async (): Promise<void> => {
+  const expectedError = new Error("Queued initialization failed");
+  const activation = createTableEditorActivationCoordinator();
+  const sourceOwner = createMountedOwner(SOURCE_EDITOR_ID);
+  const destinationRegistration = createTableEditorRegistration(DESTINATION_EDITOR_ID);
+  const destinationOwner = destinationRegistration.mount((): boolean => {
+    throw expectedError;
+  });
+  const destinationLease = createTableEditorActivationLease(
+    destinationRegistration,
+    destinationOwner,
+    createActivationLeaseContext(activation),
+  );
+  assert.equal(activation.requestActivation(sourceOwner, (): void => {}), "activated");
+  activation.prepareActivationRelease(sourceOwner);
+  assert.equal(destinationLease.requestActivation(), "queued");
+  const transition = createTransitionCoordinator(activation);
+  transition.registerTransitionGate(sourceOwner, {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      activation.releaseActivation(sourceOwner);
+      return Promise.resolve(true);
+    },
+  });
+
+  const rejection = await getRejection(transition.requestEditorTransition());
+
+  assert.equal(rejection, expectedError);
+  assert.equal(activation.getActiveOwner(), null);
+  const laterOwner = createMountedOwner("later-editor");
+  assert.equal(activation.requestActivation(laterOwner, (): void => {}), "activated");
+  assert.equal(destinationLease.releaseActivation(), false);
+  assert.equal(activation.getActiveOwner(), laterOwner);
+});
+
+test("old recovery and transition wrappers stay dead after same-ID remount", async (): Promise<void> => {
+  let oldRecoveryCount = 0;
+  let oldSettlementCount = 0;
+  let newRecoveryCount = 0;
+  let newSettlementCount = 0;
+  const registration = createTableEditorRegistration("wrapped-editor");
+  const oldOwner = registration.mount((): boolean => true);
+  const oldRecoveryGate = registration.guardRecoveryGate(oldOwner, {
+    ownsAdjustment: (): boolean => true,
+    recoverAdjustment: (): Promise<void> => {
+      oldRecoveryCount += 1;
+      return Promise.resolve();
+    },
+  });
+  const oldTransitionGate = registration.guardTransitionGate(oldOwner, {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      oldSettlementCount += 1;
+      return Promise.resolve(true);
+    },
+  });
+
+  registration.unmount(oldOwner);
+  const newOwner = registration.mount((): boolean => true);
+  const newRecoveryGate = registration.guardRecoveryGate(newOwner, {
+    ownsAdjustment: (): boolean => true,
+    recoverAdjustment: (): Promise<void> => {
+      newRecoveryCount += 1;
+      return Promise.resolve();
+    },
+  });
+  const newTransitionGate = registration.guardTransitionGate(newOwner, {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      newSettlementCount += 1;
+      return Promise.resolve(true);
+    },
+  });
+
+  assert.equal(oldRecoveryGate.ownsAdjustment("adjustment-1"), false);
+  await oldRecoveryGate.recoverAdjustment("adjustment-1");
+  assert.equal(oldTransitionGate.isLifecycleUnresolved(), false);
+  assert.equal(await oldTransitionGate.settleLifecycle(), true);
+  assert.equal(oldRecoveryCount, 0);
+  assert.equal(oldSettlementCount, 0);
+
+  assert.equal(newRecoveryGate.ownsAdjustment("adjustment-1"), true);
+  await newRecoveryGate.recoverAdjustment("adjustment-1");
+  assert.equal(newTransitionGate.isLifecycleUnresolved(), true);
+  assert.equal(await newTransitionGate.settleLifecycle(), true);
+  assert.equal(newRecoveryCount, 1);
+  assert.equal(newSettlementCount, 1);
+});
+
+test("retained hook lease callbacks stay stale after same-ID remount", async (): Promise<void> => {
+  const activation = createTableEditorActivationCoordinator();
+  const registration = createTableEditorRegistration("leased-editor");
+  const forwardedOperations: Array<string> = [];
+  const recoveryGates = new Map<EditorOwner, RecoveryGate>();
+  const transitionGates = new Map<EditorOwner, TableEditorTransitionGate>();
+  const context: ActivationLeaseContext = {
+    requestActivation: (owner, initializeEditor) => {
+      forwardedOperations.push("request");
+      return activation.requestActivation(owner, initializeEditor);
+    },
+    prepareActivationRelease: (owner): void => {
+      forwardedOperations.push("prepare");
+      activation.prepareActivationRelease(owner);
+    },
+    cancelActivationRelease: (owner): void => {
+      forwardedOperations.push("cancel-release");
+      activation.cancelActivationRelease(owner);
+    },
+    cancelActivationRequest: (owner): void => {
+      forwardedOperations.push("cancel-request");
+      activation.cancelActivationRequest(owner);
+    },
+    releaseActivation: (owner): boolean => {
+      forwardedOperations.push("release");
+      return activation.releaseActivation(owner);
+    },
+    registerRecoveryGate: (owner, gate): (() => void) => {
+      forwardedOperations.push("register-recovery");
+      recoveryGates.set(owner, gate);
+      return (): void => {
+        if (recoveryGates.get(owner) === gate) recoveryGates.delete(owner);
+      };
+    },
+    registerTransitionGate: (owner, gate): (() => void) => {
+      forwardedOperations.push("register-transition");
+      transitionGates.set(owner, gate);
+      return (): void => {
+        if (transitionGates.get(owner) === gate) transitionGates.delete(owner);
+      };
+    },
+  };
+  let oldInitializationCount = 0;
+  let newInitializationCount = 0;
+  let oldRecoveryCount = 0;
+  let oldSettlementCount = 0;
+  let newRecoveryCount = 0;
+  let newSettlementCount = 0;
+
+  const oldOwner = registration.mount((): boolean => {
+    oldInitializationCount += 1;
+    return true;
+  });
+  const oldLease = createTableEditorActivationLease(registration, oldOwner, context);
+  oldLease.registerRecoveryGate({
+    ownsAdjustment: (): boolean => true,
+    recoverAdjustment: (): Promise<void> => {
+      oldRecoveryCount += 1;
+      return Promise.resolve();
+    },
+  });
+  oldLease.registerTransitionGate({
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      oldSettlementCount += 1;
+      return Promise.resolve(true);
+    },
+  });
+  const guardedOldRecoveryGate = getRequiredMapValue(
+    recoveryGates,
+    oldOwner,
+    "old recovery gate",
+  );
+  const guardedOldTransitionGate = getRequiredMapValue(
+    transitionGates,
+    oldOwner,
+    "old transition gate",
+  );
+  assert.equal(oldLease.requestActivation(), "activated");
+  assert.equal(oldInitializationCount, 1);
+
+  registration.unmount(oldOwner);
+  activation.cancelActivationRequest(oldOwner);
+  activation.releaseActivation(oldOwner);
+  const newOwner = registration.mount((): boolean => {
+    newInitializationCount += 1;
+    return true;
+  });
+  const newLease = createTableEditorActivationLease(registration, newOwner, context);
+  assert.equal(newLease.requestActivation(), "activated");
+  assert.equal(newInitializationCount, 1);
+  const forwardedBeforeStaleCalls = [...forwardedOperations];
+
+  assert.equal(oldLease.requestActivation(), "denied");
+  assert.throws(
+    (): void => oldLease.prepareActivationRelease(),
+    /stale table editor activation lease/,
+  );
+  oldLease.cancelActivationRelease();
+  oldLease.cancelActivationRequest();
+  assert.equal(oldLease.releaseActivation(), false);
+  assert.throws(
+    (): void => {
+      oldLease.registerRecoveryGate({
+        ownsAdjustment: (): boolean => true,
+        recoverAdjustment: (): Promise<void> => Promise.resolve(),
+      });
+    },
+    /stale table editor activation lease/,
+  );
+  assert.throws(
+    (): void => {
+      oldLease.registerTransitionGate({
+        isLifecycleUnresolved: (): boolean => true,
+        settleLifecycle: (): Promise<boolean> => Promise.resolve(true),
+      });
+    },
+    /stale table editor activation lease/,
+  );
+  assert.deepEqual(forwardedOperations, forwardedBeforeStaleCalls);
+  assert.equal(guardedOldRecoveryGate.ownsAdjustment("adjustment-1"), false);
+  await guardedOldRecoveryGate.recoverAdjustment("adjustment-1");
+  assert.equal(guardedOldTransitionGate.isLifecycleUnresolved(), false);
+  assert.equal(await guardedOldTransitionGate.settleLifecycle(), true);
+  assert.equal(oldRecoveryCount, 0);
+  assert.equal(oldSettlementCount, 0);
+  assert.equal(activation.getActiveOwner(), newOwner);
+
+  newLease.registerRecoveryGate({
+    ownsAdjustment: (): boolean => true,
+    recoverAdjustment: (): Promise<void> => {
+      newRecoveryCount += 1;
+      return Promise.resolve();
+    },
+  });
+  newLease.registerTransitionGate({
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      newSettlementCount += 1;
+      return Promise.resolve(true);
+    },
+  });
+  const guardedNewRecoveryGate = getRequiredMapValue(
+    recoveryGates,
+    newOwner,
+    "new recovery gate",
+  );
+  const guardedNewTransitionGate = getRequiredMapValue(
+    transitionGates,
+    newOwner,
+    "new transition gate",
+  );
+  assert.equal(guardedNewRecoveryGate.ownsAdjustment("adjustment-1"), true);
+  await guardedNewRecoveryGate.recoverAdjustment("adjustment-1");
+  assert.equal(guardedNewTransitionGate.isLifecycleUnresolved(), true);
+  assert.equal(await guardedNewTransitionGate.settleLifecycle(), true);
+  assert.equal(newRecoveryCount, 1);
+  assert.equal(newSettlementCount, 1);
+  newLease.prepareActivationRelease();
+  newLease.cancelActivationRelease();
+  newLease.cancelActivationRequest();
+  assert.equal(newLease.releaseActivation(), false);
+  assert.equal(activation.getActiveOwner(), null);
+});
+
+test("queued initialization uses only the latest committed initializer", (): void => {
+  const calls: Array<string> = [];
+  const registration = createTableEditorRegistration(DESTINATION_EDITOR_ID);
+  const owner = registration.mount((): boolean => {
+    calls.push("first-committed");
+    return true;
+  });
+  const uncommittedCandidate = (): boolean => {
+    calls.push("discarded");
+    return true;
+  };
+  void uncommittedCandidate;
+
+  assert.equal(registration.initializeLatest(owner), true);
+  registration.updateInitializer(owner, (): boolean => {
+    calls.push("latest-committed");
+    return true;
+  });
+  assert.equal(registration.initializeLatest(owner), true);
+  assert.deepEqual(calls, ["first-committed", "latest-committed"]);
+});
+
+test("strict-style remount creates a usable new generation", (): void => {
+  let initializationCount = 0;
+  const registration = createTableEditorRegistration(SOURCE_EDITOR_ID);
+  const oldOwner = registration.mount((): boolean => {
+    initializationCount += 1;
+    return true;
+  });
+  registration.unmount(oldOwner);
+  const newOwner = registration.mount((): boolean => {
+    initializationCount += 1;
+    return true;
+  });
+
+  assert.notEqual(newOwner.generation, oldOwner.generation);
+  assert.equal(registration.initializeLatest(oldOwner), false);
+  assert.equal(registration.initializeLatest(newOwner), true);
+  assert.equal(initializationCount, 1);
+});
+
+test("synchronous unresolved-lifecycle failure cancels the prepared transfer", async (): Promise<void> => {
+  const expectedError = new Error("Unresolved lifecycle check failed");
+  const {
+    activation,
+    sourceOwner,
+    activatedDestinationIds,
+  } = createQueuedActivationScenario();
+  const coordinator = createTransitionCoordinator(activation);
+  coordinator.registerTransitionGate(sourceOwner, {
+    isLifecycleUnresolved: (): boolean => {
+      throw expectedError;
+    },
+    settleLifecycle: (): Promise<boolean> => Promise.resolve(true),
+  });
+
+  const rejection = await getRejection(coordinator.requestEditorTransition());
+
+  assert.equal(rejection, expectedError);
+  assert.equal(activation.getActiveOwner(), sourceOwner);
+  assert.equal(activation.releaseActivation(sourceOwner), false);
+  assert.deepEqual(activatedDestinationIds, []);
+});
+
+test("synchronous settlement failure cancels the prepared transfer", async (): Promise<void> => {
+  const expectedError = new Error("Lifecycle settlement failed synchronously");
+  const {
+    activation,
+    sourceOwner,
+    activatedDestinationIds,
+  } = createQueuedActivationScenario();
+  const coordinator = createTransitionCoordinator(activation);
+  const gate: TableEditorTransitionGate = {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => {
+      throw expectedError;
+    },
+  };
+  coordinator.registerTransitionGate(sourceOwner, gate);
+
+  const rejection = await getRejection(coordinator.requestEditorTransition());
+
+  assert.equal(rejection, expectedError);
+  assert.equal(activation.getActiveOwner(), sourceOwner);
+  assert.equal(activation.releaseActivation(sourceOwner), false);
+  assert.deepEqual(activatedDestinationIds, []);
+});
+
+test("rejected settlement cancels the prepared transfer", async (): Promise<void> => {
+  const expectedError = new Error("Lifecycle settlement rejected");
+  const {
+    activation,
+    sourceOwner,
+    activatedDestinationIds,
+  } = createQueuedActivationScenario();
+  const coordinator = createTransitionCoordinator(activation);
+  coordinator.registerTransitionGate(sourceOwner, {
+    isLifecycleUnresolved: (): boolean => true,
+    settleLifecycle: (): Promise<boolean> => Promise.reject(expectedError),
+  });
+
+  const rejection = await getRejection(coordinator.requestEditorTransition());
+
+  assert.equal(rejection, expectedError);
+  assert.equal(activation.getActiveOwner(), sourceOwner);
+  assert.equal(activation.releaseActivation(sourceOwner), false);
+  assert.deepEqual(activatedDestinationIds, []);
+});

--- a/apps/web/src/ui/tables/shared/TableEditorActivationProvider.tsx
+++ b/apps/web/src/ui/tables/shared/TableEditorActivationProvider.tsx
@@ -6,14 +6,378 @@ import {
   type ReactNode,
   useCallback,
   useContext,
-  useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 
+type TableEditorActivationRequestOutcome = "activated" | "queued" | "denied";
+
+type TableEditorGeneration = Readonly<{
+  token: symbol;
+}>;
+
+type TableEditorOwner = Readonly<{
+  editorId: string;
+  generation: TableEditorGeneration;
+}>;
+
+type QueuedTableEditorActivation = Readonly<{
+  owner: TableEditorOwner;
+  activate: () => void;
+}>;
+
+type TableEditorRecoveryGate = Readonly<{
+  ownsAdjustment: (adjustmentId: string) => boolean;
+  recoverAdjustment: (adjustmentId: string) => Promise<void>;
+}>;
+
+export type TableEditorTransitionGate = Readonly<{
+  isLifecycleUnresolved: () => boolean;
+  settleLifecycle: () => Promise<boolean>;
+}>;
+
+type TableEditorRegistration = Readonly<{
+  mount: (initializeEditor: () => boolean) => TableEditorOwner;
+  updateInitializer: (
+    owner: TableEditorOwner,
+    initializeEditor: () => boolean,
+  ) => void;
+  unmount: (owner: TableEditorOwner) => void;
+  isLive: (owner: TableEditorOwner) => boolean;
+  getLiveOwner: () => TableEditorOwner | null;
+  initializeLatest: (owner: TableEditorOwner) => boolean;
+  guardRecoveryGate: (
+    owner: TableEditorOwner,
+    gate: TableEditorRecoveryGate,
+  ) => TableEditorRecoveryGate;
+  guardTransitionGate: (
+    owner: TableEditorOwner,
+    gate: TableEditorTransitionGate,
+  ) => TableEditorTransitionGate;
+}>;
+
+export const createTableEditorRegistration = (
+  editorId: string,
+): TableEditorRegistration => {
+  let liveOwner: TableEditorOwner | null = null;
+  let latestInitializer: (() => boolean) | null = null;
+
+  const ownsLiveGeneration = (owner: TableEditorOwner): boolean => (
+    liveOwner !== null
+    && liveOwner.editorId === owner.editorId
+    && liveOwner.generation === owner.generation
+  );
+  const mount = (initializeEditor: () => boolean): TableEditorOwner => {
+    if (liveOwner !== null) {
+      throw new Error(`Cannot mount live table editor registration "${editorId}" twice`);
+    }
+    const owner: TableEditorOwner = {
+      editorId,
+      generation: { token: Symbol(editorId) },
+    };
+    liveOwner = owner;
+    latestInitializer = initializeEditor;
+    return owner;
+  };
+  const updateInitializer = (
+    owner: TableEditorOwner,
+    initializeEditor: () => boolean,
+  ): void => {
+    if (!ownsLiveGeneration(owner)) return;
+    latestInitializer = initializeEditor;
+  };
+  const unmount = (owner: TableEditorOwner): void => {
+    if (!ownsLiveGeneration(owner)) return;
+    liveOwner = null;
+    latestInitializer = null;
+  };
+  const getLiveOwner = (): TableEditorOwner | null => liveOwner;
+  const initializeLatest = (owner: TableEditorOwner): boolean => (
+    ownsLiveGeneration(owner)
+    && latestInitializer !== null
+    && latestInitializer()
+  );
+  const guardRecoveryGate = (
+    owner: TableEditorOwner,
+    gate: TableEditorRecoveryGate,
+  ): TableEditorRecoveryGate => ({
+    ownsAdjustment: (adjustmentId): boolean => (
+      ownsLiveGeneration(owner) && gate.ownsAdjustment(adjustmentId)
+    ),
+    recoverAdjustment: (adjustmentId): Promise<void> => (
+      ownsLiveGeneration(owner)
+        ? gate.recoverAdjustment(adjustmentId)
+        : Promise.resolve()
+    ),
+  });
+  const guardTransitionGate = (
+    owner: TableEditorOwner,
+    gate: TableEditorTransitionGate,
+  ): TableEditorTransitionGate => ({
+    isLifecycleUnresolved: (): boolean => (
+      ownsLiveGeneration(owner) && gate.isLifecycleUnresolved()
+    ),
+    settleLifecycle: (): Promise<boolean> => (
+      ownsLiveGeneration(owner)
+        ? gate.settleLifecycle()
+        : Promise.resolve(true)
+    ),
+  });
+
+  return {
+    mount,
+    updateInitializer,
+    unmount,
+    isLive: ownsLiveGeneration,
+    getLiveOwner,
+    initializeLatest,
+    guardRecoveryGate,
+    guardTransitionGate,
+  };
+};
+
+type RegisteredTableEditorTransitionGate = Readonly<{
+  owner: TableEditorOwner;
+  gate: TableEditorTransitionGate;
+}>;
+
+type TableEditorActivationCoordinator = Readonly<{
+  getActiveOwner: () => TableEditorOwner | null;
+  requestActivation: (
+    owner: TableEditorOwner,
+    activateWhenAvailable: () => void,
+  ) => TableEditorActivationRequestOutcome;
+  prepareActivationRelease: (owner: TableEditorOwner) => void;
+  cancelActivationRelease: (owner: TableEditorOwner) => void;
+  cancelActivationRequest: (owner: TableEditorOwner) => void;
+  releaseActivation: (owner: TableEditorOwner) => boolean;
+  beginTransition: () => void;
+  commitTransition: () => void;
+  cancelTransition: () => void;
+}>;
+
+export const createTableEditorActivationCoordinator = (): TableEditorActivationCoordinator => {
+  let activeOwner: TableEditorOwner | null = null;
+  let releasingOwner: TableEditorOwner | null = null;
+  let queuedActivation: QueuedTableEditorActivation | null = null;
+  let transitionActive = false;
+  let deferredReleaseOwner: TableEditorOwner | null = null;
+
+  const ownersMatch = (
+    firstOwner: TableEditorOwner | null,
+    secondOwner: TableEditorOwner,
+  ): boolean => (
+    firstOwner !== null
+    && firstOwner.editorId === secondOwner.editorId
+    && firstOwner.generation === secondOwner.generation
+  );
+  const getActiveOwner = (): TableEditorOwner | null => activeOwner;
+
+  const requestActivation = (
+    owner: TableEditorOwner,
+    activateWhenAvailable: () => void,
+  ): TableEditorActivationRequestOutcome => {
+    if (
+      ownersMatch(activeOwner, owner)
+      && (ownersMatch(releasingOwner, owner) || ownersMatch(deferredReleaseOwner, owner))
+    ) {
+      return "denied";
+    }
+    if (activeOwner !== null && !ownersMatch(activeOwner, owner)) {
+      if (!ownersMatch(releasingOwner, activeOwner)) return "denied";
+      queuedActivation = { owner, activate: activateWhenAvailable };
+      return "queued";
+    }
+    activeOwner = owner;
+    return "activated";
+  };
+
+  const prepareActivationRelease = (owner: TableEditorOwner): void => {
+    if (activeOwner === null) {
+      activeOwner = owner;
+    } else if (!ownersMatch(activeOwner, owner)) {
+      throw new Error(`Cannot prepare inactive table editor "${owner.editorId}" for release`);
+    }
+    releasingOwner = owner;
+  };
+
+  const cancelActivationRelease = (owner: TableEditorOwner): void => {
+    if (!ownersMatch(releasingOwner, owner)) return;
+    releasingOwner = null;
+    queuedActivation = null;
+  };
+
+  const cancelActivationRequest = (owner: TableEditorOwner): void => {
+    if (
+      queuedActivation !== null
+      && ownersMatch(queuedActivation.owner, owner)
+    ) {
+      queuedActivation = null;
+    }
+  };
+
+  const completeRelease = (
+    owner: TableEditorOwner,
+    activateQueuedEditor: boolean,
+  ): boolean => {
+    if (!ownersMatch(activeOwner, owner)) return false;
+    activeOwner = null;
+    releasingOwner = null;
+    const activation = queuedActivation;
+    queuedActivation = null;
+    if (!activateQueuedEditor || activation === null) return false;
+    activeOwner = activation.owner;
+    activation.activate();
+    return true;
+  };
+
+  const releaseActivation = (owner: TableEditorOwner): boolean => {
+    if (!ownersMatch(activeOwner, owner)) return false;
+    if (transitionActive) {
+      releasingOwner = owner;
+      deferredReleaseOwner = owner;
+      return queuedActivation !== null;
+    }
+    return completeRelease(owner, true);
+  };
+
+  const beginTransition = (): void => {
+    if (transitionActive) {
+      throw new Error("Cannot begin a table editor transition while another transition is active");
+    }
+    transitionActive = true;
+    deferredReleaseOwner = null;
+  };
+
+  const commitTransition = (): void => {
+    if (!transitionActive) {
+      throw new Error("Cannot commit a table editor transition that is not active");
+    }
+    transitionActive = false;
+    const releasedOwner = deferredReleaseOwner;
+    deferredReleaseOwner = null;
+    if (releasedOwner !== null) {
+      completeRelease(releasedOwner, true);
+    }
+  };
+
+  const cancelTransition = (): void => {
+    if (!transitionActive) return;
+    transitionActive = false;
+    const releasedOwner = deferredReleaseOwner;
+    deferredReleaseOwner = null;
+    queuedActivation = null;
+    releasingOwner = null;
+    if (releasedOwner !== null && ownersMatch(activeOwner, releasedOwner)) {
+      activeOwner = null;
+    }
+  };
+
+  return {
+    getActiveOwner,
+    requestActivation,
+    prepareActivationRelease,
+    cancelActivationRelease,
+    cancelActivationRequest,
+    releaseActivation,
+    beginTransition,
+    commitTransition,
+    cancelTransition,
+  };
+};
+
+type TableEditorTransitionTransaction = Readonly<{
+  begin: () => void;
+  commit: () => void;
+  cancel: () => void;
+}>;
+
+type TableEditorTransitionCoordinator = Readonly<{
+  registerTransitionGate: (
+    owner: TableEditorOwner,
+    gate: TableEditorTransitionGate,
+  ) => () => void;
+  requestEditorTransition: () => Promise<boolean>;
+}>;
+
+export const createTableEditorTransitionCoordinator = (
+  transaction: TableEditorTransitionTransaction,
+): TableEditorTransitionCoordinator => {
+  const transitionGates = new Map<TableEditorOwner, TableEditorTransitionGate>();
+  let activeTransitionRequest: Promise<boolean> | null = null;
+
+  const registerTransitionGate = (
+    owner: TableEditorOwner,
+    gate: TableEditorTransitionGate,
+  ): (() => void) => {
+    transitionGates.set(owner, gate);
+    return (): void => {
+      if (transitionGates.get(owner) === gate) {
+        transitionGates.delete(owner);
+      }
+    };
+  };
+
+  const requestEditorTransition = (): Promise<boolean> => {
+    if (activeTransitionRequest !== null) return activeTransitionRequest;
+
+    transaction.begin();
+    let request: Promise<boolean>;
+    request = Promise.resolve()
+      .then((): ReadonlyArray<RegisteredTableEditorTransitionGate> => (
+        Array.from(transitionGates, ([owner, gate]) => ({ owner, gate }))
+          .filter(({ gate }) => gate.isLifecycleUnresolved())
+      ))
+      .then((unresolvedGates): Promise<ReadonlyArray<boolean>> => (
+        Promise.all(unresolvedGates.map(({ gate }) => gate.settleLifecycle()))
+      ))
+      .then((settledLifecycles): boolean => {
+        const settled = settledLifecycles.every(Boolean);
+        if (settled) {
+          transaction.commit();
+        } else {
+          transaction.cancel();
+        }
+        return settled;
+      })
+      .catch((error: unknown): never => {
+        transaction.cancel();
+        throw error;
+      })
+      .finally((): void => {
+        if (activeTransitionRequest === request) {
+          activeTransitionRequest = null;
+        }
+      });
+    activeTransitionRequest = request;
+    return request;
+  };
+
+  return { registerTransitionGate, requestEditorTransition };
+};
+
 type TableEditorActivationContextValue = Readonly<{
-  requestActivation: (editorId: string) => boolean;
-  releaseActivation: (editorId: string) => void;
+  requestActivation: (
+    owner: TableEditorOwner,
+    activateWhenAvailable: () => void,
+  ) => TableEditorActivationRequestOutcome;
+  prepareActivationRelease: (owner: TableEditorOwner) => void;
+  cancelActivationRelease: (owner: TableEditorOwner) => void;
+  cancelActivationRequest: (owner: TableEditorOwner) => void;
+  releaseActivation: (owner: TableEditorOwner) => boolean;
+  registerRecoveryGate: (
+    owner: TableEditorOwner,
+    gate: TableEditorRecoveryGate,
+  ) => () => void;
+  requestRecoveryGate: (adjustmentId: string) => Promise<boolean>;
+  pendingRecoveryGateAdjustmentIds: ReadonlySet<string>;
+  registerTransitionGate: (
+    owner: TableEditorOwner,
+    gate: TableEditorTransitionGate,
+  ) => () => void;
+  requestEditorTransition: () => Promise<boolean>;
 }>;
 
 const TableEditorActivationContext = createContext<TableEditorActivationContextValue | null>(null);
@@ -23,24 +387,101 @@ type ProviderProps = Readonly<{
 }>;
 
 export const TableEditorActivationProvider = (props: ProviderProps): ReactElement => {
-  const activeEditorIdRef = useRef<string | null>(null);
+  const activationCoordinator = useMemo(
+    (): TableEditorActivationCoordinator => createTableEditorActivationCoordinator(),
+    [],
+  );
+  const recoveryGatesRef = useRef<Map<TableEditorOwner, TableEditorRecoveryGate>>(new Map());
+  const recoveryRequestsRef = useRef<Map<string, Promise<boolean>>>(new Map());
+  const [
+    pendingRecoveryGateAdjustmentIds,
+    setPendingRecoveryGateAdjustmentIds,
+  ] = useState<ReadonlySet<string>>(new Set());
 
-  const requestActivation = useCallback((editorId: string): boolean => {
-    const activeEditorId = activeEditorIdRef.current;
-    if (activeEditorId !== null && activeEditorId !== editorId) return false;
-    activeEditorIdRef.current = editorId;
-    return true;
+  const registerRecoveryGate = useCallback((
+    owner: TableEditorOwner,
+    gate: TableEditorRecoveryGate,
+  ): (() => void) => {
+    recoveryGatesRef.current.set(owner, gate);
+    return (): void => {
+      if (recoveryGatesRef.current.get(owner) === gate) {
+        recoveryGatesRef.current.delete(owner);
+      }
+    };
   }, []);
 
-  const releaseActivation = useCallback((editorId: string): void => {
-    if (activeEditorIdRef.current === editorId) {
-      activeEditorIdRef.current = null;
+  const requestRecoveryGate = useCallback((
+    adjustmentId: string,
+  ): Promise<boolean> => {
+    const activeRequest = recoveryRequestsRef.current.get(adjustmentId);
+    if (activeRequest !== undefined) return activeRequest;
+
+    const activeOwner = activationCoordinator.getActiveOwner();
+    const activeGate = activeOwner === null
+      ? undefined
+      : recoveryGatesRef.current.get(activeOwner);
+    let recoveryGate = activeGate !== undefined
+      && activeGate.ownsAdjustment(adjustmentId)
+      ? activeGate
+      : null;
+
+    if (recoveryGate === null) {
+      for (const [owner, gate] of recoveryGatesRef.current) {
+        if (owner === activeOwner || !gate.ownsAdjustment(adjustmentId)) continue;
+        recoveryGate = gate;
+        break;
+      }
     }
-  }, []);
+    if (recoveryGate === null) return Promise.resolve(false);
+
+    const request = recoveryGate.recoverAdjustment(adjustmentId)
+      .then((): boolean => true)
+      .finally((): void => {
+        if (recoveryRequestsRef.current.get(adjustmentId) !== request) return;
+        recoveryRequestsRef.current.delete(adjustmentId);
+        setPendingRecoveryGateAdjustmentIds((currentIds): ReadonlySet<string> => {
+          const nextIds = new Set(currentIds);
+          nextIds.delete(adjustmentId);
+          return nextIds;
+        });
+      });
+    recoveryRequestsRef.current.set(adjustmentId, request);
+    setPendingRecoveryGateAdjustmentIds((currentIds): ReadonlySet<string> =>
+      new Set([...currentIds, adjustmentId]));
+    return request;
+  }, [activationCoordinator]);
+
+  const transitionCoordinator = useMemo(
+    (): TableEditorTransitionCoordinator => (
+      createTableEditorTransitionCoordinator({
+        begin: activationCoordinator.beginTransition,
+        commit: activationCoordinator.commitTransition,
+        cancel: activationCoordinator.cancelTransition,
+      })
+    ),
+    [activationCoordinator],
+  );
 
   const value = useMemo<TableEditorActivationContextValue>(
-    () => ({ requestActivation, releaseActivation }),
-    [releaseActivation, requestActivation],
+    () => ({
+      requestActivation: activationCoordinator.requestActivation,
+      prepareActivationRelease: activationCoordinator.prepareActivationRelease,
+      cancelActivationRelease: activationCoordinator.cancelActivationRelease,
+      cancelActivationRequest: activationCoordinator.cancelActivationRequest,
+      releaseActivation: activationCoordinator.releaseActivation,
+      registerRecoveryGate,
+      requestRecoveryGate,
+      pendingRecoveryGateAdjustmentIds,
+      registerTransitionGate: transitionCoordinator.registerTransitionGate,
+      requestEditorTransition: transitionCoordinator.requestEditorTransition,
+    }),
+    [
+      activationCoordinator,
+      pendingRecoveryGateAdjustmentIds,
+      registerRecoveryGate,
+      requestRecoveryGate,
+      transitionCoordinator,
+    ],
   );
 
   return (
@@ -51,26 +492,202 @@ export const TableEditorActivationProvider = (props: ProviderProps): ReactElemen
 };
 
 type TableEditorActivation = Readonly<{
-  requestActivation: () => boolean;
-  releaseActivation: () => void;
+  requestActivation: () => TableEditorActivationRequestOutcome;
+  prepareActivationRelease: () => void;
+  cancelActivationRelease: () => void;
+  cancelActivationRequest: () => void;
+  releaseActivation: () => boolean;
+  registerRecoveryGate: (gate: TableEditorRecoveryGate) => () => void;
+  registerTransitionGate: (gate: TableEditorTransitionGate) => () => void;
 }>;
 
-export const useTableEditorActivation = (editorId: string): TableEditorActivation => {
+type TableEditorActivationLeaseContext = Readonly<Pick<
+  TableEditorActivationContextValue,
+  | "requestActivation"
+  | "prepareActivationRelease"
+  | "cancelActivationRelease"
+  | "cancelActivationRequest"
+  | "releaseActivation"
+  | "registerRecoveryGate"
+  | "registerTransitionGate"
+>>;
+
+export const createTableEditorActivationLease = (
+  registration: TableEditorRegistration,
+  owner: TableEditorOwner,
+  context: TableEditorActivationLeaseContext,
+): TableEditorActivation => {
+  const requireLiveLease = (operation: string): void => {
+    if (registration.isLive(owner)) return;
+    throw new Error(
+      `Cannot ${operation} with a stale table editor activation lease "${owner.editorId}"`,
+    );
+  };
+  const requestActivation = (): TableEditorActivationRequestOutcome => {
+    if (!registration.isLive(owner)) return "denied";
+    const initializeLatestEditor = (): void => {
+      try {
+        if (registration.initializeLatest(owner)) return;
+      } catch (error: unknown) {
+        context.releaseActivation(owner);
+        throw error;
+      }
+      context.releaseActivation(owner);
+    };
+    const outcome = context.requestActivation(owner, initializeLatestEditor);
+    if (outcome === "activated") initializeLatestEditor();
+    return outcome;
+  };
+  const prepareActivationRelease = (): void => {
+    requireLiveLease("prepare activation release");
+    context.prepareActivationRelease(owner);
+  };
+  const cancelActivationRelease = (): void => {
+    if (!registration.isLive(owner)) return;
+    context.cancelActivationRelease(owner);
+  };
+  const cancelActivationRequest = (): void => {
+    if (!registration.isLive(owner)) return;
+    context.cancelActivationRequest(owner);
+  };
+  const releaseActivation = (): boolean => (
+    registration.isLive(owner) && context.releaseActivation(owner)
+  );
+  const registerRecoveryGate = (
+    gate: TableEditorRecoveryGate,
+  ): (() => void) => {
+    requireLiveLease("register a recovery gate");
+    return context.registerRecoveryGate(
+      owner,
+      registration.guardRecoveryGate(owner, gate),
+    );
+  };
+  const registerTransitionGate = (
+    gate: TableEditorTransitionGate,
+  ): (() => void) => {
+    requireLiveLease("register a transition gate");
+    return context.registerTransitionGate(
+      owner,
+      registration.guardTransitionGate(owner, gate),
+    );
+  };
+
+  return {
+    requestActivation,
+    prepareActivationRelease,
+    cancelActivationRelease,
+    cancelActivationRequest,
+    releaseActivation,
+    registerRecoveryGate,
+    registerTransitionGate,
+  };
+};
+
+const createPendingTableEditorActivation = (
+  editorId: string,
+): TableEditorActivation => {
+  const rejectPendingOperation = (operation: string): never => {
+    throw new Error(
+      `Cannot ${operation} before table editor "${editorId}" has a committed activation lease`,
+    );
+  };
+  return {
+    requestActivation: (): TableEditorActivationRequestOutcome => "denied",
+    prepareActivationRelease: (): void => {
+      rejectPendingOperation("prepare activation release");
+    },
+    cancelActivationRelease: (): void => {},
+    cancelActivationRequest: (): void => {},
+    releaseActivation: (): boolean => false,
+    registerRecoveryGate: (): (() => void) => (): void => {},
+    registerTransitionGate: (): (() => void) => (): void => {},
+  };
+};
+
+export const useTableEditorActivation = (
+  editorId: string,
+  initializeEditor: () => boolean,
+): TableEditorActivation => {
   const context = useContext(TableEditorActivationContext);
   if (context === null) {
     throw new Error("useTableEditorActivation must be used within TableEditorActivationProvider");
   }
 
-  const requestActivation = useCallback(
-    (): boolean => context.requestActivation(editorId),
-    [context, editorId],
+  const registration = useMemo(
+    (): TableEditorRegistration => createTableEditorRegistration(editorId),
+    [editorId],
   );
-  const releaseActivation = useCallback(
-    (): void => context.releaseActivation(editorId),
-    [context, editorId],
+  const pendingActivation = useMemo(
+    (): TableEditorActivation => createPendingTableEditorActivation(editorId),
+    [editorId],
   );
+  const [activationLease, setActivationLease] = useState<TableEditorActivation | null>(null);
 
-  useEffect(() => releaseActivation, [releaseActivation]);
+  useLayoutEffect(() => {
+    const owner = registration.mount(initializeEditor);
+    const lease = createTableEditorActivationLease(registration, owner, {
+      requestActivation: context.requestActivation,
+      prepareActivationRelease: context.prepareActivationRelease,
+      cancelActivationRelease: context.cancelActivationRelease,
+      cancelActivationRequest: context.cancelActivationRequest,
+      releaseActivation: context.releaseActivation,
+      registerRecoveryGate: context.registerRecoveryGate,
+      registerTransitionGate: context.registerTransitionGate,
+    });
+    setActivationLease(lease);
+    return (): void => {
+      registration.unmount(owner);
+      setActivationLease((currentLease): TableEditorActivation | null => (
+        currentLease === lease ? null : currentLease
+      ));
+      context.cancelActivationRequest(owner);
+      context.releaseActivation(owner);
+    };
+  }, [
+    context.cancelActivationRelease,
+    context.cancelActivationRequest,
+    context.prepareActivationRelease,
+    context.registerRecoveryGate,
+    context.registerTransitionGate,
+    context.releaseActivation,
+    context.requestActivation,
+    registration,
+  ]);
+  useLayoutEffect((): void => {
+    const owner = registration.getLiveOwner();
+    if (owner === null) {
+      throw new Error(`Cannot update initializer for unmounted table editor "${editorId}"`);
+    }
+    registration.updateInitializer(owner, initializeEditor);
+  });
 
-  return { requestActivation, releaseActivation };
+  return activationLease ?? pendingActivation;
+};
+
+type TableEditorRecovery = Readonly<{
+  requestRecoveryGate: (adjustmentId: string) => Promise<boolean>;
+  pendingRecoveryGateAdjustmentIds: ReadonlySet<string>;
+}>;
+
+export const useTableEditorRecoveryGate = (): TableEditorRecovery => {
+  const context = useContext(TableEditorActivationContext);
+  if (context === null) {
+    throw new Error("useTableEditorRecoveryGate must be used within TableEditorActivationProvider");
+  }
+  return {
+    requestRecoveryGate: context.requestRecoveryGate,
+    pendingRecoveryGateAdjustmentIds: context.pendingRecoveryGateAdjustmentIds,
+  };
+};
+
+type TableEditorTransition = Readonly<{
+  requestEditorTransition: () => Promise<boolean>;
+}>;
+
+export const useTableEditorTransition = (): TableEditorTransition => {
+  const context = useContext(TableEditorActivationContext);
+  if (context === null) {
+    throw new Error("useTableEditorTransition must be used within TableEditorActivationProvider");
+  }
+  return { requestEditorTransition: context.requestEditorTransition };
 };


### PR DESCRIPTION
Adds generation-safe shared table-editor activation and transactional lifecycle gates, integrates EditableAmount and the legacy BudgetPlanCell, and adds focused provider and Playwright coverage. Validation: provider tests 16/16, Playwright 3/3, npm run lint, npm run build, and git diff --check.