### PR TITLE
Serialize budget Base editor lifecycle

### DIFF
--- a/apps/web/e2e-local/budget-adjustments.local-demo.spec.ts
+++ b/apps/web/e2e-local/budget-adjustments.local-demo.spec.ts
@@ -26,6 +26,18 @@ const createDeferred = (): Deferred => {
   return { promise, resolve: resolvePromise };
 };
 
+const readBudgetBasePlannedValue = (requestBody: unknown): number => {
+  if (
+    typeof requestBody !== "object"
+    || requestBody === null
+    || !("plannedValue" in requestBody)
+    || typeof requestBody.plannedValue !== "number"
+  ) {
+    throw new Error("Budget Base request is missing a numeric plannedValue");
+  }
+  return requestBody.plannedValue;
+};
+
 const setDemoCookies = async (
   page: Page,
   baseURL: string,
@@ -65,15 +77,17 @@ const requestMainContentRefresh = async (
   version: number,
 ): Promise<void> => {
   await page.evaluate((nextVersion): void => {
-    const channel = new BroadcastChannel("expense-tracker-main-content-invalidation");
-    channel.postMessage({
+    const message = {
       type: "main_content_invalidation",
       workspaceId: "",
       version: nextVersion,
       sourceId: "budget-base-e2e",
       emittedAt: Date.now(),
-    });
-    channel.close();
+    };
+    window.dispatchEvent(new StorageEvent("storage", {
+      key: "expense-tracker-main-content-invalidation",
+      newValue: JSON.stringify(message),
+    }));
   }, version);
 };
 
@@ -308,7 +322,7 @@ test("creates, autosaves, moves, and deletes normalized adjustment rows", async 
   await expect(page.getByTestId(`budget-adjustment-add-${diningEditorId}`)).toBeFocused();
 });
 
