### PR TITLE
Add budget Base acknowledgement reconciliation

### DIFF
--- a/apps/web/e2e-local/budget-adjustments.local-demo.spec.ts
+++ b/apps/web/e2e-local/budget-adjustments.local-demo.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Page, type Response } from "@playwright/test";
+
+import type { BudgetGridResult, BudgetRow } from "@/server/budget/getBudgetGrid";
 
 type CreatedAdjustment = Readonly<{
   adjustmentId: string;
@@ -8,6 +10,21 @@ type CreatedAdjustment = Readonly<{
   amount: number;
   note: string | null;
 }>;
+
+type Deferred = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+}>;
+
+const createDeferred = (): Deferred => {
+  let resolvePromise = (): void => {
+    throw new Error("Deferred resolver was used before initialization");
+  };
+  const promise = new Promise<void>((resolve): void => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+};
 
 const setDemoCookies = async (
   page: Page,
@@ -41,6 +58,66 @@ const getEditorId = async (
     throw new Error(`${category} budget plan trigger is missing its stable test ID`);
   }
   return testId.slice("budget-plan-open-".length);
+};
+
+const requestMainContentRefresh = async (
+  page: Page,
+  version: number,
+): Promise<void> => {
+  await page.evaluate((nextVersion): void => {
+    const channel = new BroadcastChannel("expense-tracker-main-content-invalidation");
+    channel.postMessage({
+      type: "main_content_invalidation",
+      workspaceId: "",
+      version: nextVersion,
+      sourceId: "budget-base-e2e",
+      emittedAt: Date.now(),
+    });
+    channel.close();
+  }, version);
+};
+
+const isBudgetGridRangeResponse = (
+  response: Response,
+  monthFrom: string,
+  monthTo: string,
+): boolean => {
+  const url = new URL(response.url());
+  return url.pathname === "/api/budget-grid"
+    && url.searchParams.get("monthFrom") === monthFrom
+    && url.searchParams.get("monthTo") === monthTo
+    && response.request().method() === "GET";
+};
+
+const delayFirstBudgetBaseSave = async (
+  page: Page,
+): Promise<Readonly<{
+  captured: Promise<void>;
+  release: () => void;
+}>> => {
+  const captured = createDeferred();
+  const gate = createDeferred();
+  let requestDelayed = false;
+  await page.route("**/api/budget-plan", async (route): Promise<void> => {
+    const request = route.request();
+    if (
+      requestDelayed
+      || request.method() !== "POST"
+      || new URL(request.url()).pathname !== "/api/budget-plan"
+    ) {
+      await route.continue();
+      return;
+    }
+    requestDelayed = true;
+    const response = await route.fetch();
+    if (!response.ok()) {
+      throw new Error(`Delayed Base save failed with HTTP ${response.status()}`);
+    }
+    captured.resolve();
+    await gate.promise;
+    await route.fulfill({ response });
+  });
+  return { captured: captured.promise, release: gate.resolve };
 };
 
 test("creates, autosaves, moves, and deletes normalized adjustment rows", async ({ page, baseURL }) => {
@@ -229,6 +306,232 @@ test("creates, autosaves, moves, and deletes normalized adjustment rows", async 
   await page.keyboard.press("Escape");
   await page.getByTestId(`budget-plan-open-${diningEditorId}`).click();
   await expect(page.getByTestId(`budget-adjustment-add-${diningEditorId}`)).toBeFocused();
+});
+
+test("acknowledges the current Base after a stale response reopens its pending editor", async ({ page, baseURL }) => {
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+
+  const editorId = await getEditorId(page, "spend", "Groceries", 0);
+  const month = editorId.split(":")[1];
+  if (month === undefined) {
+    throw new Error(`Cannot read month from editor ID "${editorId}"`);
+  }
+  const openButton = page.getByTestId(`budget-plan-open-${editorId}`);
+  const baseInput = page.getByTestId(`budget-plan-base-input-${editorId}`);
+  const popover = page.getByTestId(`budget-plan-popover-${editorId}`);
+  await openButton.click();
+  const originalBase = Number(await baseInput.inputValue());
+  const originalPlanText = await openButton.textContent();
+  if (originalPlanText === null) {
+    throw new Error(`Cannot read plan button ${editorId}`);
+  }
+  await page.keyboard.press("Escape");
+  await expect(popover).toHaveCount(0);
+
+  const visibleMonthFrom = offsetMonth(month, -6);
+  const visibleMonthTo = offsetMonth(month, 12);
+  const staleRangeCaptured = createDeferred();
+  const staleRangeGate = createDeferred();
+  await page.route("**/api/budget-grid?*", async (route): Promise<void> => {
+    const url = new URL(route.request().url());
+    if (
+      url.searchParams.get("monthFrom") !== visibleMonthFrom
+      || url.searchParams.get("monthTo") !== visibleMonthTo
+    ) {
+      await route.continue();
+      return;
+    }
+    const response = await route.fetch();
+    staleRangeCaptured.resolve();
+    await staleRangeGate.promise;
+    await route.fulfill({ response });
+  });
+
+  const staleRangeResponse = page.waitForResponse((response): boolean => (
+    isBudgetGridRangeResponse(
+      response,
+      visibleMonthFrom,
+      visibleMonthTo,
+    )
+  ));
+  await requestMainContentRefresh(page, 1);
+  await staleRangeCaptured.promise;
+
+  const delayedBase = await delayFirstBudgetBaseSave(page);
+  const savedBase = originalBase + 211;
+  await openButton.click();
+  await baseInput.fill(String(savedBase));
+  await page.keyboard.press("Enter");
+  await delayedBase.captured;
+  await expect(popover).toHaveCount(0);
+  await expect(page.getByTestId("budget-sync-status")).toHaveCount(1);
+  await expect(openButton).not.toHaveText(originalPlanText);
+
+  staleRangeGate.resolve();
+  expect((await staleRangeResponse).ok()).toBe(true);
+  await expect(openButton).toHaveText(originalPlanText);
+  await openButton.click();
+  await expect(baseInput).toHaveValue(String(originalBase));
+
+  delayedBase.release();
+  await expect(page.getByTestId("budget-sync-status")).toHaveCount(0);
+  await page.keyboard.press("Escape");
+  await expect(popover).toHaveCount(0);
+  await openButton.click();
+  await expect(baseInput).toHaveValue(String(savedBase));
+});
+
+test("publishes successful Fill targets through captured range generations", async ({ page, baseURL }) => {
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+
+  const sourceEditorId = await getEditorId(page, "spend", "Groceries", 0);
+  const sourceMonth = sourceEditorId.split(":")[1];
+  if (sourceMonth === undefined) {
+    throw new Error(`Cannot read month from editor ID "${sourceEditorId}"`);
+  }
+  await page.getByTestId(`budget-plan-open-${sourceEditorId}`).click();
+  await page.keyboard.press("Escape");
+  await expect(
+    page.getByTestId(`budget-plan-popover-${sourceEditorId}`),
+  ).toHaveCount(0);
+  const targetMonth = offsetMonth(sourceMonth, 1);
+  const targetEditorId = `budget-plan:${targetMonth}:spend:Groceries`;
+  const targetOpenButton = page.getByTestId(`budget-plan-open-${targetEditorId}`);
+  const targetPlanCell = page.getByTestId(`budget-plan-cell-${targetEditorId}`);
+  const delayedBase = await delayFirstBudgetBaseSave(page);
+
+  await targetOpenButton.click();
+  const targetBaseInput = page.getByTestId(
+    `budget-plan-base-input-${targetEditorId}`,
+  );
+  const originalTargetBase = Number(await targetBaseInput.inputValue());
+  const pendingTargetBase = originalTargetBase + 73;
+  const filledBase = pendingTargetBase + 137;
+  await targetBaseInput.fill(String(pendingTargetBase));
+  await page.keyboard.press("Enter");
+  await delayedBase.captured;
+  await expect(
+    page.getByTestId(`budget-plan-popover-${targetEditorId}`),
+  ).toHaveCount(0);
+  await expect(page.getByTestId("budget-sync-status")).toHaveCount(1);
+
+  const visibleMonthFrom = offsetMonth(sourceMonth, -6);
+  const visibleMonthTo = offsetMonth(sourceMonth, 12);
+  const staleRangeCaptured = createDeferred();
+  const staleRangeGate = createDeferred();
+  let rangeRequestCount = 0;
+  await page.route("**/api/budget-grid?*", async (route): Promise<void> => {
+    const url = new URL(route.request().url());
+    if (
+      url.searchParams.get("monthFrom") !== visibleMonthFrom
+      || url.searchParams.get("monthTo") !== visibleMonthTo
+    ) {
+      await route.continue();
+      return;
+    }
+    const requestNumber = rangeRequestCount + 1;
+    rangeRequestCount = requestNumber;
+    const response = await route.fetch();
+    const result = await response.json() as BudgetGridResult;
+    if (requestNumber === 1) {
+      let targetMarked = false;
+      const rows = result.rows.map((row): BudgetRow => {
+        if (
+          row.month !== targetMonth
+          || row.direction !== "spend"
+          || row.category !== "Groceries"
+        ) {
+          return row;
+        }
+        targetMarked = true;
+        return {
+          ...row,
+          hasUnconvertible: !row.hasUnconvertible,
+        };
+      });
+      if (!targetMarked) {
+        throw new Error(
+          `Cannot mark target row ${targetMonth}/spend/Groceries`,
+        );
+      }
+      staleRangeCaptured.resolve();
+      await staleRangeGate.promise;
+      await route.fulfill({ response, json: { ...result, rows } });
+      return;
+    }
+    const rows = result.rows.map((row): BudgetRow => (
+      row.month === targetMonth
+        && row.direction === "spend"
+        && row.category === "Groceries"
+        ? {
+          ...row,
+          plannedBase: originalTargetBase,
+          planned: originalTargetBase + row.plannedModifier,
+        }
+        : row
+    ));
+    await route.fulfill({ response, json: { ...result, rows } });
+  });
+
+  const staleRangeResponse = page.waitForResponse((response): boolean => (
+    isBudgetGridRangeResponse(
+      response,
+      visibleMonthFrom,
+      visibleMonthTo,
+    )
+  ));
+  await requestMainContentRefresh(page, 1);
+  await staleRangeCaptured.promise;
+
+  await page.getByTestId(`budget-plan-open-${sourceEditorId}`).click();
+  const sourceBaseInput = page.getByTestId(
+    `budget-plan-base-input-${sourceEditorId}`,
+  );
+  await sourceBaseInput.fill(String(filledBase));
+  const acknowledgedFill = page.waitForResponse((response): boolean => (
+    response.url().endsWith("/api/budget-plan-fill")
+    && response.request().method() === "POST"
+    && response.ok()
+  ));
+  await page.getByTestId(`budget-plan-fill-${sourceEditorId}`).click();
+  expect((await acknowledgedFill).ok()).toBe(true);
+  delayedBase.release();
+  await expect(page.getByTestId("budget-sync-status")).toHaveCount(0);
+  const beforeStaleRangeClass = await targetPlanCell.getAttribute("class");
+  if (beforeStaleRangeClass === null) {
+    throw new Error(`Cannot read target cell ${targetEditorId}`);
+  }
+  staleRangeGate.resolve();
+  expect((await staleRangeResponse).ok()).toBe(true);
+  await expect(targetPlanCell).not.toHaveAttribute(
+    "class",
+    beforeStaleRangeClass,
+  );
+  const staleRangeClass = await targetPlanCell.getAttribute("class");
+  if (staleRangeClass === null) {
+    throw new Error(`Cannot read updated target cell ${targetEditorId}`);
+  }
+
+  await targetOpenButton.click();
+  await expect(targetBaseInput).toHaveValue(String(filledBase));
+  await page.keyboard.press("Escape");
+
+  const newerRangeResponse = page.waitForResponse((response): boolean => (
+    isBudgetGridRangeResponse(
+      response,
+      visibleMonthFrom,
+      visibleMonthTo,
+    )
+  ));
+  await requestMainContentRefresh(page, 2);
+  expect((await newerRangeResponse).ok()).toBe(true);
+  await expect(targetPlanCell).not.toHaveAttribute("class", staleRangeClass);
+  await targetOpenButton.click();
+  await expect(targetBaseInput).toHaveValue(String(originalTargetBase));
 });
 
 test("keeps the adjustment editor usable on mobile RTL", async ({ page, baseURL }) => {

--- a/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
@@ -16,6 +16,10 @@ import { useFormat } from "@/ui/FormatProvider";
 import { BudgetAdjustmentEditor } from "@/ui/tables/budget/BudgetAdjustmentEditor";
 import { isSuccessfulBudgetAdjustmentFlushOutcome } from "@/ui/tables/budget/budgetAdjustmentRecovery";
 import { isValidBudgetAdjustmentCategory } from "@/ui/tables/budget/budgetAdjustmentRowsState";
+import {
+  consumeBudgetBaseLocalAcknowledgement,
+  type BudgetBaseLocalAcknowledgement,
+} from "@/ui/tables/budget/budgetBaseRangeReconciliation";
 import { postBudgetPlan, postBudgetPlanFill } from "@/ui/tables/budget/budgetTableApi";
 import { formatAmount, isDecember } from "@/ui/tables/budget/budgetTableLogic";
 import styles from "@/ui/tables/budget/BudgetTable.module.css";
@@ -120,6 +124,7 @@ export type BudgetPlanCellProps = Readonly<{
   effectiveAllowlist: ReadonlySet<string> | null;
   currentMonth: string;
   plannedBase: number;
+  localBaseAcknowledgement: BudgetBaseLocalAcknowledgement | null;
   plannedModifier: number;
   planned: number;
   showData: boolean;
@@ -135,11 +140,30 @@ export type BudgetPlanCellProps = Readonly<{
     kind: "base" | "modifier",
     value: number,
   ) => void;
+  onBaseMutationIssued: (
+    month: string,
+    direction: string,
+    category: string,
+  ) => number;
   onFillMonths: (
     sourceMonth: string,
     direction: string,
     category: string,
     baseValue: number,
+  ) => number;
+  onBaseAcknowledged: (
+    month: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
+  ) => void;
+  onFillMonthsAcknowledged: (
+    sourceMonth: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
   ) => void;
   onSyncStart: () => void;
   onSyncEnd: () => void;
@@ -154,6 +178,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     effectiveAllowlist,
     currentMonth,
     plannedBase,
+    localBaseAcknowledgement,
     plannedModifier,
     planned,
     showData,
@@ -163,7 +188,10 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     cmClass,
     budgetAdjustments,
     onPlanSave,
+    onBaseMutationIssued,
     onFillMonths,
+    onBaseAcknowledged,
+    onFillMonthsAcknowledged,
     onSyncStart,
     onSyncEnd,
   } = props;
@@ -185,6 +213,8 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
   >(null);
   const originalBaseRef = useRef<number>(Math.round(plannedBase));
   const isOpenRef = useRef<boolean>(false);
+  const pendingBaseSaveCountRef = useRef<number>(0);
+  const consumedLocalBaseAcknowledgementVersionRef = useRef<number>(0);
   const interactedAdjustmentIdsRef = useRef<Set<string>>(new Set());
   const settleLifecycleRef = useRef<() => Promise<boolean>>(
     (): Promise<boolean> => Promise.resolve(true),
@@ -214,7 +244,17 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     const cell = cellRef.current;
     if (!showData || cell === null) return false;
 
-    const roundedBase = Math.round(plannedBase);
+    let roundedBase = Math.round(plannedBase);
+    if (pendingBaseSaveCountRef.current === 0) {
+      const consumed = consumeBudgetBaseLocalAcknowledgement(
+        roundedBase,
+        localBaseAcknowledgement,
+        consumedLocalBaseAcknowledgementVersionRef.current,
+      );
+      roundedBase = consumed.value;
+      consumedLocalBaseAcknowledgementVersionRef.current =
+        consumed.version;
+    }
     originalBaseRef.current = roundedBase;
     setBaseInput(String(roundedBase));
     setBaseValidationError(null);
@@ -327,8 +367,14 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
 
   const saveBase = useCallback((value: number): void => {
     if (value === originalBaseRef.current) return;
+    const mutationGeneration = onBaseMutationIssued(
+      month,
+      direction,
+      category,
+    );
     const previousBase = originalBaseRef.current;
     originalBaseRef.current = value;
+    pendingBaseSaveCountRef.current += 1;
     onSyncStart();
     onPlanSave(month, direction, category, "base", value);
     void postBudgetPlan({
@@ -338,16 +384,30 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       kind: "base",
       plannedValue: value,
     })
+      .then((): void => {
+        onBaseAcknowledged(
+          month,
+          direction,
+          category,
+          value,
+          mutationGeneration,
+        );
+      })
       .catch((error: unknown): void => {
         originalBaseRef.current = previousBase;
         onPlanSave(month, direction, category, "base", previousBase);
         logBudgetTableError(`save base for ${month}/${direction}/${category}`, error);
       })
-      .finally(onSyncEnd);
+      .finally((): void => {
+        pendingBaseSaveCountRef.current -= 1;
+        onSyncEnd();
+      });
   }, [
     category,
     direction,
     month,
+    onBaseAcknowledged,
+    onBaseMutationIssued,
     onPlanSave,
     onSyncEnd,
     onSyncStart,
@@ -488,14 +548,28 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       return;
     }
 
+    const mutationGeneration = onFillMonths(
+      month,
+      direction,
+      category,
+      parsedBase.value,
+    );
     onSyncStart();
-    onFillMonths(month, direction, category, parsedBase.value);
     void postBudgetPlanFill({
       fromMonth: month,
       direction,
       category,
       baseValue: parsedBase.value,
     })
+      .then((): void => {
+        onFillMonthsAcknowledged(
+          month,
+          direction,
+          category,
+          parsedBase.value,
+          mutationGeneration,
+        );
+      })
       .catch((error: unknown): void => {
         logBudgetTableError(`fill base from ${month}/${direction}/${category}`, error);
       })
@@ -511,6 +585,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     flushInteractedAdjustments,
     month,
     onFillMonths,
+    onFillMonthsAcknowledged,
     onSyncEnd,
     onSyncStart,
     parseAndReportBase,

--- a/apps/web/src/ui/tables/budget/BudgetTable.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetTable.tsx
@@ -51,7 +51,11 @@ export const BudgetTable = (props: BudgetTableProps): ReactElement => {
         <button className={styles.todayButton} type="button" onClick={controller.scrollToCurrentMonth}>
           {t("common.today")}
         </button>
-        {controller.pendingSaves > 0 && <span className={styles.syncStatus}>{t("common.syncing")}</span>}
+        {controller.pendingSaves > 0 && (
+          <span className={styles.syncStatus} data-testid="budget-sync-status">
+            {t("common.syncing")}
+          </span>
+        )}
       </div>
       <div className={styles.scroll} ref={controller.scrollRef}>
         <TableEditorActivationProvider>
@@ -68,6 +72,9 @@ export const BudgetTable = (props: BudgetTableProps): ReactElement => {
                   <BudgetDirectionSection
                     block={block}
                     effectiveAllowlist={controller.effectiveAllowlist}
+                    localBaseAcknowledgementByCell={
+                      controller.localBaseAcknowledgementByCell
+                    }
                     columnSequence={controller.columnSequence}
                     currentMonth={controller.currentMonth}
                     currentYear={controller.currentYear}
@@ -80,7 +87,14 @@ export const BudgetTable = (props: BudgetTableProps): ReactElement => {
                     copyToClipboard={copyToClipboard}
                     openDrillDown={controller.openDrillDown}
                     onPlanSave={controller.handlePlanSave}
+                    onBaseMutationIssued={
+                      controller.handleBaseMutationIssued
+                    }
                     onFillMonths={controller.handleFillMonths}
+                    onBaseAcknowledged={controller.handleBaseAcknowledged}
+                    onFillMonthsAcknowledged={
+                      controller.handleFillMonthsAcknowledged
+                    }
                     onSyncStart={controller.onSyncStart}
                     onSyncEnd={controller.onSyncEnd}
                   />

--- a/apps/web/src/ui/tables/budget/budgetBaseRangeReconciliation.test.ts
+++ b/apps/web/src/ui/tables/budget/budgetBaseRangeReconciliation.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BudgetRow } from "@/server/budget/getBudgetGrid";
+import { getTargetFillMonths } from "@/ui/tables/budget/budgetTableLogic";
+import {
+  consumeBudgetBaseLocalAcknowledgement,
+  getCurrentBudgetBaseMutationCells,
+  getBudgetBaseCellKey,
+  issueBudgetBaseMutation,
+  protectBudgetBaseAcknowledgement,
+  publishBudgetBaseLocalAcknowledgements,
+  reconcileBudgetBaseRange,
+  retainProtectedBudgetBaseLocalAcknowledgements,
+  type BudgetBaseAcknowledgementProtection,
+  type BudgetBaseCell,
+  type BudgetBaseProtectionByCell,
+} from "@/ui/tables/budget/budgetBaseRangeReconciliation";
+
+const makeRow = (
+  month: string,
+  plannedBase: number,
+): BudgetRow => ({
+  month,
+  direction: "spend",
+  category: "Groceries",
+  plannedBase,
+  plannedModifier: -10,
+  planned: plannedBase - 10,
+  actual: 20,
+  hasUnconvertible: false,
+});
+
+const protect = (
+  value: number,
+  throughRequestGeneration: number,
+): BudgetBaseProtectionByCell => {
+  const protection: BudgetBaseAcknowledgementProtection = {
+    cell: {
+      month: "2026-08",
+      direction: "spend",
+      category: "Groceries",
+    },
+    value,
+    throughRequestGeneration,
+  };
+  return protectBudgetBaseAcknowledgement(new Map(), protection);
+};
+
+test("an acknowledged Base survives a stale response captured by an older request", (): void => {
+  const reconciled = reconcileBudgetBaseRange(
+    [makeRow("2026-08", 100)],
+    protect(250, 3),
+    { generation: 3, monthFrom: "2026-07", monthTo: "2026-09" },
+  );
+
+  assert.equal(reconciled.rows[0]?.plannedBase, 250);
+  assert.equal(reconciled.rows[0]?.planned, 240);
+  assert.equal(reconciled.protections.size, 1);
+});
+
+test("stale protection restores an acknowledged row missing from the response", (): void => {
+  const reconciled = reconcileBudgetBaseRange(
+    [],
+    protect(250, 3),
+    { generation: 2, monthFrom: "2026-08", monthTo: "2026-08" },
+  );
+
+  assert.deepEqual(reconciled.rows, [{
+    month: "2026-08",
+    direction: "spend",
+    category: "Groceries",
+    plannedBase: 250,
+    plannedModifier: 0,
+    planned: 250,
+    actual: 0,
+    hasUnconvertible: false,
+  }]);
+  assert.equal(reconciled.protections.size, 1);
+});
+
+test("a newer authoritative generation retires protection and accepts an older numeric value", (): void => {
+  const olderValue = 100;
+  const reconciled = reconcileBudgetBaseRange(
+    [makeRow("2026-08", olderValue)],
+    protect(250, 3),
+    { generation: 4, monthFrom: "2026-08", monthTo: "2026-08" },
+  );
+
+  assert.equal(reconciled.rows[0]?.plannedBase, olderValue);
+  assert.equal(reconciled.protections.size, 0);
+});
+
+test("a response for another month does not retire Base protection", (): void => {
+  const protections = protect(250, 3);
+  const rows = [makeRow("2026-07", 100)];
+  const reconciled = reconcileBudgetBaseRange(
+    rows,
+    protections,
+    { generation: 4, monthFrom: "2026-07", monthTo: "2026-07" },
+  );
+
+  assert.equal(reconciled.rows, rows);
+  assert.equal(reconciled.protections.size, 1);
+});
+
+test("successful Fill publishes the source value to every target with one local version", (): void => {
+  const sourceBase = 451;
+  const previousTargetBase = 125;
+  const sourceCell: BudgetBaseCell = {
+    month: "2026-07",
+    direction: "spend",
+    category: "Groceries",
+  };
+  const targetCells = getTargetFillMonths(sourceCell.month).map(
+    (month): BudgetBaseCell => ({ ...sourceCell, month }),
+  );
+  const firstTargetCell = targetCells[0];
+  if (firstTargetCell === undefined) {
+    throw new Error("Fill must produce at least one target month");
+  }
+  const existing = publishBudgetBaseLocalAcknowledgements(
+    new Map(),
+    [firstTargetCell],
+    previousTargetBase,
+    1,
+  );
+
+  const published = publishBudgetBaseLocalAcknowledgements(
+    existing,
+    targetCells,
+    sourceBase,
+    2,
+  );
+
+  for (const cell of targetCells) {
+    assert.deepEqual(
+      published.get(getBudgetBaseCellKey(cell)),
+      { value: sourceBase, version: 2 },
+    );
+  }
+  assert.equal(published.has(getBudgetBaseCellKey(sourceCell)), false);
+  assert.notEqual(sourceBase, previousTargetBase);
+});
+
+test("a late Base acknowledgement cannot supersede a later Fill mutation", (): void => {
+  const sourceCell: BudgetBaseCell = {
+    month: "2026-07",
+    direction: "spend",
+    category: "Groceries",
+  };
+  const targetCells = getTargetFillMonths(sourceCell.month).map(
+    (month): BudgetBaseCell => ({ ...sourceCell, month }),
+  );
+  const targetCell = targetCells[0];
+  if (targetCell === undefined) {
+    throw new Error("Fill must produce at least one target month");
+  }
+
+  const baseMutation = issueBudgetBaseMutation(0, new Map(), [targetCell]);
+  const fillMutation = issueBudgetBaseMutation(
+    baseMutation.generation,
+    baseMutation.generationByCell,
+    targetCells,
+  );
+  const currentFillCells = getCurrentBudgetBaseMutationCells(
+    fillMutation.generationByCell,
+    targetCells,
+    fillMutation.generation,
+  );
+  let acknowledgements = publishBudgetBaseLocalAcknowledgements(
+    new Map(),
+    currentFillCells,
+    451,
+    fillMutation.generation,
+  );
+
+  const lateBaseCells = getCurrentBudgetBaseMutationCells(
+    fillMutation.generationByCell,
+    [targetCell],
+    baseMutation.generation,
+  );
+  if (lateBaseCells.length > 0) {
+    acknowledgements = publishBudgetBaseLocalAcknowledgements(
+      acknowledgements,
+      lateBaseCells,
+      125,
+      baseMutation.generation,
+    );
+  }
+
+  assert.deepEqual(lateBaseCells, []);
+  assert.deepEqual(
+    acknowledgements.get(getBudgetBaseCellKey(targetCell)),
+    { value: 451, version: fillMutation.generation },
+  );
+});
+
+test("a target editor consumes only a newer local acknowledgement", (): void => {
+  const targetBase = 125;
+  const fillAcknowledgement = { value: 451, version: 2 };
+
+  assert.deepEqual(
+    consumeBudgetBaseLocalAcknowledgement(
+      targetBase,
+      fillAcknowledgement,
+      1,
+    ),
+    { value: 451, version: 2 },
+  );
+  assert.deepEqual(
+    consumeBudgetBaseLocalAcknowledgement(
+      targetBase,
+      fillAcknowledgement,
+      2,
+    ),
+    { value: targetBase, version: 2 },
+  );
+});
+
+test("a newer authoritative response retires the matching local publication", (): void => {
+  const cell: BudgetBaseCell = {
+    month: "2026-08",
+    direction: "spend",
+    category: "Groceries",
+  };
+  const acknowledgements = publishBudgetBaseLocalAcknowledgements(
+    new Map(),
+    [cell],
+    451,
+    2,
+  );
+
+  assert.equal(
+    retainProtectedBudgetBaseLocalAcknowledgements(
+      acknowledgements,
+      new Map(),
+    ).size,
+    0,
+  );
+});

--- a/apps/web/src/ui/tables/budget/budgetBaseRangeReconciliation.ts
+++ b/apps/web/src/ui/tables/budget/budgetBaseRangeReconciliation.ts
@@ -1,0 +1,248 @@
+import type { BudgetRow } from "@/server/budget/getBudgetGrid";
+
+export type BudgetBaseCell = Readonly<{
+  month: string;
+  direction: string;
+  category: string;
+}>;
+
+export type BudgetBaseAcknowledgementProtection = Readonly<{
+  cell: BudgetBaseCell;
+  value: number;
+  throughRequestGeneration: number;
+}>;
+
+export type BudgetBaseProtectionByCell = ReadonlyMap<
+  string,
+  BudgetBaseAcknowledgementProtection
+>;
+
+export type BudgetBaseLocalAcknowledgement = Readonly<{
+  value: number;
+  version: number;
+}>;
+
+export type BudgetBaseLocalAcknowledgementByCell = ReadonlyMap<
+  string,
+  BudgetBaseLocalAcknowledgement
+>;
+
+export type BudgetBaseMutationGenerationByCell = ReadonlyMap<string, number>;
+
+export type IssuedBudgetBaseMutation = Readonly<{
+  generation: number;
+  generationByCell: BudgetBaseMutationGenerationByCell;
+}>;
+
+export type ConsumedBudgetBaseLocalAcknowledgement = Readonly<{
+  value: number;
+  version: number;
+}>;
+
+export type BudgetBaseRangeRequest = Readonly<{
+  generation: number;
+  monthFrom: string;
+  monthTo: string;
+}>;
+
+export type ReconciledBudgetBaseRange = Readonly<{
+  rows: ReadonlyArray<BudgetRow>;
+  protections: BudgetBaseProtectionByCell;
+}>;
+
+export const getBudgetBaseCellKey = (cell: BudgetBaseCell): string => (
+  `${cell.month}\u0000${cell.direction}\u0000${cell.category}`
+);
+
+export const issueBudgetBaseMutation = (
+  currentGeneration: number,
+  generationByCell: BudgetBaseMutationGenerationByCell,
+  cells: ReadonlyArray<BudgetBaseCell>,
+): IssuedBudgetBaseMutation => {
+  if (!Number.isSafeInteger(currentGeneration) || currentGeneration < 0) {
+    throw new RangeError(
+      `Budget Base mutation generation must be a non-negative safe integer; received ${String(currentGeneration)}`,
+    );
+  }
+  if (currentGeneration === Number.MAX_SAFE_INTEGER) {
+    throw new RangeError(
+      "Cannot issue another Budget Base mutation: generation limit reached",
+    );
+  }
+  if (cells.length === 0) {
+    throw new RangeError("Budget Base mutation must affect at least one cell");
+  }
+
+  const generation = currentGeneration + 1;
+  const updated = new Map(generationByCell);
+  for (const cell of cells) {
+    updated.set(getBudgetBaseCellKey(cell), generation);
+  }
+  return { generation, generationByCell: updated };
+};
+
+export const getCurrentBudgetBaseMutationCells = (
+  generationByCell: BudgetBaseMutationGenerationByCell,
+  cells: ReadonlyArray<BudgetBaseCell>,
+  generation: number,
+): ReadonlyArray<BudgetBaseCell> => {
+  if (!Number.isSafeInteger(generation) || generation < 1) {
+    throw new RangeError(
+      `Budget Base mutation generation must be a positive safe integer; received ${String(generation)}`,
+    );
+  }
+  return cells.filter((cell): boolean => (
+    generationByCell.get(getBudgetBaseCellKey(cell)) === generation
+  ));
+};
+
+export const consumeBudgetBaseLocalAcknowledgement = (
+  plannedBase: number,
+  acknowledgement: BudgetBaseLocalAcknowledgement | null,
+  consumedVersion: number,
+): ConsumedBudgetBaseLocalAcknowledgement => {
+  if (
+    acknowledgement === null
+    || acknowledgement.version <= consumedVersion
+  ) {
+    return { value: plannedBase, version: consumedVersion };
+  }
+  return {
+    value: acknowledgement.value,
+    version: acknowledgement.version,
+  };
+};
+
+export const publishBudgetBaseLocalAcknowledgements = (
+  acknowledgements: BudgetBaseLocalAcknowledgementByCell,
+  cells: ReadonlyArray<BudgetBaseCell>,
+  value: number,
+  version: number,
+): BudgetBaseLocalAcknowledgementByCell => {
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new RangeError(
+      `Budget Base local acknowledgement value must be a finite integer; received ${String(value)}`,
+    );
+  }
+  if (!Number.isSafeInteger(version) || version < 1) {
+    throw new RangeError(
+      `Budget Base local acknowledgement version must be a positive safe integer; received ${String(version)}`,
+    );
+  }
+
+  const updated = new Map(acknowledgements);
+  for (const cell of cells) {
+    updated.set(getBudgetBaseCellKey(cell), { value, version });
+  }
+  return updated;
+};
+
+export const retainProtectedBudgetBaseLocalAcknowledgements = (
+  acknowledgements: BudgetBaseLocalAcknowledgementByCell,
+  protections: BudgetBaseProtectionByCell,
+): BudgetBaseLocalAcknowledgementByCell => {
+  const retained = new Map<string, BudgetBaseLocalAcknowledgement>();
+  for (const [cellKey, acknowledgement] of acknowledgements) {
+    if (protections.has(cellKey)) retained.set(cellKey, acknowledgement);
+  }
+  return retained;
+};
+
+const buildNewBudgetRow = (
+  cell: BudgetBaseCell,
+  value: number,
+): BudgetRow => ({
+  month: cell.month,
+  direction: cell.direction,
+  category: cell.category,
+  plannedBase: value,
+  plannedModifier: 0,
+  planned: value,
+  actual: 0,
+  hasUnconvertible: false,
+});
+
+export const applyBudgetBaseToRows = (
+  rows: ReadonlyArray<BudgetRow>,
+  cell: BudgetBaseCell,
+  value: number,
+): ReadonlyArray<BudgetRow> => {
+  const rowIndex = rows.findIndex((row): boolean => (
+    row.month === cell.month
+    && row.direction === cell.direction
+    && row.category === cell.category
+  ));
+  if (rowIndex < 0) return [...rows, buildNewBudgetRow(cell, value)];
+
+  const row = rows[rowIndex];
+  const updatedRow: BudgetRow = {
+    ...row,
+    plannedBase: value,
+    planned: value + row.plannedModifier,
+  };
+  return [...rows.slice(0, rowIndex), updatedRow, ...rows.slice(rowIndex + 1)];
+};
+
+export const protectBudgetBaseAcknowledgement = (
+  protections: BudgetBaseProtectionByCell,
+  protection: BudgetBaseAcknowledgementProtection,
+): BudgetBaseProtectionByCell => {
+  if (
+    !Number.isSafeInteger(protection.throughRequestGeneration)
+    || protection.throughRequestGeneration < 0
+  ) {
+    throw new RangeError(
+      `Budget Base protection generation must be a non-negative safe integer; received ${String(protection.throughRequestGeneration)}`,
+    );
+  }
+  if (
+    !Number.isFinite(protection.value)
+    || !Number.isInteger(protection.value)
+  ) {
+    throw new RangeError(
+      `Budget Base protection value must be a finite integer; received ${String(protection.value)}`,
+    );
+  }
+  const updated = new Map(protections);
+  updated.set(getBudgetBaseCellKey(protection.cell), protection);
+  return updated;
+};
+
+export const reconcileBudgetBaseRange = (
+  rows: ReadonlyArray<BudgetRow>,
+  protections: BudgetBaseProtectionByCell,
+  request: BudgetBaseRangeRequest,
+): ReconciledBudgetBaseRange => {
+  if (!Number.isSafeInteger(request.generation) || request.generation < 1) {
+    throw new RangeError(
+      `Budget Base range request generation must be a positive safe integer; received ${String(request.generation)}`,
+    );
+  }
+  if (request.monthFrom > request.monthTo) {
+    throw new RangeError(
+      `Budget Base range monthFrom "${request.monthFrom}" must not be after monthTo "${request.monthTo}"`,
+    );
+  }
+
+  let reconciledRows = rows;
+  const reconciledProtections = new Map(protections);
+  for (const [cellKey, protection] of protections) {
+    const { month } = protection.cell;
+    if (month < request.monthFrom || month > request.monthTo) continue;
+
+    if (request.generation > protection.throughRequestGeneration) {
+      reconciledProtections.delete(cellKey);
+      continue;
+    }
+    reconciledRows = applyBudgetBaseToRows(
+      reconciledRows,
+      protection.cell,
+      protection.value,
+    );
+  }
+
+  return {
+    rows: reconciledRows,
+    protections: reconciledProtections,
+  };
+};

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableController.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableController.ts
@@ -22,6 +22,7 @@ import { useBudgetTableViewport } from "@/ui/tables/budget/controller/useBudgetT
 import { useBudgetTableYearTotals } from "@/ui/tables/budget/controller/useBudgetTableYearTotals";
 import { useBudgetAdjustmentRowsController } from "@/ui/tables/budget/controller/useBudgetAdjustmentRowsController";
 import type { BudgetAdjustmentRowsController } from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
+import type { BudgetBaseLocalAcknowledgementByCell } from "@/ui/tables/budget/budgetBaseRangeReconciliation";
 
 export type BudgetTableProps = Readonly<{
   rows: ReadonlyArray<BudgetRow>;
@@ -41,6 +42,7 @@ export type BudgetTableProps = Readonly<{
 
 export type BudgetTableController = Readonly<{
   effectiveAllowlist: ReadonlySet<string> | null;
+  localBaseAcknowledgementByCell: BudgetBaseLocalAcknowledgementByCell;
   currentMonth: string;
   currentYear: string;
   months: ReadonlyArray<string>;
@@ -81,11 +83,30 @@ export type BudgetTableController = Readonly<{
     kind: "base" | "modifier",
     value: number,
   ) => void;
+  handleBaseMutationIssued: (
+    month: string,
+    direction: string,
+    category: string,
+  ) => number;
   handleFillMonths: (
     sourceMonth: string,
     direction: string,
     category: string,
     baseValue: number,
+  ) => number;
+  handleBaseAcknowledged: (
+    month: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
+  ) => void;
+  handleFillMonthsAcknowledged: (
+    sourceMonth: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
   ) => void;
   updateCommentCell: (
     month: string,
@@ -222,6 +243,8 @@ export const useBudgetTableController = (
 
   return {
     effectiveAllowlist,
+    localBaseAcknowledgementByCell:
+      rangeState.localBaseAcknowledgementByCell,
     currentMonth,
     currentYear,
     months: derivedState.months,
@@ -256,7 +279,10 @@ export const useBudgetTableController = (
     onSyncStart: rangeState.onSyncStart,
     onSyncEnd: rangeState.onSyncEnd,
     handlePlanSave: rangeState.handlePlanSave,
+    handleBaseMutationIssued: rangeState.handleBaseMutationIssued,
     handleFillMonths: rangeState.handleFillMonths,
+    handleBaseAcknowledged: rangeState.handleBaseAcknowledged,
+    handleFillMonthsAcknowledged: rangeState.handleFillMonthsAcknowledged,
     updateCommentCell,
     openDrillDown,
     handleDrillDownClose,

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
@@ -7,6 +7,20 @@ import {
   adjustCumulativeBeforeForPrependedRows,
   getTargetFillMonths,
 } from "@/ui/tables/budget/budgetTableLogic";
+import {
+  applyBudgetBaseToRows,
+  getCurrentBudgetBaseMutationCells,
+  issueBudgetBaseMutation,
+  publishBudgetBaseLocalAcknowledgements,
+  protectBudgetBaseAcknowledgement,
+  reconcileBudgetBaseRange,
+  retainProtectedBudgetBaseLocalAcknowledgements,
+  type BudgetBaseCell,
+  type BudgetBaseLocalAcknowledgementByCell,
+  type BudgetBaseMutationGenerationByCell,
+  type BudgetBaseProtectionByCell,
+  type BudgetBaseRangeRequest,
+} from "@/ui/tables/budget/budgetBaseRangeReconciliation";
 import type { BudgetAdjustmentRangeLoadOutcome } from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
 import { logBudgetTableError } from "@/ui/tables/budget/table/logBudgetTableError";
 
@@ -33,6 +47,7 @@ type UseBudgetTableRangeStateParams = Readonly<{
 
 export type BudgetTableRangeState = Readonly<{
   allRows: ReadonlyArray<BudgetRow>;
+  localBaseAcknowledgementByCell: BudgetBaseLocalAcknowledgementByCell;
   loadedFrom: string;
   loadedTo: string;
   cumBefore: CumulativeBefore;
@@ -52,11 +67,30 @@ export type BudgetTableRangeState = Readonly<{
     kind: "base" | "modifier",
     value: number,
   ) => void;
+  handleBaseMutationIssued: (
+    month: string,
+    direction: string,
+    category: string,
+  ) => number;
   handleFillMonths: (
     sourceMonth: string,
     direction: string,
     category: string,
     baseValue: number,
+  ) => number;
+  handleBaseAcknowledged: (
+    month: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
+  ) => void;
+  handleFillMonthsAcknowledged: (
+    sourceMonth: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
   ) => void;
   refreshLoadedRange: () => void;
   loadLeft: () => Promise<void>;
@@ -71,13 +105,43 @@ const applyFetchedBudgetResult = (
   setBusinessPersonalTransfers: (value: Readonly<Record<string, BusinessPersonalTransferCell>>) => void,
   setHasBusinessAccount: (value: boolean) => void,
   result: BudgetGridResult,
+  rows: ReadonlyArray<BudgetRow>,
 ): void => {
-  setAllRows(result.rows);
+  setAllRows(rows);
   setCumBefore(result.cumulativeBefore);
   setMeb(result.monthEndBalances);
   setMebByLiq(result.monthEndBalancesByLiquidity);
   setBusinessPersonalTransfers(result.businessPersonalTransfers);
   setHasBusinessAccount(result.hasBusinessAccount);
+};
+
+type GeneratedBudgetRangeLoadOutcome =
+  | Readonly<{
+    status: "accepted";
+    result: BudgetGridResult;
+    request: BudgetBaseRangeRequest;
+  }>
+  | Readonly<{
+    status: "superseded";
+    request: BudgetBaseRangeRequest;
+  }>;
+
+const enumerateRangeMonths = (
+  monthFrom: string,
+  monthTo: string,
+): ReadonlyArray<string> => {
+  if (monthFrom > monthTo) {
+    throw new RangeError(
+      `Budget range monthFrom "${monthFrom}" must not be after monthTo "${monthTo}"`,
+    );
+  }
+  const months: Array<string> = [];
+  let current = monthFrom;
+  while (true) {
+    months.push(current);
+    if (current === monthTo) return months;
+    current = offsetMonth(current, 1);
+  }
 };
 
 const buildNewBudgetRow = (
@@ -172,6 +236,10 @@ export const useBudgetTableRangeState = ({
   loadBudgetRange,
 }: UseBudgetTableRangeStateParams): BudgetTableRangeState => {
   const [allRows, setAllRows] = useState<ReadonlyArray<BudgetRow>>(rows);
+  const [
+    localBaseAcknowledgementByCell,
+    setLocalBaseAcknowledgementByCell,
+  ] = useState<BudgetBaseLocalAcknowledgementByCell>(new Map());
   const [loadedFrom, setLoadedFrom] = useState<string>(initialMonthFrom);
   const [loadedTo, setLoadedTo] = useState<string>(initialMonthTo);
   const [cumBefore, setCumBefore] = useState<CumulativeBefore>(cumulativeBefore);
@@ -186,6 +254,59 @@ export const useBudgetTableRangeState = ({
   const isLoadingLeftRef = useRef<boolean>(false);
   const isLoadingRightRef = useRef<boolean>(false);
   const initialRefreshHandledRef = useRef<boolean>(false);
+  const latestRangeRequestGenerationRef = useRef<number>(0);
+  const latestRangeRequestGenerationByMonthRef = useRef<Map<string, number>>(
+    new Map(),
+  );
+  const baseProtectionsRef = useRef<BudgetBaseProtectionByCell>(new Map());
+  const latestBaseMutationGenerationRef = useRef<number>(0);
+  const baseMutationGenerationByCellRef =
+    useRef<BudgetBaseMutationGenerationByCell>(new Map());
+
+  const loadGeneratedBudgetRange = useCallback(async (
+    monthFrom: string,
+    monthTo: string,
+  ): Promise<GeneratedBudgetRangeLoadOutcome> => {
+    if (latestRangeRequestGenerationRef.current === Number.MAX_SAFE_INTEGER) {
+      throw new RangeError("Cannot issue another budget range request: generation limit reached");
+    }
+    const generation = latestRangeRequestGenerationRef.current + 1;
+    latestRangeRequestGenerationRef.current = generation;
+    const request: BudgetBaseRangeRequest = {
+      generation,
+      monthFrom,
+      monthTo,
+    };
+    for (const month of enumerateRangeMonths(monthFrom, monthTo)) {
+      latestRangeRequestGenerationByMonthRef.current.set(month, generation);
+    }
+
+    const outcome = await loadBudgetRange(monthFrom, monthTo);
+    return outcome.status === "accepted"
+      ? { status: "accepted", result: outcome.result, request }
+      : { status: "superseded", request };
+  }, [loadBudgetRange]);
+
+  const reconcileAcceptedBaseRange = useCallback((
+    result: BudgetGridResult,
+    request: BudgetBaseRangeRequest,
+  ): ReadonlyArray<BudgetRow> => {
+    const reconciled = reconcileBudgetBaseRange(
+      result.rows,
+      baseProtectionsRef.current,
+      request,
+    );
+    baseProtectionsRef.current = reconciled.protections;
+    setLocalBaseAcknowledgementByCell(
+      (previous): BudgetBaseLocalAcknowledgementByCell => (
+        retainProtectedBudgetBaseLocalAcknowledgements(
+          previous,
+          reconciled.protections,
+        )
+      ),
+    );
+    return reconciled.rows;
+  }, []);
 
   const onSyncStart = useCallback((): void => {
     setPendingSaves((count) => count + 1);
@@ -199,15 +320,16 @@ export const useBudgetTableRangeState = ({
     onVisibleRangeRefreshStart();
 
     try {
-      const outcome = await loadBudgetRange(loadedFrom, loadedTo);
+      const outcome = await loadGeneratedBudgetRange(loadedFrom, loadedTo);
       if (outcome.status === "superseded") return;
       const result = outcome.result;
-      applyFetchedBudgetResult(setAllRows, setCumBefore, setMeb, setMebByLiq, setBusinessPersonalTransfers, setHasBusinessAccount, result);
+      const reconciledRows = reconcileAcceptedBaseRange(result, outcome.request);
+      applyFetchedBudgetResult(setAllRows, setCumBefore, setMeb, setMebByLiq, setBusinessPersonalTransfers, setHasBusinessAccount, result, reconciledRows);
       reloadCommentRange(loadedFrom, loadedTo);
     } catch (error) {
       logBudgetTableError("visible range refresh", error);
     }
-  }, [loadBudgetRange, loadedFrom, loadedTo, onVisibleRangeRefreshStart, refreshToken, reloadCommentRange]);
+  }, [loadGeneratedBudgetRange, loadedFrom, loadedTo, onVisibleRangeRefreshStart, reconcileAcceptedBaseRange, refreshToken, reloadCommentRange]);
 
   useEffect(() => {
     if (!initialRefreshHandledRef.current) {
@@ -228,14 +350,122 @@ export const useBudgetTableRangeState = ({
     setAllRows((previous) => applyPlanSaveToRows(previous, month, direction, category, kind, value));
   }, []);
 
+  const issueBaseMutation = useCallback((
+    cells: ReadonlyArray<BudgetBaseCell>,
+  ): number => {
+    const issued = issueBudgetBaseMutation(
+      latestBaseMutationGenerationRef.current,
+      baseMutationGenerationByCellRef.current,
+      cells,
+    );
+    latestBaseMutationGenerationRef.current = issued.generation;
+    baseMutationGenerationByCellRef.current = issued.generationByCell;
+    return issued.generation;
+  }, []);
+
+  const handleBaseMutationIssued = useCallback((
+    month: string,
+    direction: string,
+    category: string,
+  ): number => issueBaseMutation([{ month, direction, category }]), [
+    issueBaseMutation,
+  ]);
+
   const handleFillMonths = useCallback((
     sourceMonth: string,
     direction: string,
     category: string,
     baseValue: number,
-  ): void => {
+  ): number => {
+    const targetCells = getTargetFillMonths(sourceMonth).map(
+      (month): BudgetBaseCell => ({ month, direction, category }),
+    );
+    const mutationGeneration = issueBaseMutation(targetCells);
     setAllRows((previous) => applyFillMonthsToRows(previous, sourceMonth, direction, category, baseValue));
+    return mutationGeneration;
+  }, [issueBaseMutation]);
+
+  const publishBaseAcknowledgements = useCallback((
+    cells: ReadonlyArray<BudgetBaseCell>,
+    baseValue: number,
+    mutationGeneration: number,
+  ): void => {
+    let protections = baseProtectionsRef.current;
+    for (const cell of cells) {
+      protections = protectBudgetBaseAcknowledgement(protections, {
+        cell,
+        value: baseValue,
+        throughRequestGeneration:
+          latestRangeRequestGenerationByMonthRef.current.get(cell.month) ?? 0,
+      });
+    }
+    baseProtectionsRef.current = protections;
+    setLocalBaseAcknowledgementByCell(
+      (previous): BudgetBaseLocalAcknowledgementByCell => (
+        publishBudgetBaseLocalAcknowledgements(
+          previous,
+          cells,
+          baseValue,
+          mutationGeneration,
+        )
+      ),
+    );
   }, []);
+
+  const handleBaseAcknowledged = useCallback((
+    month: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
+  ): void => {
+    const cell = { month, direction, category };
+    const currentCells = getCurrentBudgetBaseMutationCells(
+      baseMutationGenerationByCellRef.current,
+      [cell],
+      mutationGeneration,
+    );
+    if (currentCells.length === 0) return;
+    publishBaseAcknowledgements(
+      currentCells,
+      baseValue,
+      mutationGeneration,
+    );
+    setAllRows((previous): ReadonlyArray<BudgetRow> => (
+      applyBudgetBaseToRows(previous, cell, baseValue)
+    ));
+  }, [publishBaseAcknowledgements]);
+
+  const handleFillMonthsAcknowledged = useCallback((
+    sourceMonth: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
+  ): void => {
+    const targetCells = getTargetFillMonths(sourceMonth).map(
+      (month): BudgetBaseCell => ({ month, direction, category }),
+    );
+    const currentCells = getCurrentBudgetBaseMutationCells(
+      baseMutationGenerationByCellRef.current,
+      targetCells,
+      mutationGeneration,
+    );
+    if (currentCells.length === 0) return;
+    publishBaseAcknowledgements(
+      currentCells,
+      baseValue,
+      mutationGeneration,
+    );
+    setAllRows((previous): ReadonlyArray<BudgetRow> => (
+      currentCells.reduce(
+        (updatedRows, cell): ReadonlyArray<BudgetRow> => (
+          applyBudgetBaseToRows(updatedRows, cell, baseValue)
+        ),
+        previous,
+      )
+    ));
+  }, [publishBaseAcknowledgements]);
 
   const refreshLoadedRange = useCallback((): void => {
     void runVisibleRangeRefresh();
@@ -253,10 +483,10 @@ export const useBudgetTableRangeState = ({
     const newFrom = offsetMonth(loadedFrom, -BATCH_SIZE);
 
     try {
-      const outcome = await loadBudgetRange(newFrom, newTo);
+      const outcome = await loadGeneratedBudgetRange(newFrom, newTo);
       if (outcome.status === "superseded") return;
       const result = outcome.result;
-      const prependedRows = result.rows;
+      const prependedRows = reconcileAcceptedBaseRange(result, outcome.request);
       setAllRows((previous) => [...prependedRows, ...previous]);
       setCumBefore((previous) => adjustCumulativeBeforeForPrependedRows(previous, prependedRows));
       setLoadedFrom(newFrom);
@@ -271,7 +501,7 @@ export const useBudgetTableRangeState = ({
       isLoadingLeftRef.current = false;
       setIsLoadingLeft(false);
     }
-  }, [fetchCommentRange, loadBudgetRange, loadedFrom]);
+  }, [fetchCommentRange, loadGeneratedBudgetRange, loadedFrom, reconcileAcceptedBaseRange]);
 
   const loadRight = useCallback(async (): Promise<void> => {
     if (isLoadingRightRef.current) {
@@ -285,10 +515,11 @@ export const useBudgetTableRangeState = ({
     const newTo = offsetMonth(loadedTo, BATCH_SIZE);
 
     try {
-      const outcome = await loadBudgetRange(newFrom, newTo);
+      const outcome = await loadGeneratedBudgetRange(newFrom, newTo);
       if (outcome.status === "superseded") return;
       const result = outcome.result;
-      setAllRows((previous) => [...previous, ...result.rows]);
+      const appendedRows = reconcileAcceptedBaseRange(result, outcome.request);
+      setAllRows((previous) => [...previous, ...appendedRows]);
       setLoadedTo(newTo);
       setMeb((previous) => ({ ...previous, ...result.monthEndBalances }));
       setMebByLiq((previous) => ({ ...previous, ...result.monthEndBalancesByLiquidity }));
@@ -301,10 +532,11 @@ export const useBudgetTableRangeState = ({
       isLoadingRightRef.current = false;
       setIsLoadingRight(false);
     }
-  }, [fetchCommentRange, loadBudgetRange, loadedTo]);
+  }, [fetchCommentRange, loadGeneratedBudgetRange, loadedTo, reconcileAcceptedBaseRange]);
 
   return {
     allRows,
+    localBaseAcknowledgementByCell,
     loadedFrom,
     loadedTo,
     cumBefore,
@@ -318,7 +550,10 @@ export const useBudgetTableRangeState = ({
     onSyncStart,
     onSyncEnd,
     handlePlanSave,
+    handleBaseMutationIssued,
     handleFillMonths,
+    handleBaseAcknowledged,
+    handleFillMonthsAcknowledged,
     refreshLoadedRange,
     loadLeft,
     loadRight,

--- a/apps/web/src/ui/tables/budget/table/sections/BudgetDirectionSection.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/BudgetDirectionSection.tsx
@@ -3,6 +3,7 @@
 import { Fragment, type ReactElement } from "react";
 
 import type { NumberFormat } from "@/lib/locale";
+import type { BudgetBaseLocalAcknowledgementByCell } from "@/ui/tables/budget/budgetBaseRangeReconciliation";
 import {
   type CellValue,
   type ColumnEntry,
@@ -17,6 +18,7 @@ import { DirectionSubtotalRow } from "./direction/DirectionSubtotalRow";
 export type BudgetDirectionSectionProps = Readonly<{
   block: DirectionBlock;
   effectiveAllowlist: ReadonlySet<string> | null;
+  localBaseAcknowledgementByCell: BudgetBaseLocalAcknowledgementByCell;
   columnSequence: ReadonlyArray<ColumnEntry>;
   currentMonth: string;
   currentYear: string;
@@ -35,11 +37,30 @@ export type BudgetDirectionSectionProps = Readonly<{
     kind: "base" | "modifier",
     value: number,
   ) => void;
+  onBaseMutationIssued: (
+    month: string,
+    direction: string,
+    category: string,
+  ) => number;
   onFillMonths: (
     sourceMonth: string,
     direction: string,
     category: string,
     baseValue: number,
+  ) => number;
+  onBaseAcknowledged: (
+    month: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
+  ) => void;
+  onFillMonthsAcknowledged: (
+    sourceMonth: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
   ) => void;
   onSyncStart: () => void;
   onSyncEnd: () => void;
@@ -49,6 +70,7 @@ export const BudgetDirectionSection = (props: BudgetDirectionSectionProps): Reac
   const {
     block,
     effectiveAllowlist,
+    localBaseAcknowledgementByCell,
     columnSequence,
     currentMonth,
     currentYear,
@@ -61,7 +83,10 @@ export const BudgetDirectionSection = (props: BudgetDirectionSectionProps): Reac
     copyToClipboard,
     openDrillDown,
     onPlanSave,
+    onBaseMutationIssued,
     onFillMonths,
+    onBaseAcknowledged,
+    onFillMonthsAcknowledged,
     onSyncStart,
     onSyncEnd,
   } = props;
@@ -92,6 +117,9 @@ export const BudgetDirectionSection = (props: BudgetDirectionSectionProps): Reac
             block={block}
             category={category}
             effectiveAllowlist={effectiveAllowlist}
+            localBaseAcknowledgementByCell={
+              localBaseAcknowledgementByCell
+            }
             columnSequence={columnSequence}
             currentMonth={currentMonth}
             currentYear={currentYear}
@@ -102,7 +130,10 @@ export const BudgetDirectionSection = (props: BudgetDirectionSectionProps): Reac
             copyToClipboard={copyToClipboard}
             openDrillDown={openDrillDown}
             onPlanSave={onPlanSave}
+            onBaseMutationIssued={onBaseMutationIssued}
             onFillMonths={onFillMonths}
+            onBaseAcknowledged={onBaseAcknowledged}
+            onFillMonthsAcknowledged={onFillMonthsAcknowledged}
             onSyncStart={onSyncStart}
             onSyncEnd={onSyncEnd}
           />

--- a/apps/web/src/ui/tables/budget/table/sections/direction/CategoryRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/direction/CategoryRow.tsx
@@ -5,6 +5,10 @@ import { Fragment, type ReactElement } from "react";
 import { getCellVisibility } from "@/lib/dataMask";
 import type { NumberFormat } from "@/lib/locale";
 import { BudgetPlanCell } from "@/ui/tables/budget/BudgetPlanCell";
+import {
+  getBudgetBaseCellKey,
+  type BudgetBaseLocalAcknowledgementByCell,
+} from "@/ui/tables/budget/budgetBaseRangeReconciliation";
 import type { BudgetAdjustmentRowsController } from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
 import {
   formatAmount,
@@ -30,6 +34,7 @@ type CategoryRowProps = Readonly<{
   block: DirectionBlock;
   category: string;
   effectiveAllowlist: ReadonlySet<string> | null;
+  localBaseAcknowledgementByCell: BudgetBaseLocalAcknowledgementByCell;
   columnSequence: ReadonlyArray<ColumnEntry>;
   currentMonth: string;
   currentYear: string;
@@ -46,11 +51,30 @@ type CategoryRowProps = Readonly<{
     kind: "base" | "modifier",
     value: number,
   ) => void;
+  onBaseMutationIssued: (
+    month: string,
+    direction: string,
+    category: string,
+  ) => number;
   onFillMonths: (
     sourceMonth: string,
     direction: string,
     category: string,
     baseValue: number,
+  ) => number;
+  onBaseAcknowledged: (
+    month: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
+  ) => void;
+  onFillMonthsAcknowledged: (
+    sourceMonth: string,
+    direction: string,
+    category: string,
+    baseValue: number,
+    mutationGeneration: number,
   ) => void;
   onSyncStart: () => void;
   onSyncEnd: () => void;
@@ -61,6 +85,7 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
     block,
     category,
     effectiveAllowlist,
+    localBaseAcknowledgementByCell,
     columnSequence,
     currentMonth,
     currentYear,
@@ -71,7 +96,10 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
     copyToClipboard,
     openDrillDown,
     onPlanSave,
+    onBaseMutationIssued,
     onFillMonths,
+    onBaseAcknowledged,
+    onFillMonthsAcknowledged,
     onSyncStart,
     onSyncEnd,
   } = props;
@@ -190,6 +218,13 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                 effectiveAllowlist={effectiveAllowlist}
                 currentMonth={currentMonth}
                 plannedBase={cell.plannedBase}
+                localBaseAcknowledgement={localBaseAcknowledgementByCell.get(
+                  getBudgetBaseCellKey({
+                    month: column.month,
+                    direction: block.direction,
+                    category,
+                  }),
+                ) ?? null}
                 plannedModifier={cell.plannedModifier}
                 planned={cell.planned}
                 showData={categoryVisibility.showData}
@@ -199,7 +234,10 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                 cmClass=""
                 budgetAdjustments={budgetAdjustments}
                 onPlanSave={onPlanSave}
+                onBaseMutationIssued={onBaseMutationIssued}
                 onFillMonths={onFillMonths}
+                onBaseAcknowledged={onBaseAcknowledged}
+                onFillMonthsAcknowledged={onFillMonthsAcknowledged}
                 onSyncStart={onSyncStart}
                 onSyncEnd={onSyncEnd}
               />
@@ -224,6 +262,13 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                   effectiveAllowlist={effectiveAllowlist}
                   currentMonth={currentMonth}
                   plannedBase={cell.plannedBase}
+                  localBaseAcknowledgement={localBaseAcknowledgementByCell.get(
+                    getBudgetBaseCellKey({
+                      month: column.month,
+                      direction: block.direction,
+                      category,
+                    }),
+                  ) ?? null}
                   plannedModifier={cell.plannedModifier}
                   planned={cell.planned}
                   showData={categoryVisibility.showData}
@@ -233,7 +278,10 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                   cmClass={` ${styles.currentMonthPlan}`}
                   budgetAdjustments={budgetAdjustments}
                   onPlanSave={onPlanSave}
+                  onBaseMutationIssued={onBaseMutationIssued}
                   onFillMonths={onFillMonths}
+                  onBaseAcknowledged={onBaseAcknowledged}
+                  onFillMonthsAcknowledged={onFillMonthsAcknowledged}
                   onSyncStart={onSyncStart}
                   onSyncEnd={onSyncEnd}
                 />


### PR DESCRIPTION
## Summary
- reconcile acknowledged Base values against stale budget-grid request generations
- order Base and Fill acknowledgements with per-cell mutation generations
- publish Fill targets and consume local acknowledged values safely
- cover stale responses, out-of-order acknowledgements, pending reopen, and mobile RTL behavior

## Validation
- npx tsx --test src/ui/tables/budget/budgetBaseRangeReconciliation.test.ts
- npm run test:e2e:local-demo -- e2e-local/budget-adjustments.local-demo.spec.ts
- npm run lint
- npm run build
- git diff --check