### PR TITLE
Add chat session catalog API

### DIFF
--- a/apps/web/src/app/api/chat/sessions/route.ts
+++ b/apps/web/src/app/api/chat/sessions/route.ts
@@ -1,0 +1,3 @@
+export const dynamic = "force-dynamic";
+
+export { GET } from "@/server/chat/http/sessionCatalogRoute";

--- a/apps/web/src/server/chat/http/sessionCatalogRoute.test.ts
+++ b/apps/web/src/server/chat/http/sessionCatalogRoute.test.ts
@@ -1,0 +1,289 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getSessionCatalogRouteWithDeps } from "@/server/chat/http/sessionCatalogRoute";
+import {
+  encodeChatSessionCatalogCursor,
+  type ChatSessionCatalogPage,
+} from "@/server/chat/store/sessionCatalogStore";
+import {
+  ACTIVE_WORKSPACE_RELOAD_MESSAGE,
+  WorkspaceAccessError,
+} from "@/server/workspaceErrors";
+
+const catalogPage: ChatSessionCatalogPage = {
+  sessions: [{
+    sessionId: "session-1",
+    title: "Balance check",
+    lastMessageAt: "2026-07-26T16:42:00.000Z",
+    status: "running",
+    mainContentInvalidationVersion: 8,
+  }],
+  nextCursor: null,
+};
+
+const createHeaders = (): Headers =>
+  new Headers({
+    "x-user-id": "user-1",
+    "x-workspace-id": "workspace-1",
+    cookie: "demo=true",
+  });
+
+const encodeUncheckedCursor = (cursor: unknown): string =>
+  Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+
+test("session catalog route returns the authenticated workspace page without caching", async (): Promise<void> => {
+  const response = await getSessionCatalogRouteWithDeps(
+    new Request("http://localhost/api/chat/sessions", {
+      headers: createHeaders(),
+    }),
+    {
+      listChatSessions: async (userId, workspaceId, limit, cursor) => {
+        assert.equal(userId, "user-1");
+        assert.equal(workspaceId, "workspace-1");
+        assert.equal(limit, 30);
+        assert.equal(cursor, null);
+        return catalogPage;
+      },
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), catalogPage);
+  assert.equal(
+    response.headers.get("cache-control"),
+    "no-store, no-cache, must-revalidate",
+  );
+  assert.equal(response.headers.get("pragma"), "no-cache");
+  assert.equal(response.headers.get("expires"), "0");
+});
+
+test("session catalog route decodes a cursor and forwards an explicit limit", async (): Promise<void> => {
+  const cursor = {
+    lastMessageAt: "2026-07-26T16:42:00.000123Z",
+    sessionId: "session-1",
+  } as const;
+  const encodedCursor = encodeChatSessionCatalogCursor(cursor);
+  const response = await getSessionCatalogRouteWithDeps(
+    new Request(
+      `http://localhost/api/chat/sessions?limit=12&cursor=${encodedCursor}`,
+      { headers: createHeaders() },
+    ),
+    {
+      listChatSessions: async (_userId, _workspaceId, limit, receivedCursor) => {
+        assert.equal(limit, 12);
+        assert.deepEqual(receivedCursor, cursor);
+        return { sessions: [], nextCursor: null };
+      },
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { sessions: [], nextCursor: null });
+});
+
+test("session catalog route rejects invalid limits without reading the store", async (): Promise<void> => {
+  const invalidLimits = ["0", "101", "1.5", "03"] as const;
+
+  for (const invalidLimit of invalidLimits) {
+    let storeCalled = false;
+    const response = await getSessionCatalogRouteWithDeps(
+      new Request(
+        `http://localhost/api/chat/sessions?limit=${invalidLimit}`,
+        { headers: createHeaders() },
+      ),
+      {
+        listChatSessions: async () => {
+          storeCalled = true;
+          return catalogPage;
+        },
+      },
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(
+      await response.text(),
+      "limit must be an integer between 1 and 100",
+    );
+    assert.equal(storeCalled, false);
+  }
+});
+
+test("session catalog route rejects an invalid cursor without restarting pagination", async (): Promise<void> => {
+  let storeCalled = false;
+  const response = await getSessionCatalogRouteWithDeps(
+    new Request("http://localhost/api/chat/sessions?cursor=invalid%2Bcursor", {
+      headers: createHeaders(),
+    }),
+    {
+      listChatSessions: async () => {
+        storeCalled = true;
+        return catalogPage;
+      },
+    },
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(
+    await response.text(),
+    "Invalid chat session cursor: expected a non-empty base64url value",
+  );
+  assert.equal(storeCalled, false);
+});
+
+test("session catalog route rejects year-zero cursor timestamps before querying", async (): Promise<void> => {
+  let storeCalled = false;
+  const cursor = encodeUncheckedCursor({
+    lastMessageAt: "0000-01-01T00:00:00.000000Z",
+    sessionId: "session-1",
+  });
+  const response = await getSessionCatalogRouteWithDeps(
+    new Request(
+      `http://localhost/api/chat/sessions?cursor=${cursor}`,
+      { headers: createHeaders() },
+    ),
+    {
+      listChatSessions: async () => {
+        storeCalled = true;
+        return catalogPage;
+      },
+    },
+  );
+
+  assert.equal(response.status, 400);
+  assert.match(
+    await response.text(),
+    /Invalid chat session cursor: lastMessageAt: lastMessageAt must be a canonical UTC timestamp with six fractional digits/,
+  );
+  assert.equal(storeCalled, false);
+});
+
+test("session catalog route rejects cursor payloads with malformed UTF-8", async (): Promise<void> => {
+  let storeCalled = false;
+  const cursorPrefix = Buffer.from(
+    '{"lastMessageAt":"2026-07-26T16:42:00.000123Z","sessionId":"',
+    "utf8",
+  );
+  const cursorSuffix = Buffer.from('"}', "utf8");
+  const cursor = Buffer.concat([
+    cursorPrefix,
+    Buffer.from([0xff]),
+    cursorSuffix,
+  ]).toString("base64url");
+  const response = await getSessionCatalogRouteWithDeps(
+    new Request(
+      `http://localhost/api/chat/sessions?cursor=${cursor}`,
+      { headers: createHeaders() },
+    ),
+    {
+      listChatSessions: async () => {
+        storeCalled = true;
+        return catalogPage;
+      },
+    },
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(
+    await response.text(),
+    "Invalid chat session cursor: value could not be decoded",
+  );
+  assert.equal(storeCalled, false);
+});
+
+test("session catalog route rejects non-well-formed Unicode cursor session ids", async (): Promise<void> => {
+  let storeCalled = false;
+  const cursor = encodeUncheckedCursor({
+    lastMessageAt: "2026-07-26T16:42:00.000123Z",
+    sessionId: "session-\uD800",
+  });
+  const response = await getSessionCatalogRouteWithDeps(
+    new Request(
+      `http://localhost/api/chat/sessions?cursor=${cursor}`,
+      { headers: createHeaders() },
+    ),
+    {
+      listChatSessions: async () => {
+        storeCalled = true;
+        return catalogPage;
+      },
+    },
+  );
+
+  assert.equal(response.status, 400);
+  assert.match(
+    await response.text(),
+    /Invalid chat session cursor: sessionId: sessionId must be well-formed Unicode/,
+  );
+  assert.equal(storeCalled, false);
+});
+
+test("session catalog route returns 400 for cursor session ids with control characters", async (): Promise<void> => {
+  const invalidSessionIds = [
+    "session\u0000id",
+    "session\nid",
+  ] as const;
+
+  for (const sessionId of invalidSessionIds) {
+    let storeCalled = false;
+    const cursor = encodeUncheckedCursor({
+      lastMessageAt: "2026-07-26T16:42:00.000123Z",
+      sessionId,
+    });
+    const response = await getSessionCatalogRouteWithDeps(
+      new Request(
+        `http://localhost/api/chat/sessions?cursor=${cursor}`,
+        { headers: createHeaders() },
+      ),
+      {
+        listChatSessions: async () => {
+          storeCalled = true;
+          return catalogPage;
+        },
+      },
+    );
+
+    assert.equal(response.status, 400);
+    assert.match(
+      await response.text(),
+      /Invalid chat session cursor: sessionId: sessionId must not contain control characters/,
+    );
+    assert.equal(storeCalled, false);
+  }
+});
+
+test("session catalog route returns 401 when trusted identity headers are missing", async (): Promise<void> => {
+  const requests = [
+    new Request("http://localhost/api/chat/sessions", {
+      headers: { "x-workspace-id": "workspace-1" },
+    }),
+    new Request("http://localhost/api/chat/sessions", {
+      headers: { "x-user-id": "user-1" },
+    }),
+  ] as const;
+
+  for (const request of requests) {
+    const response = await getSessionCatalogRouteWithDeps(request, {
+      listChatSessions: async () => catalogPage,
+    });
+
+    assert.equal(response.status, 401);
+    assert.match(await response.text(), /proxy misconfiguration/);
+  }
+});
+
+test("session catalog route maps inaccessible workspace context to 409", async (): Promise<void> => {
+  const response = await getSessionCatalogRouteWithDeps(
+    new Request("http://localhost/api/chat/sessions", {
+      headers: createHeaders(),
+    }),
+    {
+      listChatSessions: async (userId, workspaceId) => {
+        throw new WorkspaceAccessError(userId, workspaceId);
+      },
+    },
+  );
+
+  assert.equal(response.status, 409);
+  assert.equal(await response.text(), ACTIVE_WORKSPACE_RELOAD_MESSAGE);
+});

--- a/apps/web/src/server/chat/http/sessionCatalogRoute.ts
+++ b/apps/web/src/server/chat/http/sessionCatalogRoute.ts
@@ -1,0 +1,127 @@
+import { ApiRouteError } from "@/server/api/errors";
+import { handleRoute } from "@/server/api/handleRoute";
+import { jsonNoStore } from "@/server/api/noStore";
+import {
+  decodeChatSessionCatalogCursor,
+  InvalidChatSessionCatalogCursorError,
+  listChatSessions,
+  type ChatSessionCatalogCursor,
+} from "@/server/chat/store";
+import { extractUserId, extractWorkspaceId } from "@/server/userId";
+
+type SessionCatalogRouteDependencies = Readonly<{
+  listChatSessions: typeof listChatSessions;
+}>;
+
+type SessionCatalogQuery = Readonly<{
+  limit: number;
+  cursor: ChatSessionCatalogCursor | null;
+}>;
+
+const DEFAULT_LIMIT = 30;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 100;
+const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/;
+
+const DEFAULT_SESSION_CATALOG_ROUTE_DEPENDENCIES: SessionCatalogRouteDependencies = {
+  listChatSessions,
+};
+
+const parseSessionCatalogLimit = (rawLimit: string | null): number => {
+  if (rawLimit === null) {
+    return DEFAULT_LIMIT;
+  }
+
+  if (!POSITIVE_INTEGER_PATTERN.test(rawLimit)) {
+    throw new ApiRouteError(
+      400,
+      `limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}`,
+    );
+  }
+
+  const limit = Number(rawLimit);
+  if (
+    !Number.isSafeInteger(limit)
+    || limit < MIN_LIMIT
+    || limit > MAX_LIMIT
+  ) {
+    throw new ApiRouteError(
+      400,
+      `limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}`,
+    );
+  }
+
+  return limit;
+};
+
+const parseSessionCatalogCursor = (
+  rawCursor: string | null,
+): ChatSessionCatalogCursor | null => {
+  if (rawCursor === null) {
+    return null;
+  }
+
+  try {
+    return decodeChatSessionCatalogCursor(rawCursor);
+  } catch (error) {
+    if (error instanceof InvalidChatSessionCatalogCursorError) {
+      throw new ApiRouteError(400, error.message);
+    }
+    throw error;
+  }
+};
+
+const parseSessionCatalogQuery = (
+  searchParams: URLSearchParams,
+): SessionCatalogQuery => ({
+  limit: parseSessionCatalogLimit(searchParams.get("limit")),
+  cursor: parseSessionCatalogCursor(searchParams.get("cursor")),
+});
+
+const extractSessionCatalogRequestContext = (
+  request: Request,
+): Readonly<{
+  userId: string;
+  workspaceId: string;
+}> => {
+  try {
+    return {
+      userId: extractUserId(request),
+      workspaceId: extractWorkspaceId(request),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ApiRouteError(401, message);
+  }
+};
+
+export const getSessionCatalogRouteWithDeps = async (
+  request: Request,
+  dependencies: SessionCatalogRouteDependencies,
+): Promise<Response> =>
+  handleRoute(
+    {
+      route: "/api/chat/sessions",
+      method: "GET",
+      internalErrorMessage: "Chat session catalog load failed",
+    },
+    async (): Promise<Response> => {
+      const { userId, workspaceId } = extractSessionCatalogRequestContext(request);
+      const { limit, cursor } = parseSessionCatalogQuery(
+        new URL(request.url).searchParams,
+      );
+      const page = await dependencies.listChatSessions(
+        userId,
+        workspaceId,
+        limit,
+        cursor,
+      );
+      return jsonNoStore(page);
+    },
+  );
+
+export const GET = async (request: Request): Promise<Response> =>
+  getSessionCatalogRouteWithDeps(
+    request,
+    DEFAULT_SESSION_CATALOG_ROUTE_DEPENDENCIES,
+  );

--- a/apps/web/src/server/chat/store.ts
+++ b/apps/web/src/server/chat/store.ts
@@ -13,6 +13,10 @@ export type {
   StaleChatSessionRecoveryResult,
 } from "./store/lifecycleStore";
 
+export type {
+  ChatSessionCatalogCursor,
+} from "./store/sessionCatalogStore";
+
 export {
   ChatSessionConflictError,
   ChatSessionNotFoundError,
@@ -33,6 +37,12 @@ export {
   touchChatSessionHeartbeat,
   touchChatSessionHeartbeatWithQuery,
 } from "./store/sessionStore";
+
+export {
+  decodeChatSessionCatalogCursor,
+  InvalidChatSessionCatalogCursorError,
+  listChatSessions,
+} from "./store/sessionCatalogStore";
 
 export {
   listChatMessages,

--- a/apps/web/src/server/chat/store/sessionCatalogStore.test.ts
+++ b/apps/web/src/server/chat/store/sessionCatalogStore.test.ts
@@ -1,0 +1,484 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { QueryResult } from "pg";
+
+import type { ChatSessionRunState } from "@/server/chat/store";
+import {
+  decodeChatSessionCatalogCursor,
+  encodeChatSessionCatalogCursor,
+  InvalidChatSessionCatalogCursorError,
+  listChatSessionsWithQuery,
+} from "@/server/chat/store/sessionCatalogStore";
+import type { QueryFn } from "@/server/db/contextRunner";
+
+const createQueryResult = (
+  rows: ReadonlyArray<unknown>,
+): QueryResult => ({
+  command: "SELECT",
+  rowCount: rows.length,
+  oid: 0,
+  fields: [],
+  rows: [...rows],
+});
+
+const createCatalogRow = (
+  sessionId: string,
+  title: string | null,
+  lastMessageAt: string,
+  status: ChatSessionRunState,
+  invalidationVersion: string,
+): Readonly<Record<string, unknown>> => ({
+  session_id: sessionId,
+  title,
+  last_message_at_exact: lastMessageAt,
+  status,
+  main_content_invalidation_version: invalidationVersion,
+});
+
+const encodeUncheckedCursor = (cursor: unknown): string =>
+  Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+
+test("chat session catalog cursor round-trips both ordering fields", (): void => {
+  const cursor = {
+    lastMessageAt: "2026-07-26T16:42:00.000123Z",
+    sessionId: "session-😀",
+  } as const;
+
+  const encoded = encodeChatSessionCatalogCursor(cursor);
+
+  assert.match(encoded, /^[A-Za-z0-9_-]+$/);
+  assert.deepEqual(decodeChatSessionCatalogCursor(encoded), cursor);
+});
+
+test("chat session catalog cursor rejects malformed and incomplete values", (): void => {
+  const invalidCursors = [
+    "",
+    "not+base64url",
+    Buffer.from("{}", "utf8").toString("base64url"),
+    Buffer.from(JSON.stringify({
+      lastMessageAt: "2026-07-26",
+      sessionId: "session-2",
+    }), "utf8").toString("base64url"),
+    Buffer.from(JSON.stringify({
+      lastMessageAt: "2026-07-26T16:42:00.000Z",
+      sessionId: "session-2",
+    }), "utf8").toString("base64url"),
+  ] as const;
+
+  for (const cursor of invalidCursors) {
+    assert.throws(
+      () => decodeChatSessionCatalogCursor(cursor),
+      InvalidChatSessionCatalogCursorError,
+    );
+  }
+});
+
+test("chat session catalog cursor rejects non-well-formed Unicode session ids", (): void => {
+  const invalidSessionIds = [
+    "session-\uD800",
+    "session-\uDC00",
+  ] as const;
+
+  for (const sessionId of invalidSessionIds) {
+    const cursor = encodeUncheckedCursor({
+      lastMessageAt: "2026-07-26T16:42:00.000123Z",
+      sessionId,
+    });
+
+    assert.throws(
+      () => decodeChatSessionCatalogCursor(cursor),
+      (error: unknown): boolean =>
+        error instanceof InvalidChatSessionCatalogCursorError
+        && error.message.includes("sessionId must be well-formed Unicode"),
+    );
+  }
+});
+
+test("chat session catalog cursor rejects control characters in session ids", (): void => {
+  const invalidSessionIds = [
+    "session\u0000id",
+    "session\tid",
+    "session\u007Fid",
+  ] as const;
+
+  for (const sessionId of invalidSessionIds) {
+    const cursor = encodeUncheckedCursor({
+      lastMessageAt: "2026-07-26T16:42:00.000123Z",
+      sessionId,
+    });
+
+    assert.throws(
+      () => decodeChatSessionCatalogCursor(cursor),
+      (error: unknown): boolean =>
+        error instanceof InvalidChatSessionCatalogCursorError
+        && error.message.includes("sessionId must not contain control characters"),
+    );
+  }
+});
+
+test("listChatSessionsWithQuery returns the first page with stable ordering and a next cursor", async (): Promise<void> => {
+  let queryText = "";
+  let queryParams: ReadonlyArray<unknown> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    queryText = text;
+    queryParams = params;
+    return createQueryResult([
+      createCatalogRow(
+        "session-z",
+        "Most recent",
+        "2026-07-26T16:42:00.000123Z",
+        "running",
+        "8",
+      ),
+      createCatalogRow(
+        "session-y",
+        null,
+        "2026-07-26T16:42:00.000123Z",
+        "interrupted",
+        "7",
+      ),
+      createCatalogRow(
+        "session-x",
+        "Older",
+        "2026-07-26T15:00:00.000000Z",
+        "idle",
+        "6",
+      ),
+    ]);
+  };
+
+  const page = await listChatSessionsWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    2,
+    null,
+  );
+
+  assert.match(queryText, /WHERE user_id = \$1/);
+  assert.match(queryText, /AND workspace_id = \$2/);
+  assert.match(queryText, /AND last_message_at IS NOT NULL/);
+  assert.match(
+    queryText,
+    /ORDER BY last_message_at DESC, session_id DESC/,
+  );
+  assert.deepEqual(queryParams, ["user-1", "workspace-1", 3]);
+  assert.deepEqual(page.sessions, [
+    {
+      sessionId: "session-z",
+      title: "Most recent",
+      lastMessageAt: "2026-07-26T16:42:00.000Z",
+      status: "running",
+      mainContentInvalidationVersion: 8,
+    },
+    {
+      sessionId: "session-y",
+      title: "Untitled chat",
+      lastMessageAt: "2026-07-26T16:42:00.000Z",
+      status: "interrupted",
+      mainContentInvalidationVersion: 7,
+    },
+  ]);
+  assert.deepEqual(
+    Object.keys(page.sessions[0] ?? {}).sort(),
+    [
+      "lastMessageAt",
+      "mainContentInvalidationVersion",
+      "sessionId",
+      "status",
+      "title",
+    ],
+  );
+  assert.ok(page.nextCursor !== null);
+  assert.deepEqual(
+    decodeChatSessionCatalogCursor(page.nextCursor),
+    {
+      lastMessageAt: "2026-07-26T16:42:00.000123Z",
+      sessionId: "session-y",
+    },
+  );
+});
+
+test("listChatSessionsWithQuery applies the tuple cursor on a middle page", async (): Promise<void> => {
+  let queryText = "";
+  let queryParams: ReadonlyArray<unknown> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    queryText = text;
+    queryParams = params;
+    return createQueryResult([
+      createCatalogRow(
+        "session-x",
+        "Middle",
+        "2026-07-26T15:00:00.000456Z",
+        "idle",
+        "3",
+      ),
+      createCatalogRow(
+        "session-w",
+        "Next",
+        "2026-07-26T14:00:00.000000Z",
+        "idle",
+        "2",
+      ),
+    ]);
+  };
+
+  const page = await listChatSessionsWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    1,
+    {
+      lastMessageAt: "2026-07-26T16:42:00.000123Z",
+      sessionId: "session-y",
+    },
+  );
+
+  assert.match(
+    queryText,
+    /AND \(last_message_at, session_id\) < \(\$3::timestamptz, \$4\)/,
+  );
+  assert.match(
+    queryText,
+    /ORDER BY last_message_at DESC, session_id DESC/,
+  );
+  assert.deepEqual(queryParams, [
+    "user-1",
+    "workspace-1",
+    "2026-07-26T16:42:00.000123Z",
+    "session-y",
+    2,
+  ]);
+  assert.deepEqual(page.sessions.map((session) => session.sessionId), [
+    "session-x",
+  ]);
+  assert.ok(page.nextCursor !== null);
+  assert.deepEqual(decodeChatSessionCatalogCursor(page.nextCursor), {
+    lastMessageAt: "2026-07-26T15:00:00.000456Z",
+    sessionId: "session-x",
+  });
+});
+
+test("listChatSessionsWithQuery preserves microseconds across pagination boundaries", async (): Promise<void> => {
+  const queryCalls: Array<Readonly<{
+    text: string;
+    params: ReadonlyArray<unknown>;
+  }>> = [];
+  const queryPages: ReadonlyArray<ReadonlyArray<unknown>> = [
+    [
+      createCatalogRow(
+        "session-z",
+        "First",
+        "2026-07-26T16:42:00.123999Z",
+        "idle",
+        "5",
+      ),
+      createCatalogRow(
+        "session-y",
+        "Second",
+        "2026-07-26T16:42:00.123999Z",
+        "idle",
+        "4",
+      ),
+      createCatalogRow(
+        "session-x",
+        "Third",
+        "2026-07-26T16:42:00.123750Z",
+        "idle",
+        "3",
+      ),
+    ],
+    [
+      createCatalogRow(
+        "session-x",
+        "Third",
+        "2026-07-26T16:42:00.123750Z",
+        "idle",
+        "3",
+      ),
+      createCatalogRow(
+        "session-w",
+        "Fourth",
+        "2026-07-26T16:42:00.123001Z",
+        "idle",
+        "2",
+      ),
+      createCatalogRow(
+        "session-v",
+        "Fifth",
+        "2026-07-26T16:42:00.122999Z",
+        "idle",
+        "1",
+      ),
+    ],
+    [
+      createCatalogRow(
+        "session-v",
+        "Fifth",
+        "2026-07-26T16:42:00.122999Z",
+        "idle",
+        "1",
+      ),
+    ],
+  ];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    queryCalls.push({ text, params });
+    const rows = queryPages[queryCalls.length - 1];
+    if (rows === undefined) {
+      throw new Error(`Unexpected catalog query call ${queryCalls.length}`);
+    }
+    return createQueryResult(rows);
+  };
+
+  const firstPage = await listChatSessionsWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    2,
+    null,
+  );
+  assert.ok(firstPage.nextCursor !== null);
+  const secondPage = await listChatSessionsWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    2,
+    decodeChatSessionCatalogCursor(firstPage.nextCursor),
+  );
+  assert.ok(secondPage.nextCursor !== null);
+  const terminalPage = await listChatSessionsWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    2,
+    decodeChatSessionCatalogCursor(secondPage.nextCursor),
+  );
+
+  const sessionIds = [
+    ...firstPage.sessions,
+    ...secondPage.sessions,
+    ...terminalPage.sessions,
+  ].map((session) => session.sessionId);
+  assert.deepEqual(sessionIds, [
+    "session-z",
+    "session-y",
+    "session-x",
+    "session-w",
+    "session-v",
+  ]);
+  assert.equal(new Set(sessionIds).size, sessionIds.length);
+  assert.deepEqual(queryCalls[1]?.params, [
+    "user-1",
+    "workspace-1",
+    "2026-07-26T16:42:00.123999Z",
+    "session-y",
+    3,
+  ]);
+  assert.deepEqual(queryCalls[2]?.params, [
+    "user-1",
+    "workspace-1",
+    "2026-07-26T16:42:00.123001Z",
+    "session-w",
+    3,
+  ]);
+  assert.deepEqual(
+    firstPage.sessions.map((session) => session.lastMessageAt),
+    [
+      "2026-07-26T16:42:00.123Z",
+      "2026-07-26T16:42:00.123Z",
+    ],
+  );
+});
+
+test("listChatSessionsWithQuery returns a terminal page without a cursor", async (): Promise<void> => {
+  const queryFn: QueryFn = async (): Promise<QueryResult> =>
+    createQueryResult([
+      createCatalogRow(
+        "session-w",
+        "Last",
+        "2026-07-26T14:00:00.000000Z",
+        "idle",
+        "1",
+      ),
+    ]);
+
+  const page = await listChatSessionsWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    2,
+    {
+      lastMessageAt: "2026-07-26T15:00:00.000456Z",
+      sessionId: "session-x",
+    },
+  );
+
+  assert.deepEqual(page.sessions.map((session) => session.sessionId), [
+    "session-w",
+  ]);
+  assert.equal(page.nextCursor, null);
+});
+
+test("listChatSessionsWithQuery accepts titles up to 200 Unicode code points", async (): Promise<void> => {
+  const title = "😀".repeat(200);
+  const queryFn: QueryFn = async (): Promise<QueryResult> =>
+    createQueryResult([
+      createCatalogRow(
+        "session-emoji",
+        title,
+        "2026-07-26T14:00:00.000000Z",
+        "idle",
+        "1",
+      ),
+    ]);
+
+  const page = await listChatSessionsWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    1,
+    null,
+  );
+
+  assert.equal(Array.from(title).length, 200);
+  assert.equal(title.length, 400);
+  assert.equal(page.sessions[0]?.title, title);
+});
+
+test("listChatSessionsWithQuery rejects invalid status and invalidation version rows", async (): Promise<void> => {
+  const invalidRows = [
+    {
+      ...createCatalogRow(
+        "session-1",
+        "Invalid status",
+        "2026-07-26T14:00:00.000000Z",
+        "idle",
+        "1",
+      ),
+      status: "queued",
+    },
+    createCatalogRow(
+      "session-1",
+      "Invalid version",
+      "2026-07-26T14:00:00.000000Z",
+      "idle",
+      "-1",
+    ),
+  ] as const;
+
+  for (const row of invalidRows) {
+    const queryFn: QueryFn = async (): Promise<QueryResult> =>
+      createQueryResult([row]);
+
+    await assert.rejects(
+      listChatSessionsWithQuery(
+        queryFn,
+        "user-1",
+        "workspace-1",
+        1,
+        null,
+      ),
+      /Invalid chat session catalog database row/,
+    );
+  }
+});

