### PR TITLE
Add chat session history metadata

### DIFF
--- a/db/migrations/0058_chat_session_history_metadata.sql
+++ b/db/migrations/0058_chat_session_history_metadata.sql
@@ -1,0 +1,7 @@
+-- Add nullable chat history metadata without changing existing application writes.
+
+SET LOCAL lock_timeout = '30s';
+
+ALTER TABLE public.chat_sessions
+  ADD COLUMN title VARCHAR(200) NULL,
+  ADD COLUMN last_message_at TIMESTAMPTZ NULL;

--- a/db/migrations/0059_chat_session_history_session_policy.sql
+++ b/db/migrations/0059_chat_session_history_session_policy.sql
@@ -1,0 +1,30 @@
+-- Install opt-in session access for the metadata backfill migration.
+
+SET LOCAL lock_timeout = '30s';
+
+-- Forced RLS applies to the migration owner in production. This role-scoped
+-- policy remains inert unless the backfill enables its transaction-local
+-- setting.
+DO $$
+BEGIN
+  EXECUTE pg_catalog.format(
+    'CREATE POLICY chat_sessions_0059_history_backfill_access
+       ON public.chat_sessions
+       FOR ALL
+       TO %I
+       USING (
+         current_setting(
+           ''app.chat_session_history_metadata_backfill'',
+           true
+         ) = ''enabled''
+       )
+       WITH CHECK (
+         current_setting(
+           ''app.chat_session_history_metadata_backfill'',
+           true
+         ) = ''enabled''
+       )',
+    current_user
+  );
+END;
+$$;

--- a/db/migrations/0060_chat_session_history_item_policy.sql
+++ b/db/migrations/0060_chat_session_history_item_policy.sql
@@ -1,0 +1,24 @@
+-- Install opt-in item reads for the metadata backfill migration.
+
+SET LOCAL lock_timeout = '30s';
+
+-- Forced RLS applies to the migration owner in production. This role-scoped
+-- policy remains inert unless the backfill enables its transaction-local
+-- setting.
+DO $$
+BEGIN
+  EXECUTE pg_catalog.format(
+    'CREATE POLICY chat_items_0060_history_backfill_read
+       ON public.chat_items
+       FOR SELECT
+       TO %I
+       USING (
+         current_setting(
+           ''app.chat_session_history_metadata_backfill'',
+           true
+         ) = ''enabled''
+       )',
+    current_user
+  );
+END;
+$$;

--- a/db/migrations/0061_chat_session_history_metadata_backfill.sql
+++ b/db/migrations/0061_chat_session_history_metadata_backfill.sql
@@ -1,0 +1,106 @@
+-- Backfill chat history metadata while keeping chat reads available.
+
+SET LOCAL lock_timeout = '30s';
+
+-- Live chat transactions lock their session before writing chat items. An
+-- EXCLUSIVE session lock waits for those transactions and prevents new writers
+-- while remaining compatible with ordinary SELECT reads.
+LOCK TABLE public.chat_sessions IN EXCLUSIVE MODE;
+
+-- Block direct item writes after the session writer gate is established.
+-- SHARE remains compatible with ordinary SELECT reads.
+LOCK TABLE public.chat_items IN SHARE MODE;
+
+SELECT pg_catalog.set_config(
+  'app.chat_session_history_metadata_backfill',
+  'enabled',
+  true
+);
+
+WITH first_user_messages AS (
+  SELECT DISTINCT ON (item.session_id)
+    item.session_id,
+    item.payload
+  FROM public.chat_items AS item
+  WHERE item.item_kind = 'message'
+    AND item.payload ->> 'role' = 'user'
+  ORDER BY item.session_id, item.item_order
+),
+derived_titles AS (
+  SELECT
+    first_message.session_id,
+    LEFT(
+      COALESCE(message_text.title, attachment.title),
+      200
+    ) AS title
+  FROM first_user_messages AS first_message
+  LEFT JOIN LATERAL (
+    SELECT NULLIF(
+      btrim(
+        regexp_replace(
+          pg_catalog.string_agg(
+            content_part.value ->> 'text',
+            ''
+            ORDER BY content_part.ordinality
+          ),
+          '[[:space:]]+',
+          ' ',
+          'g'
+        )
+      ),
+      ''
+    ) AS title
+    FROM jsonb_array_elements(first_message.payload -> 'content')
+      WITH ORDINALITY AS content_part(value, ordinality)
+    WHERE content_part.value ->> 'type' = 'text'
+  ) AS message_text
+    ON true
+  LEFT JOIN LATERAL (
+    SELECT normalized_attachment.title
+    FROM (
+      SELECT
+        attachment_part.ordinality,
+        NULLIF(
+          btrim(
+            regexp_replace(
+              attachment_part.value ->> 'fileName',
+              '[[:space:]]+',
+              ' ',
+              'g'
+            )
+          ),
+          ''
+        ) AS title
+      FROM jsonb_array_elements(first_message.payload -> 'content')
+        WITH ORDINALITY AS attachment_part(value, ordinality)
+      WHERE attachment_part.value ->> 'type' = 'file'
+    ) AS normalized_attachment
+    WHERE normalized_attachment.title IS NOT NULL
+    ORDER BY normalized_attachment.ordinality
+    LIMIT 1
+  ) AS attachment
+    ON true
+),
+message_activity AS (
+  SELECT
+    item.session_id,
+    MAX(GREATEST(item.created_at, item.updated_at)) AS last_message_at
+  FROM public.chat_items AS item
+  WHERE item.item_kind = 'message'
+  GROUP BY item.session_id
+),
+session_metadata AS (
+  SELECT
+    title.session_id,
+    title.title,
+    activity.last_message_at
+  FROM derived_titles AS title
+  JOIN message_activity AS activity
+    ON activity.session_id = title.session_id
+)
+UPDATE public.chat_sessions AS session
+SET
+  title = metadata.title,
+  last_message_at = metadata.last_message_at
+FROM session_metadata AS metadata
+WHERE session.session_id = metadata.session_id;

