### PR TITLE
Normalize budget adjustment row lifecycle

### DIFF
--- a/apps/web/e2e-local/budget-adjustments.local-demo.spec.ts
+++ b/apps/web/e2e-local/budget-adjustments.local-demo.spec.ts
@@ -103,6 +103,31 @@ const isBudgetGridRangeResponse = (
     && response.request().method() === "GET";
 };
 
+const isBudgetGridResponse = (response: Response): boolean =>
+  new URL(response.url()).pathname === "/api/budget-grid"
+  && response.request().method() === "GET";
+
+const gotoBudgetAndWaitForGrid = async (page: Page): Promise<void> => {
+  const initialBudgetGridResponse = page.waitForResponse(isBudgetGridResponse);
+  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+  expect((await initialBudgetGridResponse).ok()).toBe(true);
+};
+
+const adjustmentRequestFieldEquals = (
+  response: Response,
+  field: "category" | "month",
+  expectedValue: string,
+): boolean => {
+  const requestBody: unknown = response.request().postDataJSON();
+  if (typeof requestBody !== "object" || requestBody === null) return false;
+  if (field === "category") {
+    return "category" in requestBody
+      && requestBody.category === expectedValue;
+  }
+  return "month" in requestBody
+    && requestBody.month === expectedValue;
+};
+
 const delayFirstBudgetBaseSave = async (
   page: Page,
 ): Promise<Readonly<{
@@ -135,9 +160,10 @@ const delayFirstBudgetBaseSave = async (
 };
 
 test("creates, autosaves, moves, and deletes normalized adjustment rows", async ({ page, baseURL }) => {
+  test.slow();
   if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
   await setDemoCookies(page, baseURL, "en");
-  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+  await gotoBudgetAndWaitForGrid(page);
 
   const editorId = await getEditorId(page, "spend", "Groceries", 0);
   const month = editorId.split(":")[1];
@@ -165,7 +191,7 @@ test("creates, autosaves, moves, and deletes normalized adjustment rows", async 
     }
   });
   await baseInput.fill("987");
-  await page.keyboard.press("Escape");
+  await baseInput.press("Escape");
   await expect(page.getByTestId(`budget-plan-popover-${editorId}`)).toHaveCount(0);
   await expect(openButton).toBeFocused();
   await openButton.click();
@@ -255,13 +281,120 @@ test("creates, autosaves, moves, and deletes normalized adjustment rows", async 
   expect(blankAmountResponse.request().postDataJSON()).toEqual({ amount: 0 });
   await expect(row).toBeVisible();
 
+  await page.evaluate((params): void => {
+    const monthControl = document.querySelector(
+      `[data-testid="${params.monthTestId}"]`,
+    );
+    const baseControl = document.querySelector(
+      `[data-testid="${params.baseTestId}"]`,
+    );
+    if (!(monthControl instanceof HTMLInputElement)) {
+      throw new Error("Budget adjustment Month control is not an input");
+    }
+    if (!(baseControl instanceof HTMLInputElement)) {
+      throw new Error("Budget Base control is not an input");
+    }
+    const setInputValue = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    if (setInputValue === undefined) {
+      throw new Error("HTML input value setter is unavailable");
+    }
+    setInputValue.call(monthControl, "");
+    monthControl.dispatchEvent(new Event("input", { bubbles: true }));
+    setInputValue.call(monthControl, params.month);
+    monthControl.dispatchEvent(new Event("input", { bubbles: true }));
+    baseControl.focus();
+  }, {
+    monthTestId: `budget-adjustment-month-${adjustmentId}`,
+    baseTestId: `budget-plan-base-input-${editorId}`,
+    month,
+  });
+  await page.waitForTimeout(50);
+  await expect(baseInput).toBeFocused();
+  await expect(monthInput).toHaveValue(month);
+  await expect(monthInput).toHaveAttribute("aria-invalid", "false");
+  await expect(monthInput).toHaveJSProperty("validationMessage", "");
+  expect(locationPatchCount).toBe(0);
+
+  await monthInput.fill("");
+  await categoryInput.selectOption("Dining");
+  await expect(monthInput).toBeFocused();
+  await expect(monthInput).toHaveAttribute("aria-invalid", "true");
+  await expect(categoryInput).toHaveAttribute("aria-invalid", "false");
+  await expect(categoryInput).toHaveJSProperty("validationMessage", "");
+  await categoryInput.selectOption("Groceries");
+  await monthInput.fill(month);
+  await expect(monthInput).toBeFocused();
+  await expect(monthInput).toHaveAttribute("aria-invalid", "false");
+  await expect(categoryInput).toHaveAttribute("aria-invalid", "false");
+  await expect(monthInput).toHaveJSProperty("validationMessage", "");
+  await expect(categoryInput).toHaveJSProperty("validationMessage", "");
+  await page.waitForTimeout(700);
+  expect(locationPatchCount).toBe(0);
+
+  await categoryInput.evaluate((element): void => {
+    if (!(element instanceof HTMLSelectElement)) {
+      throw new Error("Budget adjustment Category control is not a select");
+    }
+    element.focus();
+    element.value = "";
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await expect(row).toBeVisible();
+  await expect(categoryInput).toBeFocused();
+  await expect(categoryInput).toHaveAttribute("aria-invalid", "true");
+  await page.waitForTimeout(700);
+  expect(locationPatchCount).toBe(0);
+
+  await categoryInput.selectOption("Groceries");
+  await expect(row).toBeVisible();
+  await expect(categoryInput).toBeFocused();
+  await expect(categoryInput).toHaveAttribute("aria-invalid", "false");
+  await page.waitForTimeout(700);
+  expect(locationPatchCount).toBe(0);
+
+  const monthMoveStarted = createDeferred();
+  const monthMoveGate = createDeferred();
+  await page.route(
+    `**/api/budget-adjustments/${adjustmentId}`,
+    async (route): Promise<void> => {
+      const body: unknown = route.request().postDataJSON();
+      if (
+        route.request().method() !== "PATCH"
+        || typeof body !== "object"
+        || body === null
+        || !("month" in body)
+      ) {
+        await route.continue();
+        return;
+      }
+      const response = await route.fetch();
+      monthMoveStarted.resolve();
+      await monthMoveGate.promise;
+      await route.fulfill({ response });
+    },
+  );
   const monthMove = page.waitForResponse((response): boolean =>
     response.url().includes(`/api/budget-adjustments/${adjustmentId}`)
-      && response.request().method() === "PATCH");
+      && response.request().method() === "PATCH"
+      && adjustmentRequestFieldEquals(response, "month", destinationMonth));
   await monthInput.fill(destinationMonth);
+  await monthMoveStarted.promise;
+  await expect(row).toBeVisible();
+  await expect(monthInput).toHaveValue(destinationMonth);
+  await expect(monthInput).toBeFocused();
+  await expect(addButton).not.toBeFocused();
+  expect(baseRequestCount).toBe(0);
+  await baseInput.click();
+  await expect(baseInput).toBeFocused();
+  monthMoveGate.resolve();
   expect((await monthMove).ok()).toBe(true);
+  await page.unroute(`**/api/budget-adjustments/${adjustmentId}`);
   await expect(row).toHaveCount(0);
-  await expect(addButton).toBeFocused();
+  await expect(baseInput).toBeFocused();
+  await expect(addButton).not.toBeFocused();
   expect(locationPatchCount).toBe(1);
 
   const destinationEditorId = `budget-plan:${destinationMonth}:spend:Groceries`;
@@ -292,7 +425,8 @@ test("creates, autosaves, moves, and deletes normalized adjustment rows", async 
 
   const categoryMove = page.waitForResponse((response): boolean =>
     response.url().includes(`/api/budget-adjustments/${adjustmentId}`)
-      && response.request().method() === "PATCH");
+      && response.request().method() === "PATCH"
+      && adjustmentRequestFieldEquals(response, "category", "Dining"));
   await categoryInput.selectOption("Dining");
   expect((await categoryMove).ok()).toBe(true);
   await expect(row).toHaveCount(0);
@@ -300,6 +434,10 @@ test("creates, autosaves, moves, and deletes normalized adjustment rows", async 
   expect(locationPatchCount).toBe(2);
 
   const diningEditorId = `budget-plan:${destinationMonth}:spend:Dining`;
+  await destinationAddButton.press("Escape");
+  await expect(
+    page.getByTestId(`budget-plan-popover-${destinationEditorId}`),
+  ).toHaveCount(0);
   await page.getByTestId(`budget-plan-open-${diningEditorId}`).click();
   await expect(row).toBeVisible();
   await page.getByTestId(`budget-adjustment-delete-${adjustmentId}`).click();
@@ -307,6 +445,7 @@ test("creates, autosaves, moves, and deletes normalized adjustment rows", async 
   await expect(dialog).toContainText("Annual stock-up");
   await page.getByTestId(`budget-adjustment-delete-cancel-${adjustmentId}`).click();
   await expect(dialog).toHaveCount(0);
+  expect(baseRequestCount).toBe(0);
 
   await page.getByTestId(`budget-adjustment-delete-${adjustmentId}`).click();
   const deleteResponsePromise = page.waitForResponse((response): boolean =>
@@ -322,10 +461,442 @@ test("creates, autosaves, moves, and deletes normalized adjustment rows", async 
   await expect(page.getByTestId(`budget-adjustment-add-${diningEditorId}`)).toBeFocused();
 });
 
+test("keeps a delayed move editable in its source when a newer location draft is invalid", async ({ page, baseURL }) => {
+  test.slow();
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  await gotoBudgetAndWaitForGrid(page);
+
+  const adjustmentId = "demo-adjustment-groceries-seasonal";
+  const sourceEditorId = await getEditorId(page, "spend", "Groceries", 0);
+  const sourceMonth = sourceEditorId.split(":")[1];
+  if (sourceMonth === undefined) {
+    throw new Error(`Cannot read month from editor ID "${sourceEditorId}"`);
+  }
+  const destinationMonth = offsetMonth(sourceMonth, 2);
+  const destinationEditorId =
+    `budget-plan:${destinationMonth}:spend:Groceries`;
+  const sourcePopover = page.getByTestId(
+    `budget-plan-popover-${sourceEditorId}`,
+  );
+  const destinationPopover = page.getByTestId(
+    `budget-plan-popover-${destinationEditorId}`,
+  );
+  const moveStarted = createDeferred();
+  const moveGate = createDeferred();
+  await page.route(
+    `**/api/budget-adjustments/${adjustmentId}`,
+    async (route): Promise<void> => {
+      if (route.request().method() !== "PATCH") {
+        await route.continue();
+        return;
+      }
+      const response = await route.fetch();
+      moveStarted.resolve();
+      await moveGate.promise;
+      await route.fulfill({ response });
+    },
+  );
+
+  await page.getByTestId(`budget-plan-open-${sourceEditorId}`).click();
+  const row = page.getByTestId(`budget-adjustment-row-${adjustmentId}`);
+  const monthInput = page.getByTestId(
+    `budget-adjustment-month-${adjustmentId}`,
+  );
+  const categoryInput = page.getByTestId(
+    `budget-adjustment-category-${adjustmentId}`,
+  );
+  const moveResponse = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${adjustmentId}`)
+      && response.request().method() === "PATCH"
+      && adjustmentRequestFieldEquals(
+        response,
+        "month",
+        destinationMonth,
+      ));
+  await monthInput.fill(destinationMonth);
+  await moveStarted.promise;
+  await categoryInput.evaluate((element): void => {
+    if (!(element instanceof HTMLSelectElement)) {
+      throw new Error("Budget adjustment Category control is not a select");
+    }
+    element.focus();
+    element.value = "";
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await expect(categoryInput).toBeFocused();
+  await expect(categoryInput).toHaveAttribute("aria-invalid", "true");
+
+  moveGate.resolve();
+  expect((await moveResponse).ok()).toBe(true);
+  await page.unroute(`**/api/budget-adjustments/${adjustmentId}`);
+  await expect(row).toBeVisible();
+  await expect(monthInput).toHaveValue(destinationMonth);
+  await expect(categoryInput).toHaveAttribute("aria-invalid", "true");
+  await expect(categoryInput).toBeFocused();
+
+  await page.getByTestId(`budget-plan-open-${destinationEditorId}`).click();
+  await expect(sourcePopover).toBeVisible();
+  await expect(destinationPopover).toHaveCount(0);
+  await expect(row).toBeVisible();
+  await expect(categoryInput).toBeFocused();
+
+  await categoryInput.selectOption("Groceries");
+  await expect(row).toHaveCount(0);
+  await expect(
+    page.getByTestId(`budget-adjustment-add-${sourceEditorId}`),
+  ).toBeFocused();
+
+  await page.getByTestId(`budget-plan-open-${destinationEditorId}`).click();
+  await expect(sourcePopover).toHaveCount(0);
+  await expect(destinationPopover).toBeVisible();
+  await expect(row).toBeVisible();
+});
+
+const settleAcknowledgedMoveAfterRetryEdit = async (
+  page: Page,
+  baseURL: string | undefined,
+  retryTrigger: "autosave" | "Enter",
+): Promise<void> => {
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  await gotoBudgetAndWaitForGrid(page);
+
+  const adjustmentId = "demo-adjustment-groceries-seasonal";
+  const sourceEditorId = await getEditorId(page, "spend", "Groceries", 0);
+  const sourceMonth = sourceEditorId.split(":")[1];
+  if (sourceMonth === undefined) {
+    throw new Error(`Cannot read month from editor ID "${sourceEditorId}"`);
+  }
+  const destinationMonth = offsetMonth(sourceMonth, 2);
+  const destinationEditorId =
+    `budget-plan:${destinationMonth}:spend:Groceries`;
+  const sourcePopover = page.getByTestId(
+    `budget-plan-popover-${sourceEditorId}`,
+  );
+  const destinationPopover = page.getByTestId(
+    `budget-plan-popover-${destinationEditorId}`,
+  );
+  const moveStarted = createDeferred();
+  const moveGate = createDeferred();
+  let patchAttempt = 0;
+  let allowRetry = false;
+  await page.route(
+    `**/api/budget-adjustments/${adjustmentId}`,
+    async (route): Promise<void> => {
+      if (route.request().method() !== "PATCH") {
+        await route.continue();
+        return;
+      }
+      patchAttempt += 1;
+      if (patchAttempt === 1) {
+        const response = await route.fetch();
+        moveStarted.resolve();
+        await moveGate.promise;
+        await route.fulfill({ response });
+        return;
+      }
+      if (!allowRetry) {
+        await route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Forced follow-up conflict" }),
+        });
+        return;
+      }
+      await route.continue();
+    },
+  );
+
+  await page.getByTestId(`budget-plan-open-${sourceEditorId}`).click();
+  await expect(sourcePopover).toBeVisible();
+  const row = page.getByTestId(`budget-adjustment-row-${adjustmentId}`);
+  const monthInput = page.getByTestId(
+    `budget-adjustment-month-${adjustmentId}`,
+  );
+  const amountInput = page.getByTestId(
+    `budget-adjustment-amount-${adjustmentId}`,
+  );
+  const recoveryButton = page.getByTestId(
+    `budget-adjustment-recovery-${adjustmentId}`,
+  );
+  const moveResponse = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${adjustmentId}`)
+      && response.request().method() === "PATCH"
+      && adjustmentRequestFieldEquals(
+        response,
+        "month",
+        destinationMonth,
+      ));
+  const failedFollowUp = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${adjustmentId}`)
+      && response.request().method() === "PATCH"
+      && response.status() === 409);
+  await monthInput.fill(destinationMonth);
+  await moveStarted.promise;
+  await amountInput.fill("88");
+  await expect(amountInput).toBeFocused();
+  moveGate.resolve();
+
+  expect((await moveResponse).ok()).toBe(true);
+  expect((await failedFollowUp).ok()).toBe(false);
+  await expect(row).toBeVisible();
+  await expect(monthInput).toHaveValue(destinationMonth);
+  await expect(amountInput).toHaveValue("88");
+  await expect(amountInput).toBeFocused();
+  await expect(recoveryButton).toBeVisible();
+  await expect(recoveryButton).toBeEnabled();
+
+  await page.getByTestId(`budget-plan-open-${destinationEditorId}`).click();
+  await expect(sourcePopover).toBeVisible();
+  await expect(destinationPopover).toHaveCount(0);
+  await expect(row).toBeVisible();
+  await expect(recoveryButton).toBeEnabled();
+
+  allowRetry = true;
+  const retryResponse = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${adjustmentId}`)
+      && response.request().method() === "PATCH"
+      && response.ok());
+  await amountInput.fill("89");
+  if (retryTrigger === "Enter") await amountInput.press("Enter");
+  expect((await retryResponse).ok()).toBe(true);
+  await expect(row).toHaveCount(0);
+  await expect(
+    page.getByTestId(`budget-adjustment-add-${sourceEditorId}`),
+  ).toBeFocused();
+
+  await page.getByTestId(`budget-plan-open-${destinationEditorId}`).click();
+  await expect(sourcePopover).toHaveCount(0);
+  await expect(destinationPopover).toBeVisible();
+  await expect(row).toBeVisible();
+  await expect(amountInput).toHaveValue("89");
+};
+
+test("settles an acknowledged move after an autosave retry edit", async ({ page, baseURL }) => {
+  test.slow();
+  await settleAcknowledgedMoveAfterRetryEdit(page, baseURL, "autosave");
+});
+
+test("settles an acknowledged move after an Enter retry edit", async ({ page, baseURL }) => {
+  test.slow();
+  await settleAcknowledgedMoveAfterRetryEdit(page, baseURL, "Enter");
+});
+
+test("keeps a one-option Category correction private and blocks unavailable drafts", async ({ page, baseURL }) => {
+  test.slow();
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  await gotoBudgetAndWaitForGrid(page);
+
+  const adjustmentId = "demo-adjustment-groceries-seasonal";
+  const editorId = await getEditorId(page, "spend", "Groceries", 0);
+  const popover = page.getByTestId(`budget-plan-popover-${editorId}`);
+  await page.getByTestId(`budget-plan-open-${editorId}`).click();
+  await expect(popover).toBeVisible();
+
+  const categoryInput = page.getByTestId(
+    `budget-adjustment-category-${adjustmentId}`,
+  );
+  const requestedCategories: Array<string> = [];
+  await page.route(
+    `**/api/budget-adjustments/${adjustmentId}`,
+    async (route): Promise<void> => {
+      if (route.request().method() !== "PATCH") {
+        await route.continue();
+        return;
+      }
+      const requestBody: unknown = route.request().postDataJSON();
+      if (
+        typeof requestBody !== "object"
+        || requestBody === null
+        || !("category" in requestBody)
+        || typeof requestBody.category !== "string"
+      ) {
+        throw new Error("Budget adjustment Category PATCH is missing its category");
+      }
+      requestedCategories.push(requestBody.category);
+      await route.continue();
+    },
+  );
+
+  await categoryInput.evaluate((element): void => {
+    if (!(element instanceof HTMLSelectElement)) {
+      throw new Error("Budget adjustment Category control is not a select");
+    }
+    element.focus();
+    element.value = "";
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await expect(categoryInput).toHaveValue("");
+  await expect(categoryInput).toBeFocused();
+  await expect(categoryInput).toHaveAttribute("aria-invalid", "true");
+  await expect(popover).toContainText("Choose a category.");
+
+  await categoryInput.press("Enter");
+  await page.waitForTimeout(700);
+  expect(requestedCategories).toEqual([]);
+  await expect(categoryInput).toHaveAttribute("aria-invalid", "true");
+
+  await categoryInput.evaluate((element): void => {
+    if (!(element instanceof HTMLSelectElement)) {
+      throw new Error("Budget adjustment Category control is not a select");
+    }
+    for (const option of [...element.options]) {
+      if (option.value !== "" && option.value !== "Groceries") option.remove();
+    }
+    element.value = "";
+  });
+  expect(await categoryInput.locator("option").evaluateAll(
+    (options): ReadonlyArray<Readonly<{ value: string; text: string }>> =>
+      options.map((option): Readonly<{ value: string; text: string }> => ({
+        value: (option as HTMLOptionElement).value,
+        text: option.textContent ?? "",
+      })),
+  )).toEqual([
+    { value: "", text: "" },
+    { value: "Groceries", text: "Groceries" },
+  ]);
+  await expect(categoryInput).toHaveValue("");
+
+  await categoryInput.selectOption("Groceries");
+  await expect(categoryInput).toHaveValue("Groceries");
+  await expect(categoryInput).toHaveAttribute("aria-invalid", "false");
+  await page.waitForTimeout(700);
+  expect(requestedCategories).toEqual([]);
+});
+
+test("keeps failed adjustment settlement editable and retryable across editor handoff", async ({ page, baseURL }) => {
+  test.slow();
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  await gotoBudgetAndWaitForGrid(page);
+
+  const adjustmentId = "demo-adjustment-groceries-seasonal";
+  const editorId = await getEditorId(page, "spend", "Groceries", 0);
+  const month = editorId.split(":")[1];
+  if (month === undefined) throw new Error(`Cannot read month from editor ID "${editorId}"`);
+  const destinationEditorId = `budget-plan:${month}:spend:Dining`;
+  const sourcePopover = page.getByTestId(`budget-plan-popover-${editorId}`);
+  const destinationPopover = page.getByTestId(
+    `budget-plan-popover-${destinationEditorId}`,
+  );
+  let baseRequestCount = 0;
+  page.on("request", (request): void => {
+    if (request.url().endsWith("/api/budget-plan") && request.method() === "POST") {
+      baseRequestCount += 1;
+    }
+  });
+
+  let allowPatch = false;
+  let delayRecoveryFailure = false;
+  const recoveryFailureStarted = createDeferred();
+  const recoveryFailureGate = createDeferred();
+  await page.route(
+    `**/api/budget-adjustments/${adjustmentId}`,
+    async (route): Promise<void> => {
+      if (route.request().method() !== "PATCH" || allowPatch) {
+        await route.continue();
+        return;
+      }
+      if (delayRecoveryFailure) {
+        recoveryFailureStarted.resolve();
+        await recoveryFailureGate.promise;
+      }
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Private forced adjustment failure" }),
+      });
+    },
+  );
+
+  await page.getByTestId(`budget-plan-open-${editorId}`).click();
+  const amountInput = page.getByTestId(`budget-adjustment-amount-${adjustmentId}`);
+  const recoveryButton = page.getByTestId(
+    `budget-adjustment-recovery-${adjustmentId}`,
+  );
+  const baseInput = page.getByTestId(`budget-plan-base-input-${editorId}`);
+  const failedSave = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${adjustmentId}`)
+      && response.request().method() === "PATCH"
+      && response.status() === 500);
+  await amountInput.fill("37");
+  await amountInput.press("Enter");
+  expect((await failedSave).ok()).toBe(false);
+  await expect(recoveryButton).toBeVisible();
+  await expect(recoveryButton).toBeEnabled();
+  await expect(sourcePopover).toContainText("The adjustment could not be saved.");
+  await expect(sourcePopover).not.toContainText("Private forced adjustment failure");
+  await expect(amountInput).toBeFocused();
+
+  const focusedRecoveryFailure = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${adjustmentId}`)
+      && response.request().method() === "PATCH"
+      && response.status() === 500);
+  await recoveryButton.click();
+  expect((await focusedRecoveryFailure).ok()).toBe(false);
+  await expect(recoveryButton).toBeEnabled();
+  await expect(amountInput).toBeFocused();
+
+  await page.getByTestId(`budget-plan-open-${destinationEditorId}`).click();
+  await expect(sourcePopover).toBeVisible();
+  await expect(destinationPopover).toHaveCount(0);
+  await expect(recoveryButton).toBeEnabled();
+
+  await amountInput.fill("38");
+  delayRecoveryFailure = true;
+  const failedRecoveryRange = page.waitForResponse((response): boolean => {
+    const url = new URL(response.url());
+    return url.pathname === "/api/budget-grid"
+      && response.request().method() === "GET"
+      && url.searchParams.get("monthFrom") === month
+      && url.searchParams.get("monthTo") === month;
+  });
+  const failedRecoveryPatch = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${adjustmentId}`)
+      && response.request().method() === "PATCH"
+      && response.status() === 500);
+  await recoveryButton.click();
+  await recoveryFailureStarted.promise;
+  await baseInput.click();
+  await expect(baseInput).toBeFocused();
+  recoveryFailureGate.resolve();
+  expect((await failedRecoveryRange).ok()).toBe(true);
+  expect((await failedRecoveryPatch).ok()).toBe(false);
+  await expect(recoveryButton).toBeVisible();
+  await expect(recoveryButton).toBeEnabled();
+  await expect(baseInput).toBeFocused();
+
+  allowPatch = true;
+  const recoveredRange = page.waitForResponse((response): boolean => {
+    const url = new URL(response.url());
+    return url.pathname === "/api/budget-grid"
+      && response.request().method() === "GET"
+      && url.searchParams.get("monthFrom") === month
+      && url.searchParams.get("monthTo") === month;
+  });
+  const recoveredPatch = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${adjustmentId}`)
+      && response.request().method() === "PATCH"
+      && response.ok());
+  await recoveryButton.click();
+  expect((await recoveredRange).ok()).toBe(true);
+  expect((await recoveredPatch).ok()).toBe(true);
+  await expect(recoveryButton).toHaveCount(0);
+  await expect(amountInput).toHaveValue("38");
+  await expect(amountInput).toBeFocused();
+
+  await page.getByTestId(`budget-plan-open-${destinationEditorId}`).click();
+  await expect(sourcePopover).toHaveCount(0);
+  await expect(destinationPopover).toBeVisible();
+  expect(baseRequestCount).toBe(0);
+});
+
 test("keeps a stale Base save open until its acknowledgement is safe to reopen", async ({ page, baseURL }) => {
   if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
   await setDemoCookies(page, baseURL, "en");
-  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+  await gotoBudgetAndWaitForGrid(page);
 
   const editorId = await getEditorId(page, "spend", "Groceries", 0);
   const month = editorId.split(":")[1];
@@ -399,7 +970,7 @@ test("keeps a stale Base save open until its acknowledgement is safe to reopen",
 test("reprojects the final Base acknowledgement after a superseded save fails", async ({ page, baseURL }) => {
   if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
   await setDemoCookies(page, baseURL, "en");
-  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+  await gotoBudgetAndWaitForGrid(page);
 
   const editorId = await getEditorId(page, "spend", "Groceries", 0);
   const openButton = page.getByTestId(`budget-plan-open-${editorId}`);
@@ -460,7 +1031,7 @@ test("reprojects the final Base acknowledgement after a superseded save fails", 
 test("Escape finishes the active Base save without persisting a newer draft", async ({ page, baseURL }) => {
   if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
   await setDemoCookies(page, baseURL, "en");
-  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+  await gotoBudgetAndWaitForGrid(page);
 
   const editorId = await getEditorId(page, "spend", "Groceries", 0);
   const openButton = page.getByTestId(`budget-plan-open-${editorId}`);
@@ -516,7 +1087,7 @@ test("Escape finishes the active Base save without persisting a newer draft", as
 test("serializes superseding Base saves and rolls a definitive failure back for retry", async ({ page, baseURL }) => {
   if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
   await setDemoCookies(page, baseURL, "en");
-  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+  await gotoBudgetAndWaitForGrid(page);
 
   const editorId = await getEditorId(page, "spend", "Groceries", 0);
   const openButton = page.getByTestId(`budget-plan-open-${editorId}`);
@@ -622,7 +1193,7 @@ test("serializes superseding Base saves and rolls a definitive failure back for 
 test("publishes successful Fill targets through captured range generations", async ({ page, baseURL }) => {
   if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
   await setDemoCookies(page, baseURL, "en");
-  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+  await gotoBudgetAndWaitForGrid(page);
 
   const sourceEditorId = await getEditorId(page, "spend", "Groceries", 0);
   const sourceMonth = sourceEditorId.split(":")[1];
@@ -783,7 +1354,7 @@ test("keeps the adjustment editor usable on mobile RTL", async ({ page, baseURL 
   if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
   await page.setViewportSize({ width: 390, height: 844 });
   await setDemoCookies(page, baseURL, "ar");
-  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+  await gotoBudgetAndWaitForGrid(page);
   await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
   const chatCloseButton = page.getByTestId("chat-sidebar-close");
   if (await chatCloseButton.isVisible()) await chatCloseButton.click();

--- a/apps/web/src/ui/tables/budget/BudgetAdjustmentEditor.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetAdjustmentEditor.tsx
@@ -8,12 +8,18 @@ import {
   getBudgetAdjustmentCategoryOptions,
   isValidBudgetAdjustmentNoteInput,
   parseBudgetAdjustmentAmount,
+  parseBudgetAdjustmentDraft,
   type BudgetAdjustmentDraftError,
   type BudgetAdjustmentEditorRow,
 } from "@/ui/tables/budget/budgetAdjustmentRowsState";
+import {
+  isSuccessfulBudgetAdjustmentFlushOutcome,
+  recoverBudgetAdjustment,
+} from "@/ui/tables/budget/budgetAdjustmentRecovery";
 import styles from "@/ui/tables/budget/BudgetTable.module.css";
 import type {
   BudgetAdjustmentCellLocation,
+  BudgetAdjustmentFlushOutcome,
   BudgetAdjustmentRowsController,
 } from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
 import { logBudgetTableError } from "@/ui/tables/budget/table/logBudgetTableError";
@@ -26,12 +32,17 @@ type BudgetAdjustmentEditorProps = Readonly<{
   currentMonth: string;
   categories: ReadonlyArray<string>;
   effectiveAllowlist: ReadonlySet<string> | null;
+  editorAnchorByAdjustmentId: ReadonlyMap<
+    string,
+    BudgetAdjustmentCellLocation
+  >;
   controller: BudgetAdjustmentRowsController;
   onInitialFocusTargetChange: (
     target: HTMLInputElement | HTMLButtonElement | null,
   ) => void;
   onInteraction: (adjustmentId: string) => void;
   onDeleteSuccess: (adjustmentId: string) => void;
+  onSettlementSuccess: (adjustmentId: string) => void;
 }>;
 
 const getValidationMessageKey = (
@@ -48,6 +59,30 @@ const getValidationMessageKey = (
       return "budget.adjustmentInvalidCategory";
     case "invalidNote":
       return "budget.adjustmentInvalidNote";
+  }
+};
+
+type BudgetAdjustmentLocationField = "month" | "category";
+
+type AsyncFocusRestorer = (
+  getFocusTarget: () => HTMLElement | null | undefined,
+) => void;
+
+const getLocationValidationField = (
+  error: BudgetAdjustmentDraftError,
+): BudgetAdjustmentLocationField => {
+  switch (error.code) {
+    case "invalidMonth":
+    case "pastMonth":
+      return "month";
+    case "invalidCategory":
+      return "category";
+    case "invalidAmount":
+    case "unsafeAmount":
+    case "invalidNote":
+      throw new Error(
+        `Expected a budget adjustment location error; received "${error.code}"`,
+      );
   }
 };
 
@@ -79,20 +114,36 @@ export const BudgetAdjustmentEditor = (
     currentMonth,
     categories,
     effectiveAllowlist,
+    editorAnchorByAdjustmentId,
     controller,
     onInitialFocusTargetChange,
     onInteraction,
     onDeleteSuccess,
+    onSettlementSuccess,
   } = props;
   const { t } = useTranslation();
   const accessibilityId = useId();
-  const rows = controller.getCellRows(location, effectiveAllowlist);
+  const rows = controller.getCellRows(
+    location,
+    effectiveAllowlist,
+    editorAnchorByAdjustmentId,
+  );
   const categoryOptions = useMemo<ReadonlyArray<string>>(
     () => getBudgetAdjustmentCategoryOptions(categories, effectiveAllowlist),
     [categories, effectiveAllowlist],
   );
+  const categoryOptionSet = useMemo<ReadonlySet<string>>(
+    () => new Set(categoryOptions),
+    [categoryOptions],
+  );
   const amountInputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
   const noteInputRefs = useRef<Map<string, HTMLTextAreaElement>>(new Map());
+  const monthInputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+  const categoryInputRefs = useRef<Map<string, HTMLSelectElement>>(new Map());
+  const focusedAdjustmentIdRef = useRef<string | null>(null);
+  const locationValidationFrameByAdjustmentIdRef = useRef<Map<string, number>>(
+    new Map(),
+  );
   const addButtonRef = useRef<HTMLButtonElement>(null);
   const deleteDialogRef = useRef<HTMLDialogElement>(null);
   const deleteCancelButtonRef = useRef<HTMLButtonElement>(null);
@@ -114,6 +165,13 @@ export const BudgetAdjustmentEditor = (
     () => (): void => onInitialFocusTargetChange(null),
     [onInitialFocusTargetChange],
   );
+
+  useEffect(() => (): void => {
+    for (const frame of locationValidationFrameByAdjustmentIdRef.current.values()) {
+      window.cancelAnimationFrame(frame);
+    }
+    locationValidationFrameByAdjustmentIdRef.current.clear();
+  }, []);
 
   useEffect(() => {
     if (deleteCandidate === null) return;
@@ -141,6 +199,66 @@ export const BudgetAdjustmentEditor = (
     }
     addButtonRef.current?.focus();
   }, [controller.rows, deleteCandidate]);
+
+  useEffect(() => {
+    for (const row of rows) {
+      if (
+        row.draft.category === ""
+        || categoryOptionSet.has(row.draft.category)
+      ) {
+        continue;
+      }
+      onInteraction(row.adjustmentId);
+      controller.replaceDraft(row.adjustmentId, {
+        ...row.draft,
+        category: "",
+      });
+    }
+  }, [categoryOptionSet, controller, onInteraction, rows]);
+
+  useEffect(() => {
+    const displayedAdjustmentIds = new Set(
+      rows.map((row): string => row.adjustmentId),
+    );
+    for (const [adjustmentId, anchor] of editorAnchorByAdjustmentId) {
+      if (
+        anchor.month !== location.month
+        || anchor.direction !== location.direction
+        || anchor.category !== location.category
+        || displayedAdjustmentIds.has(adjustmentId)
+      ) {
+        continue;
+      }
+      const currentRow = controller.getRow(adjustmentId, null);
+      if (
+        currentRow === null
+        || (
+          currentRow.confirmed.month === location.month
+          && currentRow.direction === location.direction
+          && currentRow.confirmed.category === location.category
+        )
+      ) {
+        continue;
+      }
+      const rowOwnedFocus = focusedAdjustmentIdRef.current === adjustmentId;
+      if (rowOwnedFocus) focusedAdjustmentIdRef.current = null;
+      onSettlementSuccess(adjustmentId);
+      if (!rowOwnedFocus) continue;
+      window.requestAnimationFrame((): void => {
+        const activeElement = document.activeElement;
+        if (activeElement !== document.body && activeElement !== null) return;
+        addButtonRef.current?.focus();
+      });
+    }
+  }, [
+    controller,
+    editorAnchorByAdjustmentId,
+    location.category,
+    location.direction,
+    location.month,
+    onSettlementSuccess,
+    rows,
+  ]);
 
   const flushRow = (adjustmentId: string): void => {
     onInteraction(adjustmentId);
@@ -185,14 +303,131 @@ export const BudgetAdjustmentEditor = (
     return false;
   };
 
-  const replaceLocationDraft = (
+  const cancelLocationValidationFrame = (adjustmentId: string): void => {
+    const frame = locationValidationFrameByAdjustmentIdRef.current.get(
+      adjustmentId,
+    );
+    if (frame === undefined) return;
+    window.cancelAnimationFrame(frame);
+    locationValidationFrameByAdjustmentIdRef.current.delete(adjustmentId);
+  };
+
+  const clearLocationInputValidity = (adjustmentId: string): void => {
+    cancelLocationValidationFrame(adjustmentId);
+    monthInputRefs.current.get(adjustmentId)?.setCustomValidity("");
+    categoryInputRefs.current.get(adjustmentId)?.setCustomValidity("");
+  };
+
+  const getLocationInput = (
+    adjustmentId: string,
+    field: BudgetAdjustmentLocationField,
+  ): HTMLInputElement | HTMLSelectElement | undefined => (
+    field === "month"
+      ? monthInputRefs.current.get(adjustmentId)
+      : categoryInputRefs.current.get(adjustmentId)
+  );
+
+  const reportLocationValidation = (
+    adjustmentId: string,
+    error: BudgetAdjustmentDraftError,
+    actionTarget: HTMLElement,
+  ): void => {
+    const field = getLocationValidationField(error);
+    const message = t(getValidationMessageKey(error));
+    let frame = 0;
+    frame = window.requestAnimationFrame((): void => {
+      if (
+        locationValidationFrameByAdjustmentIdRef.current.get(adjustmentId)
+        !== frame
+      ) {
+        return;
+      }
+      locationValidationFrameByAdjustmentIdRef.current.delete(adjustmentId);
+      const currentRow = controller.getRow(adjustmentId, null);
+      if (currentRow === null) return;
+      const currentValidation = parseBudgetAdjustmentDraft(
+        currentRow.draft,
+        currentMonth,
+      );
+      if (currentValidation.ok || currentValidation.error.code !== error.code) {
+        return;
+      }
+      const input = getLocationInput(adjustmentId, field);
+      if (input === undefined) return;
+      input.setCustomValidity(message);
+      if (document.activeElement !== actionTarget) return;
+      input.focus();
+      input.reportValidity();
+    });
+    locationValidationFrameByAdjustmentIdRef.current.set(adjustmentId, frame);
+  };
+
+  const captureFocusAfterAsyncAction = (
+    actionTarget: HTMLElement,
+  ): AsyncFocusRestorer => {
+    const actionOwnedFocus = document.activeElement === actionTarget;
+    return (getFocusTarget): void => {
+      window.requestAnimationFrame((): void => {
+        const activeElement = document.activeElement;
+        const actionLostFocus = (
+          actionOwnedFocus
+          || !actionTarget.isConnected
+        ) && (activeElement === document.body || activeElement === null);
+        if (activeElement !== actionTarget && !actionLostFocus) return;
+        getFocusTarget()?.focus();
+      });
+    };
+  };
+
+  const replaceLocationDraft = async (
     row: BudgetAdjustmentEditorRow,
     draft: BudgetAdjustmentEditorRow["draft"],
-  ): void => {
+    field: BudgetAdjustmentLocationField,
+    actionTarget: HTMLButtonElement | HTMLInputElement | HTMLSelectElement,
+  ): Promise<void> => {
     if (draft.month === row.draft.month && draft.category === row.draft.category) return;
     if (reportInvalidNonLocationField(row)) return;
+
+    clearLocationInputValidity(row.adjustmentId);
     replaceDraft(row, draft);
-    window.requestAnimationFrame((): void => addButtonRef.current?.focus());
+    const parsed = parseBudgetAdjustmentDraft(draft, currentMonth);
+    if (!parsed.ok) {
+      reportLocationValidation(
+        row.adjustmentId,
+        parsed.error,
+        actionTarget,
+      );
+      return;
+    }
+
+    const restoreFocus = captureFocusAfterAsyncAction(actionTarget);
+    let outcome: BudgetAdjustmentFlushOutcome;
+    try {
+      outcome = await controller.flushRow(row.adjustmentId);
+    } catch (error: unknown) {
+      logBudgetTableError(
+        `move budget adjustment ${row.adjustmentId}`,
+        error,
+      );
+      restoreFocus(() => getLocationInput(row.adjustmentId, field));
+      return;
+    }
+    if (!isSuccessfulBudgetAdjustmentFlushOutcome(outcome)) {
+      restoreFocus(() => getLocationInput(row.adjustmentId, field));
+      return;
+    }
+
+    const currentRow = controller.getRow(row.adjustmentId, null);
+    const remainsInCell = currentRow !== null
+      && currentRow.confirmed.month === location.month
+      && currentRow.direction === location.direction
+      && currentRow.confirmed.category === location.category;
+    if (remainsInCell) {
+      restoreFocus(() => getLocationInput(row.adjustmentId, field));
+      return;
+    }
+    onSettlementSuccess(row.adjustmentId);
+    restoreFocus(() => addButtonRef.current);
   };
 
   const setAddButton = (element: HTMLButtonElement | null): void => {
@@ -221,16 +456,58 @@ export const BudgetAdjustmentEditor = (
     flushRow(adjustmentId);
   };
 
-  const handleErrorAction = (row: BudgetAdjustmentEditorRow): void => {
-    const error = controller.errorByAdjustmentId.get(row.adjustmentId);
-    if (error === undefined) return;
+  const getRecoveryFocusTarget = (
+    adjustmentId: string,
+  ): HTMLElement | undefined => {
+    const currentRow = controller.getRow(adjustmentId, null);
+    if (currentRow === null) return undefined;
+    const parsed = parseBudgetAdjustmentDraft(currentRow.draft, currentMonth);
+    if (parsed.ok) return amountInputRefs.current.get(adjustmentId);
+    switch (parsed.error.code) {
+      case "invalidAmount":
+      case "unsafeAmount":
+        return amountInputRefs.current.get(adjustmentId);
+      case "invalidMonth":
+      case "pastMonth":
+        return monthInputRefs.current.get(adjustmentId);
+      case "invalidCategory":
+        return categoryInputRefs.current.get(adjustmentId);
+      case "invalidNote":
+        return noteInputRefs.current.get(adjustmentId);
+    }
+  };
+
+  const handleErrorAction = async (
+    row: BudgetAdjustmentEditorRow,
+    actionTarget: HTMLButtonElement,
+  ): Promise<void> => {
+    if (!controller.errorByAdjustmentId.has(row.adjustmentId)) return;
+    const restoreFocus = captureFocusAfterAsyncAction(actionTarget);
     onInteraction(row.adjustmentId);
-    const operation = error.action === "refresh-range"
-      ? controller.refreshRow(row.adjustmentId)
-      : controller.flushRow(row.adjustmentId);
-    void operation.catch((cause: unknown): void => {
+    try {
+      const outcome = await recoverBudgetAdjustment(
+        controller,
+        row.adjustmentId,
+      );
+      if (outcome !== "recovered") {
+        restoreFocus(() => getRecoveryFocusTarget(row.adjustmentId));
+        return;
+      }
+      const currentRow = controller.getRow(row.adjustmentId, null);
+      const rowLeftEditor = (
+        currentRow === null
+        || currentRow.confirmed.month !== location.month
+        || currentRow.direction !== location.direction
+        || currentRow.confirmed.category !== location.category
+      );
+      onSettlementSuccess(row.adjustmentId);
+      restoreFocus(() => rowLeftEditor
+        ? addButtonRef.current
+        : getRecoveryFocusTarget(row.adjustmentId));
+    } catch (cause: unknown) {
       logBudgetTableError(`recover budget adjustment ${row.adjustmentId}`, cause);
-    });
+      restoreFocus(() => getRecoveryFocusTarget(row.adjustmentId));
+    }
   };
 
   const closeDeleteDialog = (): void => {
@@ -320,13 +597,21 @@ export const BudgetAdjustmentEditor = (
             ? null
             : t(getValidationMessageKey(validation));
           const errorId = `${accessibilityId}-${row.adjustmentId}-error`;
+          const categoryCorrectionErrorId =
+            `${accessibilityId}-${row.adjustmentId}-category-correction`;
           const previousMonth = getPreviousMonth(row.draft.month, currentMonth);
           const nextMonth = getNextMonth(row.draft.month);
+          const categoryUnavailable = !categoryOptionSet.has(
+            row.draft.category,
+          );
+          const showCategoryCorrectionError = categoryUnavailable
+            && validation?.code !== "invalidCategory";
           const amountInvalid = validation?.code === "invalidAmount"
             || validation?.code === "unsafeAmount";
           const monthInvalid = validation?.code === "invalidMonth"
             || validation?.code === "pastMonth";
-          const categoryInvalid = validation?.code === "invalidCategory";
+          const categoryInvalid = categoryUnavailable
+            || validation?.code === "invalidCategory";
           const noteInvalid = validation?.code === "invalidNote";
 
           return (
@@ -335,6 +620,29 @@ export const BudgetAdjustmentEditor = (
               className={styles.adjustmentRow}
               role="row"
               data-testid={`budget-adjustment-row-${row.adjustmentId}`}
+              onFocusCapture={(): void => {
+                focusedAdjustmentIdRef.current = row.adjustmentId;
+              }}
+              onBlurCapture={(event): void => {
+                const nextTarget = event.relatedTarget;
+                if (
+                  nextTarget instanceof Node
+                  && event.currentTarget.contains(nextTarget)
+                ) {
+                  return;
+                }
+                const rowElement = event.currentTarget;
+                queueMicrotask((): void => {
+                  if (
+                    !rowElement.isConnected
+                    || focusedAdjustmentIdRef.current !== row.adjustmentId
+                    || rowElement.contains(document.activeElement)
+                  ) {
+                    return;
+                  }
+                  focusedAdjustmentIdRef.current = null;
+                });
+              }}
             >
               <label className={styles.adjustmentField} role="cell">
                 <span className={styles.adjustmentMobileLabel}>{t("budget.adjustmentAmount")}</span>
@@ -397,14 +705,26 @@ export const BudgetAdjustmentEditor = (
                     data-testid={`budget-adjustment-month-previous-${row.adjustmentId}`}
                     aria-label={t("budget.adjustmentPreviousMonth")}
                     disabled={previousMonth === null}
-                    onClick={() => {
+                    onClick={(event) => {
                       if (previousMonth === null) return;
-                      replaceLocationDraft(row, { ...row.draft, month: previousMonth });
+                      void replaceLocationDraft(
+                        row,
+                        { ...row.draft, month: previousMonth },
+                        "month",
+                        event.currentTarget,
+                      );
                     }}
                   >
                     −1
                   </button>
                   <input
+                    ref={(element) => {
+                      if (element === null) {
+                        monthInputRefs.current.delete(row.adjustmentId);
+                      } else {
+                        monthInputRefs.current.set(row.adjustmentId, element);
+                      }
+                    }}
                     type="month"
                     className={styles.adjustmentMonthInput}
                     data-testid={`budget-adjustment-month-${row.adjustmentId}`}
@@ -415,10 +735,14 @@ export const BudgetAdjustmentEditor = (
                     min={currentMonth}
                     max={MAX_MONTH}
                     value={row.draft.month}
-                    onChange={(event) => replaceLocationDraft(row, {
-                      ...row.draft,
-                      month: event.target.value,
-                    })}
+                    onChange={(event) => {
+                      void replaceLocationDraft(
+                        row,
+                        { ...row.draft, month: event.target.value },
+                        "month",
+                        event.currentTarget,
+                      );
+                    }}
                     onBlur={() => flushRow(row.adjustmentId)}
                     onKeyDown={(event) => handleEditorKeyDown(event, row.adjustmentId)}
                   />
@@ -428,9 +752,14 @@ export const BudgetAdjustmentEditor = (
                     data-testid={`budget-adjustment-month-next-${row.adjustmentId}`}
                     aria-label={t("budget.adjustmentNextMonth")}
                     disabled={nextMonth === null}
-                    onClick={() => {
+                    onClick={(event) => {
                       if (nextMonth === null) return;
-                      replaceLocationDraft(row, { ...row.draft, month: nextMonth });
+                      void replaceLocationDraft(
+                        row,
+                        { ...row.draft, month: nextMonth },
+                        "month",
+                        event.currentTarget,
+                      );
                     }}
                   >
                     +1
@@ -440,20 +769,38 @@ export const BudgetAdjustmentEditor = (
               <label className={styles.adjustmentField} role="cell">
                 <span className={styles.adjustmentMobileLabel}>{t("budget.adjustmentCategory")}</span>
                 <select
+                  ref={(element) => {
+                    if (element === null) {
+                      categoryInputRefs.current.delete(row.adjustmentId);
+                    } else {
+                      categoryInputRefs.current.set(row.adjustmentId, element);
+                    }
+                  }}
                   className={styles.adjustmentSelect}
                   data-testid={`budget-adjustment-category-${row.adjustmentId}`}
                   aria-label={t("budget.adjustmentCategory")}
                   aria-invalid={categoryInvalid}
-                  aria-describedby={categoryInvalid && validationMessage !== null ? errorId : undefined}
+                  aria-describedby={
+                    showCategoryCorrectionError
+                      ? categoryCorrectionErrorId
+                      : categoryInvalid && validationMessage !== null
+                        ? errorId
+                        : undefined
+                  }
                   required
-                  value={row.draft.category}
-                  onChange={(event) => replaceLocationDraft(row, {
-                    ...row.draft,
-                    category: event.target.value,
-                  })}
+                  value={categoryUnavailable ? "" : row.draft.category}
+                  onChange={(event) => {
+                    void replaceLocationDraft(
+                      row,
+                      { ...row.draft, category: event.target.value },
+                      "category",
+                      event.currentTarget,
+                    );
+                  }}
                   onBlur={() => flushRow(row.adjustmentId)}
                   onKeyDown={(event) => handleEditorKeyDown(event, row.adjustmentId)}
                 >
+                  {categoryUnavailable && <option value="" disabled />}
                   {categoryOptions.map((category) => (
                     <option key={category} value={category}>{category}</option>
                   ))}
@@ -485,17 +832,29 @@ export const BudgetAdjustmentEditor = (
                   {validationMessage}
                 </span>
               )}
+              {showCategoryCorrectionError && (
+                <span
+                  id={categoryCorrectionErrorId}
+                  className={styles.adjustmentError}
+                  role="alert"
+                >
+                  {t("budget.adjustmentInvalidCategory")}
+                </span>
+              )}
               {rowError !== undefined && (
                 <span className={styles.adjustmentError} role="alert">
-                  <span>
-                    {effectiveAllowlist === null
-                      ? rowError.message
-                      : t("budget.adjustmentSaveFailed")}
-                  </span>
+                  <span>{t("budget.adjustmentSaveFailed")}</span>
                   <button
                     type="button"
                     className={styles.adjustmentRecoveryButton}
-                    onClick={() => handleErrorAction(row)}
+                    data-testid={`budget-adjustment-recovery-${row.adjustmentId}`}
+                    disabled={controller.recoveringAdjustmentIds.has(
+                      row.adjustmentId,
+                    )}
+                    onClick={(event) => void handleErrorAction(
+                      row,
+                      event.currentTarget,
+                    )}
                   >
                     {rowError.action === "refresh-range"
                       ? t("budget.adjustmentRefresh")

--- a/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
@@ -15,7 +15,10 @@ import type { NumberFormat } from "@/lib/locale";
 import type { BudgetAdjustmentDirection } from "@/server/budget/budgetAdjustments";
 import { useFormat } from "@/ui/FormatProvider";
 import { BudgetAdjustmentEditor } from "@/ui/tables/budget/BudgetAdjustmentEditor";
-import { isSuccessfulBudgetAdjustmentFlushOutcome } from "@/ui/tables/budget/budgetAdjustmentRecovery";
+import {
+  isSuccessfulBudgetAdjustmentFlushOutcome,
+  recoverBudgetAdjustment,
+} from "@/ui/tables/budget/budgetAdjustmentRecovery";
 import { isValidBudgetAdjustmentCategory } from "@/ui/tables/budget/budgetAdjustmentRowsState";
 import {
   consumeBudgetBaseLocalAcknowledgement,
@@ -24,7 +27,10 @@ import {
 import { postBudgetPlan, postBudgetPlanFill } from "@/ui/tables/budget/budgetTableApi";
 import { formatAmount, isDecember } from "@/ui/tables/budget/budgetTableLogic";
 import styles from "@/ui/tables/budget/BudgetTable.module.css";
-import type { BudgetAdjustmentRowsController } from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
+import type {
+  BudgetAdjustmentCellLocation,
+  BudgetAdjustmentRowsController,
+} from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
 import {
   createBudgetBaseEditorController,
   type BudgetBaseDraftSnapshot,
@@ -258,7 +264,9 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
   const popoverActionPendingRef = useRef<boolean>(false);
   const activePopoverActionRef = useRef<Promise<boolean> | null>(null);
   const hiddenSettlementRef = useRef<Promise<boolean> | null>(null);
-  const interactedAdjustmentIdsRef = useRef<Set<string>>(new Set());
+  const interactedAdjustmentAnchorByIdRef = useRef<
+    Map<string, BudgetAdjustmentCellLocation>
+  >(new Map());
   const settleLifecycleRef = useRef<() => Promise<boolean>>(
     (): Promise<boolean> => Promise.resolve(true),
   );
@@ -375,7 +383,6 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       setBaseValidationError(null);
       setBaseSaveError(null);
       setShouldFocusBaseAfterAction(false);
-      interactedAdjustmentIdsRef.current = new Set();
     }
     baseInputRef.current?.setCustomValidity("");
     adjustmentInitialFocusRef.current = null;
@@ -397,8 +404,32 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
     cancelActivationRelease,
     cancelActivationRequest,
     releaseActivation,
+    registerRecoveryGate,
     registerTransitionGate,
   } = useTableEditorActivation(editorId, initializePopover);
+  const retainAdjustmentCell = budgetAdjustments.retainCell;
+
+  useEffect(() => {
+    if (
+      !isOpen
+      || adjustmentDirection === null
+      || !isValidBudgetAdjustmentCategory(category)
+    ) {
+      return;
+    }
+    return retainAdjustmentCell(editorId, {
+      month,
+      direction: adjustmentDirection,
+      category,
+    });
+  }, [
+    adjustmentDirection,
+    category,
+    editorId,
+    isOpen,
+    month,
+    retainAdjustmentCell,
+  ]);
 
   const openPopover = (): void => {
     if (!showDataRef.current || isOpenRef.current) return;
@@ -616,16 +647,23 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
   }, []);
 
   const clearTrackedAdjustment = useCallback((adjustmentId: string): void => {
-    interactedAdjustmentIdsRef.current.delete(adjustmentId);
+    interactedAdjustmentAnchorByIdRef.current.delete(adjustmentId);
   }, []);
 
   const flushInteractedAdjustments = useCallback(async (): Promise<boolean> => {
-    const adjustmentIds = [...interactedAdjustmentIdsRef.current].filter(
-      (adjustmentId): boolean => (
-        budgetAdjustments.getRow(adjustmentId, effectiveAllowlist) !== null
+    const existingAdjustmentIds = new Set(
+      budgetAdjustments.rows.map((row): string => row.adjustmentId),
+    );
+    const adjustmentIds = [
+      ...interactedAdjustmentAnchorByIdRef.current.keys(),
+    ].filter(
+      (adjustmentId): boolean => existingAdjustmentIds.has(adjustmentId),
+    );
+    interactedAdjustmentAnchorByIdRef.current = new Map(
+      [...interactedAdjustmentAnchorByIdRef.current].filter(
+        ([adjustmentId]): boolean => existingAdjustmentIds.has(adjustmentId),
       ),
     );
-    interactedAdjustmentIdsRef.current = new Set(adjustmentIds);
     const failedAdjustmentIds = (await Promise.all(adjustmentIds.map(
       async (adjustmentId): Promise<string | null> => {
         try {
@@ -643,19 +681,45 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       },
     ))).filter((adjustmentId): adjustmentId is string => adjustmentId !== null);
     if (failedAdjustmentIds.length > 0) {
+      const failedAdjustmentIdSet = new Set(failedAdjustmentIds);
+      interactedAdjustmentAnchorByIdRef.current = new Map(
+        [...interactedAdjustmentAnchorByIdRef.current].filter(
+          ([adjustmentId]): boolean => failedAdjustmentIdSet.has(adjustmentId),
+        ),
+      );
       focusAdjustmentFlushFailure(failedAdjustmentIds);
       return false;
     }
-    interactedAdjustmentIdsRef.current = new Set();
+    interactedAdjustmentAnchorByIdRef.current = new Map();
     return true;
   }, [
     budgetAdjustments,
-    effectiveAllowlist,
     focusAdjustmentFlushFailure,
   ]);
 
+  const recoverTrackedAdjustment = useCallback(async (
+    adjustmentId: string,
+  ): Promise<void> => {
+    const outcome = await recoverBudgetAdjustment(
+      budgetAdjustments,
+      adjustmentId,
+    );
+    if (outcome !== "recovered") {
+      throw new Error(
+        `Budget adjustment "${adjustmentId}" could not be recovered`,
+      );
+    }
+    clearTrackedAdjustment(adjustmentId);
+  }, [budgetAdjustments, clearTrackedAdjustment]);
+
+  useEffect(() => registerRecoveryGate({
+    ownsAdjustment: (adjustmentId): boolean =>
+      interactedAdjustmentAnchorByIdRef.current.has(adjustmentId),
+    recoverAdjustment: recoverTrackedAdjustment,
+  }), [recoverTrackedAdjustment, registerRecoveryGate]);
+
   const finishPopoverClose = useCallback((): boolean => {
-    interactedAdjustmentIdsRef.current = new Set();
+    interactedAdjustmentAnchorByIdRef.current = new Map();
     setPopoverOpen(false);
     return releaseActivation();
   }, [releaseActivation, setPopoverOpen]);
@@ -869,7 +933,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       const baseOutcome = await settleCurrentBase();
       if (baseOutcome.status !== "settled") return false;
     }
-    if (interactedAdjustmentIdsRef.current.size === 0) return true;
+    if (interactedAdjustmentAnchorByIdRef.current.size === 0) return true;
     return flushInteractedAdjustments();
   }, [
     baseController,
@@ -886,7 +950,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       || baseController.isPersistencePending()
       || activePopoverActionRef.current !== null
       || hiddenSettlementRef.current !== null
-      || interactedAdjustmentIdsRef.current.size > 0
+      || interactedAdjustmentAnchorByIdRef.current.size > 0
     ),
     settleLifecycle: (): Promise<boolean> => settleLifecycleRef.current(),
   }), [baseController, registerTransitionGate]);
@@ -901,6 +965,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
         && (
           needsBaseSaveRecoveryRef.current
           || needsBaseValidationRecoveryRef.current
+          || interactedAdjustmentAnchorByIdRef.current.size > 0
         )
       ) {
         requestActivation();
@@ -938,7 +1003,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
           const baseOutcome = await settleCurrentBase();
           if (baseOutcome.status !== "settled") return false;
           if (!await flushInteractedAdjustments()) return false;
-          interactedAdjustmentIdsRef.current = new Set();
+          interactedAdjustmentAnchorByIdRef.current = new Map();
           return true;
         });
       })
@@ -952,6 +1017,7 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
           && (
             needsBaseSaveRecoveryRef.current
             || needsBaseValidationRecoveryRef.current
+            || interactedAdjustmentAnchorByIdRef.current.size > 0
           )
           && !isOpenRef.current
         ) {
@@ -1099,12 +1165,19 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
                 currentMonth={currentMonth}
                 categories={directionCategories}
                 effectiveAllowlist={effectiveAllowlist}
+                editorAnchorByAdjustmentId={
+                  interactedAdjustmentAnchorByIdRef.current
+                }
                 controller={budgetAdjustments}
                 onInitialFocusTargetChange={setAdjustmentInitialFocusTarget}
                 onInteraction={(adjustmentId): void => {
-                  interactedAdjustmentIdsRef.current.add(adjustmentId);
+                  interactedAdjustmentAnchorByIdRef.current.set(
+                    adjustmentId,
+                    adjustmentLocation,
+                  );
                 }}
                 onDeleteSuccess={clearTrackedAdjustment}
+                onSettlementSuccess={clearTrackedAdjustment}
               />
               <div className={styles.popoverDivider} />
             </>

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.test.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.test.ts
@@ -17,6 +17,7 @@ import {
   getBudgetAdjustmentCellKey,
   getBudgetAdjustmentCellRows,
   getBudgetAdjustmentCellTotal,
+  getBudgetAdjustmentEditorCellRows,
   getBudgetAdjustmentRowCellKey,
   isBudgetAdjustmentCategoryVisible,
   isBudgetAdjustmentRowVisible,
@@ -236,6 +237,115 @@ test("keeps moved drafts private until confirmed and draft categories are both v
       new Set(),
     ),
     [createBudgetRow("2026-07", "spend", "Allowed", 100, 0)],
+  );
+});
+
+test("anchors editor rows to confirmed cells and reveals invalid drafts only to their owner", (): void => {
+  const confirmed = createBudgetAdjustmentEditorRow(createAdjustment(
+    "owned-row",
+    47,
+    "2026-07",
+    "spend",
+    "Allowed",
+    "owner-visible note",
+    "2026-07-01T00:00:00.000Z",
+  ));
+  const invalid = replaceBudgetAdjustmentDraft([confirmed], confirmed.adjustmentId, {
+    ...confirmed.draft,
+    month: "2026-08",
+    category: "Masked",
+  })[0];
+  const allowlist = new Set(["Allowed"]);
+  const sourceParams = [
+    [invalid],
+    "2026-07",
+    "spend",
+    "Allowed",
+    allowlist,
+  ] as const;
+  const sourceAnchor = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Allowed",
+  };
+  const editorAnchors = new Map([
+    [invalid.adjustmentId, sourceAnchor],
+  ]);
+
+  assert.deepEqual(
+    getBudgetAdjustmentEditorCellRows(...sourceParams, new Map()),
+    [],
+  );
+  assert.deepEqual(
+    getBudgetAdjustmentEditorCellRows(
+      ...sourceParams,
+      editorAnchors,
+    ).map((row) => row.adjustmentId),
+    [invalid.adjustmentId],
+  );
+  assert.deepEqual(
+    getBudgetAdjustmentEditorCellRows(
+      [invalid],
+      "2026-08",
+      "spend",
+      "Masked",
+      allowlist,
+      editorAnchors,
+    ),
+    [],
+  );
+  assert.deepEqual(
+    getBudgetAdjustmentEditorCellRows(
+      [invalid],
+      "2026-08",
+      "spend",
+      "Masked",
+      null,
+      editorAnchors,
+    ),
+    [],
+  );
+
+  const acknowledgedMove = {
+    ...invalid,
+    confirmed: {
+      ...invalid.confirmed,
+      month: "2026-08",
+      category: "Masked",
+    },
+  };
+  assert.deepEqual(
+    getBudgetAdjustmentEditorCellRows(
+      [acknowledgedMove],
+      "2026-07",
+      "spend",
+      "Allowed",
+      allowlist,
+      editorAnchors,
+    ).map((row) => row.adjustmentId),
+    [invalid.adjustmentId],
+  );
+  assert.deepEqual(
+    getBudgetAdjustmentEditorCellRows(
+      [acknowledgedMove],
+      "2026-08",
+      "spend",
+      "Masked",
+      null,
+      editorAnchors,
+    ),
+    [],
+  );
+  assert.deepEqual(
+    getBudgetAdjustmentEditorCellRows(
+      [acknowledgedMove],
+      "2026-08",
+      "spend",
+      "Masked",
+      null,
+      new Map(),
+    ).map((row) => row.adjustmentId),
+    [invalid.adjustmentId],
   );
 });
 

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.ts
@@ -113,6 +113,34 @@ export const isBudgetAdjustmentRowVisible = (
   isBudgetAdjustmentCategoryVisible(row.confirmed.category, effectiveAllowlist)
   && isBudgetAdjustmentCategoryVisible(row.draft.category, effectiveAllowlist);
 
+export const getBudgetAdjustmentEditorCellRows = (
+  rows: ReadonlyArray<BudgetAdjustmentEditorRow>,
+  month: string,
+  direction: BudgetAdjustmentDirection,
+  category: string,
+  effectiveAllowlist: ReadonlySet<string> | null,
+  unresolvedEditorAnchorByAdjustmentId: ReadonlyMap<
+    string,
+    ProtectedBudgetAdjustmentCell
+  >,
+): ReadonlyArray<BudgetAdjustmentEditorRow> => sortBudgetAdjustmentRows(
+  rows.filter((row): boolean => {
+    const editorAnchor = unresolvedEditorAnchorByAdjustmentId.get(
+      row.adjustmentId,
+    );
+    if (editorAnchor !== undefined) {
+      return editorAnchor.month === month
+        && editorAnchor.direction === direction
+        && editorAnchor.category === category
+        && isBudgetAdjustmentCategoryVisible(category, effectiveAllowlist);
+    }
+    return row.confirmed.month === month
+      && row.direction === direction
+      && row.confirmed.category === category
+      && isBudgetAdjustmentRowVisible(row, effectiveAllowlist);
+  }),
+);
+
 const isValidDraftLocation = (draft: BudgetAdjustmentDraft, planFrom: string): boolean =>
   MONTH_PATTERN.test(draft.month)
   && draft.month >= planFrom

--- a/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.test.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.test.ts
@@ -402,6 +402,156 @@ test("serializes and coalesces one row while allowing another row to save indepe
   );
 });
 
+test("keeps an acknowledged move anchored while a newer invalid draft is unresolved", async (): Promise<void> => {
+  const initial = createAdjustment(FIRST_ID, 1, "2026-07", "Food", null);
+  const moved = applyPatch(initial, { month: "2026-08" });
+  const firstPatch = createDeferred<BudgetAdjustment>();
+  const harness = createHarness([initial]);
+  harness.setPatchHandler((_adjustmentId, _params) => firstPatch.promise);
+  const source = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Food",
+  };
+  const destination = {
+    month: "2026-08",
+    direction: "spend" as const,
+    category: "Food",
+  };
+  const editorAnchors = new Map([[FIRST_ID, source]]);
+
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("1", "2026-08", "Food", ""),
+  );
+  const flush = harness.runtime.commands.flushRow(FIRST_ID);
+  await settleStart();
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("1", "2026-08", "", ""),
+  );
+  firstPatch.resolve(moved);
+
+  assert.equal(await flush, "invalid");
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(
+      source,
+      null,
+      editorAnchors,
+    ).map((row) => row.adjustmentId),
+    [FIRST_ID],
+  );
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(
+      destination,
+      null,
+      editorAnchors,
+    ),
+    [],
+  );
+
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("1", "2026-08", "Food", ""),
+  );
+  assert.equal(await harness.runtime.commands.flushRow(FIRST_ID), "unchanged");
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(source, null, editorAnchors),
+    [],
+  );
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(
+      destination,
+      null,
+      editorAnchors,
+    ).map((row) => row.adjustmentId),
+    [FIRST_ID],
+  );
+});
+
+test("keeps an acknowledged move anchored through a failed follow-up patch", async (): Promise<void> => {
+  const initial = createAdjustment(FIRST_ID, 1, "2026-07", "Food", null);
+  const moved = applyPatch(initial, { month: "2026-08" });
+  const firstPatch = createDeferred<BudgetAdjustment>();
+  const harness = createHarness([initial]);
+  let patchAttempt = 0;
+  harness.setPatchHandler(async (_adjustmentId, params): Promise<BudgetAdjustment> => {
+    patchAttempt += 1;
+    if (patchAttempt === 1) return firstPatch.promise;
+    if (patchAttempt === 2) {
+      throw new BudgetAdjustmentApiError(
+        "Budget adjustment update",
+        409,
+        "forced follow-up conflict",
+      );
+    }
+    return applyPatch(moved, params);
+  });
+  const source = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Food",
+  };
+  const destination = {
+    month: "2026-08",
+    direction: "spend" as const,
+    category: "Food",
+  };
+  const editorAnchors = new Map([[FIRST_ID, source]]);
+
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("1", "2026-08", "Food", ""),
+  );
+  const flush = harness.runtime.commands.flushRow(FIRST_ID);
+  await settleStart();
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("2", "2026-08", "Food", ""),
+  );
+  firstPatch.resolve(moved);
+
+  assert.equal(await flush, "error");
+  assert.equal(
+    harness.runtime.getSnapshot().errorByAdjustmentId.get(FIRST_ID)?.classification,
+    "definitive",
+  );
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(
+      source,
+      null,
+      editorAnchors,
+    ).map((row) => row.adjustmentId),
+    [FIRST_ID],
+  );
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(
+      destination,
+      null,
+      editorAnchors,
+    ),
+    [],
+  );
+
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("3", "2026-08", "Food", ""),
+  );
+  assert.equal(await harness.runtime.commands.flushRow(FIRST_ID), "saved");
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(source, null, editorAnchors),
+    [],
+  );
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(
+      destination,
+      null,
+      editorAnchors,
+    ).map((row) => row.adjustmentId),
+    [FIRST_ID],
+  );
+});
+
 test("retries a lost create with the identical UUID and payload before patching a newer edit", async (): Promise<void> => {
   const lostCreate = createDeferred<BudgetAdjustment>();
   const retryCreate = createDeferred<BudgetAdjustment>();
@@ -760,7 +910,10 @@ test("publishes mutation snapshots until unsubscribed and exposes cell selectors
   assert.equal(snapshots[0]?.pendingMutationCount, 1);
   assert.equal(harness.runtime.commands.getRow(FIRST_ID, null)?.draft.amountInput, "2");
   assert.equal(harness.runtime.commands.getRow(SECOND_ID, null), null);
-  assert.equal(harness.runtime.commands.getCellRows(location, null).length, 1);
+  assert.equal(
+    harness.runtime.commands.getCellRows(location, null, new Map()).length,
+    1,
+  );
   assert.equal(harness.runtime.commands.getCellTotal(location, null), 2);
 
   unsubscribe();
@@ -771,7 +924,7 @@ test("publishes mutation snapshots until unsubscribed and exposes cell selectors
   assert.equal(snapshots.length, 1);
 });
 
-test("uses one filtered presentation rule for selectors and projected budget rows", (): void => {
+test("keeps filtered editor ownership private while projected budget rows stay masked", (): void => {
   const harness = createHarness([
     createAdjustment(FIRST_ID, 47, "2026-07", "Masked", "private note"),
   ]);
@@ -784,6 +937,11 @@ test("uses one filtered presentation rule for selectors and projected budget row
     month: "2026-07",
     direction: "spend" as const,
     category: "Allowed",
+  };
+  const source = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Masked",
   };
   const protectedPrivateCell = {
     month: "2026-07",
@@ -805,7 +963,10 @@ test("uses one filtered presentation rule for selectors and projected budget row
     hasUnconvertible: false,
   }];
 
-  assert.deepEqual(harness.runtime.commands.getCellRows(destination, allowlist), []);
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(destination, allowlist, new Map()),
+    [],
+  );
   assert.equal(harness.runtime.commands.getCellTotal(destination, allowlist), 0);
   assert.equal(harness.runtime.commands.getRow(FIRST_ID, allowlist), null);
   assert.equal(
@@ -829,7 +990,18 @@ test("uses one filtered presentation rule for selectors and projected budget row
     [...harness.runtime.getSnapshot().protectedCellKeys],
     ["2026-07\u0000spend\u0000Masked"],
   );
-  assert.equal(harness.runtime.commands.getCellRows(destination, null).length, 1);
+  assert.equal(
+    harness.runtime.commands.getCellRows(source, null, new Map()).length,
+    1,
+  );
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(
+      source,
+      allowlist,
+      new Map([[FIRST_ID, source]]),
+    ),
+    [],
+  );
   assert.equal(
     harness.runtime.commands.applyToBudgetRows(
       budgetRows,
@@ -842,10 +1014,15 @@ test("uses one filtered presentation rule for selectors and projected budget row
   release();
 });
 
-test("keeps an unknown draft category private in the public row selector", (): void => {
+test("reveals invalid filtered drafts only in their owning confirmed editor cell", (): void => {
   const harness = createHarness([
     createAdjustment(FIRST_ID, 12, "2026-07", "Allowed", null),
   ]);
+  const source = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Allowed",
+  };
   harness.runtime.commands.replaceDraft(
     FIRST_ID,
     createDraft("12", "2026-07", "Unknown", ""),
@@ -853,9 +1030,38 @@ test("keeps an unknown draft category private in the public row selector", (): v
   const allowlist = new Set(["Allowed"]);
 
   assert.equal(harness.runtime.commands.getRow(FIRST_ID, allowlist), null);
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(source, allowlist, new Map()),
+    [],
+  );
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(
+      source,
+      allowlist,
+      new Map([[FIRST_ID, source]]),
+    ).map((row) => row.adjustmentId),
+    [FIRST_ID],
+  );
   assert.equal(
     harness.runtime.commands.getRow(FIRST_ID, null)?.draft.category,
     "Unknown",
+  );
+
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("12", "2026-07", "", ""),
+  );
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(source, allowlist, new Map()),
+    [],
+  );
+  assert.deepEqual(
+    harness.runtime.commands.getCellRows(
+      source,
+      allowlist,
+      new Map([[FIRST_ID, source]]),
+    ).map((row) => row.adjustmentId),
+    [FIRST_ID],
   );
 });
 

--- a/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.ts
@@ -30,8 +30,8 @@ import {
 import {
   applyBudgetAdjustmentRowsWithProtectedCells,
   getBudgetAdjustmentCellKey,
-  getBudgetAdjustmentCellRows,
   getBudgetAdjustmentCellTotal,
+  getBudgetAdjustmentEditorCellRows,
   isBudgetAdjustmentRowVisible,
   parseBudgetAdjustmentDraft,
   type BudgetAdjustmentDraft,
@@ -115,6 +115,10 @@ export type BudgetAdjustmentRowsControllerCommands = Readonly<{
   getCellRows: (
     location: BudgetAdjustmentCellLocation,
     effectiveAllowlist: ReadonlySet<string> | null,
+    editorAnchorByAdjustmentId: ReadonlyMap<
+      string,
+      BudgetAdjustmentCellLocation
+    >,
   ) => ReadonlyArray<BudgetAdjustmentEditorRow>;
   getCellTotal: (
     location: BudgetAdjustmentCellLocation,
@@ -783,12 +787,31 @@ export const createBudgetAdjustmentRowsController = (
   const getCellRows = (
     location: BudgetAdjustmentCellLocation,
     effectiveAllowlist: ReadonlySet<string> | null,
-  ): ReadonlyArray<BudgetAdjustmentEditorRow> => getBudgetAdjustmentCellRows(
-    getVisibleRows(effectiveAllowlist),
+    editorAnchorByAdjustmentId: ReadonlyMap<
+      string,
+      BudgetAdjustmentCellLocation
+    >,
+  ): ReadonlyArray<BudgetAdjustmentEditorRow> => getBudgetAdjustmentEditorCellRows(
+    reconciliation.rows,
     location.month,
     location.direction,
     location.category,
-    dependencies.planFrom,
+    effectiveAllowlist,
+    new Map([...editorAnchorByAdjustmentId].filter(
+      ([adjustmentId]): boolean => (
+        reconciliation.optimisticCreateByAdjustmentId.has(adjustmentId)
+        || reconciliation.ambiguousRangeRequirementByAdjustmentId.has(
+          adjustmentId,
+        )
+        || hasDirtyFields(reconciliation, adjustmentId)
+        || timers.has(adjustmentId)
+        || suspendedAutosaveIds.has(adjustmentId)
+        || activeFlushes.has(adjustmentId)
+        || activeRecoveries.has(adjustmentId)
+        || deleteRequestedIds.has(adjustmentId)
+        || rowErrors.has(adjustmentId)
+      )
+    )),
   );
 
   const getRow = (


### PR DESCRIPTION
Summary
- normalize budget-adjustment create, autosave, move, delete, and recovery lifecycles
- preserve filtered-mode privacy and source-editor ownership during delayed or failed settlement
- add focused controller, reconciliation, activation, browser, mobile, and RTL coverage

Validation
- 107 focused controller/reconciliation/activation tests
- all 12 local-demo adjustment scenarios
- apps/web lint
- apps/web production build
- git diff --check