### PR TITLE
Finalize normalized budget adjustment recovery and Demo persistence

### DIFF
--- a/apps/web/e2e-local/budget-adjustments.local-demo.spec.ts
+++ b/apps/web/e2e-local/budget-adjustments.local-demo.spec.ts
@@ -118,6 +118,72 @@ const gotoBudgetAndWaitForGrid = async (page: Page): Promise<void> => {
   expect((await initialBudgetGridResponse).ok()).toBe(true);
 };
 
+const reloadBudgetAndWaitForGrid = async (page: Page): Promise<void> => {
+  const initialBudgetGridResponse = page.waitForResponse(isBudgetGridResponse);
+  await page.reload({ waitUntil: "domcontentloaded" });
+  expect((await initialBudgetGridResponse).ok()).toBe(true);
+};
+
+const extendBudgetThroughMonth = async (
+  page: Page,
+  targetMonth: string,
+): Promise<void> => {
+  const targetHeader = page.locator(`[data-month="${targetMonth}"]`);
+  while (await targetHeader.count() === 0) {
+    const loadedMonthHeaders = page.locator("[data-month]");
+    const loadedMonthCount = await loadedMonthHeaders.count();
+    if (loadedMonthCount === 0) {
+      throw new Error("Budget table has no rendered month headers");
+    }
+    const loadedTo = await loadedMonthHeaders.nth(loadedMonthCount - 1)
+      .getAttribute("data-month");
+    if (loadedTo === null) {
+      throw new Error("Last budget month header has no data-month");
+    }
+    const monthTo = offsetMonth(loadedTo, 6);
+    await page.getByTestId("budget-table-scroll").evaluate((element): void => {
+      element.scrollLeft = element.scrollWidth;
+      element.dispatchEvent(new Event("scroll"));
+    });
+    await expect(page.locator(`[data-month="${monthTo}"]`)).toHaveCount(
+      1,
+      { timeout: 15_000 },
+    );
+  }
+};
+
+const readFormattedAmount = async (
+  page: Page,
+  testId: string,
+): Promise<number> => {
+  const text = await page.getByTestId(testId).textContent();
+  if (text === null) {
+    throw new Error(`Budget amount ${testId} has no text content`);
+  }
+  const amount = Number(text.replaceAll(",", "").trim());
+  if (!Number.isFinite(amount)) {
+    throw new Error(`Budget amount ${testId} is not numeric: "${text}"`);
+  }
+  return amount;
+};
+
+const expectFormattedAmount = async (
+  page: Page,
+  testId: string,
+  expected: number,
+): Promise<void> => {
+  await expect.poll(() => readFormattedAmount(page, testId)).toBe(expected);
+};
+
+const getCookieValue = async (
+  page: Page,
+  baseURL: string,
+  name: string,
+): Promise<string | null> => (
+  (await page.context().cookies(baseURL)).find((cookie) => cookie.name === name)
+    ?.value ?? null
+);
+
 const captureModeReload = async (page: Page): Promise<ModeReloadCapture> => {
   const started = createDeferred();
   let requestCount = 0;
@@ -490,6 +556,292 @@ test("creates, autosaves, moves, and deletes normalized adjustment rows", async 
   await page.keyboard.press("Escape");
   await page.getByTestId(`budget-plan-open-${diningEditorId}`).click();
   await expect(page.getByTestId(`budget-adjustment-add-${diningEditorId}`)).toBeFocused();
+});
+
+test("keeps cross-year totals and Demo adjustment state coherent across reloads and mode transitions", async ({ page, baseURL }) => {
+  test.slow();
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  await gotoBudgetAndWaitForGrid(page);
+
+  const seasonalId = "demo-adjustment-groceries-seasonal";
+  const deletedSeedId = "demo-adjustment-groceries-discount";
+  const currentEditorId = await getEditorId(page, "spend", "Groceries", 0);
+  const currentMonth = currentEditorId.split(":")[1];
+  if (currentMonth === undefined) {
+    throw new Error(`Cannot read month from editor ID "${currentEditorId}"`);
+  }
+  const currentYear = currentMonth.slice(0, 4);
+  const destinationYear = String(Number(currentYear) + 1);
+  const destinationMonth = `${destinationYear}-01`;
+  const destinationYearEnd = `${destinationYear}-12`;
+  await extendBudgetThroughMonth(page, destinationYearEnd);
+
+  const currentYearTestId =
+    `budget-year-plan-${currentYear}:spend:Groceries`;
+  const destinationYearTestId =
+    `budget-year-plan-${destinationYear}:spend:Groceries`;
+  const destinationEditorId =
+    `budget-plan:${destinationMonth}:spend:Groceries`;
+  const currentPlanBeforeEdit = await readFormattedAmount(
+    page,
+    currentYearTestId,
+  );
+  const destinationPlanBeforeMove = await readFormattedAmount(
+    page,
+    destinationYearTestId,
+  );
+  const currentCellBeforeEdit = await readFormattedAmount(
+    page,
+    `budget-plan-open-${currentEditorId}`,
+  );
+  const destinationCellBeforeMove = await readFormattedAmount(
+    page,
+    `budget-plan-open-${destinationEditorId}`,
+  );
+
+  await page.getByTestId(`budget-plan-open-${currentEditorId}`).click();
+  const seasonalAmount = page.getByTestId(
+    `budget-adjustment-amount-${seasonalId}`,
+  );
+  const seasonalNote = page.getByTestId(
+    `budget-adjustment-note-${seasonalId}`,
+  );
+  const seasonalMonth = page.getByTestId(
+    `budget-adjustment-month-${seasonalId}`,
+  );
+  const originalSeasonalAmount = Number(await seasonalAmount.inputValue());
+  if (!Number.isFinite(originalSeasonalAmount)) {
+    throw new Error("Seasonal Demo adjustment amount is not numeric");
+  }
+  const editedSeasonalAmount = 80;
+  const editedSeasonalDelta = editedSeasonalAmount - originalSeasonalAmount;
+  const editedYearRefresh = page.waitForResponse((response): boolean =>
+    isBudgetGridRangeResponse(
+      response,
+      `${currentYear}-01`,
+      `${currentYear}-12`,
+    ));
+  const editedPatch = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${seasonalId}`)
+      && response.request().method() === "PATCH"
+      && response.ok());
+  await seasonalAmount.fill(String(editedSeasonalAmount));
+  await seasonalNote.fill("Cross-year persisted");
+  await seasonalNote.press("Tab");
+  expect((await editedPatch).ok()).toBe(true);
+  expect((await editedYearRefresh).ok()).toBe(true);
+
+  const currentPlanBeforeMove = currentPlanBeforeEdit + editedSeasonalDelta;
+  const currentCellBeforeMove = currentCellBeforeEdit + editedSeasonalDelta;
+  await expectFormattedAmount(
+    page,
+    currentYearTestId,
+    currentPlanBeforeMove,
+  );
+  await expectFormattedAmount(
+    page,
+    `budget-plan-open-${currentEditorId}`,
+    currentCellBeforeMove,
+  );
+
+  const currentYearRefresh = page.waitForResponse((response): boolean =>
+    isBudgetGridRangeResponse(
+      response,
+      `${currentYear}-01`,
+      `${currentYear}-12`,
+    ));
+  const destinationYearRefresh = page.waitForResponse((response): boolean =>
+    isBudgetGridRangeResponse(
+      response,
+      `${destinationYear}-01`,
+      `${destinationYear}-12`,
+    ));
+  const movePatch = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${seasonalId}`)
+      && response.request().method() === "PATCH"
+      && adjustmentRequestFieldEquals(response, "month", destinationMonth)
+      && response.ok());
+  await seasonalMonth.fill(destinationMonth);
+  expect((await movePatch).ok()).toBe(true);
+  expect((await currentYearRefresh).ok()).toBe(true);
+  expect((await destinationYearRefresh).ok()).toBe(true);
+
+  await expectFormattedAmount(
+    page,
+    currentYearTestId,
+    currentPlanBeforeMove - editedSeasonalAmount,
+  );
+  await expectFormattedAmount(
+    page,
+    destinationYearTestId,
+    destinationPlanBeforeMove + editedSeasonalAmount,
+  );
+  await expectFormattedAmount(
+    page,
+    `budget-plan-open-${currentEditorId}`,
+    currentCellBeforeMove - editedSeasonalAmount,
+  );
+  await expectFormattedAmount(
+    page,
+    `budget-plan-open-${destinationEditorId}`,
+    destinationCellBeforeMove + editedSeasonalAmount,
+  );
+
+  const zeroMonth = offsetMonth(currentMonth, 2);
+  const zeroEditorId =
+    `budget-plan:${zeroMonth}:spend:Travel reserve`;
+  await page.getByTestId(`budget-plan-open-${zeroEditorId}`).click();
+  const zeroCreate = page.waitForResponse((response): boolean =>
+    response.url().endsWith("/api/budget-adjustments")
+      && response.request().method() === "POST"
+      && response.ok());
+  await page.getByTestId(`budget-adjustment-add-${zeroEditorId}`).click();
+  const zeroAdjustment = await (await zeroCreate).json() as CreatedAdjustment;
+  expect(zeroAdjustment).toMatchObject({
+    month: zeroMonth,
+    direction: "spend",
+    category: "Travel reserve",
+    amount: 0,
+    note: null,
+  });
+  const zeroId = zeroAdjustment.adjustmentId;
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId(`budget-plan-open-${currentEditorId}`).click();
+  await page.getByTestId(`budget-adjustment-delete-${deletedSeedId}`).click();
+  const deleteSeed = page.waitForResponse((response): boolean =>
+    response.url().includes(`/api/budget-adjustments/${deletedSeedId}`)
+      && response.request().method() === "DELETE"
+      && response.ok());
+  await page.getByTestId(
+    `budget-adjustment-delete-confirm-${deletedSeedId}`,
+  ).click();
+  expect((await deleteSeed).ok()).toBe(true);
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("budget-sync-status")).toHaveCount(0);
+
+  await reloadBudgetAndWaitForGrid(page);
+  await extendBudgetThroughMonth(page, destinationYearEnd);
+  await expectFormattedAmount(
+    page,
+    currentYearTestId,
+    currentPlanBeforeMove - 55,
+  );
+  await expectFormattedAmount(
+    page,
+    destinationYearTestId,
+    destinationPlanBeforeMove + editedSeasonalAmount,
+  );
+  await page.getByTestId(`budget-plan-open-${currentEditorId}`).click();
+  await expect(
+    page.getByTestId(`budget-adjustment-row-${deletedSeedId}`),
+  ).toHaveCount(0);
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId(`budget-plan-open-${destinationEditorId}`).click();
+  await expect(
+    page.getByTestId(`budget-adjustment-amount-${seasonalId}`),
+  ).toHaveValue(String(editedSeasonalAmount));
+  await expect(
+    page.getByTestId(`budget-adjustment-note-${seasonalId}`),
+  ).toHaveValue("Cross-year persisted");
+  await expect(
+    page.getByTestId(`budget-adjustment-month-${seasonalId}`),
+  ).toHaveValue(destinationMonth);
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId(`budget-plan-open-${zeroEditorId}`).click();
+  await expect(
+    page.getByTestId(`budget-adjustment-amount-${zeroId}`),
+  ).toHaveValue("0");
+  await expect(
+    page.getByTestId(`budget-adjustment-note-${zeroId}`),
+  ).toHaveValue("");
+  await page.keyboard.press("Escape");
+
+  const sessionCookieBeforeTransitions = await getCookieValue(
+    page,
+    baseURL,
+    "demo_budget_adjustments",
+  );
+  expect(sessionCookieBeforeTransitions).not.toBeNull();
+
+  const allModeReload = await captureModeReload(page);
+  await page.getByTestId("mode-all").click();
+  await allModeReload.started;
+  await expect(page.getByTestId("mode-transition-complete")).toHaveCount(1);
+  expect(await getCookieValue(
+    page,
+    baseURL,
+    "demo_budget_adjustments",
+  )).toBe(sessionCookieBeforeTransitions);
+
+  await page.unroute("**/budget");
+  await setDemoCookies(page, baseURL, "en");
+  await gotoBudgetAndWaitForGrid(page);
+  await page.getByTestId(`budget-plan-open-${destinationEditorId}`).click();
+  await expect(
+    page.getByTestId(`budget-adjustment-note-${seasonalId}`),
+  ).toHaveValue("Cross-year persisted");
+  await page.keyboard.press("Escape");
+
+  const filteredModeReload = await captureModeReload(page);
+  await page.getByTestId("mode-filtered").click();
+  await filteredModeReload.started;
+  await expect(page.getByTestId("mode-transition-complete")).toHaveCount(1);
+  expect(await getCookieValue(
+    page,
+    baseURL,
+    "demo_budget_adjustments",
+  )).toBe(sessionCookieBeforeTransitions);
+
+  await page.unroute("**/budget");
+  await setDemoCookies(page, baseURL, "en");
+  await gotoBudgetAndWaitForGrid(page);
+  await page.getByTestId(`budget-plan-open-${currentEditorId}`).click();
+  await expect(
+    page.getByTestId(`budget-adjustment-row-${deletedSeedId}`),
+  ).toHaveCount(0);
+  await page.keyboard.press("Escape");
+  await page.getByTestId(`budget-plan-open-${zeroEditorId}`).click();
+  await expect(
+    page.getByTestId(`budget-adjustment-amount-${zeroId}`),
+  ).toHaveValue("0");
+});
+
+test("recovers a malformed Demo adjustment session through the explicit reset", async ({ page, baseURL }) => {
+  if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
+  await setDemoCookies(page, baseURL, "en");
+  const origin = new URL(baseURL);
+  await page.context().addCookies([{
+    name: "demo_budget_adjustments",
+    value: "invalid-cookie",
+    domain: origin.hostname,
+    path: "/",
+    sameSite: "Lax",
+  }]);
+
+  await page.goto("/budget", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("page-load-error")).toBeVisible();
+  const resetDemoAdjustments = page.getByTestId(
+    "page-load-error-reset-demo-adjustments",
+  );
+  await expect(resetDemoAdjustments).toBeVisible();
+
+  page.once("dialog", (dialog): void => {
+    void dialog.accept();
+  });
+  const recoveredGrid = page.waitForResponse(isBudgetGridResponse);
+  await resetDemoAdjustments.click();
+  expect((await recoveredGrid).ok()).toBe(true);
+
+  await expect(page.getByTestId("page-load-error")).toHaveCount(0);
+  expect(await getCookieValue(
+    page,
+    baseURL,
+    "demo_budget_adjustments",
+  )).toBeNull();
 });
 
 test("keeps a delayed move editable in its source when a newer location draft is invalid", async ({ page, baseURL }) => {

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import type { ReactElement } from "react";
+import { useEffect, useState, type ReactElement } from "react";
+import { useTranslation } from "react-i18next";
 
+import { DEMO_BUDGET_ADJUSTMENTS_COOKIE } from "@/lib/demoCookies";
 import alertStyles from "@/ui/Alert.module.css";
 import controlsStyles from "@/ui/Controls.module.css";
 
@@ -12,17 +14,49 @@ type Props = Readonly<{
 
 export default function GlobalError(props: Props): ReactElement {
   const { error, reset } = props;
+  const { t } = useTranslation();
+  const [canResetDemoAdjustments, setCanResetDemoAdjustments] =
+    useState<boolean>(false);
+
+  useEffect((): void => {
+    const cookiePrefix = `${DEMO_BUDGET_ADJUSTMENTS_COOKIE}=`;
+    setCanResetDemoAdjustments(document.cookie.split(";").some((part): boolean =>
+      part.trim().startsWith(cookiePrefix)));
+  }, []);
+
+  const resetDemoAdjustments = (): void => {
+    if (!window.confirm(
+      t("pageError.resetDemoChangesConfirm"),
+    )) {
+      return;
+    }
+    document.cookie =
+      `${DEMO_BUDGET_ADJUSTMENTS_COOKIE}=; path=/; max-age=0; samesite=lax`;
+    window.location.reload();
+  };
 
   return (
     <main className="container">
-      <section className="panel">
+      <section className="panel" data-testid="page-load-error">
         <div className={alertStyles.alert}>
           <strong>Failed to load page</strong>
           <span>{error.message}</span>
         </div>
-        <button className={controlsStyles.segment} type="button" onClick={reset}>
-          Retry
-        </button>
+        <div className={controlsStyles.segmented}>
+          <button className={controlsStyles.segment} type="button" onClick={reset}>
+            Retry
+          </button>
+          {canResetDemoAdjustments && (
+            <button
+              className={controlsStyles.segment}
+              type="button"
+              data-testid="page-load-error-reset-demo-adjustments"
+              onClick={resetDemoAdjustments}
+            >
+              {t("pageError.resetDemoChanges")}
+            </button>
+          )}
+        </div>
       </section>
     </main>
   );

--- a/apps/web/src/i18n/ar.json
+++ b/apps/web/src/i18n/ar.json
@@ -15,6 +15,8 @@
   "mode.all": "الكل",
   "mode.filtered": "مُصفّى",
   "mode.demo": "تجريبي",
+  "pageError.resetDemoChanges": "إعادة ضبط تغييرات الوضع التجريبي",
+  "pageError.resetDemoChangesConfirm": "هل تريد إعادة ضبط جميع تغييرات الميزانية التجريبية؟ لا يمكن التراجع عن ذلك.",
   "account.workspaces": "مساحات العمل",
   "account.newWorkspace": "+ مساحة عمل جديدة",
   "account.workspaceName": "اسم مساحة العمل",

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -15,6 +15,8 @@
   "mode.all": "All",
   "mode.filtered": "Filtered",
   "mode.demo": "Demo",
+  "pageError.resetDemoChanges": "Reset Demo changes",
+  "pageError.resetDemoChangesConfirm": "Reset all Demo budget changes? This cannot be undone.",
   "account.workspaces": "Workspaces",
   "account.newWorkspace": "+ New workspace",
   "account.workspaceName": "Workspace name",

--- a/apps/web/src/i18n/es.json
+++ b/apps/web/src/i18n/es.json
@@ -15,6 +15,8 @@
   "mode.all": "Todo",
   "mode.filtered": "Filtrado",
   "mode.demo": "Demo",
+  "pageError.resetDemoChanges": "Restablecer cambios de Demo",
+  "pageError.resetDemoChangesConfirm": "¿Restablecer todos los cambios del presupuesto de Demo? Esta acción no se puede deshacer.",
   "account.workspaces": "Espacios de trabajo",
   "account.newWorkspace": "+ Nuevo espacio",
   "account.workspaceName": "Nombre del espacio",

--- a/apps/web/src/i18n/fa.json
+++ b/apps/web/src/i18n/fa.json
@@ -15,6 +15,8 @@
   "mode.all": "همه",
   "mode.filtered": "فیلتر شده",
   "mode.demo": "نمایشی",
+  "pageError.resetDemoChanges": "بازنشانی تغییرات نمایشی",
+  "pageError.resetDemoChangesConfirm": "همه تغییرات بودجه نمایشی بازنشانی شوند؟ این کار قابل بازگشت نیست.",
   "account.workspaces": "فضاهای کاری",
   "account.newWorkspace": "+ فضای کاری جدید",
   "account.workspaceName": "نام فضای کاری",

--- a/apps/web/src/i18n/he.json
+++ b/apps/web/src/i18n/he.json
@@ -15,6 +15,8 @@
   "mode.all": "הכל",
   "mode.filtered": "מסונן",
   "mode.demo": "הדגמה",
+  "pageError.resetDemoChanges": "איפוס שינויי הדגמה",
+  "pageError.resetDemoChangesConfirm": "לאפס את כל שינויי תקציב ההדגמה? לא ניתן לבטל פעולה זו.",
   "account.workspaces": "סביבות עבודה",
   "account.newWorkspace": "+ סביבת עבודה חדשה",
   "account.workspaceName": "שם סביבת העבודה",

--- a/apps/web/src/i18n/ru.json
+++ b/apps/web/src/i18n/ru.json
@@ -15,6 +15,8 @@
   "mode.all": "Все",
   "mode.filtered": "Фильтр",
   "mode.demo": "Демо",
+  "pageError.resetDemoChanges": "Сбросить изменения демо",
+  "pageError.resetDemoChangesConfirm": "Сбросить все изменения демо-бюджета? Это действие нельзя отменить.",
   "account.workspaces": "Рабочие пространства",
   "account.newWorkspace": "+ Новое пространство",
   "account.workspaceName": "Название пространства",

--- a/apps/web/src/i18n/uk.json
+++ b/apps/web/src/i18n/uk.json
@@ -15,6 +15,8 @@
   "mode.all": "Усі",
   "mode.filtered": "Фільтр",
   "mode.demo": "Демо",
+  "pageError.resetDemoChanges": "Скинути зміни демо",
+  "pageError.resetDemoChangesConfirm": "Скинути всі зміни демо-бюджету? Цю дію неможливо скасувати.",
   "account.workspaces": "Робочі простори",
   "account.newWorkspace": "+ Новий простір",
   "account.workspaceName": "Назва простору",

--- a/apps/web/src/i18n/zh.json
+++ b/apps/web/src/i18n/zh.json
@@ -15,6 +15,8 @@
   "mode.all": "全部",
   "mode.filtered": "筛选",
   "mode.demo": "演示",
+  "pageError.resetDemoChanges": "重置演示更改",
+  "pageError.resetDemoChangesConfirm": "要重置所有演示预算更改吗？此操作无法撤销。",
   "account.workspaces": "工作区",
   "account.newWorkspace": "+ 新建工作区",
   "account.workspaceName": "工作区名称",

--- a/apps/web/src/server/budget/budgetAdjustments.test.ts
+++ b/apps/web/src/server/budget/budgetAdjustments.test.ts
@@ -5,7 +5,16 @@ import type { QueryResult } from "pg";
 import { getCurrentMonth, offsetMonth } from "@/lib/monthUtils";
 import { BUDGET_ADJUSTMENT_BY_ID_QUERY, BUDGET_ADJUSTMENTS_DETAIL_QUERY, BudgetAdjustmentConflictError, CREATE_BUDGET_ADJUSTMENT_QUERY, buildPatchBudgetAdjustmentQuery, createBudgetAdjustmentWithQuery, mapBudgetAdjustmentRow, type BudgetAdjustment, type CreateBudgetAdjustmentParams } from "@/server/budget/budgetAdjustments";
 import type { QueryFn } from "@/server/db/contextRunner";
-import { createDemoBudgetAdjustment, EMPTY_DEMO_BUDGET_ADJUSTMENT_SESSION, parseDemoBudgetAdjustmentSessionCookie, serializeDemoBudgetAdjustmentSessionCookie, type DemoBudgetAdjustmentSessionState } from "@/server/demo/budgetAdjustments";
+import {
+  createDemoBudgetAdjustment,
+  deleteDemoBudgetAdjustment,
+  EMPTY_DEMO_BUDGET_ADJUSTMENT_SESSION,
+  getDemoBudgetAdjustmentsForSession,
+  parseDemoBudgetAdjustmentSessionCookie,
+  patchDemoBudgetAdjustment,
+  serializeDemoBudgetAdjustmentSessionCookie,
+  type DemoBudgetAdjustmentSessionState,
+} from "@/server/demo/budgetAdjustments";
 import { getDemoBudgetAdjustments, getDemoBudgetGrid } from "@/server/demo/data";
 
 const CREATE_PARAMS: CreateBudgetAdjustmentParams = {
@@ -291,6 +300,65 @@ test("demo adjustment session state is validated and bounded without eviction", 
   assert.throws(
     () => serializeDemoBudgetAdjustmentSessionCookie(state),
     /supports at most 8 changed rows/,
+  );
+});
+
+test("demo adjustment session serialization preserves zero rows, null notes, moves, and seeded deletions", (): void => {
+  const adjustmentId = "00000000-0000-4000-8000-000000000010";
+  const destinationMonth = offsetMonth(getCurrentMonth(), 3);
+  const seededAdjustment = getDemoBudgetAdjustments()[0];
+  assert.ok(seededAdjustment);
+  let state = createDemoBudgetAdjustment(
+    EMPTY_DEMO_BUDGET_ADJUSTMENT_SESSION,
+    {
+      adjustmentId,
+      month: getCurrentMonth(),
+      direction: "spend",
+      category: "Groceries",
+      amount: 0,
+      note: null,
+    },
+  ).state;
+  state = patchDemoBudgetAdjustment(
+    state,
+    adjustmentId,
+    {
+      month: destinationMonth,
+      category: "Travel reserve",
+      amount: 0,
+      note: null,
+    },
+    "2026-07-24T12:00:00.000Z",
+  ).state;
+  state = deleteDemoBudgetAdjustment(
+    state,
+    seededAdjustment.adjustmentId,
+  );
+
+  const cookie = serializeDemoBudgetAdjustmentSessionCookie(state);
+  const cookieValue = cookie.split(";", 1)[0]?.split("=", 2)[1];
+  assert.ok(cookieValue);
+  const restored = getDemoBudgetAdjustmentsForSession(
+    parseDemoBudgetAdjustmentSessionCookie(cookieValue),
+  );
+
+  assert.equal(
+    restored.some((adjustment) =>
+      adjustment.adjustmentId === seededAdjustment.adjustmentId),
+    false,
+  );
+  assert.deepEqual(
+    restored.find((adjustment) => adjustment.adjustmentId === adjustmentId),
+    {
+      adjustmentId,
+      month: destinationMonth,
+      direction: "spend",
+      category: "Travel reserve",
+      amount: 0,
+      note: null,
+      createdAt: "2000-01-01T00:00:00.000Z",
+      updatedAt: "2026-07-24T12:00:00.000Z",
+    },
   );
 });
 

--- a/apps/web/src/server/demo/budgetAdjustments.ts
+++ b/apps/web/src/server/demo/budgetAdjustments.ts
@@ -55,7 +55,7 @@ const validateSessionIds = (state: DemoBudgetAdjustmentSessionState): void => {
     if (rowIds.has(row.adjustmentId)) {
       throw new ApiRouteError(
         400,
-        "Invalid demo budget adjustment session: duplicate row ID. Leave Demo mode to reset it.",
+        "Invalid demo budget adjustment session: duplicate row ID. Use Reset Demo changes on the error page.",
       );
     }
     rowIds.add(row.adjustmentId);
@@ -65,7 +65,7 @@ const validateSessionIds = (state: DemoBudgetAdjustmentSessionState): void => {
     if (deletedIds.has(adjustmentId) || rowIds.has(adjustmentId)) {
       throw new ApiRouteError(
         400,
-        "Invalid demo budget adjustment session: conflicting deleted ID. Leave Demo mode to reset it.",
+        "Invalid demo budget adjustment session: conflicting deleted ID. Use Reset Demo changes on the error page.",
       );
     }
     deletedIds.add(adjustmentId);
@@ -83,14 +83,14 @@ export const parseDemoBudgetAdjustmentSessionCookie = (
   } catch {
     throw new ApiRouteError(
       400,
-      "Invalid demo budget adjustment session cookie. Leave Demo mode to reset it.",
+      "Invalid demo budget adjustment session cookie. Use Reset Demo changes on the error page.",
     );
   }
   const parsed = demoBudgetAdjustmentSessionSchema.safeParse(input);
   if (!parsed.success) {
     throw new ApiRouteError(
       400,
-      "Invalid demo budget adjustment session cookie. Leave Demo mode to reset it.",
+      "Invalid demo budget adjustment session cookie. Use Reset Demo changes on the error page.",
     );
   }
   const state: DemoBudgetAdjustmentSessionState = {
@@ -121,7 +121,7 @@ export const serializeDemoBudgetAdjustmentSessionCookie = (
     || state.deletedAdjustmentIds.length > MAX_SESSION_ROWS) {
     throw new ApiRouteError(
       409,
-      `Demo budget adjustment session supports at most ${MAX_SESSION_ROWS} changed rows. Delete an adjustment or leave Demo mode to reset it.`,
+      `Demo budget adjustment session supports at most ${MAX_SESSION_ROWS} changed rows. Delete an adjustment to free space.`,
     );
   }
   validateSessionIds(state);
@@ -136,7 +136,7 @@ export const serializeDemoBudgetAdjustmentSessionCookie = (
   if (value.length > MAX_SESSION_COOKIE_VALUE_LENGTH) {
     throw new ApiRouteError(
       409,
-      "Demo budget adjustment session is full. Shorten notes, delete an adjustment, or leave Demo mode to reset it.",
+      "Demo budget adjustment session is full. Shorten notes or delete an adjustment to free space.",
     );
   }
   return `${DEMO_BUDGET_ADJUSTMENTS_COOKIE}=${value}; Path=/; SameSite=Lax`;

--- a/apps/web/src/ui/FilteredModeProvider.tsx
+++ b/apps/web/src/ui/FilteredModeProvider.tsx
@@ -2,7 +2,6 @@
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactElement, type ReactNode } from "react";
 
-import { DEMO_BUDGET_ADJUSTMENTS_COOKIE } from "@/lib/demoCookies";
 import type { AutoFilterDelayMinutes } from "@/lib/locale";
 import {
   getAutoFilterDelayMs,
@@ -203,7 +202,6 @@ export const FilteredModeProvider = (props: ProviderProps): ReactElement => {
     if (isDemoMode) {
       localStorage.setItem(STORAGE_MODE_KEY, request.target);
       document.cookie = "demo=; path=/; max-age=0";
-      document.cookie = `${DEMO_BUDGET_ADJUSTMENTS_COOKIE}=; path=/; max-age=0`;
       window.location.reload();
       return;
     }

--- a/apps/web/src/ui/tables/budget/BudgetTable.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetTable.tsx
@@ -56,7 +56,11 @@ export const BudgetTable = (props: BudgetTableProps): ReactElement => {
           </span>
         )}
       </div>
-      <div className={styles.scroll} ref={controller.scrollRef}>
+      <div
+        className={styles.scroll}
+        data-testid="budget-table-scroll"
+        ref={controller.scrollRef}
+      >
         <table className={styles.table}>
           <BudgetTableHeader
             columnSequence={controller.columnSequence}

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.test.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.test.ts
@@ -322,8 +322,8 @@ test("anchors editor rows to confirmed cells and reveals invalid drafts only to 
       "Allowed",
       allowlist,
       editorAnchors,
-    ).map((row) => row.adjustmentId),
-    [invalid.adjustmentId],
+    ),
+    [],
   );
   assert.deepEqual(
     getBudgetAdjustmentEditorCellRows(

--- a/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.ts
+++ b/apps/web/src/ui/tables/budget/budgetAdjustmentRowsState.ts
@@ -132,7 +132,11 @@ export const getBudgetAdjustmentEditorCellRows = (
       return editorAnchor.month === month
         && editorAnchor.direction === direction
         && editorAnchor.category === category
-        && isBudgetAdjustmentCategoryVisible(category, effectiveAllowlist);
+        && isBudgetAdjustmentCategoryVisible(category, effectiveAllowlist)
+        && isBudgetAdjustmentCategoryVisible(
+          row.confirmed.category,
+          effectiveAllowlist,
+        );
     }
     return row.confirmed.month === month
       && row.direction === direction

--- a/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.test.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.test.ts
@@ -628,18 +628,221 @@ test("classifies definitive patch failures and reconciles ambiguous failures by 
     harness.runtime.getSnapshot().errorByAdjustmentId.get(FIRST_ID)?.httpStatus,
     503,
   );
+  assert.deepEqual(
+    harness.invalidatedYears.map((years) => [...years].sort()),
+    [["2026", "2027"]],
+  );
   assert.equal(await harness.runtime.commands.flushRow(FIRST_ID), "refresh-required");
   assert.equal(harness.patchCalls.length, 2);
 
   const canonical = applyPatch(initial, { amount: 2, month: "2027-01" });
-  harness.setRangeHandler(async (): Promise<BudgetGridResult> => createGrid([canonical], []));
-  assert.deepEqual(await harness.runtime.commands.refreshRow(FIRST_ID), {
-    status: "accepted",
-    result: createGrid([canonical], []),
-  });
+  const rangeResult = createGrid([canonical], []);
+  harness.setRangeHandler(async (): Promise<BudgetGridResult> => rangeResult);
+  assert.deepEqual(
+    await harness.runtime.commands.loadRange("2026-12", "2027-01"),
+    { status: "accepted", result: rangeResult },
+  );
   assert.deepEqual(harness.rangeCalls, [{ monthFrom: "2026-12", monthTo: "2027-01" }]);
+  assert.deepEqual(
+    harness.invalidatedYears.map((years) => [...years].sort()),
+    [["2026", "2027"], ["2026", "2027"]],
+  );
   assert.equal(harness.runtime.getSnapshot().errorByAdjustmentId.has(FIRST_ID), false);
   assert.equal(await harness.runtime.commands.flushRow(FIRST_ID), "unchanged");
+});
+
+test("rolls definitive patch projections back while keeping the failed draft editable", async (): Promise<void> => {
+  const initial = createAdjustment(FIRST_ID, 1, "2026-12", "Food", null);
+  const harness = createHarness([initial]);
+  const source = {
+    month: "2026-12",
+    direction: "spend" as const,
+    category: "Food",
+  };
+  const destination = {
+    month: "2027-01",
+    direction: "spend" as const,
+    category: "Dining",
+  };
+  harness.setPatchHandler(async (): Promise<BudgetAdjustment> => {
+    throw new BudgetAdjustmentApiError(
+      "Budget adjustment update",
+      409,
+      "conflict",
+    );
+  });
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("9", "2027-01", "Dining", "retry me"),
+  );
+
+  assert.equal(harness.runtime.commands.getCellTotal(source, null), 0);
+  assert.equal(harness.runtime.commands.getCellTotal(destination, null), 9);
+  assert.equal(await harness.runtime.commands.flushRow(FIRST_ID), "error");
+
+  const failed = harness.runtime.getSnapshot();
+  assert.equal(failed.rows[0]?.draft.amountInput, "9");
+  assert.equal(failed.rows[0]?.draft.month, "2027-01");
+  assert.equal(failed.rows[0]?.draft.category, "Dining");
+  assert.equal(failed.rows[0]?.draft.noteInput, "retry me");
+  assert.equal(harness.runtime.commands.getCellTotal(source, null), 1);
+  assert.equal(harness.runtime.commands.getCellTotal(destination, null), 0);
+  assert.equal(
+    harness.runtime.commands.getCellTotal(source, new Set(["Food"])),
+    1,
+  );
+  assert.equal(
+    harness.runtime.commands.getCellTotal(destination, new Set(["Food"])),
+    0,
+  );
+  assert.deepEqual(
+    harness.runtime.commands.applyToBudgetRows(
+      [
+        {
+          month: "2026-12",
+          direction: "spend",
+          category: "Food",
+          plannedBase: 100,
+          plannedModifier: 1,
+          planned: 101,
+          actual: 0,
+          hasUnconvertible: false,
+        },
+        {
+          month: "2027-01",
+          direction: "spend",
+          category: "Dining",
+          plannedBase: 200,
+          plannedModifier: 0,
+          planned: 200,
+          actual: 0,
+          hasUnconvertible: false,
+        },
+      ],
+      "2026-12",
+      "2027-01",
+      null,
+    ).map((row) => [
+      row.month,
+      row.category,
+      row.plannedModifier,
+      row.planned,
+    ]),
+    [
+      ["2026-12", "Food", 1, 101],
+      ["2027-01", "Dining", 0, 200],
+    ],
+  );
+  assert.deepEqual(harness.invalidatedYears, []);
+});
+
+test("rolls definitive delete projections back and permits editing before an explicit retry", async (): Promise<void> => {
+  const initial = createAdjustment(FIRST_ID, 1, "2026-12", "Food", null);
+  const harness = createHarness([initial]);
+  const source = {
+    month: "2026-12",
+    direction: "spend" as const,
+    category: "Food",
+  };
+  const destination = {
+    month: "2027-01",
+    direction: "spend" as const,
+    category: "Dining",
+  };
+  harness.setDeleteHandler(async (): Promise<DeleteBudgetAdjustmentOutcome> => {
+    throw new BudgetAdjustmentApiError(
+      "Budget adjustment delete",
+      409,
+      "conflict",
+    );
+  });
+  harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("9", "2027-01", "Dining", "retry me"),
+  );
+
+  assert.equal(harness.runtime.commands.getCellTotal(source, null), 0);
+  assert.equal(harness.runtime.commands.getCellTotal(destination, null), 9);
+  assert.equal(
+    await harness.runtime.commands.requestDelete(FIRST_ID),
+    "error",
+  );
+
+  const failed = harness.runtime.getSnapshot();
+  assert.equal(
+    failed.errorByAdjustmentId.get(FIRST_ID)?.classification,
+    "definitive",
+  );
+  assert.equal(failed.errorByAdjustmentId.get(FIRST_ID)?.operation, "delete");
+  assert.equal(failed.rows[0]?.draft.amountInput, "9");
+  assert.equal(failed.rows[0]?.draft.month, "2027-01");
+  assert.equal(failed.rows[0]?.draft.category, "Dining");
+  assert.equal(failed.rows[0]?.draft.noteInput, "retry me");
+  assert.equal(harness.runtime.commands.getCellTotal(source, null), 1);
+  assert.equal(harness.runtime.commands.getCellTotal(destination, null), 0);
+
+  assert.doesNotThrow(() => harness.runtime.commands.replaceDraft(
+    FIRST_ID,
+    createDraft("10", "2027-01", "Dining", "editable"),
+  ));
+  const edited = harness.runtime.getSnapshot();
+  assert.equal(edited.errorByAdjustmentId.has(FIRST_ID), false);
+  assert.equal(edited.rows[0]?.draft.amountInput, "10");
+  assert.equal(edited.rows[0]?.draft.noteInput, "editable");
+  assert.equal(harness.runtime.commands.getCellTotal(source, null), 0);
+  assert.equal(harness.runtime.commands.getCellTotal(destination, null), 10);
+
+  harness.setDeleteHandler(
+    async (): Promise<DeleteBudgetAdjustmentOutcome> => "deleted",
+  );
+  assert.equal(
+    await harness.runtime.commands.requestDelete(FIRST_ID),
+    "deleted",
+  );
+  assert.deepEqual(harness.deleteCalls, [FIRST_ID, FIRST_ID]);
+  assert.equal(harness.runtime.getSnapshot().rows.length, 0);
+});
+
+test("removes a definitively failed optimistic create from projections without losing its editor", async (): Promise<void> => {
+  const harness = createHarness([]);
+  harness.setCreateHandler(async (): Promise<BudgetAdjustment> => {
+    throw new BudgetAdjustmentApiError(
+      "Budget adjustment create",
+      409,
+      "conflict",
+    );
+  });
+  const location = {
+    month: "2026-07",
+    direction: "spend" as const,
+    category: "Adjustment only",
+  };
+  const adjustmentId = harness.runtime.commands.addRow(location);
+  harness.runtime.commands.replaceDraft(
+    adjustmentId,
+    createDraft("5", "2026-07", "Adjustment only", "retry me"),
+  );
+
+  assert.equal(harness.runtime.commands.getCellTotal(location, null), 5);
+  assert.equal(await harness.runtime.commands.flushRow(adjustmentId), "error");
+  assert.equal(
+    harness.runtime.getSnapshot().errorByAdjustmentId.get(adjustmentId)?.classification,
+    "definitive",
+  );
+  assert.equal(
+    harness.runtime.commands.getRow(adjustmentId, null)?.draft.amountInput,
+    "5",
+  );
+  assert.equal(harness.runtime.commands.getCellTotal(location, null), 0);
+  assert.deepEqual(
+    harness.runtime.commands.applyToBudgetRows(
+      [],
+      "2026-07",
+      "2026-07",
+      null,
+    ),
+    [],
+  );
 });
 
 test("keeps an ambiguous patch retryable when refresh returns the unchanged row", async (): Promise<void> => {

--- a/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.ts
@@ -471,6 +471,9 @@ export const createBudgetAdjustmentRowsController = (
       reconciliation = classification === "definitive"
         ? reconcileBudgetAdjustmentDeleteDefinitiveFailure(reconciliation, issued.request)
         : reconcileBudgetAdjustmentDeleteAmbiguousFailure(reconciliation, issued.request);
+      if (classification === "definitive") {
+        deleteRequestedIds.delete(adjustmentId);
+      }
       setRowError(adjustmentId, "delete", error, classification === "ambiguous");
       if (classification === "ambiguous") {
         invalidateYears([issued.request.confirmed.month]);
@@ -648,12 +651,35 @@ export const createBudgetAdjustmentRowsController = (
     publish();
     try {
       const result = await dependencies.fetchRange(monthFrom, monthTo);
+      const ambiguityRequirementsBeforeResponse =
+        reconciliation.ambiguousRangeRequirementByAdjustmentId;
       const previousRows = reconciliation.rows;
       reconciliation = reconcileBudgetAdjustmentRangeResponse(
         reconciliation,
         issued.request,
         result.adjustments,
       );
+      const resolvedAmbiguityMonths = [
+        ...ambiguityRequirementsBeforeResponse,
+      ].flatMap(([adjustmentId, requirement]): ReadonlyArray<string> => {
+        if (
+          reconciliation.ambiguousRangeRequirementByAdjustmentId.has(
+            adjustmentId,
+          )
+        ) {
+          return [];
+        }
+        const refreshedRow = reconciliation.rows.find((row): boolean =>
+          row.adjustmentId === adjustmentId);
+        return [
+          requirement.sourceMonth,
+          requirement.targetMonth,
+          ...(refreshedRow === undefined ? [] : [refreshedRow.confirmed.month]),
+        ];
+      });
+      if (resolvedAmbiguityMonths.length > 0) {
+        invalidateYears(resolvedAmbiguityMonths);
+      }
       clearRemovedRowState(previousRows);
       clearRecoveredRangeErrors();
       for (const [adjustmentId, rowError] of rowErrors) {
@@ -784,6 +810,36 @@ export const createBudgetAdjustmentRowsController = (
     (row): boolean => isBudgetAdjustmentRowVisible(row, effectiveAllowlist),
   );
 
+  const getProjectedRows = (
+    effectiveAllowlist: ReadonlySet<string> | null,
+  ): ReadonlyArray<BudgetAdjustmentEditorRow> => reconciliation.rows.flatMap(
+    (row): ReadonlyArray<BudgetAdjustmentEditorRow> => {
+      const rowError = rowErrors.get(row.adjustmentId);
+      if (
+        rowError?.classification === "definitive"
+        && rowError.operation === "create"
+        && reconciliation.optimisticCreateByAdjustmentId.has(row.adjustmentId)
+      ) {
+        return [];
+      }
+      const projectedRow = rowError?.classification === "definitive"
+        && (rowError.operation === "patch" || rowError.operation === "delete")
+        ? {
+          ...row,
+          draft: {
+            amountInput: String(row.confirmed.amount),
+            noteInput: row.confirmed.note ?? "",
+            month: row.confirmed.month,
+            category: row.confirmed.category,
+          },
+        }
+        : row;
+      return isBudgetAdjustmentRowVisible(projectedRow, effectiveAllowlist)
+        ? [projectedRow]
+        : [];
+    },
+  );
+
   const getCellRows = (
     location: BudgetAdjustmentCellLocation,
     effectiveAllowlist: ReadonlySet<string> | null,
@@ -827,7 +883,7 @@ export const createBudgetAdjustmentRowsController = (
     effectiveAllowlist: ReadonlySet<string> | null,
   ): number =>
     getBudgetAdjustmentCellTotal(
-      getVisibleRows(effectiveAllowlist),
+      getProjectedRows(effectiveAllowlist),
       location.month,
       location.direction,
       location.category,
@@ -867,7 +923,7 @@ export const createBudgetAdjustmentRowsController = (
     effectiveAllowlist: ReadonlySet<string> | null,
   ): ReadonlyArray<BudgetRow> => applyBudgetAdjustmentRowsWithProtectedCells(
     budgetRows,
-    getVisibleRows(effectiveAllowlist),
+    getProjectedRows(effectiveAllowlist),
     loadedFrom,
     loadedTo,
     dependencies.planFrom,

--- a/apps/web/src/ui/tables/budget/table/sections/direction/CategoryRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/direction/CategoryRow.tsx
@@ -134,6 +134,9 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
               <td
                 key={`total-${column.year}`}
                 className={`${styles.cell} ${styles.yearTotal}${categoryVisibility.maskClass}${yearTotalStateClass}${categoryVisibility.showData ? ` ${styles.cellClickable}` : ""}`}
+                data-testid={categoryVisibility.showData
+                  ? `budget-year-actual-${column.year}:${block.direction}:${category}`
+                  : undefined}
                 onClick={categoryVisibility.showData
                   ? () => openDrillDown(buildCategoryYearDrillDownFilter(column.year, block.direction, category))
                   : undefined}
@@ -150,7 +153,13 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
               yearData.directionCategoryTotals.get(block.direction)?.get(category) ?? zeroCellValue;
             const yearTotalStateClass = buildYearTotalStateClass(yearData.taintedCategories.has(`${block.direction}::${category}`), false);
             return (
-              <td key={`total-${column.year}`} className={`${styles.cell} ${styles.yearTotal}${categoryVisibility.maskClass}${yearTotalStateClass}`}>
+              <td
+                key={`total-${column.year}`}
+                className={`${styles.cell} ${styles.yearTotal}${categoryVisibility.maskClass}${yearTotalStateClass}`}
+                data-testid={categoryVisibility.showData
+                  ? `budget-year-plan-${column.year}:${block.direction}:${category}`
+                  : undefined}
+              >
                 {categoryVisibility.showData ? formatAmount(yearCell.planned, numberFormat) : ""}
               </td>
             );
@@ -166,11 +175,19 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
             const yearTotalActualStateClass = buildYearTotalStateClass(yearData.taintedCategories.has(`${block.direction}::${category}`), isActualOver);
             return (
               <Fragment key={`total-${column.year}`}>
-                <td className={`${styles.cell} ${styles.yearTotal}${categoryVisibility.maskClass}${yearTotalPlanStateClass}`}>
+                <td
+                  className={`${styles.cell} ${styles.yearTotal}${categoryVisibility.maskClass}${yearTotalPlanStateClass}`}
+                  data-testid={categoryVisibility.showData
+                    ? `budget-year-plan-${column.year}:${block.direction}:${category}`
+                    : undefined}
+                >
                   {categoryVisibility.showData ? formatAmount(yearCell.planned, numberFormat) : ""}
                 </td>
                 <td
                   className={`${styles.cell} ${styles.yearTotal}${categoryVisibility.maskClass}${yearTotalActualStateClass}${categoryVisibility.showData ? ` ${styles.cellClickable}` : ""}`}
+                  data-testid={categoryVisibility.showData
+                    ? `budget-year-actual-${column.year}:${block.direction}:${category}`
+                    : undefined}
                   onClick={categoryVisibility.showData
                     ? () => openDrillDown(buildCategoryYearDrillDownFilter(column.year, block.direction, category))
                     : undefined}


### PR DESCRIPTION
Summary
- keep normalized adjustment projections and loaded year totals coherent across recovery and cross-year moves
- preserve Demo adjustment session state across reloads and mode transitions, with an explicit localized reset path
- tighten Filtered-mode privacy and add stable local-Demo coverage for persistence, totals, recovery, mobile, and RTL behavior

Validation
- 98 focused state, controller, server, and route tests
- 17 local-Demo Playwright tests
- npm run lint
- npm run build
- locale parity and git diff --check