--- a/apps/web/src/server/chat/store/sessionCatalogStore.ts
+++ b/apps/web/src/server/chat/store/sessionCatalogStore.ts
@@ -1,0 +1,297 @@
+import { z } from "zod";
+
+import { withUserContext } from "@/server/db";
+import type { QueryFn } from "@/server/db/contextRunner";
+import {
+  parseMainContentInvalidationVersion,
+  type ChatSessionRunState,
+} from "./shared";
+
+export type ChatSessionCatalogItem = Readonly<{
+  sessionId: string;
+  title: string;
+  lastMessageAt: string;
+  status: ChatSessionRunState;
+  mainContentInvalidationVersion: number;
+}>;
+
+export type ChatSessionCatalogPage = Readonly<{
+  sessions: ReadonlyArray<ChatSessionCatalogItem>;
+  nextCursor: string | null;
+}>;
+
+export type ChatSessionCatalogCursor = Readonly<{
+  lastMessageAt: string;
+  sessionId: string;
+}>;
+
+const UNTITLED_CHAT_SESSION_TITLE = "Untitled chat";
+const MAX_CURSOR_LENGTH = 2048;
+const MAX_SESSION_ID_LENGTH = 200;
+const BASE64_URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001F\u007F-\u009F]/u;
+const EXACT_UTC_TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.)(\d{6})Z$/;
+
+const hasCodePointLengthBetween = (
+  value: string,
+  minLength: number,
+  maxLength: number,
+): boolean => {
+  const length = Array.from(value).length;
+  return length >= minLength && length <= maxLength;
+};
+
+const sessionIdSchema = z.string()
+  .refine(
+    (value: string): boolean => value.isWellFormed(),
+    "sessionId must be well-formed Unicode",
+  )
+  .refine(
+    (value: string): boolean =>
+      hasCodePointLengthBetween(value, 1, MAX_SESSION_ID_LENGTH),
+    `sessionId must contain 1-${MAX_SESSION_ID_LENGTH} characters`,
+  )
+  .refine(
+    (value: string): boolean => !CONTROL_CHARACTER_PATTERN.test(value),
+    "sessionId must not contain control characters",
+  );
+
+const titleSchema = z.string().refine(
+  (value: string): boolean => hasCodePointLengthBetween(value, 1, 200),
+  "title must contain 1-200 characters",
+);
+
+const exactUtcTimestampSchema = z.string().refine(
+  (value: string): boolean => {
+    const match = EXACT_UTC_TIMESTAMP_PATTERN.exec(value);
+    if (match === null) {
+      return false;
+    }
+
+    const prefix = match[1];
+    const microseconds = match[2];
+    if (
+      prefix === undefined
+      || microseconds === undefined
+      || prefix.startsWith("0000-")
+    ) {
+      return false;
+    }
+
+    const millisecondTimestamp = `${prefix}${microseconds.slice(0, 3)}Z`;
+    const timestamp = Date.parse(millisecondTimestamp);
+    return !Number.isNaN(timestamp)
+      && new Date(timestamp).toISOString() === millisecondTimestamp;
+  },
+  "lastMessageAt must be a canonical UTC timestamp with six fractional digits",
+);
+
+const chatSessionCatalogRowSchema = z.object({
+  session_id: sessionIdSchema,
+  title: titleSchema.nullable(),
+  last_message_at_exact: exactUtcTimestampSchema,
+  status: z.enum(["idle", "running", "interrupted"]),
+  main_content_invalidation_version: z.string().regex(/^\d+$/),
+}).strict();
+
+type ChatSessionCatalogRow = z.infer<typeof chatSessionCatalogRowSchema>;
+
+const chatSessionCatalogCursorSchema = z.object({
+  lastMessageAt: exactUtcTimestampSchema,
+  sessionId: sessionIdSchema,
+}).strict();
+
+export class InvalidChatSessionCatalogCursorError extends Error {
+  public constructor(reason: string) {
+    super(`Invalid chat session cursor: ${reason}`);
+    this.name = "InvalidChatSessionCatalogCursorError";
+  }
+}
+
+const parseChatSessionCatalogCursor = (
+  cursor: unknown,
+): ChatSessionCatalogCursor => {
+  const result = chatSessionCatalogCursorSchema.safeParse(cursor);
+  if (!result.success) {
+    const details = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "cursor"}: ${issue.message}`)
+      .join("; ");
+    throw new InvalidChatSessionCatalogCursorError(details);
+  }
+
+  return result.data;
+};
+
+export const encodeChatSessionCatalogCursor = (
+  cursor: ChatSessionCatalogCursor,
+): string =>
+  Buffer.from(
+    JSON.stringify(parseChatSessionCatalogCursor(cursor)),
+    "utf8",
+  ).toString("base64url");
+
+export const decodeChatSessionCatalogCursor = (
+  encodedCursor: string,
+): ChatSessionCatalogCursor => {
+  if (
+    encodedCursor.length === 0
+    || encodedCursor.length > MAX_CURSOR_LENGTH
+    || !BASE64_URL_PATTERN.test(encodedCursor)
+  ) {
+    throw new InvalidChatSessionCatalogCursorError(
+      "expected a non-empty base64url value",
+    );
+  }
+
+  let parsedJson: unknown;
+  try {
+    const cursorBuffer = Buffer.from(encodedCursor, "base64url");
+    if (cursorBuffer.toString("base64url") !== encodedCursor) {
+      throw new Error("non-canonical base64url");
+    }
+    const cursorJson = new TextDecoder("utf-8", { fatal: true }).decode(
+      cursorBuffer,
+    );
+    parsedJson = JSON.parse(cursorJson) as unknown;
+  } catch {
+    throw new InvalidChatSessionCatalogCursorError(
+      "value could not be decoded",
+    );
+  }
+
+  return parseChatSessionCatalogCursor(parsedJson);
+};
+
+export const CHAT_SESSION_CATALOG_FIRST_PAGE_QUERY = `
+  SELECT
+    session_id,
+    title,
+    to_char(
+      last_message_at AT TIME ZONE 'UTC',
+      'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+    ) AS last_message_at_exact,
+    status,
+    main_content_invalidation_version
+  FROM public.chat_sessions
+  WHERE user_id = $1
+    AND workspace_id = $2
+    AND last_message_at IS NOT NULL
+  ORDER BY last_message_at DESC, session_id DESC
+  LIMIT $3
+`;
+
+export const CHAT_SESSION_CATALOG_AFTER_CURSOR_QUERY = `
+  SELECT
+    session_id,
+    title,
+    to_char(
+      last_message_at AT TIME ZONE 'UTC',
+      'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+    ) AS last_message_at_exact,
+    status,
+    main_content_invalidation_version
+  FROM public.chat_sessions
+  WHERE user_id = $1
+    AND workspace_id = $2
+    AND last_message_at IS NOT NULL
+    AND (last_message_at, session_id) < ($3::timestamptz, $4)
+  ORDER BY last_message_at DESC, session_id DESC
+  LIMIT $5
+`;
+
+const parseChatSessionCatalogRow = (
+  row: unknown,
+  rowIndex: number,
+): ChatSessionCatalogRow => {
+  const result = chatSessionCatalogRowSchema.safeParse(row);
+  if (!result.success) {
+    const details = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "row"}: ${issue.message}`)
+      .join("; ");
+    throw new Error(
+      `Invalid chat session catalog database row at index ${rowIndex}: ${details}`,
+    );
+  }
+
+  return result.data;
+};
+
+const mapChatSessionCatalogRow = (
+  row: ChatSessionCatalogRow,
+): Readonly<{
+  session: ChatSessionCatalogItem;
+  cursor: ChatSessionCatalogCursor;
+}> => ({
+  session: {
+    sessionId: row.session_id,
+    title: row.title ?? UNTITLED_CHAT_SESSION_TITLE,
+    lastMessageAt: `${row.last_message_at_exact.slice(0, -4)}Z`,
+    status: row.status,
+    mainContentInvalidationVersion: parseMainContentInvalidationVersion(
+      row.main_content_invalidation_version,
+      "catalog read",
+    ),
+  },
+  cursor: {
+    lastMessageAt: row.last_message_at_exact,
+    sessionId: row.session_id,
+  },
+});
+
+export const listChatSessionsWithQuery = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  limit: number,
+  cursor: ChatSessionCatalogCursor | null,
+): Promise<ChatSessionCatalogPage> => {
+  const fetchLimit = limit + 1;
+  const result = cursor === null
+    ? await queryFn(
+      CHAT_SESSION_CATALOG_FIRST_PAGE_QUERY,
+      [userId, workspaceId, fetchLimit],
+    )
+    : await queryFn(
+      CHAT_SESSION_CATALOG_AFTER_CURSOR_QUERY,
+      [
+        userId,
+        workspaceId,
+        cursor.lastMessageAt,
+        cursor.sessionId,
+        fetchLimit,
+      ],
+    );
+  const mappedRows = result.rows.map(
+    (row, rowIndex) =>
+      mapChatSessionCatalogRow(parseChatSessionCatalogRow(row, rowIndex)),
+  );
+  const pageRows = mappedRows.slice(0, limit);
+  const sessions = pageRows.map(
+    (row): ChatSessionCatalogItem => row.session,
+  );
+  const lastRow = pageRows.at(-1);
+  const nextCursor = mappedRows.length > limit && lastRow !== undefined
+    ? encodeChatSessionCatalogCursor(lastRow.cursor)
+    : null;
+
+  return { sessions, nextCursor };
+};
+
+export const listChatSessions = async (
+  userId: string,
+  workspaceId: string,
+  limit: number,
+  cursor: ChatSessionCatalogCursor | null,
+): Promise<ChatSessionCatalogPage> =>
+  withUserContext(
+    userId,
+    workspaceId,
+    async (queryFn): Promise<ChatSessionCatalogPage> =>
+      listChatSessionsWithQuery(
+        queryFn,
+        userId,
+        workspaceId,
+        limit,
+        cursor,
+      ),
+  );


### PR DESCRIPTION
## Summary
- add authenticated paginated chat session catalog endpoint
- preserve exact PostgreSQL microseconds in opaque keyset cursors
- validate limits, cursor encoding, Unicode, and persisted row data
- add focused store and route coverage

## Validation
- 20/20 focused tests passed
- npm run lint
- npm run build
- git diff --check