-test("acknowledges the current Base after a stale response reopens its pending editor", async ({ page, baseURL }) => {
+test("keeps a stale Base save open until its acknowledgement is safe to reopen", async ({ page, baseURL }) => {
   if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
   await setDemoCookies(page, baseURL, "en");
   await page.goto("/budget", { waitUntil: "domcontentloaded" });
@@ -365,22 +379,244 @@ test("acknowledges the current Base after a stale response reopens its pending e
   await baseInput.fill(String(savedBase));
   await page.keyboard.press("Enter");
   await delayedBase.captured;
-  await expect(popover).toHaveCount(0);
+  await expect(popover).toHaveAttribute("aria-busy", "true");
+  await expect(baseInput).toBeDisabled();
   await expect(page.getByTestId("budget-sync-status")).toHaveCount(1);
   await expect(openButton).not.toHaveText(originalPlanText);
 
   staleRangeGate.resolve();
   expect((await staleRangeResponse).ok()).toBe(true);
   await expect(openButton).toHaveText(originalPlanText);
-  await openButton.click();
-  await expect(baseInput).toHaveValue(String(originalBase));
+  await expect(baseInput).toHaveValue(String(savedBase));
 
   delayedBase.release();
   await expect(page.getByTestId("budget-sync-status")).toHaveCount(0);
-  await page.keyboard.press("Escape");
   await expect(popover).toHaveCount(0);
   await openButton.click();
   await expect(baseInput).toHaveValue(String(savedBase));
+});
+
+test("reprojects the final Base acknowledgement after a superseded save fails", async ({ page, baseURL }) => {
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+
+  const editorId = await getEditorId(page, "spend", "Groceries", 0);
+  const openButton = page.getByTestId(`budget-plan-open-${editorId}`);
+  const popover = page.getByTestId(`budget-plan-popover-${editorId}`);
+  const baseInput = page.getByTestId(`budget-plan-base-input-${editorId}`);
+  const failedSaveStarted = createDeferred();
+  const failedSaveGate = createDeferred();
+  const requestedValues: Array<number> = [];
+  await page.route("**/api/budget-plan", async (route): Promise<void> => {
+    const request = route.request();
+    if (
+      request.method() !== "POST"
+      || new URL(request.url()).pathname !== "/api/budget-plan"
+    ) {
+      await route.continue();
+      return;
+    }
+
+    requestedValues.push(readBudgetBasePlannedValue(request.postDataJSON()));
+    failedSaveStarted.resolve();
+    await failedSaveGate.promise;
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Forced superseded Base failure" }),
+    });
+  });
+
+  await openButton.click();
+  const originalBase = Number(await baseInput.inputValue());
+  const originalPlanText = await openButton.textContent();
+  if (originalPlanText === null) {
+    throw new Error(`Cannot read plan button ${editorId}`);
+  }
+  const supersededBase = originalBase + 83;
+  await baseInput.fill(String(supersededBase));
+  await failedSaveStarted.promise;
+  await baseInput.fill(String(originalBase));
+  await baseInput.press("Enter");
+  await expect(popover).toHaveAttribute("aria-busy", "true");
+
+  const failedSave = page.waitForResponse((response): boolean => (
+    response.url().endsWith("/api/budget-plan")
+    && response.request().method() === "POST"
+    && response.status() === 500
+  ));
+  failedSaveGate.resolve();
+  expect((await failedSave).ok()).toBe(false);
+  await expect(popover).toHaveCount(0);
+  await expect(openButton).toHaveText(originalPlanText);
+  expect(requestedValues).toEqual([supersededBase]);
+
+  await openButton.click();
+  await expect(baseInput).toHaveValue(String(originalBase));
+  await page.keyboard.press("Escape");
+});
+
+test("Escape finishes the active Base save without persisting a newer draft", async ({ page, baseURL }) => {
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+
+  const editorId = await getEditorId(page, "spend", "Groceries", 0);
+  const openButton = page.getByTestId(`budget-plan-open-${editorId}`);
+  const popover = page.getByTestId(`budget-plan-popover-${editorId}`);
+  const baseInput = page.getByTestId(`budget-plan-base-input-${editorId}`);
+  const activeSaveStarted = createDeferred();
+  const activeSaveGate = createDeferred();
+  const requestedValues: Array<number> = [];
+  await page.route("**/api/budget-plan", async (route): Promise<void> => {
+    const request = route.request();
+    if (
+      request.method() !== "POST"
+      || new URL(request.url()).pathname !== "/api/budget-plan"
+    ) {
+      await route.continue();
+      return;
+    }
+
+    requestedValues.push(readBudgetBasePlannedValue(request.postDataJSON()));
+    if (requestedValues.length === 1) {
+      const response = await route.fetch();
+      activeSaveStarted.resolve();
+      await activeSaveGate.promise;
+      await route.fulfill({ response });
+      return;
+    }
+    await route.continue();
+  });
+
+  await openButton.click();
+  const originalBase = Number(await baseInput.inputValue());
+  const activeBase = originalBase + 91;
+  const discardedBase = activeBase + 1;
+  await baseInput.fill(String(activeBase));
+  await activeSaveStarted.promise;
+  await baseInput.fill(String(discardedBase));
+  await page.keyboard.press("Escape");
+  await expect(popover).toHaveAttribute("aria-busy", "true");
+  await expect(baseInput).toBeDisabled();
+  expect(requestedValues).toEqual([activeBase]);
+
+  activeSaveGate.resolve();
+  await expect(popover).toHaveCount(0);
+  await expect(openButton).toBeFocused();
+  await page.waitForTimeout(700);
+  expect(requestedValues).toEqual([activeBase]);
+
+  await openButton.click();
+  await expect(baseInput).toHaveValue(String(activeBase));
+  await page.keyboard.press("Escape");
+});
+
+test("serializes superseding Base saves and rolls a definitive failure back for retry", async ({ page, baseURL }) => {
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+
+  const editorId = await getEditorId(page, "spend", "Groceries", 0);
+  const openButton = page.getByTestId(`budget-plan-open-${editorId}`);
+  const popover = page.getByTestId(`budget-plan-popover-${editorId}`);
+  const baseInput = page.getByTestId(`budget-plan-base-input-${editorId}`);
+  const firstSaveStarted = createDeferred();
+  const firstSaveGate = createDeferred();
+  const requestedValues: Array<number> = [];
+  let saveCount = 0;
+  await page.route("**/api/budget-plan", async (route): Promise<void> => {
+    const request = route.request();
+    if (
+      request.method() !== "POST"
+      || new URL(request.url()).pathname !== "/api/budget-plan"
+    ) {
+      await route.continue();
+      return;
+    }
+
+    requestedValues.push(readBudgetBasePlannedValue(request.postDataJSON()));
+    saveCount += 1;
+    if (saveCount === 1) {
+      const response = await route.fetch();
+      firstSaveStarted.resolve();
+      await firstSaveGate.promise;
+      await route.fulfill({ response });
+      return;
+    }
+    if (saveCount === 2) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Forced latest Base failure" }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await openButton.click();
+  const originalBase = Number(await baseInput.inputValue());
+  const firstValue = originalBase + 101;
+  const failedValue = firstValue + 1;
+  const retryValue = failedValue + 1;
+  await baseInput.fill(String(firstValue));
+  await firstSaveStarted.promise;
+  await baseInput.fill(String(failedValue));
+  await baseInput.press("Enter");
+  await expect(popover).toHaveAttribute("aria-busy", "true");
+  await expect(baseInput).toBeDisabled();
+  expect(requestedValues).toEqual([firstValue]);
+
+  const failedSave = page.waitForResponse((response): boolean => (
+    response.url().endsWith("/api/budget-plan")
+    && response.request().method() === "POST"
+    && response.status() === 500
+  ));
+  firstSaveGate.resolve();
+  expect((await failedSave).ok()).toBe(false);
+  await expect(popover).toBeVisible();
+  await expect(popover).toHaveAttribute("aria-busy", "false");
+  await expect(baseInput).toHaveValue(String(firstValue));
+  await expect(baseInput).toBeFocused();
+  await expect(page.getByTestId(`budget-plan-base-error-${editorId}`)).toHaveText(
+    "The Base amount could not be saved. Try again.",
+  );
+  expect(requestedValues).toEqual([firstValue, failedValue]);
+  expect(await baseInput.evaluate((element): Readonly<{
+    start: number | null;
+    end: number | null;
+  }> => {
+    if (!(element instanceof HTMLInputElement)) {
+      throw new Error("Budget Base control must be an input");
+    }
+    return {
+      start: element.selectionStart,
+      end: element.selectionEnd,
+    };
+  })).toEqual({
+    start: 0,
+    end: String(firstValue).length,
+  });
+
+  await page.keyboard.press("Escape");
+  await expect(popover).toHaveCount(0);
+  await expect(openButton).toBeFocused();
+  await openButton.click();
+  await expect(baseInput).toHaveValue(String(firstValue));
+
+  const retrySave = page.waitForResponse((response): boolean => (
+    response.url().endsWith("/api/budget-plan")
+    && response.request().method() === "POST"
+    && response.ok()
+  ));
+  await baseInput.fill(String(retryValue));
+  await baseInput.press("Enter");
+  expect((await retrySave).ok()).toBe(true);
+  await expect(popover).toHaveCount(0);
+  await openButton.click();
+  await expect(baseInput).toHaveValue(String(retryValue));
 });
 
 test("publishes successful Fill targets through captured range generations", async ({ page, baseURL }) => {
@@ -414,9 +650,10 @@ test("publishes successful Fill targets through captured range generations", asy
   await targetBaseInput.fill(String(pendingTargetBase));
   await page.keyboard.press("Enter");
   await delayedBase.captured;
-  await expect(
-    page.getByTestId(`budget-plan-popover-${targetEditorId}`),
-  ).toHaveCount(0);
+  const targetPopover = page.getByTestId(
+    `budget-plan-popover-${targetEditorId}`,
+  );
+  await expect(targetPopover).toHaveAttribute("aria-busy", "true");
   await expect(page.getByTestId("budget-sync-status")).toHaveCount(1);
 
   const visibleMonthFrom = offsetMonth(sourceMonth, -6);
@@ -487,7 +724,30 @@ test("publishes successful Fill targets through captured range generations", asy
   await requestMainContentRefresh(page, 1);
   await staleRangeCaptured.promise;
 
+  const beforeStaleRangeClass = await targetPlanCell.getAttribute("class");
+  if (beforeStaleRangeClass === null) {
+    throw new Error(`Cannot read target cell ${targetEditorId}`);
+  }
   await page.getByTestId(`budget-plan-open-${sourceEditorId}`).click();
+  const sourcePopover = page.getByTestId(
+    `budget-plan-popover-${sourceEditorId}`,
+  );
+  await expect(targetPopover).toHaveAttribute("aria-busy", "true");
+  await expect(sourcePopover).toHaveCount(0);
+  staleRangeGate.resolve();
+  expect((await staleRangeResponse).ok()).toBe(true);
+  await expect(targetPlanCell).not.toHaveAttribute(
+    "class",
+    beforeStaleRangeClass,
+  );
+  const staleRangeClass = await targetPlanCell.getAttribute("class");
+  if (staleRangeClass === null) {
+    throw new Error(`Cannot read updated target cell ${targetEditorId}`);
+  }
+
+  delayedBase.release();
+  await expect(targetPopover).toHaveCount(0);
+  await expect(sourcePopover).toBeVisible();
   const sourceBaseInput = page.getByTestId(
     `budget-plan-base-input-${sourceEditorId}`,
   );
@@ -499,22 +759,7 @@ test("publishes successful Fill targets through captured range generations", asy
   ));
   await page.getByTestId(`budget-plan-fill-${sourceEditorId}`).click();
   expect((await acknowledgedFill).ok()).toBe(true);
-  delayedBase.release();
   await expect(page.getByTestId("budget-sync-status")).toHaveCount(0);
-  const beforeStaleRangeClass = await targetPlanCell.getAttribute("class");
-  if (beforeStaleRangeClass === null) {
-    throw new Error(`Cannot read target cell ${targetEditorId}`);
-  }
-  staleRangeGate.resolve();
-  expect((await staleRangeResponse).ok()).toBe(true);
-  await expect(targetPlanCell).not.toHaveAttribute(
-    "class",
-    beforeStaleRangeClass,
-  );
-  const staleRangeClass = await targetPlanCell.getAttribute("class");
-  if (staleRangeClass === null) {
-    throw new Error(`Cannot read updated target cell ${targetEditorId}`);
-  }
 
   await targetOpenButton.click();
   await expect(targetBaseInput).toHaveValue(String(filledBase));

--- a/apps/web/e2e-local/monetary-input.local-demo.spec.ts
+++ b/apps/web/e2e-local/monetary-input.local-demo.spec.ts
@@ -99,6 +99,15 @@ test("keeps the invalid budget plan popover as the only active popover", async (
 
   await secondOpenButton.click();
 
+  const baseError = page.getByTestId(`budget-plan-base-error-${firstEditorId}`);
   await expect(firstInput).toHaveAttribute("aria-invalid", "true");
+  await expect(firstInput).toBeEnabled();
+  await expect(firstInput).toBeFocused();
+  await expect(baseError).toHaveText("Enter a valid number in the selected format.");
+  const describedBy = await firstInput.getAttribute("aria-describedby");
+  if (describedBy === null) {
+    throw new Error("Invalid Budget Base input must describe its validation error");
+  }
+  await expect(baseError).toHaveAttribute("id", describedBy);
   await expect(page.locator('[data-testid^="budget-plan-base-input-budget-plan:"]')).toHaveCount(1);
 });

--- a/apps/web/src/i18n/ar.json
+++ b/apps/web/src/i18n/ar.json
@@ -221,6 +221,7 @@
   "budget.actual": "الفعلي",
   "budget.openPlanEditor": "تعديل ميزانية {{category}} لشهر {{month}}، المبلغ المخطط {{amount}}",
   "budget.popoverBase": "الأساس",
+  "budget.baseSaveFailed": "تعذر حفظ المبلغ الأساسي. حاول مرة أخرى.",
   "budget.popoverTotal": "المجموع",
   "budget.popoverFill": "ملء الأشهر →",
   "budget.adjustments": "التعديلات",

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -221,6 +221,7 @@
   "budget.actual": "Actual",
   "budget.openPlanEditor": "Edit {{category}} budget for {{month}}, plan {{amount}}",
   "budget.popoverBase": "Base",
+  "budget.baseSaveFailed": "The Base amount could not be saved. Try again.",
   "budget.popoverTotal": "Total",
   "budget.popoverFill": "Fill months →",
   "budget.adjustments": "Adjustments",

--- a/apps/web/src/i18n/es.json
+++ b/apps/web/src/i18n/es.json
@@ -221,6 +221,7 @@
   "budget.actual": "Real",
   "budget.openPlanEditor": "Editar el presupuesto de {{category}} para {{month}}, plan {{amount}}",
   "budget.popoverBase": "Base",
+  "budget.baseSaveFailed": "No se pudo guardar el importe base. Inténtalo de nuevo.",
   "budget.popoverTotal": "Total",
   "budget.popoverFill": "Copiar a los meses siguientes →",
   "budget.adjustments": "Ajustes",

--- a/apps/web/src/i18n/fa.json
+++ b/apps/web/src/i18n/fa.json
@@ -221,6 +221,7 @@
   "budget.actual": "عملکرد",
   "budget.openPlanEditor": "ویرایش بودجه {{category}} برای {{month}}، مبلغ برنامه {{amount}}",
   "budget.popoverBase": "مبلغ پایه",
+  "budget.baseSaveFailed": "ذخیره مبلغ پایه ممکن نشد. دوباره تلاش کنید.",
   "budget.popoverTotal": "مجموع",
   "budget.popoverFill": "پر کردن ماه‌ها →",
   "budget.adjustments": "تعدیل‌ها",

--- a/apps/web/src/i18n/he.json
+++ b/apps/web/src/i18n/he.json
@@ -221,6 +221,7 @@
   "budget.actual": "בפועל",
   "budget.openPlanEditor": "עריכת התקציב של {{category}} עבור {{month}}, סכום מתוכנן {{amount}}",
   "budget.popoverBase": "בסיס",
+  "budget.baseSaveFailed": "לא ניתן לשמור את סכום הבסיס. נסו שוב.",
   "budget.popoverTotal": "סה״כ",
   "budget.popoverFill": "מלא חודשים →",
   "budget.adjustments": "התאמות",

--- a/apps/web/src/i18n/ru.json
+++ b/apps/web/src/i18n/ru.json
@@ -221,6 +221,7 @@
   "budget.actual": "Факт",
   "budget.openPlanEditor": "Изменить бюджет «{{category}}» за {{month}}, план {{amount}}",
   "budget.popoverBase": "Базовая сумма",
+  "budget.baseSaveFailed": "Не удалось сохранить базовую сумму. Повторите попытку.",
   "budget.popoverTotal": "Итого",
   "budget.popoverFill": "Заполнить до конца года →",
   "budget.adjustments": "Корректировки",

--- a/apps/web/src/i18n/uk.json
+++ b/apps/web/src/i18n/uk.json
@@ -221,6 +221,7 @@
   "budget.actual": "Факт",
   "budget.openPlanEditor": "Редагувати бюджет «{{category}}» за {{month}}, план {{amount}}",
   "budget.popoverBase": "Базова сума",
+  "budget.baseSaveFailed": "Не вдалося зберегти базову суму. Спробуйте ще раз.",
   "budget.popoverTotal": "Разом",
   "budget.popoverFill": "Заповнити наступні місяці →",
   "budget.adjustments": "Коригування",

--- a/apps/web/src/i18n/zh.json
+++ b/apps/web/src/i18n/zh.json
@@ -221,6 +221,7 @@
   "budget.actual": "实际",
   "budget.openPlanEditor": "编辑 {{month}} 的“{{category}}”预算，计划金额 {{amount}}",
   "budget.popoverBase": "基础值",
+  "budget.baseSaveFailed": "无法保存基础金额。请重试。",
   "budget.popoverTotal": "总计",
   "budget.popoverFill": "应用到后续月份 →",
   "budget.adjustments": "调整项",

--- a/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import {
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useRef,
   useState,
@@ -24,6 +25,12 @@ import { postBudgetPlan, postBudgetPlanFill } from "@/ui/tables/budget/budgetTab
 import { formatAmount, isDecember } from "@/ui/tables/budget/budgetTableLogic";
 import styles from "@/ui/tables/budget/BudgetTable.module.css";
 import type { BudgetAdjustmentRowsController } from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
+import {
+  createBudgetBaseEditorController,
+  type BudgetBaseDraftSnapshot,
+  type BudgetBaseEditorController,
+  type BudgetBaseSettlementOutcome,
+} from "@/ui/tables/budget/controller/budgetBaseEditorController";
 import { logBudgetTableError } from "@/ui/tables/budget/table/logBudgetTableError";
 import { parseMonetaryNumberEdit } from "@/ui/tables/shared/format";
 import { useTableEditorActivation } from "@/ui/tables/shared/TableEditorActivationProvider";
@@ -32,6 +39,7 @@ import tableStateStyles from "@/ui/tables/shared/TableStates.module.css";
 const POPOVER_WIDTH = 720;
 const POPOVER_VIEWPORT_MARGIN = 8;
 const POPOVER_CELL_GAP = 4;
+const BASE_AUTOSAVE_DELAY_MS = 600;
 
 type PopoverPosition = Readonly<{
   top: number;
@@ -48,6 +56,13 @@ type TextDirection = "ltr" | "rtl";
 type RoundedBaseInputResult =
   | Readonly<{ ok: true; value: number }>
   | Readonly<{ ok: false }>;
+
+type PresentedBaseMutation = Readonly<{
+  snapshot: BudgetBaseDraftSnapshot;
+  mutationGeneration: number;
+}>;
+
+type PopoverCloseOutcome = "closed" | "transferred" | "retained";
 
 const parseRoundedBaseInput = (
   input: string,
@@ -198,10 +213,17 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
 
   const { numberFormat } = useFormat();
   const { t } = useTranslation();
+  const accessibilityId = useId();
   const editorId = `budget-plan:${month}:${direction}:${category}`;
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [baseInput, setBaseInput] = useState<string>("");
   const [baseValidationError, setBaseValidationError] = useState<string | null>(null);
+  const [baseSaveError, setBaseSaveError] = useState<string | null>(null);
+  const [isPopoverActionPending, setIsPopoverActionPending] = useState<boolean>(false);
+  const [shouldFocusBaseAfterAction, setShouldFocusBaseAfterAction] =
+    useState<boolean>(false);
+  const [shouldRestoreTriggerFocus, setShouldRestoreTriggerFocus] =
+    useState<boolean>(false);
   const [popoverPos, setPopoverPos] = useState<PopoverPosition>({ top: 0, left: 0 });
 
   const cellRef = useRef<HTMLTableCellElement>(null);
@@ -211,14 +233,36 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
   const adjustmentInitialFocusRef = useRef<
     HTMLInputElement | HTMLButtonElement | null
   >(null);
-  const originalBaseRef = useRef<number>(Math.round(plannedBase));
   const isOpenRef = useRef<boolean>(false);
-  const pendingBaseSaveCountRef = useRef<number>(0);
+  const showDataRef = useRef<boolean>(showData);
+  const previousShowDataRef = useRef<boolean>(showData);
+  const baseInputValueRef = useRef<string>("");
+  const persistBaseSnapshotRef = useRef<
+    (snapshot: BudgetBaseDraftSnapshot) => Promise<void>
+  >((_snapshot): Promise<void> => Promise.reject(
+    new Error(`Budget Base persistence is not initialized for ${editorId}`),
+  ));
+  const baseControllerRef = useRef<BudgetBaseEditorController | null>(null);
+  if (baseControllerRef.current === null) {
+    baseControllerRef.current = createBudgetBaseEditorController(
+      Math.round(plannedBase),
+      (snapshot): Promise<void> => persistBaseSnapshotRef.current(snapshot),
+    );
+  }
+  const baseController = baseControllerRef.current;
   const consumedLocalBaseAcknowledgementVersionRef = useRef<number>(0);
+  const presentedBaseMutationRef = useRef<PresentedBaseMutation | null>(null);
+  const handledBaseFailureRevisionRef = useRef<number | null>(null);
+  const needsBaseSaveRecoveryRef = useRef<boolean>(false);
+  const needsBaseValidationRecoveryRef = useRef<boolean>(false);
+  const popoverActionPendingRef = useRef<boolean>(false);
+  const activePopoverActionRef = useRef<Promise<boolean> | null>(null);
+  const hiddenSettlementRef = useRef<Promise<boolean> | null>(null);
   const interactedAdjustmentIdsRef = useRef<Set<string>>(new Set());
   const settleLifecycleRef = useRef<() => Promise<boolean>>(
     (): Promise<boolean> => Promise.resolve(true),
   );
+  showDataRef.current = showData;
 
   const adjustmentDirection = getAdjustmentDirection(direction);
   const adjustmentLocation = adjustmentDirection === null
@@ -240,12 +284,82 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     adjustmentInitialFocusRef.current = target;
   }, []);
 
+  const persistBaseSnapshot = useCallback(async (
+    snapshot: BudgetBaseDraftSnapshot,
+  ): Promise<void> => {
+    if (snapshot.value === null) {
+      throw new Error(
+        `Cannot persist invalid Base draft revision ${String(snapshot.revision)} for ${month}/${direction}/${category}`,
+      );
+    }
+    const mutationGeneration = onBaseMutationIssued(
+      month,
+      direction,
+      category,
+    );
+    presentedBaseMutationRef.current = { snapshot, mutationGeneration };
+    onSyncStart();
+    onPlanSave(month, direction, category, "base", snapshot.value);
+    try {
+      await postBudgetPlan({
+        month,
+        direction,
+        category,
+        kind: "base",
+        plannedValue: snapshot.value,
+      });
+      onBaseAcknowledged(
+        month,
+        direction,
+        category,
+        snapshot.value,
+        mutationGeneration,
+      );
+    } catch (error: unknown) {
+      logBudgetTableError(`save base for ${month}/${direction}/${category}`, error);
+      throw error;
+    } finally {
+      onSyncEnd();
+    }
+  }, [
+    category,
+    direction,
+    month,
+    onBaseAcknowledged,
+    onBaseMutationIssued,
+    onPlanSave,
+    onSyncEnd,
+    onSyncStart,
+  ]);
+  persistBaseSnapshotRef.current = persistBaseSnapshot;
+
   const initializePopover = (): boolean => {
     const cell = cellRef.current;
-    if (!showData || cell === null) return false;
+    if (
+      !showDataRef.current
+      || cell === null
+      || hiddenSettlementRef.current !== null
+      || baseController.isPersistencePending()
+    ) {
+      return false;
+    }
 
-    let roundedBase = Math.round(plannedBase);
-    if (pendingBaseSaveCountRef.current === 0) {
+    const recoveringSave = needsBaseSaveRecoveryRef.current;
+    const recoveringValidation = needsBaseValidationRecoveryRef.current;
+    if (recoveringSave) {
+      const acknowledgedBase = baseController.getAcknowledgement().value;
+      baseInputValueRef.current = String(acknowledgedBase);
+      setBaseInput(baseInputValueRef.current);
+      setBaseValidationError(null);
+      setBaseSaveError(t("budget.baseSaveFailed"));
+      setShouldFocusBaseAfterAction(true);
+    } else if (recoveringValidation) {
+      setBaseInput(baseInputValueRef.current);
+      setBaseValidationError(t("common.invalidNumber"));
+      setBaseSaveError(null);
+      setShouldFocusBaseAfterAction(true);
+    } else {
+      let roundedBase = Math.round(plannedBase);
       const consumed = consumeBudgetBaseLocalAcknowledgement(
         roundedBase,
         localBaseAcknowledgement,
@@ -254,13 +368,17 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       roundedBase = consumed.value;
       consumedLocalBaseAcknowledgementVersionRef.current =
         consumed.version;
+      baseController.synchronizeAcknowledgement(roundedBase);
+      presentedBaseMutationRef.current = null;
+      baseInputValueRef.current = String(roundedBase);
+      setBaseInput(baseInputValueRef.current);
+      setBaseValidationError(null);
+      setBaseSaveError(null);
+      setShouldFocusBaseAfterAction(false);
+      interactedAdjustmentIdsRef.current = new Set();
     }
-    originalBaseRef.current = roundedBase;
-    setBaseInput(String(roundedBase));
-    setBaseValidationError(null);
     baseInputRef.current?.setCustomValidity("");
     adjustmentInitialFocusRef.current = null;
-    interactedAdjustmentIdsRef.current = new Set();
 
     const rect = cell.getBoundingClientRect();
     setPopoverPos(getPopoverPosition(
@@ -283,8 +401,16 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
   } = useTableEditorActivation(editorId, initializePopover);
 
   const openPopover = (): void => {
-    if (!showData || isOpenRef.current) return;
-    requestActivation();
+    if (!showDataRef.current || isOpenRef.current) return;
+    const hiddenSettlement = hiddenSettlementRef.current;
+    if (hiddenSettlement === null) {
+      requestActivation();
+      return;
+    }
+    void hiddenSettlement.then((): void => {
+      if (!showDataRef.current || isOpenRef.current) return;
+      requestActivation();
+    });
   };
 
   const updatePopoverPosition = useCallback((): void => {
@@ -347,70 +473,126 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     if (focusTarget instanceof HTMLInputElement) focusTarget.select();
   }, [isOpen]);
 
-  const parseAndReportBase = useCallback((): RoundedBaseInputResult => {
-    const parsed = parseRoundedBaseInput(
-      baseInput,
-      originalBaseRef.current,
-      numberFormat,
-    );
-    if (parsed.ok) {
+  useEffect(() => {
+    if (
+      !isOpen
+      || !showData
+      || !shouldFocusBaseAfterAction
+      || isPopoverActionPending
+    ) {
+      return;
+    }
+    const animationFrameId = window.requestAnimationFrame((): void => {
+      const input = baseInputRef.current;
+      if (input === null) return;
+      input.setCustomValidity(baseValidationError ?? "");
+      input.focus();
+      input.select();
+      if (baseValidationError !== null) input.reportValidity();
+      setShouldFocusBaseAfterAction(false);
+    });
+    return () => window.cancelAnimationFrame(animationFrameId);
+  }, [
+    baseValidationError,
+    isOpen,
+    isPopoverActionPending,
+    shouldFocusBaseAfterAction,
+    showData,
+  ]);
+
+  useEffect(() => {
+    if (isOpen || !shouldRestoreTriggerFocus || !showData) return;
+    setShouldRestoreTriggerFocus(false);
+    triggerButtonRef.current?.focus();
+  }, [isOpen, shouldRestoreTriggerFocus, showData]);
+
+  const validateCurrentBase = useCallback((): boolean => {
+    const draft = baseController.getDraft();
+    if (draft.value !== null) {
       setBaseValidationError(null);
       baseInputRef.current?.setCustomValidity("");
-      return parsed;
+      return true;
     }
+    needsBaseValidationRecoveryRef.current = true;
     const message = t("common.invalidNumber");
     setBaseValidationError(message);
+    setShouldFocusBaseAfterAction(true);
     baseInputRef.current?.setCustomValidity(message);
     baseInputRef.current?.reportValidity();
-    return parsed;
-  }, [baseInput, numberFormat, t]);
+    return false;
+  }, [baseController, t]);
 
-  const saveBase = useCallback((value: number): void => {
-    if (value === originalBaseRef.current) return;
-    const mutationGeneration = onBaseMutationIssued(
-      month,
-      direction,
-      category,
-    );
-    const previousBase = originalBaseRef.current;
-    originalBaseRef.current = value;
-    pendingBaseSaveCountRef.current += 1;
-    onSyncStart();
-    onPlanSave(month, direction, category, "base", value);
-    void postBudgetPlan({
-      month,
-      direction,
-      category,
-      kind: "base",
-      plannedValue: value,
-    })
-      .then((): void => {
+  const handleDefinitiveBaseFailure = useCallback((
+    outcome: Extract<BudgetBaseSettlementOutcome, { status: "failed" }>,
+  ): void => {
+    if (handledBaseFailureRevisionRef.current === outcome.draft.revision) return;
+    handledBaseFailureRevisionRef.current = outcome.draft.revision;
+    const rolledBack = baseController.rollbackToAcknowledgement();
+    if (rolledBack.value === null) {
+      throw new Error(
+        `Budget Base rollback produced an invalid draft for ${month}/${direction}/${category}`,
+      );
+    }
+    baseInputValueRef.current = String(rolledBack.value);
+    onPlanSave(month, direction, category, "base", rolledBack.value);
+    needsBaseSaveRecoveryRef.current = true;
+    needsBaseValidationRecoveryRef.current = false;
+    setBaseInput(baseInputValueRef.current);
+    setBaseValidationError(null);
+    baseInputRef.current?.setCustomValidity("");
+    if (showDataRef.current) {
+      setBaseSaveError(t("budget.baseSaveFailed"));
+      setShouldFocusBaseAfterAction(true);
+    } else {
+      setBaseSaveError(null);
+    }
+  }, [
+    baseController,
+    category,
+    direction,
+    month,
+    onPlanSave,
+    t,
+  ]);
+
+  const settleCurrentBase = useCallback(async (): Promise<BudgetBaseSettlementOutcome> => {
+    const outcome = await baseController.settleLatest();
+    if (outcome.status === "failed") {
+      handleDefinitiveBaseFailure(outcome);
+    } else if (outcome.status === "settled") {
+      const presentedMutation = presentedBaseMutationRef.current;
+      if (
+        presentedMutation !== null
+        && presentedMutation.snapshot.value !== outcome.acknowledgement.value
+      ) {
         onBaseAcknowledged(
           month,
           direction,
           category,
-          value,
-          mutationGeneration,
+          outcome.acknowledgement.value,
+          presentedMutation.mutationGeneration,
         );
-      })
-      .catch((error: unknown): void => {
-        originalBaseRef.current = previousBase;
-        onPlanSave(month, direction, category, "base", previousBase);
-        logBudgetTableError(`save base for ${month}/${direction}/${category}`, error);
-      })
-      .finally((): void => {
-        pendingBaseSaveCountRef.current -= 1;
-        onSyncEnd();
-      });
+        presentedBaseMutationRef.current = {
+          snapshot: {
+            revision: outcome.acknowledgement.revision,
+            value: outcome.acknowledgement.value,
+          },
+          mutationGeneration: presentedMutation.mutationGeneration,
+        };
+      }
+      needsBaseSaveRecoveryRef.current = false;
+      needsBaseValidationRecoveryRef.current = false;
+      handledBaseFailureRevisionRef.current = null;
+      if (showDataRef.current) setBaseSaveError(null);
+    }
+    return outcome;
   }, [
+    baseController,
     category,
     direction,
+    handleDefinitiveBaseFailure,
     month,
     onBaseAcknowledged,
-    onBaseMutationIssued,
-    onPlanSave,
-    onSyncEnd,
-    onSyncStart,
   ]);
 
   const focusAdjustmentFlushFailure = useCallback((
@@ -472,111 +654,170 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     focusAdjustmentFlushFailure,
   ]);
 
-  const finishPopoverClose = useCallback((): void => {
+  const finishPopoverClose = useCallback((): boolean => {
     interactedAdjustmentIdsRef.current = new Set();
     setPopoverOpen(false);
-    releaseActivation();
+    return releaseActivation();
   }, [releaseActivation, setPopoverOpen]);
 
-  const closePopover = useCallback(async (): Promise<boolean> => {
-    if (!isOpenRef.current) return true;
-    prepareActivationRelease();
-    const parsedBase = parseAndReportBase();
-    if (!parsedBase.ok) {
-      cancelActivationRelease();
-      return false;
+  const runExclusivePopoverAction = useCallback((
+    action: () => Promise<boolean>,
+  ): Promise<boolean> => {
+    if (activePopoverActionRef.current !== null) {
+      return activePopoverActionRef.current;
     }
-    saveBase(parsedBase.value);
-    if (!await flushInteractedAdjustments()) {
-      cancelActivationRelease();
-      return false;
-    }
-    finishPopoverClose();
-    return true;
-  }, [
-    cancelActivationRelease,
-    finishPopoverClose,
-    flushInteractedAdjustments,
-    parseAndReportBase,
-    prepareActivationRelease,
-    saveBase,
-  ]);
-
-  const cancelBaseAndClosePopover = useCallback(async (): Promise<boolean> => {
-    if (!isOpenRef.current) return true;
-    prepareActivationRelease();
-    const originalBase = String(originalBaseRef.current);
-    setBaseInput(originalBase);
-    setBaseValidationError(null);
-    baseInputRef.current?.setCustomValidity("");
-    if (!await flushInteractedAdjustments()) {
-      cancelActivationRelease();
-      return false;
-    }
-    finishPopoverClose();
-    return true;
-  }, [
-    cancelActivationRelease,
-    finishPopoverClose,
-    flushInteractedAdjustments,
-    prepareActivationRelease,
-  ]);
-
-  const restoreTriggerFocus = useCallback((): void => {
-    window.requestAnimationFrame((): void => triggerButtonRef.current?.focus());
+    popoverActionPendingRef.current = true;
+    setIsPopoverActionPending(true);
+    let request: Promise<boolean>;
+    request = Promise.resolve()
+      .then(action)
+      .finally((): void => {
+        if (activePopoverActionRef.current !== request) return;
+        activePopoverActionRef.current = null;
+        popoverActionPendingRef.current = false;
+        setIsPopoverActionPending(false);
+      });
+    activePopoverActionRef.current = request;
+    return request;
   }, []);
 
+  const closePopover = useCallback(async (): Promise<PopoverCloseOutcome> => {
+    if (!isOpenRef.current) return "closed";
+    if (activePopoverActionRef.current !== null) return "retained";
+    if (!validateCurrentBase()) return "retained";
+    prepareActivationRelease();
+    let activationReleased = false;
+    let transferred = false;
+    const settled = await runExclusivePopoverAction(async (): Promise<boolean> => {
+      const baseOutcome = await settleCurrentBase();
+      if (baseOutcome.status !== "settled") return false;
+      if (!await flushInteractedAdjustments()) return false;
+      transferred = finishPopoverClose();
+      activationReleased = true;
+      return true;
+    });
+    if (!activationReleased) cancelActivationRelease();
+    if (!settled) return "retained";
+    return transferred ? "transferred" : "closed";
+  }, [
+    cancelActivationRelease,
+    finishPopoverClose,
+    flushInteractedAdjustments,
+    prepareActivationRelease,
+    runExclusivePopoverAction,
+    settleCurrentBase,
+    validateCurrentBase,
+  ]);
+
+  const cancelBaseAndClosePopover = useCallback(async (): Promise<PopoverCloseOutcome> => {
+    if (!isOpenRef.current) return "closed";
+    if (activePopoverActionRef.current !== null) return "retained";
+    prepareActivationRelease();
+    let activationReleased = false;
+    let transferred = false;
+    const settled = await runExclusivePopoverAction(async (): Promise<boolean> => {
+      const cancellationOutcome = await baseController.cancelDraft();
+      if (cancellationOutcome.status === "failed") {
+        handleDefinitiveBaseFailure({
+          status: "failed",
+          acknowledgement: cancellationOutcome.acknowledgement,
+          draft: cancellationOutcome.draft,
+          error: cancellationOutcome.error,
+        });
+        return false;
+      }
+
+      const rolledBack = cancellationOutcome.draft;
+      if (rolledBack.value === null) {
+        throw new Error(
+          `Budget Base rollback produced an invalid draft for ${month}/${direction}/${category}`,
+        );
+      }
+      baseInputValueRef.current = String(rolledBack.value);
+      onPlanSave(month, direction, category, "base", rolledBack.value);
+      needsBaseSaveRecoveryRef.current = false;
+      needsBaseValidationRecoveryRef.current = false;
+      handledBaseFailureRevisionRef.current = null;
+      setBaseInput(baseInputValueRef.current);
+      setBaseValidationError(null);
+      setBaseSaveError(null);
+      baseInputRef.current?.setCustomValidity("");
+      if (!await flushInteractedAdjustments()) return false;
+      transferred = finishPopoverClose();
+      activationReleased = true;
+      return true;
+    });
+    if (!activationReleased) cancelActivationRelease();
+    if (!settled) return "retained";
+    return transferred ? "transferred" : "closed";
+  }, [
+    baseController,
+    cancelActivationRelease,
+    category,
+    direction,
+    finishPopoverClose,
+    flushInteractedAdjustments,
+    handleDefinitiveBaseFailure,
+    month,
+    onPlanSave,
+    prepareActivationRelease,
+    runExclusivePopoverAction,
+  ]);
+
   const closePopoverAndRestoreFocus = useCallback(async (): Promise<void> => {
-    if (await closePopover()) restoreTriggerFocus();
-  }, [closePopover, restoreTriggerFocus]);
+    if (await closePopover() === "closed") setShouldRestoreTriggerFocus(true);
+  }, [closePopover]);
 
   const cancelBaseAndRestoreFocus = useCallback(async (): Promise<void> => {
-    if (await cancelBaseAndClosePopover()) restoreTriggerFocus();
-  }, [cancelBaseAndClosePopover, restoreTriggerFocus]);
+    if (await cancelBaseAndClosePopover() === "closed") {
+      setShouldRestoreTriggerFocus(true);
+    }
+  }, [cancelBaseAndClosePopover]);
 
   const handleFill = useCallback(async (): Promise<void> => {
-    if (!isOpenRef.current) return;
+    if (!isOpenRef.current || activePopoverActionRef.current !== null) return;
+    if (!validateCurrentBase()) return;
     prepareActivationRelease();
-    const parsedBase = parseAndReportBase();
-    if (!parsedBase.ok) {
-      cancelActivationRelease();
-      return;
-    }
-    saveBase(parsedBase.value);
-    if (!await flushInteractedAdjustments()) {
-      cancelActivationRelease();
-      return;
-    }
-
-    const mutationGeneration = onFillMonths(
-      month,
-      direction,
-      category,
-      parsedBase.value,
-    );
-    onSyncStart();
-    void postBudgetPlanFill({
-      fromMonth: month,
-      direction,
-      category,
-      baseValue: parsedBase.value,
-    })
-      .then((): void => {
-        onFillMonthsAcknowledged(
-          month,
-          direction,
-          category,
-          parsedBase.value,
-          mutationGeneration,
-        );
+    let activationReleased = false;
+    const settled = await runExclusivePopoverAction(async (): Promise<boolean> => {
+      const baseOutcome = await settleCurrentBase();
+      if (baseOutcome.status !== "settled") return false;
+      if (!await flushInteractedAdjustments()) return false;
+      const baseValue = baseOutcome.acknowledgement.value;
+      const mutationGeneration = onFillMonths(
+        month,
+        direction,
+        category,
+        baseValue,
+      );
+      onSyncStart();
+      void postBudgetPlanFill({
+        fromMonth: month,
+        direction,
+        category,
+        baseValue,
       })
-      .catch((error: unknown): void => {
-        logBudgetTableError(`fill base from ${month}/${direction}/${category}`, error);
-      })
-      .finally(onSyncEnd);
+        .then((): void => {
+          onFillMonthsAcknowledged(
+            month,
+            direction,
+            category,
+            baseValue,
+            mutationGeneration,
+          );
+        })
+        .catch((error: unknown): void => {
+          logBudgetTableError(`fill base from ${month}/${direction}/${category}`, error);
+        })
+        .finally(onSyncEnd);
 
-    finishPopoverClose();
-    restoreTriggerFocus();
+      const transferred = finishPopoverClose();
+      activationReleased = true;
+      if (!transferred) setShouldRestoreTriggerFocus(true);
+      return true;
+    });
+    if (!activationReleased) cancelActivationRelease();
+    if (!settled && showDataRef.current) setShouldFocusBaseAfterAction(true);
   }, [
     cancelActivationRelease,
     category,
@@ -588,37 +829,144 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     onFillMonthsAcknowledged,
     onSyncEnd,
     onSyncStart,
-    parseAndReportBase,
     prepareActivationRelease,
-    restoreTriggerFocus,
-    saveBase,
+    runExclusivePopoverAction,
+    settleCurrentBase,
+    validateCurrentBase,
+  ]);
+
+  useEffect(() => {
+    if (
+      !isOpen
+      || !showData
+      || isPopoverActionPending
+      || !baseController.isDirty()
+      || baseController.getDraft().value === null
+    ) {
+      return;
+    }
+    const timer = window.setTimeout((): void => {
+      void settleCurrentBase();
+    }, BASE_AUTOSAVE_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [
+    baseController,
+    baseInput,
+    isOpen,
+    isPopoverActionPending,
+    settleCurrentBase,
+    showData,
   ]);
 
   const settleLifecycle = useCallback(async (): Promise<boolean> => {
-    if (isOpenRef.current) return closePopover();
+    const hiddenSettlement = hiddenSettlementRef.current;
+    if (hiddenSettlement !== null) return hiddenSettlement;
+
+    const activeAction = activePopoverActionRef.current;
+    if (activeAction !== null && !await activeAction) return false;
+    if (isOpenRef.current) return await closePopover() !== "retained";
+    if (baseController.isDirty() || baseController.isPersistencePending()) {
+      const baseOutcome = await settleCurrentBase();
+      if (baseOutcome.status !== "settled") return false;
+    }
     if (interactedAdjustmentIdsRef.current.size === 0) return true;
     return flushInteractedAdjustments();
-  }, [closePopover, flushInteractedAdjustments]);
+  }, [
+    baseController,
+    closePopover,
+    flushInteractedAdjustments,
+    settleCurrentBase,
+  ]);
   settleLifecycleRef.current = settleLifecycle;
 
   useEffect(() => registerTransitionGate({
     isLifecycleUnresolved: (): boolean => (
-      isOpenRef.current || interactedAdjustmentIdsRef.current.size > 0
+      isOpenRef.current
+      || baseController.isDirty()
+      || baseController.isPersistencePending()
+      || activePopoverActionRef.current !== null
+      || hiddenSettlementRef.current !== null
+      || interactedAdjustmentIdsRef.current.size > 0
     ),
     settleLifecycle: (): Promise<boolean> => settleLifecycleRef.current(),
-  }), [registerTransitionGate]);
+  }), [baseController, registerTransitionGate]);
 
-  useEffect(() => {
-    if (showData) return;
+  useLayoutEffect(() => {
+    const previouslyShowedData = previousShowDataRef.current;
+    previousShowDataRef.current = showData;
+    if (showData) {
+      if (
+        !previouslyShowedData
+        && hiddenSettlementRef.current === null
+        && (
+          needsBaseSaveRecoveryRef.current
+          || needsBaseValidationRecoveryRef.current
+        )
+      ) {
+        requestActivation();
+      }
+      return;
+    }
+    if (!previouslyShowedData) return;
+
     cancelActivationRequest();
-    if (!isOpenRef.current) return;
+    setShouldRestoreTriggerFocus(false);
+    setShouldFocusBaseAfterAction(false);
+    setBaseValidationError(null);
+    setBaseSaveError(null);
+    const activeElement = document.activeElement;
+    if (
+      activeElement instanceof HTMLElement
+      && (
+        popoverRef.current?.contains(activeElement) === true
+        || cellRef.current?.contains(activeElement) === true
+      )
+    ) {
+      activeElement.blur();
+    }
+
+    const wasOpen = isOpenRef.current;
+    if (!wasOpen && activePopoverActionRef.current === null) return;
+    if (activePopoverActionRef.current === null) prepareActivationRelease();
     setPopoverOpen(false);
-    releaseActivation();
-    void flushInteractedAdjustments();
+    let hiddenSettlement: Promise<boolean>;
+    hiddenSettlement = Promise.resolve()
+      .then(async (): Promise<boolean> => {
+        const activeAction = activePopoverActionRef.current;
+        if (activeAction !== null) return activeAction;
+        return runExclusivePopoverAction(async (): Promise<boolean> => {
+          const baseOutcome = await settleCurrentBase();
+          if (baseOutcome.status !== "settled") return false;
+          if (!await flushInteractedAdjustments()) return false;
+          interactedAdjustmentIdsRef.current = new Set();
+          return true;
+        });
+      })
+      .finally((): void => {
+        releaseActivation();
+        if (hiddenSettlementRef.current === hiddenSettlement) {
+          hiddenSettlementRef.current = null;
+        }
+        if (
+          showDataRef.current
+          && (
+            needsBaseSaveRecoveryRef.current
+            || needsBaseValidationRecoveryRef.current
+          )
+          && !isOpenRef.current
+        ) {
+          requestActivation();
+        }
+      });
+    hiddenSettlementRef.current = hiddenSettlement;
   }, [
     cancelActivationRequest,
     flushInteractedAdjustments,
+    prepareActivationRelease,
     releaseActivation,
+    requestActivation,
+    runExclusivePopoverAction,
+    settleCurrentBase,
     setPopoverOpen,
     showData,
   ]);
@@ -648,8 +996,25 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
 
   useEffect(() => {
     if (!isOpen) return;
+    const handleFocusIn = (event: FocusEvent): void => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (
+        popoverRef.current?.contains(target) === true
+        || cellRef.current?.contains(target) === true
+      ) {
+        return;
+      }
+      void closePopover();
+    };
+    document.addEventListener("focusin", handleFocusIn);
+    return () => document.removeEventListener("focusin", handleFocusIn);
+  }, [closePopover, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
     const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.key !== "Escape") return;
+      if (event.key !== "Escape" || popoverActionPendingRef.current) return;
       if (
         popoverRef.current?.querySelector(
           '[data-budget-adjustment-delete-dialog="true"]',
@@ -666,7 +1031,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
 
   const parsedBase = parseRoundedBaseInput(
     baseInput,
-    originalBaseRef.current,
+    baseController.getAcknowledgement().value,
     numberFormat,
   );
   const computedTotal = parsedBase.ok ? parsedBase.value + adjustmentTotal : 0;
@@ -682,6 +1047,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       amount: formattedPlanned,
     })
     : "";
+  const baseError = baseSaveError ?? baseValidationError;
 
   return (
     <td
@@ -720,6 +1086,8 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
           className={styles.popover}
           style={{ top: popoverPos.top, left: popoverPos.left }}
           data-testid={`budget-plan-popover-${editorId}`}
+          aria-busy={isPopoverActionPending}
+          inert={isPopoverActionPending}
           role="dialog"
           aria-label={accessibleName}
         >
@@ -750,10 +1118,26 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
               className={styles.popoverInput}
               data-testid={`budget-plan-base-input-${editorId}`}
               value={baseInput}
-              aria-invalid={baseValidationError !== null}
+              aria-invalid={baseError !== null}
+              aria-describedby={baseError === null
+                ? undefined
+                : `${accessibilityId}-base-error`}
+              disabled={isPopoverActionPending}
               onChange={(event) => {
-                setBaseInput(event.target.value);
+                const nextInput = event.target.value;
+                const parsed = parseRoundedBaseInput(
+                  nextInput,
+                  baseController.getAcknowledgement().value,
+                  numberFormat,
+                );
+                baseInputValueRef.current = nextInput;
+                baseController.updateDraft(parsed.ok ? parsed.value : null);
+                needsBaseSaveRecoveryRef.current = false;
+                needsBaseValidationRecoveryRef.current = !parsed.ok;
+                handledBaseFailureRevisionRef.current = null;
+                setBaseInput(nextInput);
                 setBaseValidationError(null);
+                setBaseSaveError(null);
                 event.currentTarget.setCustomValidity("");
               }}
               onKeyDown={(event) => {
@@ -763,6 +1147,16 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
               }}
             />
           </label>
+          {baseError !== null && (
+            <span
+              id={`${accessibilityId}-base-error`}
+              className={styles.adjustmentError}
+              data-testid={`budget-plan-base-error-${editorId}`}
+              role="alert"
+            >
+              {baseError}
+            </span>
+          )}
           <div className={styles.popoverDivider} />
           <div className={styles.popoverTotal}>
             <span className={styles.popoverLabel}>{t("budget.popoverTotal")}</span>
@@ -777,6 +1171,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
                 type="button"
                 className={styles.popoverFillButton}
                 data-testid={`budget-plan-fill-${editorId}`}
+                disabled={isPopoverActionPending}
                 onClick={() => void handleFill()}
               >
                 {t("budget.popoverFill")}

--- a/apps/web/src/ui/tables/budget/controller/budgetBaseEditorController.test.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetBaseEditorController.test.ts
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createBudgetBaseEditorController,
+  type BudgetBaseDraftSnapshot,
+} from "@/ui/tables/budget/controller/budgetBaseEditorController";
+
+type Deferred<T> = Readonly<{
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+}>;
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolvePromise = (_value: T): void => {
+    throw new Error("Deferred resolver was used before initialization");
+  };
+  let rejectPromise = (_error: Error): void => {
+    throw new Error("Deferred rejecter was used before initialization");
+  };
+  const promise = new Promise<T>((resolve, reject): void => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+};
+
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+test("serializes Base saves and settles through the newest superseding draft", async (): Promise<void> => {
+  const firstSave = createDeferred<void>();
+  const secondSave = createDeferred<void>();
+  const secondSaveStarted = createDeferred<void>();
+  const calls: Array<BudgetBaseDraftSnapshot> = [];
+  const controller = createBudgetBaseEditorController(
+    100,
+    (snapshot): Promise<void> => {
+      calls.push(snapshot);
+      if (calls.length === 2) secondSaveStarted.resolve();
+      return calls.length === 1 ? firstSave.promise : secondSave.promise;
+    },
+  );
+
+  controller.updateDraft(200);
+  const settlement = controller.settleLatest();
+  await flushMicrotasks();
+  assert.deepEqual(calls.map((snapshot) => snapshot.value), [200]);
+
+  controller.updateDraft(300);
+  const joinedSettlement = controller.settleLatest();
+  assert.equal(joinedSettlement, settlement);
+
+  let settled = false;
+  void settlement.then((): void => {
+    settled = true;
+  });
+  firstSave.resolve();
+  await secondSaveStarted.promise;
+  assert.equal(settled, false);
+  assert.deepEqual(calls.map((snapshot) => snapshot.value), [200, 300]);
+
+  secondSave.resolve();
+  assert.deepEqual(await settlement, {
+    status: "settled",
+    acknowledgement: { revision: 2, value: 300 },
+  });
+  assert.equal(settled, true);
+});
+
+test("skips a queued revision superseded before its request begins", async (): Promise<void> => {
+  const firstSave = createDeferred<void>();
+  const calls: Array<number> = [];
+  const controller = createBudgetBaseEditorController(
+    100,
+    (snapshot): Promise<void> => {
+      if (snapshot.value === null) {
+        throw new Error("A valid Base snapshot is required");
+      }
+      calls.push(snapshot.value);
+      return calls.length === 1 ? firstSave.promise : Promise.resolve();
+    },
+  );
+
+  controller.updateDraft(200);
+  const settlement = controller.settleLatest();
+  await flushMicrotasks();
+  controller.updateDraft(300);
+  controller.updateDraft(400);
+  firstSave.resolve();
+
+  assert.equal((await settlement).status, "settled");
+  assert.deepEqual(calls, [200, 400]);
+  assert.equal(controller.getAcknowledgement().value, 400);
+});
+
+test("continues after a superseded failure and reports only the newest result", async (): Promise<void> => {
+  const firstSave = createDeferred<void>();
+  const calls: Array<number> = [];
+  const controller = createBudgetBaseEditorController(
+    100,
+    (snapshot): Promise<void> => {
+      if (snapshot.value === null) {
+        throw new Error("A valid Base snapshot is required");
+      }
+      calls.push(snapshot.value);
+      return calls.length === 1 ? firstSave.promise : Promise.resolve();
+    },
+  );
+
+  controller.updateDraft(200);
+  const settlement = controller.settleLatest();
+  await flushMicrotasks();
+  controller.updateDraft(300);
+  firstSave.reject(new Error("superseded failure"));
+
+  assert.deepEqual(await settlement, {
+    status: "settled",
+    acknowledgement: { revision: 2, value: 300 },
+  });
+  assert.deepEqual(calls, [200, 300]);
+});
+
+test("settles back to the acknowledgement after a superseded save fails", async (): Promise<void> => {
+  const failedSave = createDeferred<void>();
+  const calls: Array<number> = [];
+  const controller = createBudgetBaseEditorController(
+    100,
+    (snapshot): Promise<void> => {
+      if (snapshot.value === null) {
+        throw new Error("A valid Base snapshot is required");
+      }
+      calls.push(snapshot.value);
+      return failedSave.promise;
+    },
+  );
+
+  controller.updateDraft(200);
+  const settlement = controller.settleLatest();
+  await flushMicrotasks();
+  controller.updateDraft(100);
+  failedSave.reject(new Error("superseded failure"));
+
+  assert.deepEqual(await settlement, {
+    status: "settled",
+    acknowledgement: { revision: 2, value: 100 },
+  });
+  assert.deepEqual(calls, [200]);
+});
+
+test("returns a definitive failure with the latest acknowledged Base", async (): Promise<void> => {
+  const failure = new Error("save failed");
+  const controller = createBudgetBaseEditorController(
+    100,
+    (): Promise<void> => Promise.reject(failure),
+  );
+
+  const failedDraft = controller.updateDraft(200);
+  assert.deepEqual(await controller.settleLatest(), {
+    status: "failed",
+    acknowledgement: { revision: 0, value: 100 },
+    draft: failedDraft,
+    error: failure,
+  });
+
+  assert.deepEqual(controller.rollbackToAcknowledgement(), {
+    revision: failedDraft.revision,
+    value: 100,
+  });
+  assert.equal(controller.isDirty(), false);
+});
+
+test("cancellation finishes only the active save before discarding a newer valid draft", async (): Promise<void> => {
+  const save = createDeferred<void>();
+  const calls: Array<number> = [];
+  const controller = createBudgetBaseEditorController(
+    100,
+    (snapshot): Promise<void> => {
+      if (snapshot.value === null) {
+        throw new Error("A valid Base snapshot is required");
+      }
+      calls.push(snapshot.value);
+      return save.promise;
+    },
+  );
+
+  controller.updateDraft(200);
+  const settlement = controller.settleLatest();
+  await flushMicrotasks();
+  controller.updateDraft(300);
+
+  const cancellation = controller.cancelDraft();
+  let cancellationResolved = false;
+  void cancellation.then((): void => {
+    cancellationResolved = true;
+  });
+  await flushMicrotasks();
+  assert.equal(cancellationResolved, false);
+
+  save.resolve();
+  assert.deepEqual(await settlement, {
+    status: "interrupted",
+    acknowledgement: { revision: 1, value: 200 },
+    draft: { revision: 2, value: 300 },
+  });
+  assert.deepEqual(await cancellation, {
+    status: "cancelled",
+    acknowledgement: { revision: 1, value: 200 },
+    draft: { revision: 2, value: 200 },
+  });
+  assert.deepEqual(controller.getDraft(), {
+    revision: 2,
+    value: 200,
+  });
+  assert.deepEqual(calls, [200]);
+});
+
+test("cancellation dismisses an already-recovered failure without another revision", async (): Promise<void> => {
+  const failure = new Error("save failed");
+  let callCount = 0;
+  const controller = createBudgetBaseEditorController(
+    100,
+    (): Promise<void> => {
+      callCount += 1;
+      return Promise.reject(failure);
+    },
+  );
+
+  const failedDraft = controller.updateDraft(200);
+  assert.equal((await controller.settleLatest()).status, "failed");
+  assert.deepEqual(controller.rollbackToAcknowledgement(), {
+    revision: failedDraft.revision,
+    value: 100,
+  });
+
+  assert.deepEqual(await controller.cancelDraft(), {
+    status: "cancelled",
+    acknowledgement: { revision: 0, value: 100 },
+    draft: { revision: failedDraft.revision, value: 100 },
+  });
+  assert.equal(controller.getDraft().revision, failedDraft.revision);
+  assert.equal(callCount, 1);
+});
+
+test("accepts finite rounded Base values outside the safe integer range", (): void => {
+  const outsideSafeIntegerRange = Number.MAX_SAFE_INTEGER + 1;
+  const controller = createBudgetBaseEditorController(
+    outsideSafeIntegerRange,
+    (): Promise<void> => Promise.resolve(),
+  );
+
+  assert.deepEqual(controller.getAcknowledgement(), {
+    revision: 0,
+    value: outsideSafeIntegerRange,
+  });
+  assert.deepEqual(controller.updateDraft(-outsideSafeIntegerRange), {
+    revision: 1,
+    value: -outsideSafeIntegerRange,
+  });
+});
+
+test("rejects reinitialization while persistence or a dirty draft is unsettled", async (): Promise<void> => {
+  const save = createDeferred<void>();
+  const controller = createBudgetBaseEditorController(
+    100,
+    (): Promise<void> => save.promise,
+  );
+
+  controller.updateDraft(200);
+  assert.throws(
+    (): void => controller.synchronizeAcknowledgement(300),
+    /lifecycle is unresolved/,
+  );
+
+  const settlement = controller.settleLatest();
+  await flushMicrotasks();
+  assert.throws(
+    (): void => controller.synchronizeAcknowledgement(300),
+    /lifecycle is unresolved/,
+  );
+  save.resolve();
+  await settlement;
+
+  controller.synchronizeAcknowledgement(300);
+  assert.deepEqual(controller.getDraft(), { revision: 1, value: 300 });
+  assert.deepEqual(controller.getAcknowledgement(), { revision: 1, value: 300 });
+});

--- a/apps/web/src/ui/tables/budget/controller/budgetBaseEditorController.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetBaseEditorController.ts
@@ -1,0 +1,279 @@
+export type BudgetBaseDraftSnapshot = Readonly<{
+  revision: number;
+  value: number | null;
+}>;
+
+export type BudgetBaseAcknowledgement = Readonly<{
+  revision: number;
+  value: number;
+}>;
+
+export type BudgetBaseSettlementOutcome =
+  | Readonly<{
+    status: "settled";
+    acknowledgement: BudgetBaseAcknowledgement;
+  }>
+  | Readonly<{
+    status: "interrupted";
+    acknowledgement: BudgetBaseAcknowledgement;
+    draft: BudgetBaseDraftSnapshot;
+  }>
+  | Readonly<{
+    status: "invalid";
+    draft: BudgetBaseDraftSnapshot;
+  }>
+  | Readonly<{
+    status: "failed";
+    acknowledgement: BudgetBaseAcknowledgement;
+    draft: BudgetBaseDraftSnapshot;
+    error: unknown;
+  }>;
+
+export type BudgetBaseCancellationOutcome =
+  | Readonly<{
+    status: "cancelled";
+    acknowledgement: BudgetBaseAcknowledgement;
+    draft: BudgetBaseDraftSnapshot;
+  }>
+  | Readonly<{
+    status: "failed";
+    acknowledgement: BudgetBaseAcknowledgement;
+    draft: BudgetBaseDraftSnapshot;
+    error: unknown;
+  }>;
+
+type BudgetBasePersistenceOutcome =
+  | Readonly<{
+    status: "acknowledged" | "unchanged" | "superseded";
+    snapshot: BudgetBaseDraftSnapshot;
+  }>
+  | Readonly<{
+    status: "failed";
+    snapshot: BudgetBaseDraftSnapshot;
+    error: unknown;
+  }>;
+
+export type BudgetBaseEditorController = Readonly<{
+  getAcknowledgement: () => BudgetBaseAcknowledgement;
+  getDraft: () => BudgetBaseDraftSnapshot;
+  isDirty: () => boolean;
+  isPersistencePending: () => boolean;
+  synchronizeAcknowledgement: (value: number) => void;
+  updateDraft: (value: number | null) => BudgetBaseDraftSnapshot;
+  settleLatest: () => Promise<BudgetBaseSettlementOutcome>;
+  cancelDraft: () => Promise<BudgetBaseCancellationOutcome>;
+  rollbackToAcknowledgement: () => BudgetBaseDraftSnapshot;
+}>;
+
+const assertBaseValue = (value: number, context: string): void => {
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new RangeError(
+      `${context} must be a finite integer; received ${String(value)}`,
+    );
+  }
+};
+
+const nextRevision = (revision: number): number => {
+  if (!Number.isSafeInteger(revision) || revision < 0) {
+    throw new RangeError(
+      `Budget Base draft revision must be a non-negative safe integer; received ${String(revision)}`,
+    );
+  }
+  if (revision === Number.MAX_SAFE_INTEGER) {
+    throw new RangeError("Cannot create another Budget Base draft revision");
+  }
+  return revision + 1;
+};
+
+export const createBudgetBaseEditorController = (
+  initialValue: number,
+  persist: (snapshot: BudgetBaseDraftSnapshot) => Promise<void>,
+): BudgetBaseEditorController => {
+  assertBaseValue(initialValue, "Initial Budget Base value");
+
+  let acknowledgement: BudgetBaseAcknowledgement = {
+    revision: 0,
+    value: initialValue,
+  };
+  let draft: BudgetBaseDraftSnapshot = {
+    revision: 0,
+    value: initialValue,
+  };
+  let persistenceTail: Promise<void> = Promise.resolve();
+  let pendingPersistenceCount = 0;
+  let activeSettlement: Promise<BudgetBaseSettlementOutcome> | null = null;
+  let interruptActiveSettlement = false;
+  const persistenceByRevision =
+    new Map<number, Promise<BudgetBasePersistenceOutcome>>();
+
+  const isDirty = (): boolean => (
+    draft.value === null || draft.value !== acknowledgement.value
+  );
+
+  const executePersistence = async (
+    snapshot: BudgetBaseDraftSnapshot,
+  ): Promise<BudgetBasePersistenceOutcome> => {
+    if (snapshot.revision < draft.revision) {
+      return { status: "superseded", snapshot };
+    }
+    if (snapshot.value === null) {
+      throw new Error(
+        `Cannot persist invalid Budget Base draft revision ${String(snapshot.revision)}`,
+      );
+    }
+    if (snapshot.value === acknowledgement.value) {
+      acknowledgement = {
+        revision: snapshot.revision,
+        value: snapshot.value,
+      };
+      return { status: "unchanged", snapshot };
+    }
+
+    try {
+      await persist(snapshot);
+      acknowledgement = {
+        revision: snapshot.revision,
+        value: snapshot.value,
+      };
+      return { status: "acknowledged", snapshot };
+    } catch (error: unknown) {
+      return { status: "failed", snapshot, error };
+    }
+  };
+
+  const persistSnapshot = (
+    snapshot: BudgetBaseDraftSnapshot,
+  ): Promise<BudgetBasePersistenceOutcome> => {
+    const existing = persistenceByRevision.get(snapshot.revision);
+    if (existing !== undefined) return existing;
+
+    const previousTail = persistenceTail;
+    pendingPersistenceCount += 1;
+    let request: Promise<BudgetBasePersistenceOutcome>;
+    request = previousTail
+      .then((): Promise<BudgetBasePersistenceOutcome> => (
+        executePersistence(snapshot)
+      ))
+      .finally((): void => {
+        pendingPersistenceCount -= 1;
+        if (persistenceByRevision.get(snapshot.revision) === request) {
+          persistenceByRevision.delete(snapshot.revision);
+        }
+      });
+    persistenceByRevision.set(snapshot.revision, request);
+    persistenceTail = request.then((): void => undefined);
+    return request;
+  };
+
+  const runSettlement = async (): Promise<BudgetBaseSettlementOutcome> => {
+    while (true) {
+      const snapshot = draft;
+      if (snapshot.value === null) {
+        return { status: "invalid", draft: snapshot };
+      }
+
+      const outcome = await persistSnapshot(snapshot);
+      if (interruptActiveSettlement) {
+        if (outcome.status === "failed") {
+          return {
+            status: "failed",
+            acknowledgement,
+            draft: snapshot,
+            error: outcome.error,
+          };
+        }
+        return {
+          status: "interrupted",
+          acknowledgement,
+          draft,
+        };
+      }
+      if (draft.revision !== snapshot.revision) continue;
+      if (outcome.status === "failed") {
+        return {
+          status: "failed",
+          acknowledgement,
+          draft: snapshot,
+          error: outcome.error,
+        };
+      }
+      return { status: "settled", acknowledgement };
+    }
+  };
+
+  const settleLatest = (): Promise<BudgetBaseSettlementOutcome> => {
+    if (activeSettlement !== null) return activeSettlement;
+
+    let request: Promise<BudgetBaseSettlementOutcome>;
+    request = runSettlement().finally((): void => {
+      if (activeSettlement === request) activeSettlement = null;
+    });
+    activeSettlement = request;
+    return request;
+  };
+
+  const rollbackToAcknowledgement = (): BudgetBaseDraftSnapshot => {
+    draft = {
+      revision: draft.revision,
+      value: acknowledgement.value,
+    };
+    return draft;
+  };
+
+  const cancelDraft = async (): Promise<BudgetBaseCancellationOutcome> => {
+    const settlement = activeSettlement;
+    if (settlement !== null) {
+      interruptActiveSettlement = true;
+      let outcome: BudgetBaseSettlementOutcome;
+      try {
+        outcome = await settlement;
+      } finally {
+        interruptActiveSettlement = false;
+      }
+      if (outcome.status === "failed") {
+        return outcome;
+      }
+    }
+
+    const cancelledDraft = rollbackToAcknowledgement();
+    return {
+      status: "cancelled",
+      acknowledgement,
+      draft: cancelledDraft,
+    };
+  };
+
+  const synchronizeAcknowledgement = (value: number): void => {
+    assertBaseValue(value, "Synchronized Budget Base value");
+    if (pendingPersistenceCount > 0 || activeSettlement !== null || isDirty()) {
+      throw new Error(
+        "Cannot synchronize Budget Base acknowledgement while its editor lifecycle is unresolved",
+      );
+    }
+    acknowledgement = { revision: draft.revision, value };
+    draft = { revision: draft.revision, value };
+  };
+
+  const updateDraft = (value: number | null): BudgetBaseDraftSnapshot => {
+    if (value !== null) assertBaseValue(value, "Budget Base draft value");
+    draft = {
+      revision: nextRevision(draft.revision),
+      value,
+    };
+    return draft;
+  };
+
+  return {
+    getAcknowledgement: (): BudgetBaseAcknowledgement => acknowledgement,
+    getDraft: (): BudgetBaseDraftSnapshot => draft,
+    isDirty,
+    isPersistencePending: (): boolean => (
+      pendingPersistenceCount > 0 || activeSettlement !== null
+    ),
+    synchronizeAcknowledgement,
+    updateDraft,
+    settleLatest,
+    cancelDraft,
+    rollbackToAcknowledgement,
+  };
+};


### PR DESCRIPTION
## Summary

- serialize Base autosave, Enter, blur, Escape, handoff, hidden settlement, and Fill Months
- reconcile superseding saves and recover definitive failures without leaking masked data
- add controller, local-demo, monetary-input, mobile, RTL, and locale coverage

## Validation

- focused Base controller, reconciliation, and activation tests
- relevant local-demo Playwright Base lifecycle and monetary/mobile RTL scenarios
- locale key parity across all eight locales
- `cd apps/web && npm run lint && npm run build`
- `git diff --check`