### PR TITLE
Lazy chat session backend

### DIFF
--- a/apps/web/src/app/api/chat/new/route.ts
+++ b/apps/web/src/app/api/chat/new/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@/server/chat/http/freshSessionRoute";

--- a/apps/web/src/server/chat/http/freshSessionRoute.test.ts
+++ b/apps/web/src/server/chat/http/freshSessionRoute.test.ts
@@ -1,0 +1,370 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CHAT_MODEL_ID } from "@/lib/chatModels";
+import type { SupportedLocale } from "@/lib/locale";
+import {
+  postFreshChatSessionRouteWithDeps,
+  prependSessionEvent,
+} from "@/server/chat/http/freshSessionRoute";
+import { CHAT_STREAM_INTERRUPTED_ERROR } from "@/server/chat/http/sessionRecovery";
+import type {
+  ChatRunStartReservation,
+} from "@/server/chat/runtime/runtime";
+import type {
+  PersistedChatMessageItem,
+  PreparedChatRun,
+} from "@/server/chat/store";
+import type { ChatStreamEvent, ContentPart } from "@/server/chat/types";
+
+const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
+
+const createHeaders = (): Headers =>
+  new Headers({
+    "content-type": "application/json",
+    "x-user-id": "user-1",
+    "x-workspace-id": "workspace-1",
+  });
+
+const createRequest = (body: unknown): Request =>
+  new Request("http://localhost/api/chat/new", {
+    method: "POST",
+    headers: createHeaders(),
+    body: JSON.stringify(body),
+  });
+
+const createAssistantItem = (): PersistedChatMessageItem => ({
+  itemId: "assistant-1",
+  sessionId: "session-1",
+  role: "assistant",
+  content: [],
+  state: "in_progress",
+  isError: false,
+  isStopped: false,
+  timestamp: 0,
+  updatedAt: 0,
+});
+
+const createPreparedRun = (
+  content: ReadonlyArray<ContentPart>,
+): PreparedChatRun => ({
+  sessionId: "session-1",
+  activeRunId: "run-1",
+  assistantItem: createAssistantItem(),
+  localMessages: [],
+  turnInput: content,
+});
+
+const createReservation = (): ChatRunStartReservation => ({
+  sessionId: "session-1",
+  reservationId: Symbol("session-1"),
+});
+
+const createDependencies = (
+  overrides: Partial<Parameters<typeof postFreshChatSessionRouteWithDeps>[1]>,
+): Parameters<typeof postFreshChatSessionRouteWithDeps>[1] => ({
+  getLocaleFromRequest: overrides.getLocaleFromRequest
+    ?? (() => "en" as SupportedLocale),
+  reserveChatRunStart: overrides.reserveChatRunStart
+    ?? (() => createReservation()),
+  releaseChatRunStartReservation: overrides.releaseChatRunStartReservation
+    ?? (() => undefined),
+  prepareFreshChatRun: overrides.prepareFreshChatRun
+    ?? (async (_userId, _workspaceId, content) => createPreparedRun(content)),
+  persistAssistantTerminalError: overrides.persistAssistantTerminalError
+    ?? (async () => undefined),
+  startPersistedChatRun: overrides.startPersistedChatRun
+    ?? (() => (async function* (): AsyncGenerator<ChatStreamEvent> {
+      yield { type: "done" };
+    })()),
+  isServerDraining: overrides.isServerDraining ?? (() => false),
+  log: overrides.log ?? (() => undefined),
+});
+
+const withOpenAiApiKey = async (
+  run: () => Promise<void>,
+): Promise<void> => {
+  const previousValue = process.env[OPENAI_API_KEY_ENV];
+  process.env[OPENAI_API_KEY_ENV] = "test-key";
+  try {
+    await run();
+  } finally {
+    if (previousValue === undefined) {
+      delete process.env[OPENAI_API_KEY_ENV];
+    } else {
+      process.env[OPENAI_API_KEY_ENV] = previousValue;
+    }
+  }
+};
+
+const withSuppressedConsoleLog = async (
+  run: () => Promise<void>,
+): Promise<void> => {
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  try {
+    await run();
+  } finally {
+    console.log = originalLog;
+  }
+};
+
+test("POST /api/chat/new starts one prepared session and identifies it in the first stream event", async (): Promise<void> => {
+  await withOpenAiApiKey(async (): Promise<void> => {
+    const content: ReadonlyArray<ContentPart> = [{ type: "text", text: "Hello" }];
+    let prepareCallCount = 0;
+    let startedSessionId: string | null = null;
+
+    const response = await postFreshChatSessionRouteWithDeps(
+      createRequest({
+        content,
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createDependencies({
+        prepareFreshChatRun: async (userId, workspaceId, preparedContent) => {
+          prepareCallCount += 1;
+          assert.equal(userId, "user-1");
+          assert.equal(workspaceId, "workspace-1");
+          assert.deepEqual(preparedContent, content);
+          return createPreparedRun(preparedContent);
+        },
+        startPersistedChatRun: (params) => {
+          startedSessionId = params.sessionId;
+          return (async function* (): AsyncGenerator<ChatStreamEvent> {
+            yield { type: "done" };
+          })();
+        },
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Content-Type"), "text/event-stream");
+    assert.equal(response.headers.get("X-Chat-Session-Id"), "session-1");
+    assert.equal(prepareCallCount, 1);
+    assert.equal(startedSessionId, "session-1");
+    assert.equal(
+      await response.text(),
+      [
+        "data: {\"type\":\"session\",\"sessionId\":\"session-1\"}",
+        "",
+        "data: {\"type\":\"done\"}",
+        "",
+        "",
+      ].join("\n"),
+    );
+  });
+});
+
+test("prependSessionEvent closes an unconsumed runtime iterator after the session event", async (): Promise<void> => {
+  let runtimeIteratorClosed = false;
+  const runtimeEvents = (async function* (): AsyncGenerator<ChatStreamEvent> {
+    yield { type: "done" };
+  })();
+  const returnRuntimeEvents = runtimeEvents.return.bind(runtimeEvents);
+  runtimeEvents.return = async (value): Promise<IteratorResult<ChatStreamEvent>> => {
+    runtimeIteratorClosed = true;
+    return returnRuntimeEvents(value);
+  };
+  const events = prependSessionEvent("session-1", runtimeEvents);
+
+  assert.deepEqual(await events.next(), {
+    done: false,
+    value: { type: "session", sessionId: "session-1" },
+  });
+
+  await events.return(undefined);
+
+  assert.equal(runtimeIteratorClosed, true);
+});
+
+test("POST /api/chat/new validation failures do not prepare or start a session", async (): Promise<void> => {
+  await withOpenAiApiKey(async (): Promise<void> => {
+    let prepareCallCount = 0;
+    let runtimeStartCallCount = 0;
+    const response = await postFreshChatSessionRouteWithDeps(
+      createRequest({
+        content: [],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createDependencies({
+        prepareFreshChatRun: async (_userId, _workspaceId, content) => {
+          prepareCallCount += 1;
+          return createPreparedRun(content);
+        },
+        startPersistedChatRun: () => {
+          runtimeStartCallCount += 1;
+          return (async function* (): AsyncGenerator<ChatStreamEvent> {
+            yield { type: "done" };
+          })();
+        },
+      }),
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(await response.text(), "content array is empty");
+    assert.equal(prepareCallCount, 0);
+    assert.equal(runtimeStartCallCount, 0);
+  });
+});
+
+test("POST /api/chat/new rejects existing-session identifiers before persistence", async (): Promise<void> => {
+  await withOpenAiApiKey(async (): Promise<void> => {
+    let prepareCallCount = 0;
+    const response = await postFreshChatSessionRouteWithDeps(
+      createRequest({
+        sessionId: "session-existing",
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createDependencies({
+        prepareFreshChatRun: async (_userId, _workspaceId, content) => {
+          prepareCallCount += 1;
+          return createPreparedRun(content);
+        },
+      }),
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(
+      await response.text(),
+      "sessionId is not supported for fresh chat requests",
+    );
+    assert.equal(prepareCallCount, 0);
+  });
+});
+
+test("POST /api/chat/new transaction failures do not start a runtime or persist a terminal update", async (): Promise<void> => {
+  await withOpenAiApiKey(async (): Promise<void> => {
+    await withSuppressedConsoleLog(async (): Promise<void> => {
+      let runtimeStartCallCount = 0;
+      let terminalPersistCallCount = 0;
+      const response = await postFreshChatSessionRouteWithDeps(
+        createRequest({
+          content: [{ type: "text", text: "Hello" }],
+          model: CHAT_MODEL_ID,
+          timezone: "Europe/Madrid",
+        }),
+        createDependencies({
+          prepareFreshChatRun: async (): Promise<PreparedChatRun> => {
+            throw new Error("transaction rolled back");
+          },
+          startPersistedChatRun: () => {
+            runtimeStartCallCount += 1;
+            return (async function* (): AsyncGenerator<ChatStreamEvent> {
+              yield { type: "done" };
+            })();
+          },
+          persistAssistantTerminalError: async () => {
+            terminalPersistCallCount += 1;
+          },
+        }),
+      );
+
+      assert.equal(response.status, 500);
+      assert.equal(await response.text(), "Fresh chat start failed");
+      assert.equal(runtimeStartCallCount, 0);
+      assert.equal(terminalPersistCallCount, 0);
+    });
+  });
+});
+
+test("POST /api/chat/new returns session then safe error after persisting a runtime-start failure", async (): Promise<void> => {
+  await withOpenAiApiKey(async (): Promise<void> => {
+    await withSuppressedConsoleLog(async (): Promise<void> => {
+      const reservation = createReservation();
+      let releasedReservation: ChatRunStartReservation | null = null;
+      const terminalParams: Array<Readonly<{
+        sessionId: string;
+        activeRunId: string;
+        assistantItemId: string;
+        errorMessage: string;
+        sessionState: string;
+      }>> = [];
+      const response = await postFreshChatSessionRouteWithDeps(
+        createRequest({
+          content: [{ type: "text", text: "Hello" }],
+          model: CHAT_MODEL_ID,
+          timezone: "Europe/Madrid",
+        }),
+        createDependencies({
+          reserveChatRunStart: () => reservation,
+          releaseChatRunStartReservation: (released) => {
+            releasedReservation = released;
+          },
+          startPersistedChatRun: () => {
+            throw new Error("runtime registry failed");
+          },
+          persistAssistantTerminalError: async (_userId, _workspaceId, params) => {
+            terminalParams.push(params);
+          },
+        }),
+      );
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("Content-Type"), "text/event-stream");
+      assert.equal(response.headers.get("X-Chat-Session-Id"), "session-1");
+      assert.equal(
+        await response.text(),
+        [
+          "data: {\"type\":\"session\",\"sessionId\":\"session-1\"}",
+          "",
+          `data: ${JSON.stringify({ type: "error", message: CHAT_STREAM_INTERRUPTED_ERROR })}`,
+          "",
+          "",
+        ].join("\n"),
+      );
+      assert.equal(releasedReservation, reservation);
+      assert.equal(terminalParams[0]?.sessionId, "session-1");
+      assert.equal(terminalParams[0]?.activeRunId, "run-1");
+      assert.equal(terminalParams[0]?.assistantItemId, "assistant-1");
+      assert.equal(terminalParams[0]?.sessionState, "interrupted");
+      assert.equal(terminalParams[0]?.errorMessage, CHAT_STREAM_INTERRUPTED_ERROR);
+    });
+  });
+});
+
+test("POST /api/chat/new preserves safe session identity when runtime start and failure persistence both fail", async (): Promise<void> => {
+  await withOpenAiApiKey(async (): Promise<void> => {
+    const loggedEvents: Array<unknown> = [];
+    const response = await postFreshChatSessionRouteWithDeps(
+      createRequest({
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createDependencies({
+        startPersistedChatRun: () => {
+          throw new Error("internal runtime registry details");
+        },
+        persistAssistantTerminalError: async () => {
+          throw new Error("internal database persistence details");
+        },
+        log: (event) => {
+          loggedEvents.push(event);
+        },
+      }),
+    );
+
+    const responseBody = await response.text();
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Content-Type"), "text/event-stream");
+    assert.equal(response.headers.get("X-Chat-Session-Id"), "session-1");
+    assert.equal(
+      responseBody,
+      [
+        "data: {\"type\":\"session\",\"sessionId\":\"session-1\"}",
+        "",
+        `data: ${JSON.stringify({ type: "error", message: CHAT_STREAM_INTERRUPTED_ERROR })}`,
+        "",
+        "",
+      ].join("\n"),
+    );
+    assert.equal(responseBody.includes("internal runtime registry details"), false);
+    assert.equal(responseBody.includes("internal database persistence details"), false);
+    assert.equal(loggedEvents.length, 2);
+    assert.match(JSON.stringify(loggedEvents[0]), /internal runtime registry details/);
+    assert.match(JSON.stringify(loggedEvents[1]), /internal database persistence details/);
+  });
+});

--- a/apps/web/src/server/chat/http/freshSessionRoute.ts
+++ b/apps/web/src/server/chat/http/freshSessionRoute.ts
@@ -1,0 +1,286 @@
+import { CHAT_MODEL_ID } from "@/lib/chatModels";
+import { getLocaleFromRequest } from "@/lib/localeCookie";
+import { handleRoute } from "@/server/api/handleRoute";
+import {
+  buildChatRequestDiagnostics,
+  extractChatRequestContext,
+  parseFreshChatRequestBody,
+  type ChatRequestContext,
+  type FreshChatRequestBody,
+} from "@/server/chat/http/request";
+import { createChatErrorLogEvent } from "@/server/chat/logging";
+import {
+  CHAT_STREAM_HEARTBEAT_INTERVAL_MS,
+  createChatEventStream,
+} from "@/server/chat/http/sse";
+import {
+  CHAT_STREAM_INTERRUPTED_ERROR,
+} from "@/server/chat/http/sessionRecovery";
+import {
+  releaseChatRunStartReservation,
+  reserveChatRunStart,
+  startPersistedChatRun,
+} from "@/server/chat/runtime/runtime";
+import {
+  persistAssistantTerminalError,
+  prepareFreshChatRun,
+} from "@/server/chat/store";
+import type { ChatStreamEvent } from "@/server/chat/types";
+import { log } from "@/server/logger";
+import {
+  CHAT_SERVER_DRAINING_MESSAGE,
+  isServerDraining,
+} from "@/server/shutdownCoordinator";
+
+type FreshChatSessionRouteDependencies = Readonly<{
+  getLocaleFromRequest: typeof getLocaleFromRequest;
+  reserveChatRunStart: typeof reserveChatRunStart;
+  releaseChatRunStartReservation: typeof releaseChatRunStartReservation;
+  prepareFreshChatRun: typeof prepareFreshChatRun;
+  persistAssistantTerminalError: typeof persistAssistantTerminalError;
+  startPersistedChatRun: typeof startPersistedChatRun;
+  isServerDraining: typeof isServerDraining;
+  log: typeof log;
+}>;
+
+const DEFAULT_FRESH_CHAT_SESSION_ROUTE_DEPENDENCIES: FreshChatSessionRouteDependencies = {
+  getLocaleFromRequest,
+  reserveChatRunStart,
+  releaseChatRunStartReservation,
+  prepareFreshChatRun,
+  persistAssistantTerminalError,
+  startPersistedChatRun,
+  isServerDraining,
+  log,
+};
+
+export const prependSessionEvent = (
+  sessionId: string,
+  events: AsyncGenerator<ChatStreamEvent>,
+): AsyncGenerator<ChatStreamEvent> => {
+  let sessionEventPending = true;
+  let isClosed = false;
+  const iterator = (async function* (): AsyncGenerator<ChatStreamEvent> {
+    return;
+  })();
+
+  iterator.next = async (): Promise<IteratorResult<ChatStreamEvent>> => {
+    if (isClosed) {
+      return { done: true, value: undefined };
+    }
+    if (sessionEventPending) {
+      sessionEventPending = false;
+      return {
+        done: false,
+        value: { type: "session", sessionId },
+      };
+    }
+
+    try {
+      const next = await events.next();
+      if (next.done) {
+        isClosed = true;
+      }
+      return next;
+    } catch (error) {
+      isClosed = true;
+      throw error;
+    }
+  };
+  iterator.return = async (): Promise<IteratorResult<ChatStreamEvent>> => {
+    isClosed = true;
+    await events.return(undefined);
+    return { done: true, value: undefined };
+  };
+  iterator.throw = async (error: unknown): Promise<IteratorResult<ChatStreamEvent>> => {
+    isClosed = true;
+    await events.return(undefined);
+    throw error;
+  };
+  return iterator;
+};
+
+const createRuntimeStartErrorEvents = async function* (): AsyncGenerator<ChatStreamEvent> {
+  yield { type: "error", message: CHAT_STREAM_INTERRUPTED_ERROR };
+};
+
+const persistRuntimeStartFailure = async (
+  dependencies: FreshChatSessionRouteDependencies,
+  context: ChatRequestContext,
+  preparedRun: Awaited<ReturnType<typeof prepareFreshChatRun>>,
+): Promise<void> => {
+  await dependencies.persistAssistantTerminalError(
+    context.userId,
+    context.workspaceId,
+    {
+      sessionId: preparedRun.sessionId,
+      activeRunId: preparedRun.activeRunId,
+      assistantItemId: preparedRun.assistantItem.itemId,
+      assistantContent: [],
+      errorMessage: CHAT_STREAM_INTERRUPTED_ERROR,
+      sessionState: "interrupted",
+    },
+  );
+};
+
+export const postFreshChatSessionRouteWithDeps = async (
+  request: Request,
+  dependencies: FreshChatSessionRouteDependencies,
+): Promise<Response> =>
+  handleRoute(
+    {
+      route: "/api/chat/new",
+      method: "POST",
+      internalErrorMessage: "Fresh chat start failed",
+    },
+    async (): Promise<Response> => {
+      if (dependencies.isServerDraining()) {
+        dependencies.log({
+          domain: "api",
+          action: "shutdown_chat_request_rejected",
+          route: "/api/chat/new",
+          method: "POST",
+        });
+        return new Response(CHAT_SERVER_DRAINING_MESSAGE, { status: 503 });
+      }
+
+      let body: FreshChatRequestBody;
+      try {
+        body = parseFreshChatRequestBody(await request.json());
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return new Response(message, { status: 400 });
+      }
+
+      if (body.model !== CHAT_MODEL_ID) {
+        return new Response(
+          `Unsupported model: ${body.model}. Expected ${CHAT_MODEL_ID}`,
+          { status: 400 },
+        );
+      }
+
+      const requestId = crypto.randomUUID();
+      const envKey = "OPENAI_API_KEY";
+      const apiKey = process.env[envKey];
+      if (apiKey === undefined || apiKey === "") {
+        const diagnostics = buildChatRequestDiagnostics(requestId, body.model, body.content);
+        dependencies.log(createChatErrorLogEvent(
+          diagnostics,
+          "config",
+          `${envKey} environment variable is not set`,
+        ));
+        return new Response(`${envKey} environment variable is not set`, { status: 500 });
+      }
+
+      let context: ChatRequestContext;
+      try {
+        context = extractChatRequestContext(request);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const diagnostics = buildChatRequestDiagnostics(requestId, body.model, body.content);
+        dependencies.log(createChatErrorLogEvent(diagnostics, "auth", error));
+        return new Response(message, { status: 401 });
+      }
+
+      const locale = dependencies.getLocaleFromRequest(request);
+      let preparedRun: Awaited<ReturnType<typeof prepareFreshChatRun>>;
+      try {
+        preparedRun = await dependencies.prepareFreshChatRun(
+          context.userId,
+          context.workspaceId,
+          body.content,
+        );
+      } catch (error) {
+        const diagnostics = buildChatRequestDiagnostics(
+          requestId,
+          body.model,
+          body.content,
+          context.userId,
+          context.workspaceId,
+        );
+        dependencies.log(createChatErrorLogEvent(diagnostics, "agent", error));
+        throw error;
+      }
+
+      const diagnostics = buildChatRequestDiagnostics(
+        requestId,
+        body.model,
+        body.content,
+        context.userId,
+        context.workspaceId,
+        preparedRun.sessionId,
+      );
+      const events = await (async (): Promise<AsyncGenerator<ChatStreamEvent>> => {
+        let reservation: ReturnType<typeof reserveChatRunStart> = null;
+        let runtimeStarted = false;
+        try {
+          reservation = dependencies.reserveChatRunStart(preparedRun.sessionId);
+          if (reservation === null) {
+            throw new Error(
+              `Fresh chat runtime reservation failed after persistence: sessionId=${preparedRun.sessionId}`,
+            );
+          }
+
+          const startedEvents = dependencies.startPersistedChatRun({
+            requestId,
+            userId: context.userId,
+            workspaceId: context.workspaceId,
+            sessionId: preparedRun.sessionId,
+            activeRunId: preparedRun.activeRunId,
+            locale,
+            timezone: body.timezone,
+            assistantItemId: preparedRun.assistantItem.itemId,
+            localMessages: preparedRun.localMessages,
+            turnInput: preparedRun.turnInput,
+            diagnostics: {
+              requestId,
+              userId: context.userId,
+              workspaceId: context.workspaceId,
+              sessionId: preparedRun.sessionId,
+              model: body.model,
+              messageCount: diagnostics.messageCount,
+              hasAttachments: diagnostics.hasAttachments,
+              attachmentFileNames: diagnostics.attachmentFileNames,
+            },
+          }, reservation);
+          runtimeStarted = true;
+          return startedEvents;
+        } catch (error) {
+          dependencies.log(createChatErrorLogEvent(diagnostics, "agent", error));
+          try {
+            await persistRuntimeStartFailure(dependencies, context, preparedRun);
+          } catch (persistError) {
+            dependencies.log(createChatErrorLogEvent(diagnostics, "agent", persistError));
+          }
+          return createRuntimeStartErrorEvents();
+        } finally {
+          if (!runtimeStarted && reservation !== null) {
+            dependencies.releaseChatRunStartReservation(reservation);
+          }
+        }
+      })();
+
+      const stream = createChatEventStream({
+        events: prependSessionEvent(preparedRun.sessionId, events),
+        heartbeatIntervalMs: CHAT_STREAM_HEARTBEAT_INTERVAL_MS,
+        onStreamError: (error: string): void => {
+          dependencies.log(createChatErrorLogEvent(diagnostics, "stream", error));
+        },
+      });
+
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+          "X-Chat-Session-Id": preparedRun.sessionId,
+        },
+      });
+    },
+  );
+
+export const POST = async (request: Request): Promise<Response> =>
+  postFreshChatSessionRouteWithDeps(
+    request,
+    DEFAULT_FRESH_CHAT_SESSION_ROUTE_DEPENDENCIES,
+  );

--- a/apps/web/src/server/chat/http/request.ts
+++ b/apps/web/src/server/chat/http/request.ts
@@ -13,6 +13,12 @@ export type ChatRequestBody = Readonly<{
   timezone: string;
 }>;
 
+export type FreshChatRequestBody = Readonly<{
+  content: ReadonlyArray<ContentPart>;
+  model: string;
+  timezone: string;
+}>;
+
 export type ChatRequestContext = Readonly<{
   userId: string;
   workspaceId: string;
@@ -103,7 +109,7 @@ export const extractChatRequestContext = (request: Request): ChatRequestContext 
   workspaceId: extractWorkspaceId(request),
 });
 
-export const parseChatRequestBody = (body: unknown): ChatRequestBody => {
+const parseChatMessageRequestBody = (body: unknown): FreshChatRequestBody => {
   if (!isRecord(body)) {
     throw new Error("Invalid chat request body");
   }
@@ -114,7 +120,7 @@ export const parseChatRequestBody = (body: unknown): ChatRequestBody => {
     }
   }
 
-  const candidate = body as Partial<ChatRequestBody>;
+  const candidate = body as Partial<FreshChatRequestBody>;
   if (!Array.isArray(candidate.content) || candidate.content.length === 0) {
     throw new Error("content array is empty");
   }
@@ -127,18 +133,34 @@ export const parseChatRequestBody = (body: unknown): ChatRequestBody => {
   if (typeof candidate.timezone !== "string" || candidate.timezone.length === 0) {
     throw new Error("timezone must be a non-empty string");
   }
-  if (typeof candidate.sessionId !== "string" || candidate.sessionId.trim().length === 0) {
-    throw new Error("sessionId must be a non-empty string");
-  }
 
   validateChatAttachments(candidate.content);
 
   return {
-    sessionId: candidate.sessionId,
     content: candidate.content,
     model: candidate.model,
     timezone: candidate.timezone,
   };
+};
+
+export const parseChatRequestBody = (body: unknown): ChatRequestBody => {
+  const parsedBody = parseChatMessageRequestBody(body);
+  if (!isRecord(body) || typeof body.sessionId !== "string" || body.sessionId.trim().length === 0) {
+    throw new Error("sessionId must be a non-empty string");
+  }
+
+  return {
+    sessionId: body.sessionId,
+    ...parsedBody,
+  };
+};
+
+export const parseFreshChatRequestBody = (body: unknown): FreshChatRequestBody => {
+  if (isRecord(body) && "sessionId" in body) {
+    throw new Error("sessionId is not supported for fresh chat requests");
+  }
+
+  return parseChatMessageRequestBody(body);
 };
 
 export const buildChatRequestDiagnostics = (

--- a/apps/web/src/server/chat/runtime/runtime.test.ts
+++ b/apps/web/src/server/chat/runtime/runtime.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { LangfuseObservation } from "@langfuse/tracing";
+import { prependSessionEvent } from "@/server/chat/http/freshSessionRoute";
+import { createChatEventStream } from "@/server/chat/http/sse";
 import { buildChatCompletionInput } from "@/server/chat/openai/responses/input";
 import type { StoredOpenAIReplayItem } from "@/server/chat/openai/responses/replayItems";
 import {
   clearActiveChatRunForTests,
   createActiveChatRunForTests,
+  getActiveChatRunSubscriberCountForTests,
   hasActiveChatRun,
   markActiveChatRunCancellationPersisted,
   releaseChatRunStartReservation,
@@ -43,6 +46,26 @@ const createDeferred = (): Deferred => {
     resolve: resolvePromise,
   };
 };
+
+const resolvesWithin = async (
+  promise: Promise<unknown>,
+  timeoutMs: number,
+): Promise<boolean> =>
+  new Promise<boolean>((resolve) => {
+    const timeout = setTimeout(() => {
+      resolve(false);
+    }, timeoutMs);
+    void promise.then(
+      (): void => {
+        clearTimeout(timeout);
+        resolve(true);
+      },
+      (): void => {
+        clearTimeout(timeout);
+        resolve(true);
+      },
+    );
+  });
 
 const requireReservation = (
   sessionId: string,
@@ -475,6 +498,99 @@ test("reserveChatRunStart can be released before runtime start", (): void => {
 
   const secondReservation = requireReservation(sessionId);
   releaseChatRunStartReservation(secondReservation);
+});
+
+test("cancelling the session-prefixed SSE stream unsubscribes a pending read without aborting the backend run", async (): Promise<void> => {
+  const sessionId = "session-unconsumed-subscriber";
+  const params = createRunParams(sessionId);
+  const runStarted = createDeferred();
+  const releaseBackendRun = createDeferred();
+  const backendRunFinished = createDeferred();
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const runtimeEvents = startPersistedChatRunWithDeps(
+    params,
+    requireReservation(sessionId),
+    createRuntimeDependencies(
+      {
+        runOpenAILoop: async (): Promise<Readonly<{
+          openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+        }>> => {
+          runStarted.resolve();
+          await releaseBackendRun.promise;
+          return { openaiItems: [] };
+        },
+        endTaskProtection: async (): Promise<void> => {
+          backendRunFinished.resolve();
+        },
+      },
+      recorded,
+    ),
+  );
+  const stream = createChatEventStream({
+    events: prependSessionEvent(sessionId, runtimeEvents),
+    heartbeatIntervalMs: 10_000,
+    onStreamError: () => undefined,
+  });
+  const reader = stream.getReader();
+
+  try {
+    await runStarted.promise;
+    const firstChunk = await reader.read();
+    assert.equal(firstChunk.done, false);
+    assert.equal(
+      new TextDecoder().decode(firstChunk.value),
+      `data: ${JSON.stringify({ type: "session", sessionId })}\n\n`,
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    assert.equal(getActiveChatRunSubscriberCountForTests(sessionId), 1);
+    assert.equal(hasActiveChatRun(sessionId, params.activeRunId), true);
+
+    const cancellation = reader.cancel();
+
+    assert.equal(await resolvesWithin(cancellation, 250), true);
+    await cancellation;
+    assert.equal(getActiveChatRunSubscriberCountForTests(sessionId), 0);
+    assert.equal(hasActiveChatRun(sessionId, params.activeRunId), true);
+
+    releaseBackendRun.resolve();
+    await backendRunFinished.promise;
+    assert.equal(hasActiveChatRun(sessionId, params.activeRunId), false);
+  } finally {
+    releaseBackendRun.resolve();
+    await reader.cancel().catch((): void => undefined);
+    clearActiveChatRunForTests(sessionId);
+  }
+});
+
+test("separate session ids keep independent active backend runs", (): void => {
+  const firstSessionId = "session-parallel-1";
+  const secondSessionId = "session-parallel-2";
+  const firstActiveRunId = "run-parallel-1";
+  const secondActiveRunId = "run-parallel-2";
+
+  createActiveChatRunForTests(firstSessionId, firstActiveRunId);
+  createActiveChatRunForTests(secondSessionId, secondActiveRunId);
+
+  try {
+    assert.equal(hasActiveChatRun(firstSessionId, firstActiveRunId), true);
+    assert.equal(hasActiveChatRun(secondSessionId, secondActiveRunId), true);
+    assert.deepEqual(stopActiveChatRun(firstSessionId, firstActiveRunId), {
+      stopped: true,
+      activeRunId: firstActiveRunId,
+    });
+    assert.equal(hasActiveChatRun(secondSessionId, secondActiveRunId), true);
+  } finally {
+    clearActiveChatRunForTests(firstSessionId);
+    clearActiveChatRunForTests(secondSessionId);
+  }
 });
 
 test("stopActiveChatRun ignores mismatched active run ids", (): void => {

--- a/apps/web/src/server/chat/runtime/runtime.ts
+++ b/apps/web/src/server/chat/runtime/runtime.ts
@@ -308,6 +308,16 @@ const createChatRunSubscriber = (
     });
   };
 
+  const closeSubscriber = (): void => {
+    const activeRun = activeChatRuns.get(sessionId);
+    if (activeRun !== undefined && subscriber !== null) {
+      activeRun.subscribers.delete(subscriber);
+    }
+    if (subscriber !== null) {
+      subscriber.close();
+    }
+  };
+
   subscriber = {
     push: (event: ChatStreamEvent): void => {
       if (isClosed) {
@@ -329,25 +339,28 @@ const createChatRunSubscriber = (
       isClosed = true;
       resolvePending({ done: true, value: undefined });
     },
-    createIterator: async function* (): AsyncGenerator<ChatStreamEvent> {
-      try {
-        while (true) {
-          const next = await nextEvent();
-          if (next.done) {
-            return;
-          }
+    createIterator: (): AsyncGenerator<ChatStreamEvent> => {
+      const iterator = (async function* (): AsyncGenerator<ChatStreamEvent> {
+        try {
+          while (true) {
+            const next = await nextEvent();
+            if (next.done) {
+              return;
+            }
 
-          yield next.value;
+            yield next.value;
+          }
+        } finally {
+          closeSubscriber();
         }
-      } finally {
-        const activeRun = activeChatRuns.get(sessionId);
-        if (activeRun !== undefined && subscriber !== null) {
-          activeRun.subscribers.delete(subscriber);
-        }
-        if (subscriber !== null) {
-          subscriber.close();
-        }
-      }
+      })();
+
+      const returnIterator = iterator.return.bind(iterator);
+      iterator.return = async (value): Promise<IteratorResult<ChatStreamEvent>> => {
+        closeSubscriber();
+        return returnIterator(value);
+      };
+      return iterator;
     },
   };
 
@@ -878,3 +891,8 @@ export const clearActiveChatRunForTests = (
   activeChatRuns.delete(sessionId);
   chatRunStartReservations.delete(sessionId);
 };
+
+export const getActiveChatRunSubscriberCountForTests = (
+  sessionId: string,
+): number =>
+  activeChatRuns.get(sessionId)?.subscribers.size ?? 0;

--- a/apps/web/src/server/chat/store.ts
+++ b/apps/web/src/server/chat/store.ts
@@ -63,6 +63,7 @@ export {
   persistAssistantCancelled,
   persistAssistantTerminalError,
   prepareChatRun,
+  prepareFreshChatRun,
   recoverStaleChatSession,
   recoverStaleChatSessionWithQuery,
 } from "./store/lifecycleStore";

--- a/apps/web/src/server/chat/store/lifecycleStore.test.ts
+++ b/apps/web/src/server/chat/store/lifecycleStore.test.ts
@@ -6,10 +6,15 @@ import {
   completeChatRunWithQuery,
   persistAssistantCancelledWithQuery,
   persistAssistantTerminalErrorWithQuery,
+  prepareChatRunWithQuery,
+  prepareFreshChatRunWithQuery,
   recoverStaleChatSessionWithQuery,
 } from "@/server/chat/store/lifecycleStore";
 import { updateAssistantMessageItemWithQuery } from "@/server/chat/store/messageStore";
-import { ChatSessionRunTransitionError } from "@/server/chat/store/shared";
+import {
+  ChatSessionConflictError,
+  ChatSessionRunTransitionError,
+} from "@/server/chat/store/shared";
 import type { QueryFn } from "@/server/db/contextRunner";
 
 type RecordedQuery = Readonly<{
@@ -174,6 +179,51 @@ const createTerminalRunParams = (): Readonly<{
   assistantContent: [{ type: "text", text: "Answer" }],
 });
 
+const createFreshRunQueryFn = (
+  recordedQueries: Array<RecordedQuery>,
+  failAssistantInsert: boolean,
+): QueryFn => async (text, params): Promise<QueryResult> => {
+  recordedQueries.push({ text, params });
+
+  if (text.includes("INSERT INTO public.chat_sessions")) {
+    return createQueryResult([createSessionRow("running", String(params[2]))]);
+  }
+
+  if (text.includes("INSERT INTO public.chat_items")) {
+    const payload = JSON.parse(String(params[2])) as Readonly<{
+      role: "user" | "assistant";
+      content: ReadonlyArray<Readonly<{ type: "text"; text: string }>>;
+    }>;
+    if (payload.role === "assistant" && failAssistantInsert) {
+      throw new Error("assistant insert failed");
+    }
+    return createQueryResult([{
+      item_id: `${payload.role}-1`,
+      session_id: "session-1",
+      state: String(params[1]),
+      payload,
+      created_at: "2026-05-02T13:00:00.000Z",
+      updated_at: "2026-05-02T13:00:00.000Z",
+    }]);
+  }
+
+  if (text.includes("FROM public.chat_items")) {
+    return createQueryResult([{
+      item_id: "user-1",
+      session_id: "session-1",
+      state: "completed",
+      payload: {
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+      },
+      created_at: "2026-05-02T13:00:00.000Z",
+      updated_at: "2026-05-02T13:00:00.000Z",
+    }]);
+  }
+
+  throw new Error(`Unexpected query: ${text}`);
+};
+
 const withSuppressedConsoleLog = async (
   run: () => Promise<void>,
 ): Promise<void> => {
@@ -198,6 +248,81 @@ test("completeChatRunWithQuery locks the active run before updating the assistan
   assert.match(recordedQueries[0].text, /active_run_id = \$2/);
   assert.equal(recordedQueries[1].text.includes("UPDATE public.chat_items"), true);
   assert.equal(recordedQueries[2].text.includes("UPDATE public.chat_sessions"), true);
+});
+
+test("prepareFreshChatRunWithQuery creates one running session and the two required items", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  const preparedRun = await prepareFreshChatRunWithQuery(
+    createFreshRunQueryFn(recordedQueries, false),
+    "user-1",
+    "workspace-1",
+    [{ type: "text", text: "  Hello\nworld  " }],
+  );
+
+  assert.equal(preparedRun.sessionId, "session-1");
+  assert.equal(preparedRun.assistantItem.role, "assistant");
+  assert.equal(preparedRun.assistantItem.state, "in_progress");
+  assert.equal(preparedRun.localMessages.length, 1);
+  assert.equal(recordedQueries.length, 4);
+  assert.equal(recordedQueries[0].text.includes("INSERT INTO public.chat_sessions"), true);
+  assert.equal(recordedQueries[0].params[3], "Hello world");
+  assert.equal(recordedQueries[1].text.includes("INSERT INTO public.chat_items"), true);
+  assert.equal(recordedQueries[2].text.includes("FROM public.chat_items"), true);
+  assert.equal(recordedQueries[3].text.includes("INSERT INTO public.chat_items"), true);
+});
+
+test("prepareFreshChatRunWithQuery propagates item failures to the enclosing transaction", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+
+  await assert.rejects(
+    prepareFreshChatRunWithQuery(
+      createFreshRunQueryFn(recordedQueries, true),
+      "user-1",
+      "workspace-1",
+      [{ type: "text", text: "Hello" }],
+    ),
+    /assistant insert failed/,
+  );
+
+  assert.equal(
+    recordedQueries.filter((query) => query.text.includes("INSERT INTO public.chat_sessions")).length,
+    1,
+  );
+  assert.equal(
+    recordedQueries.filter((query) => query.text.includes("INSERT INTO public.chat_items")).length,
+    2,
+  );
+});
+
+test("prepareChatRunWithQuery explicitly rejects a second run in the same session", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions")) {
+      return createQueryResult([createSessionRow("running", "run-1")]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  await assert.rejects(
+    prepareChatRunWithQuery(
+      queryFn,
+      "user-1",
+      "workspace-1",
+      "session-1",
+      [{ type: "text", text: "Another message" }],
+    ),
+    (error: unknown): boolean =>
+      error instanceof ChatSessionConflictError
+      && error.message.includes("session-1"),
+  );
+
+  assert.equal(recordedQueries.length, 2);
+  assert.equal(
+    recordedQueries.some((query) => query.text.includes("INSERT INTO public.chat_items")),
+    false,
+  );
 });
 
 test("persistAssistantTerminalErrorWithQuery locks the active run before updating chat items", async (): Promise<void> => {

--- a/apps/web/src/server/chat/store/lifecycleStore.ts
+++ b/apps/web/src/server/chat/store/lifecycleStore.ts
@@ -26,6 +26,8 @@ import {
 import { buildLocalChatMessages } from "./snapshotStore";
 import {
   completeChatSessionRunWithQuery,
+  createRunningChatSessionWithQuery,
+  deriveChatSessionTitle,
   lockActiveChatSessionRunWithQuery,
   lockChatSessionWithQuery,
   lockRequestedChatSessionWithQuery,
@@ -127,6 +129,52 @@ export const prepareChatRun = async (
 ): Promise<PreparedChatRun> =>
   withUserContext(userId, workspaceId, async (queryFn) =>
     prepareChatRunWithQuery(queryFn, userId, workspaceId, requestedSessionId, content));
+
+export const prepareFreshChatRunWithQuery = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  content: ReadonlyArray<ContentPart>,
+): Promise<PreparedChatRun> => {
+  const activeRunId = randomUUID();
+  const sessionRow = await createRunningChatSessionWithQuery(
+    queryFn,
+    userId,
+    workspaceId,
+    activeRunId,
+    deriveChatSessionTitle(content),
+  );
+  await insertChatItemWithQuery(queryFn, {
+    sessionId: sessionRow.session_id,
+    role: "user",
+    state: "completed",
+    content,
+  });
+
+  const persistedMessages = await listChatMessagesWithQuery(queryFn, sessionRow.session_id);
+  const assistantItem = await insertChatItemWithQuery(queryFn, {
+    sessionId: sessionRow.session_id,
+    role: "assistant",
+    state: "in_progress",
+    content: [],
+  });
+
+  return {
+    sessionId: sessionRow.session_id,
+    activeRunId,
+    assistantItem,
+    localMessages: buildLocalChatMessages(persistedMessages),
+    turnInput: content,
+  };
+};
+
+export const prepareFreshChatRun = async (
+  userId: string,
+  workspaceId: string,
+  content: ReadonlyArray<ContentPart>,
+): Promise<PreparedChatRun> =>
+  withUserContext(userId, workspaceId, async (queryFn) =>
+    prepareFreshChatRunWithQuery(queryFn, userId, workspaceId, content));
 
 export const completeChatRunWithQuery = async (
   queryFn: QueryFn,

--- a/apps/web/src/server/chat/store/messageStore.test.ts
+++ b/apps/web/src/server/chat/store/messageStore.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { QueryResult } from "pg";
+import {
+  insertChatItemWithQuery,
+  updateChatItemAndInvalidateMainContentWithQuery,
+  updateChatItemWithQuery,
+} from "@/server/chat/store/messageStore";
+import type { QueryFn } from "@/server/db/contextRunner";
+
+const createQueryResult = (
+  role: "user" | "assistant",
+  state: "in_progress" | "completed" | "error",
+  content: ReadonlyArray<Readonly<{ type: "text"; text: string }>>,
+  invalidationVersion: string | undefined,
+): QueryResult => ({
+  command: "SELECT",
+  rowCount: 1,
+  oid: 0,
+  fields: [],
+  rows: [{
+    item_id: `${role}-1`,
+    session_id: "session-1",
+    state,
+    payload: { role, content },
+    created_at: "2026-05-02T13:00:00.000Z",
+    updated_at: "2026-05-02T13:00:00.000Z",
+    ...(invalidationVersion === undefined
+      ? {}
+      : { main_content_invalidation_version: invalidationVersion }),
+  }],
+});
+
+test("insertChatItemWithQuery records user activity but not an empty assistant placeholder", async (): Promise<void> => {
+  const recordedQueries: Array<Readonly<{
+    text: string;
+    params: ReadonlyArray<unknown>;
+  }>> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    const payload = JSON.parse(String(params[2])) as Readonly<{
+      role: "user" | "assistant";
+      content: ReadonlyArray<Readonly<{ type: "text"; text: string }>>;
+    }>;
+    return createQueryResult(
+      payload.role,
+      String(params[1]) as "in_progress" | "completed",
+      payload.content,
+      undefined,
+    );
+  };
+
+  await insertChatItemWithQuery(queryFn, {
+    sessionId: "session-1",
+    role: "user",
+    state: "completed",
+    content: [{ type: "text", text: "Hello" }],
+  });
+  await insertChatItemWithQuery(queryFn, {
+    sessionId: "session-1",
+    role: "assistant",
+    state: "in_progress",
+    content: [],
+  });
+
+  assert.match(recordedQueries[0].text, /last_message_at = CASE/);
+  assert.equal(recordedQueries[0].params[3], true);
+  assert.equal(recordedQueries[1].params[3], false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("title =")), false);
+});
+
+test("assistant progress and final updates advance visible session activity", async (): Promise<void> => {
+  const activityFlags: Array<unknown> = [];
+  const queryFn: QueryFn = async (_text, params): Promise<QueryResult> => {
+    activityFlags.push(params[4]);
+    const payload = JSON.parse(String(params[2])) as Readonly<{
+      content: ReadonlyArray<Readonly<{ type: "text"; text: string }>>;
+    }>;
+    return createQueryResult(
+      "assistant",
+      String(params[3]) as "in_progress" | "completed",
+      payload.content,
+      undefined,
+    );
+  };
+
+  await updateChatItemWithQuery(queryFn, {
+    sessionId: "session-1",
+    itemId: "assistant-1",
+    content: [{ type: "text", text: "Working" }],
+    state: "in_progress",
+  });
+  await updateChatItemWithQuery(queryFn, {
+    sessionId: "session-1",
+    itemId: "assistant-1",
+    content: [{ type: "text", text: "Done" }],
+    state: "completed",
+  });
+
+  assert.deepEqual(activityFlags, [true, true]);
+});
+
+test("assistant terminal errors and invalidating progress advance visible session activity", async (): Promise<void> => {
+  const recordedQueries: Array<Readonly<{
+    text: string;
+    activityFlag: unknown;
+  }>> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, activityFlag: params[4] });
+    const payload = JSON.parse(String(params[2])) as Readonly<{
+      content: ReadonlyArray<Readonly<{ type: "text"; text: string }>>;
+    }>;
+    return createQueryResult(
+      "assistant",
+      String(params[3]) as "in_progress" | "error",
+      payload.content,
+      text.includes("main_content_invalidation_version")
+        ? "1"
+        : undefined,
+    );
+  };
+
+  await updateChatItemWithQuery(queryFn, {
+    sessionId: "session-1",
+    itemId: "assistant-1",
+    content: [],
+    state: "error",
+  });
+  await updateChatItemAndInvalidateMainContentWithQuery(queryFn, {
+    sessionId: "session-1",
+    itemId: "assistant-1",
+    content: [{ type: "text", text: "Updated" }],
+    state: "in_progress",
+  });
+
+  assert.deepEqual(
+    recordedQueries.map((query) => query.activityFlag),
+    [true, true],
+  );
+  assert.match(recordedQueries[0].text, /last_message_at = CASE/);
+  assert.match(recordedQueries[1].text, /last_message_at = CASE/);
+});

--- a/apps/web/src/server/chat/store/messageStore.ts
+++ b/apps/web/src/server/chat/store/messageStore.ts
@@ -60,9 +60,14 @@ const INSERT_CHAT_ITEM_SQL = `
     RETURNING item_id, session_id, state, payload, created_at, updated_at
   ),
   touched_session AS (
-    UPDATE public.chat_sessions
-    SET updated_at = now()
-    WHERE session_id = (SELECT session_id FROM inserted_item)
+    UPDATE public.chat_sessions AS session
+    SET updated_at = inserted_item.updated_at,
+        last_message_at = CASE
+          WHEN $4 THEN inserted_item.updated_at
+          ELSE session.last_message_at
+        END
+    FROM inserted_item
+    WHERE session.session_id = inserted_item.session_id
   )
   SELECT item_id, session_id, state, payload, created_at, updated_at
   FROM inserted_item
@@ -79,9 +84,14 @@ const UPDATE_CHAT_ITEM_SQL = `
     RETURNING item_id, session_id, state, payload, created_at, updated_at
   ),
   touched_session AS (
-    UPDATE public.chat_sessions
-    SET updated_at = now()
-    WHERE session_id = (SELECT session_id FROM updated_item)
+    UPDATE public.chat_sessions AS session
+    SET updated_at = updated_item.updated_at,
+        last_message_at = CASE
+          WHEN $5 THEN updated_item.updated_at
+          ELSE session.last_message_at
+        END
+    FROM updated_item
+    WHERE session.session_id = updated_item.session_id
   )
   SELECT item_id, session_id, state, payload, created_at, updated_at
   FROM updated_item
@@ -98,10 +108,15 @@ const UPDATE_CHAT_ITEM_AND_INVALIDATE_MAIN_CONTENT_SQL = `
     RETURNING item_id, session_id, state, payload, created_at, updated_at
   ),
   invalidated_session AS (
-    UPDATE public.chat_sessions
+    UPDATE public.chat_sessions AS session
     SET main_content_invalidation_version = main_content_invalidation_version + 1,
-        updated_at = now()
-    WHERE session_id = (SELECT session_id FROM updated_item)
+        updated_at = updated_item.updated_at,
+        last_message_at = CASE
+          WHEN $5 THEN updated_item.updated_at
+          ELSE session.last_message_at
+        END
+    FROM updated_item
+    WHERE session.session_id = updated_item.session_id
     RETURNING main_content_invalidation_version
   )
   SELECT
@@ -139,6 +154,16 @@ const toChatItemPayload = (
     : {}),
 });
 
+const isVisibleChatItemActivity = (
+  role: "user" | "assistant",
+  state: ChatItemState,
+  content: ReadonlyArray<ContentPart>,
+): boolean =>
+  role === "user"
+  || content.length > 0
+  || state === "error"
+  || state === "cancelled";
+
 export const mapChatItemRow = (row: ChatItemRow): PersistedChatMessageItem => ({
   itemId: row.item_id,
   sessionId: row.session_id,
@@ -168,6 +193,7 @@ export const insertChatItemWithQuery = async (
     params.sessionId,
     params.state,
     JSON.stringify(toChatItemPayload(params.role, params.content, params.assistantOpenAIItems)),
+    isVisibleChatItemActivity(params.role, params.state, params.content),
   ]);
 
   return mapChatItemRow(
@@ -184,6 +210,7 @@ export const updateChatItemWithQuery = async (
     params.sessionId,
     JSON.stringify(toChatItemPayload("assistant", params.content, params.assistantOpenAIItems)),
     params.state,
+    isVisibleChatItemActivity("assistant", params.state, params.content),
   ]);
 
   return mapChatItemRow(
@@ -203,6 +230,7 @@ export const updateChatItemAndInvalidateMainContentWithQuery = async (
     params.sessionId,
     JSON.stringify(toChatItemPayload("assistant", params.content, params.assistantOpenAIItems)),
     params.state,
+    isVisibleChatItemActivity("assistant", params.state, params.content),
   ]);
 
   const row = result.rows[0] as ChatItemWithInvalidationRow | undefined;

--- a/apps/web/src/server/chat/store/sessionStore.test.ts
+++ b/apps/web/src/server/chat/store/sessionStore.test.ts
@@ -4,7 +4,10 @@ import type { QueryResult } from "pg";
 import { ChatSessionRunTransitionError } from "@/server/chat/store";
 import {
   completeChatSessionRunWithQuery,
+  createRunningChatSessionWithQuery,
+  deriveChatSessionTitle,
   lockActiveChatSessionRunWithQuery,
+  startChatSessionRunWithQuery,
   touchChatSessionHeartbeatWithQuery,
 } from "@/server/chat/store/sessionStore";
 import type { QueryFn } from "@/server/db/contextRunner";
@@ -52,7 +55,75 @@ test("touchChatSessionHeartbeatWithQuery only touches heartbeat for the matching
   assert.match(queryText, /SET active_run_heartbeat_at = \$3/);
   assert.match(queryText, /AND active_run_id = \$2/);
   assert.match(queryText, /AND status = 'running'/);
+  assert.equal(queryText.includes("last_message_at"), false);
   assert.deepEqual(queryParams, ["session-1", "run-1", "2026-05-02T13:00:00.000Z"]);
+});
+
+test("deriveChatSessionTitle normalizes first-message text and caps it at 200 characters", (): void => {
+  const title = deriveChatSessionTitle([
+    { type: "text", text: "  Monthly\n" },
+    { type: "text", text: `${" budget".repeat(40)}  ` },
+  ]);
+
+  assert.equal(title?.startsWith("Monthly budget"), true);
+  assert.equal(Array.from(title ?? "").length, 200);
+});
+
+test("deriveChatSessionTitle uses the first normalized filename without attachment bytes", (): void => {
+  const title = deriveChatSessionTitle([
+    {
+      type: "file",
+      fileName: "  July\n statement.pdf  ",
+      mediaType: "application/pdf",
+      base64Data: "private-attachment-bytes",
+    },
+  ]);
+
+  assert.equal(title, "July statement.pdf");
+  assert.equal(title?.includes("private-attachment-bytes"), false);
+});
+
+test("createRunningChatSessionWithQuery creates a titled active session with initial activity", async (): Promise<void> => {
+  let queryText = "";
+  let queryParams: ReadonlyArray<unknown> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    queryText = text;
+    queryParams = params;
+    return createQueryResult([createSessionRow("running", "run-1")]);
+  };
+
+  await createRunningChatSessionWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    "run-1",
+    "First message",
+  );
+
+  assert.match(queryText, /VALUES \(\$1, \$2, 'running', \$3, now\(\), 0, \$4, now\(\), now\(\)\)/);
+  assert.match(queryText, /last_message_at/);
+  assert.deepEqual(queryParams, ["user-1", "workspace-1", "run-1", "First message"]);
+});
+
+test("startChatSessionRunWithQuery scopes independent running transitions by session id", async (): Promise<void> => {
+  const recordedParams: Array<ReadonlyArray<unknown>> = [];
+  const queryFn: QueryFn = async (_text, params): Promise<QueryResult> => {
+    recordedParams.push(params);
+    return createQueryResult([
+      createSessionRow("running", String(params[1])),
+    ]);
+  };
+  const heartbeatAt = new Date("2026-05-02T13:00:00.000Z");
+
+  await Promise.all([
+    startChatSessionRunWithQuery(queryFn, "session-1", "run-1", heartbeatAt),
+    startChatSessionRunWithQuery(queryFn, "session-2", "run-2", heartbeatAt),
+  ]);
+
+  assert.deepEqual(recordedParams, [
+    ["session-1", "run-1", "2026-05-02T13:00:00.000Z"],
+    ["session-2", "run-2", "2026-05-02T13:00:00.000Z"],
+  ]);
 });
 
 test("completeChatSessionRunWithQuery requires the matching active run id", async (): Promise<void> => {

--- a/apps/web/src/server/chat/store/sessionStore.ts
+++ b/apps/web/src/server/chat/store/sessionStore.ts
@@ -1,5 +1,6 @@
 import { queryAs, withUserContext } from "@/server/db";
 import type { QueryFn } from "@/server/db/contextRunner";
+import type { ContentPart } from "@/server/chat/types";
 import {
   ChatSessionRunTransitionError,
   ChatSessionNotFoundError,
@@ -71,6 +72,22 @@ const INSERT_SESSION_SQL = `
     updated_at
   )
   VALUES ($1, $2, 'idle', NULL, NULL, 0, now())
+  RETURNING session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+`;
+
+const INSERT_RUNNING_SESSION_SQL = `
+  INSERT INTO public.chat_sessions (
+    user_id,
+    workspace_id,
+    status,
+    active_run_id,
+    active_run_heartbeat_at,
+    main_content_invalidation_version,
+    title,
+    last_message_at,
+    updated_at
+  )
+  VALUES ($1, $2, 'running', $3, now(), 0, $4, now(), now())
   RETURNING session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
 `;
 
@@ -179,6 +196,52 @@ export const createChatSessionWithQuery = async (
 ): Promise<ChatSessionRow> => {
   const result = await queryFn(INSERT_SESSION_SQL, [userId, workspaceId]);
   return requireSessionRow(result.rows[0] as ChatSessionRow | undefined, "insert");
+};
+
+const normalizeChatSessionTitle = (value: string): string | null => {
+  const normalizedValue = value.replace(/\s+/gu, " ").trim();
+  if (normalizedValue === "") {
+    return null;
+  }
+
+  return Array.from(normalizedValue).slice(0, 200).join("");
+};
+
+export const deriveChatSessionTitle = (
+  content: ReadonlyArray<ContentPart>,
+): string | null => {
+  const textTitle = normalizeChatSessionTitle(
+    content
+      .filter((part): part is Extract<ContentPart, { type: "text" }> => part.type === "text")
+      .map((part) => part.text)
+      .join(""),
+  );
+  if (textTitle !== null) {
+    return textTitle;
+  }
+
+  const firstFile = content.find(
+    (part): part is Extract<ContentPart, { type: "file" }> => part.type === "file",
+  );
+  return firstFile === undefined
+    ? null
+    : normalizeChatSessionTitle(firstFile.fileName);
+};
+
+export const createRunningChatSessionWithQuery = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  activeRunId: string,
+  title: string | null,
+): Promise<ChatSessionRow> => {
+  const result = await queryFn(INSERT_RUNNING_SESSION_SQL, [
+    userId,
+    workspaceId,
+    activeRunId,
+    title,
+  ]);
+  return requireSessionRow(result.rows[0] as ChatSessionRow | undefined, "running insert");
 };
 
 export const resolveRequestedChatSessionWithQuery = async (

--- a/apps/web/src/server/chat/types.ts
+++ b/apps/web/src/server/chat/types.ts
@@ -58,6 +58,10 @@ export type ChatMessage = Readonly<{
 
 export type ChatStreamEvent =
   | Readonly<{
+    type: "session";
+    sessionId: string;
+  }>
+  | Readonly<{
     type: "delta";
     text: string;
     itemId: string;


### PR DESCRIPTION
## Summary
- create chat sessions only when the first valid message starts work
- persist initial chat state atomically and maintain activity metadata
- preserve backend runs when SSE clients disconnect or switch sessions

## Validation
- focused fresh-session/runtime tests: 23/23
- mandated item-03 tests: 29/29
- compatibility tests: 36/36
- item-02 catalog safeguard: 20/20
- npm run lint
- npm run build
- git diff --check