--- a/db/migrations/0062_chat_session_history_session_policy_cleanup.sql
+++ b/db/migrations/0062_chat_session_history_session_policy_cleanup.sql
@@ -1,0 +1,6 @@
+-- Remove the temporary session access used by the metadata backfill.
+
+SET LOCAL lock_timeout = '30s';
+
+DROP POLICY chat_sessions_0059_history_backfill_access
+  ON public.chat_sessions;

--- a/db/migrations/0063_chat_session_history_item_policy_cleanup.sql
+++ b/db/migrations/0063_chat_session_history_item_policy_cleanup.sql
@@ -1,0 +1,6 @@
+-- Remove the temporary item access used by the metadata backfill.
+
+SET LOCAL lock_timeout = '30s';
+
+DROP POLICY chat_items_0060_history_backfill_read
+  ON public.chat_items;

--- a/db/migrations/0064_chat_session_history_metadata_index.sql
+++ b/db/migrations/0064_chat_session_history_metadata_index.sql
@@ -1,0 +1,15 @@
+-- Add the chat history pagination index after the metadata backfill commits.
+
+SET LOCAL lock_timeout = '30s';
+
+-- A regular index build blocks table writers but remains compatible with
+-- ordinary SELECT reads. The migration runner intentionally wraps each file in
+-- its own transaction, so concurrent index creation is not available here.
+CREATE INDEX chat_sessions_user_workspace_last_message_idx
+  ON public.chat_sessions (
+    user_id,
+    workspace_id,
+    last_message_at DESC,
+    session_id DESC
+  )
+  WHERE last_message_at IS NOT NULL;

--- a/db/tests/0058_chat_session_history_metadata.sql
+++ b/db/tests/0058_chat_session_history_metadata.sql
@@ -1,0 +1,319 @@
+BEGIN;
+
+SELECT pg_catalog.set_config('app.user_id', 'local', true);
+SELECT pg_catalog.set_config('app.workspace_id', 'local', true);
+
+DROP INDEX public.chat_sessions_user_workspace_last_message_idx;
+
+ALTER TABLE public.chat_sessions
+  DROP COLUMN title,
+  DROP COLUMN last_message_at;
+
+INSERT INTO public.chat_sessions (
+  session_id,
+  user_id,
+  workspace_id,
+  status,
+  created_at,
+  updated_at
+) VALUES
+  (
+    '0058-text-session',
+    'local',
+    'local',
+    'idle',
+    '2026-01-01 10:00:00+00',
+    '2026-01-01 12:00:00+00'
+  ),
+  (
+    '0058-attachment-session',
+    'local',
+    'local',
+    'idle',
+    '2026-01-02 10:00:00+00',
+    '2026-01-02 12:00:00+00'
+  ),
+  (
+    '0058-untitled-session',
+    'local',
+    'local',
+    'idle',
+    '2026-01-03 10:00:00+00',
+    '2026-01-03 12:00:00+00'
+  ),
+  (
+    '0058-long-title-session',
+    'local',
+    'local',
+    'idle',
+    '2026-01-03 13:00:00+00',
+    '2026-01-03 13:00:00+00'
+  ),
+  (
+    '0058-empty-session',
+    'local',
+    'local',
+    'idle',
+    '2026-01-04 10:00:00+00',
+    '2026-01-04 12:00:00+00'
+  ),
+  (
+    '0058-assistant-only-session',
+    'local',
+    'local',
+    'idle',
+    '2026-01-05 10:00:00+00',
+    '2026-01-05 12:00:00+00'
+  );
+
+INSERT INTO public.chat_items (
+  item_id,
+  session_id,
+  item_kind,
+  state,
+  payload,
+  created_at,
+  updated_at
+) VALUES
+  (
+    '0058-text-user-item',
+    '0058-text-session',
+    'message',
+    'completed',
+    jsonb_build_object(
+      'role',
+      'user',
+      'content',
+      jsonb_build_array(
+        jsonb_build_object('type', 'text', 'text', E'  Reconcile\n   July  '),
+        jsonb_build_object('type', 'text', 'text', E'\tbalances  ')
+      )
+    ),
+    '2026-01-01 10:01:00+00',
+    '2026-01-01 10:01:00+00'
+  ),
+  (
+    '0058-text-assistant-item',
+    '0058-text-session',
+    'message',
+    'completed',
+    jsonb_build_object(
+      'role',
+      'assistant',
+      'content',
+      jsonb_build_array(jsonb_build_object('type', 'text', 'text', 'Done'))
+    ),
+    '2026-01-01 10:02:00+00',
+    '2026-01-01 10:03:00+00'
+  ),
+  (
+    '0058-attachment-user-item',
+    '0058-attachment-session',
+    'message',
+    'completed',
+    jsonb_build_object(
+      'role',
+      'user',
+      'content',
+      jsonb_build_array(
+        jsonb_build_object('type', 'text', 'text', E' \n '),
+        jsonb_build_object(
+          'type',
+          'file',
+          'fileName',
+          E' \t ',
+          'mediaType',
+          'text/plain',
+          'base64Data',
+          'fixture-bytes'
+        ),
+        jsonb_build_object(
+          'type',
+          'file',
+          'fileName',
+          E'  July\n statement.xlsx ',
+          'mediaType',
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          'base64Data',
+          'fixture-bytes'
+        )
+      )
+    ),
+    '2026-01-02 10:01:00+00',
+    '2026-01-02 10:01:00+00'
+  ),
+  (
+    '0058-untitled-user-item',
+    '0058-untitled-session',
+    'message',
+    'completed',
+    jsonb_build_object(
+      'role',
+      'user',
+      'content',
+      jsonb_build_array(
+        jsonb_build_object(
+          'type',
+          'image',
+          'mediaType',
+          'image/png',
+          'base64Data',
+          'fixture-bytes'
+        )
+      )
+    ),
+    '2026-01-03 10:01:00+00',
+    '2026-01-03 10:01:00+00'
+  ),
+  (
+    '0058-long-title-user-item',
+    '0058-long-title-session',
+    'message',
+    'completed',
+    jsonb_build_object(
+      'role',
+      'user',
+      'content',
+      jsonb_build_array(
+        jsonb_build_object('type', 'text', 'text', repeat(chr(30028), 201))
+      )
+    ),
+    '2026-01-03 13:01:00+00',
+    '2026-01-03 13:01:00+00'
+  ),
+  (
+    '0058-assistant-only-item',
+    '0058-assistant-only-session',
+    'message',
+    'completed',
+    jsonb_build_object(
+      'role',
+      'assistant',
+      'content',
+      jsonb_build_array(jsonb_build_object('type', 'text', 'text', 'No user message'))
+    ),
+    '2026-01-05 10:01:00+00',
+    '2026-01-05 10:01:00+00'
+  );
+
+SELECT pg_catalog.set_config('app.user_id', '', true);
+SELECT pg_catalog.set_config('app.workspace_id', '', true);
+
+\ir ../migrations/0058_chat_session_history_metadata.sql
+\ir ../migrations/0059_chat_session_history_session_policy.sql
+\ir ../migrations/0060_chat_session_history_item_policy.sql
+\ir ../migrations/0061_chat_session_history_metadata_backfill.sql
+\ir ../migrations/0062_chat_session_history_session_policy_cleanup.sql
+\ir ../migrations/0063_chat_session_history_item_policy_cleanup.sql
+\ir ../migrations/0064_chat_session_history_metadata_index.sql
+
+SELECT pg_catalog.set_config('app.user_id', 'local', true);
+SELECT pg_catalog.set_config('app.workspace_id', 'local', true);
+
+DO $$
+DECLARE
+  v_title public.chat_sessions.title%TYPE;
+  v_last_message_at TIMESTAMPTZ;
+  v_index_definition TEXT;
+BEGIN
+  SELECT session.title, session.last_message_at
+    INTO v_title, v_last_message_at
+    FROM public.chat_sessions AS session
+    WHERE session.session_id = '0058-text-session';
+
+  IF v_title IS DISTINCT FROM 'Reconcile July balances' THEN
+    RAISE EXCEPTION
+      'chat session metadata test failed: expected normalized text title, found %',
+      v_title;
+  END IF;
+
+  IF v_last_message_at IS DISTINCT FROM '2026-01-01 10:03:00+00'::TIMESTAMPTZ THEN
+    RAISE EXCEPTION
+      'chat session metadata test failed: expected latest item activity, found %',
+      v_last_message_at;
+  END IF;
+
+  SELECT session.title, session.last_message_at
+    INTO v_title, v_last_message_at
+    FROM public.chat_sessions AS session
+    WHERE session.session_id = '0058-attachment-session';
+
+  IF v_title IS DISTINCT FROM 'July statement.xlsx' THEN
+    RAISE EXCEPTION
+      'chat session metadata test failed: expected attachment filename title, found %',
+      v_title;
+  END IF;
+
+  IF v_last_message_at IS NULL THEN
+    RAISE EXCEPTION
+      'chat session metadata test failed: attachment-only user session has no activity';
+  END IF;
+
+  SELECT session.title, session.last_message_at
+    INTO v_title, v_last_message_at
+    FROM public.chat_sessions AS session
+    WHERE session.session_id = '0058-untitled-session';
+
+  IF v_title IS NOT NULL OR v_last_message_at IS NULL THEN
+    RAISE EXCEPTION
+      'chat session metadata test failed: expected untitled user session with activity, found title %, activity %',
+      v_title,
+      v_last_message_at;
+  END IF;
+
+  SELECT session.title
+    INTO v_title
+    FROM public.chat_sessions AS session
+    WHERE session.session_id = '0058-long-title-session';
+
+  IF char_length(v_title) IS DISTINCT FROM 200 THEN
+    RAISE EXCEPTION
+      'chat session metadata test failed: expected 200-character title, found % characters',
+      char_length(v_title);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.chat_sessions AS session
+    WHERE session.session_id IN (
+      '0058-empty-session',
+      '0058-assistant-only-session'
+    )
+      AND session.last_message_at IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION
+      'chat session metadata test failed: session without a user message received activity';
+  END IF;
+
+  SELECT pg_catalog.pg_get_indexdef(index.indexrelid)
+    INTO v_index_definition
+    FROM pg_catalog.pg_index AS index
+    WHERE index.indexrelid =
+      'public.chat_sessions_user_workspace_last_message_idx'::REGCLASS;
+
+  IF v_index_definition NOT LIKE
+    '%(user_id, workspace_id, last_message_at DESC, session_id DESC) WHERE (last_message_at IS NOT NULL)' THEN
+    RAISE EXCEPTION
+      'chat session metadata test failed: unexpected history index definition: %',
+      v_index_definition;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_policy AS policy
+    WHERE policy.polrelid IN (
+      'public.chat_items'::REGCLASS,
+      'public.chat_sessions'::REGCLASS
+    )
+      AND policy.polname IN (
+        'chat_sessions_0059_history_backfill_access',
+        'chat_items_0060_history_backfill_read'
+      )
+  ) THEN
+    RAISE EXCEPTION
+      'chat session metadata test failed: temporary migration policy remains installed';
+  END IF;
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add nullable chat-session title and activity metadata
- backfill deterministic history metadata under forced RLS with lock-safe, independently deployable phases
- add the partial history pagination index and focused SQL coverage

## Validation
- complete fresh PostgreSQL 18 migration chain through 0064
- focused rollback-only test as non-superuser/non-BYPASSRLS owner
- migration runner rerun/skip behavior for 0058-0064
- partial-index EXPLAIN and concurrent lock/read scenarios
- lifecycle writer consistency, temporary-policy cleanup, and whitespace check