### PR TITLE
feat(web): add chat workspace state foundation

### DIFF
--- a/apps/web/src/ui/chat/workspace/chatActivityPolicy.test.ts
+++ b/apps/web/src/ui/chat/workspace/chatActivityPolicy.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CHAT_INACTIVITY_THRESHOLD_MS,
+  resolveChatActivityPolicy,
+  shouldReevaluateChatActivityAfterVisibilityChange,
+  type SelectedChatSessionActivity,
+} from "./chatActivityPolicy";
+
+const NOW_MS = Date.parse("2026-07-26T12:00:00.000Z");
+
+const createSelectedSession = (
+  lastMessageAt: string,
+  status: SelectedChatSessionActivity["status"],
+): SelectedChatSessionActivity => ({
+  sessionId: "session-1",
+  lastMessageAt,
+  status,
+});
+
+test("automatic bootstrap uses a local draft when no historical session is selected", (): void => {
+  assert.deepEqual(
+    resolveChatActivityPolicy({
+      currentTimeMs: NOW_MS,
+      selectedSession: null,
+      selectionReason: "automatic",
+      inactivityThresholdMs: CHAT_INACTIVITY_THRESHOLD_MS,
+    }),
+    { kind: "select_draft" },
+  );
+});
+
+test("automatic bootstrap keeps exactly six hours and rolls over just after it", (): void => {
+  const lastMessageAt = "2026-07-26T06:00:00.000Z";
+  const selectedSession = createSelectedSession(lastMessageAt, "idle");
+
+  assert.deepEqual(
+    resolveChatActivityPolicy({
+      currentTimeMs: NOW_MS,
+      selectedSession,
+      selectionReason: "automatic",
+      inactivityThresholdMs: CHAT_INACTIVITY_THRESHOLD_MS,
+    }),
+    { kind: "keep_session", sessionId: "session-1" },
+  );
+  assert.deepEqual(
+    resolveChatActivityPolicy({
+      currentTimeMs: NOW_MS + 1,
+      selectedSession,
+      selectionReason: "automatic",
+      inactivityThresholdMs: CHAT_INACTIVITY_THRESHOLD_MS,
+    }),
+    { kind: "select_draft" },
+  );
+});
+
+test("an old running session remains selected automatically", (): void => {
+  assert.deepEqual(
+    resolveChatActivityPolicy({
+      currentTimeMs: NOW_MS,
+      selectedSession: createSelectedSession(
+        "2026-07-25T00:00:00.000Z",
+        "running",
+      ),
+      selectionReason: "automatic",
+      inactivityThresholdMs: CHAT_INACTIVITY_THRESHOLD_MS,
+    }),
+    { kind: "keep_session", sessionId: "session-1" },
+  );
+});
+
+test("an explicitly selected old historical session remains selected", (): void => {
+  assert.deepEqual(
+    resolveChatActivityPolicy({
+      currentTimeMs: NOW_MS,
+      selectedSession: createSelectedSession(
+        "2026-07-25T00:00:00.000Z",
+        "interrupted",
+      ),
+      selectionReason: "explicit",
+      inactivityThresholdMs: CHAT_INACTIVITY_THRESHOLD_MS,
+    }),
+    { kind: "keep_session", sessionId: "session-1" },
+  );
+});
+
+test("opening an old session does not refresh server-provided message activity", (): void => {
+  const oldServerActivity = createSelectedSession(
+    "2026-07-25T00:00:00.000Z",
+    "idle",
+  );
+
+  assert.deepEqual(
+    resolveChatActivityPolicy({
+      currentTimeMs: NOW_MS,
+      selectedSession: oldServerActivity,
+      selectionReason: "automatic",
+      inactivityThresholdMs: CHAT_INACTIVITY_THRESHOLD_MS,
+    }),
+    { kind: "select_draft" },
+  );
+});
+
+test("visibility return requests re-evaluation without an inactivity timer", (): void => {
+  assert.equal(
+    shouldReevaluateChatActivityAfterVisibilityChange("hidden", "visible"),
+    true,
+  );
+  assert.equal(
+    shouldReevaluateChatActivityAfterVisibilityChange("visible", "hidden"),
+    false,
+  );
+  assert.equal(
+    shouldReevaluateChatActivityAfterVisibilityChange("visible", "visible"),
+    false,
+  );
+});
+
+test("activity policy rejects malformed server timestamps explicitly", (): void => {
+  assert.throws(
+    () => resolveChatActivityPolicy({
+      currentTimeMs: NOW_MS,
+      selectedSession: createSelectedSession(
+        "2026-07-26T06:00:00Z",
+        "idle",
+      ),
+      selectionReason: "automatic",
+      inactivityThresholdMs: CHAT_INACTIVITY_THRESHOLD_MS,
+    }),
+    /lastMessageAt must be a canonical UTC timestamp/u,
+  );
+});

--- a/apps/web/src/ui/chat/workspace/chatActivityPolicy.ts
+++ b/apps/web/src/ui/chat/workspace/chatActivityPolicy.ts
@@ -1,0 +1,82 @@
+import {
+  parseChatIdentifier,
+  parseChatSessionTimestamp,
+  type ChatSessionStatus,
+} from "./chatSessionSummaryTransport";
+import type { ChatSelectionReason } from "./chatWorkspaceState";
+
+export const CHAT_INACTIVITY_THRESHOLD_MS = 6 * 60 * 60 * 1000;
+
+export type SelectedChatSessionActivity = Readonly<{
+  sessionId: string;
+  lastMessageAt: string;
+  status: ChatSessionStatus;
+}>;
+
+export type ChatActivityPolicyInput = Readonly<{
+  currentTimeMs: number;
+  selectedSession: SelectedChatSessionActivity | null;
+  selectionReason: ChatSelectionReason;
+  inactivityThresholdMs: number;
+}>;
+
+export type ChatActivityPolicyDecision =
+  | Readonly<{ kind: "select_draft" }>
+  | Readonly<{ kind: "keep_session"; sessionId: string }>;
+
+export type ChatPageVisibility = "hidden" | "visible";
+
+const requireNonNegativeFiniteNumber = (
+  value: number,
+  context: string,
+): number => {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${context} must be a finite non-negative number`);
+  }
+
+  return value;
+};
+
+export const resolveChatActivityPolicy = (
+  input: ChatActivityPolicyInput,
+): ChatActivityPolicyDecision => {
+  const currentTimeMs = requireNonNegativeFiniteNumber(
+    input.currentTimeMs,
+    "Chat activity currentTimeMs",
+  );
+  const inactivityThresholdMs = requireNonNegativeFiniteNumber(
+    input.inactivityThresholdMs,
+    "Chat activity inactivityThresholdMs",
+  );
+  if (input.selectedSession === null) {
+    return { kind: "select_draft" };
+  }
+
+  const sessionId = parseChatIdentifier(
+    input.selectedSession.sessionId,
+    "Chat activity sessionId",
+  );
+  if (
+    input.selectedSession.status === "running"
+    || input.selectionReason === "explicit"
+  ) {
+    return { kind: "keep_session", sessionId };
+  }
+
+  const lastMessageAt = parseChatSessionTimestamp(
+    input.selectedSession.lastMessageAt,
+    "Chat activity lastMessageAt",
+  );
+  const inactiveForMs = currentTimeMs - Date.parse(lastMessageAt);
+  if (inactiveForMs > inactivityThresholdMs) {
+    return { kind: "select_draft" };
+  }
+
+  return { kind: "keep_session", sessionId };
+};
+
+export const shouldReevaluateChatActivityAfterVisibilityChange = (
+  previousVisibility: ChatPageVisibility,
+  nextVisibility: ChatPageVisibility,
+): boolean =>
+  previousVisibility === "hidden" && nextVisibility === "visible";

--- a/apps/web/src/ui/chat/workspace/chatSelectionStorage.test.ts
+++ b/apps/web/src/ui/chat/workspace/chatSelectionStorage.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildChatTargetUrl,
+  getChatSelectionStorageKey,
+  readChatSelection,
+  readChatSessionTargetFromSearchParams,
+  writeChatSelection,
+  type ChatSelectionScope,
+} from "./chatSelectionStorage";
+
+const createStorage = (): Storage => {
+  const values = new Map<string, string>();
+
+  return {
+    get length(): number {
+      return values.size;
+    },
+    clear: (): void => values.clear(),
+    getItem: (key: string): string | null => values.get(key) ?? null,
+    key: (index: number): string | null => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string): void => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string): void => {
+      values.set(key, value);
+    },
+  };
+};
+
+test("selection keys isolate authenticated users, workspaces, and demo mode", (): void => {
+  const scopes: ReadonlyArray<ChatSelectionScope> = [
+    { mode: "workspace", userId: "user-1", workspaceId: "workspace-1" },
+    { mode: "workspace", userId: "user-2", workspaceId: "workspace-1" },
+    { mode: "workspace", userId: "user-1", workspaceId: "workspace-2" },
+    { mode: "demo", userId: "user-1" },
+  ];
+  const keys = scopes.map(getChatSelectionStorageKey);
+
+  assert.equal(new Set(keys).size, keys.length);
+});
+
+test("session storage round-trips only the selected target per tab", (): void => {
+  const firstTabStorage = createStorage();
+  const secondTabStorage = createStorage();
+  const scope: ChatSelectionScope = {
+    mode: "workspace",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  };
+
+  writeChatSelection(
+    firstTabStorage,
+    scope,
+    { kind: "draft", draftId: "draft-1" },
+  );
+  assert.deepEqual(readChatSelection(firstTabStorage, scope), {
+    kind: "draft",
+    draftId: "draft-1",
+  });
+  assert.equal(readChatSelection(secondTabStorage, scope), null);
+
+  writeChatSelection(
+    firstTabStorage,
+    scope,
+    { kind: "session", sessionId: "session-1" },
+  );
+  assert.deepEqual(readChatSelection(firstTabStorage, scope), {
+    kind: "session",
+    sessionId: "session-1",
+  });
+});
+
+test("invalid stored selections fail explicitly without inventing a session id", (): void => {
+  const storage = createStorage();
+  const scope: ChatSelectionScope = {
+    mode: "workspace",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  };
+  const storageKey = getChatSelectionStorageKey(scope);
+
+  storage.setItem(storageKey, "not-json");
+  assert.throws(
+    () => readChatSelection(storage, scope),
+    /Stored chat selection is not valid JSON/u,
+  );
+
+  storage.setItem(storageKey, JSON.stringify({
+    kind: "session",
+    sessionId: "",
+  }));
+  assert.throws(
+    () => readChatSelection(storage, scope),
+    /Stored chat selection sessionId must contain 1-200 characters/u,
+  );
+});
+
+test("fullscreen URL parsing validates one explicit historical session", (): void => {
+  assert.equal(
+    readChatSessionTargetFromSearchParams(new URLSearchParams()),
+    null,
+  );
+  assert.deepEqual(
+    readChatSessionTargetFromSearchParams(
+      new URLSearchParams("session=session%2Fone"),
+    ),
+    { kind: "session", sessionId: "session/one" },
+  );
+  assert.throws(
+    () => readChatSessionTargetFromSearchParams(
+      new URLSearchParams("session=one&session=two"),
+    ),
+    /at most one session query parameter/u,
+  );
+  assert.throws(
+    () => readChatSessionTargetFromSearchParams(
+      new URLSearchParams("session="),
+    ),
+    /session query parameter must contain 1-200 characters/u,
+  );
+});
+
+test("fullscreen target URLs are canonical for sessions and local drafts", (): void => {
+  assert.equal(
+    buildChatTargetUrl({ kind: "session", sessionId: "session/one" }),
+    "/chat?session=session%2Fone",
+  );
+  assert.equal(
+    buildChatTargetUrl({ kind: "draft", draftId: "draft-1" }),
+    "/chat",
+  );
+});

--- a/apps/web/src/ui/chat/workspace/chatSelectionStorage.ts
+++ b/apps/web/src/ui/chat/workspace/chatSelectionStorage.ts
@@ -1,0 +1,152 @@
+import { parseChatIdentifier } from "./chatSessionSummaryTransport";
+import type { ChatTarget } from "./chatWorkspaceState";
+
+const CHAT_SELECTION_STORAGE_PREFIX = "expense-tracker-chat-selection:v1:";
+
+export type ChatSelectionScope =
+  | Readonly<{
+    mode: "demo";
+    userId: string;
+  }>
+  | Readonly<{
+    mode: "workspace";
+    userId: string;
+    workspaceId: string;
+  }>;
+
+const isRecord = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const requireStorageKeyPart = (
+  value: string,
+  context: string,
+): string =>
+  encodeURIComponent(parseChatIdentifier(value, context));
+
+export const getChatSelectionStorageKey = (
+  scope: ChatSelectionScope,
+): string => {
+  const userId = requireStorageKeyPart(
+    scope.userId,
+    "Chat selection scope userId",
+  );
+  if (scope.mode === "demo") {
+    return `${CHAT_SELECTION_STORAGE_PREFIX}demo:${userId}`;
+  }
+
+  const workspaceId = requireStorageKeyPart(
+    scope.workspaceId,
+    "Chat selection scope workspaceId",
+  );
+  return `${CHAT_SELECTION_STORAGE_PREFIX}workspace:${userId}:${workspaceId}`;
+};
+
+export const parseStoredChatTarget = (
+  rawValue: string,
+): ChatTarget => {
+  let value: unknown;
+  try {
+    value = JSON.parse(rawValue) as unknown;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Stored chat selection is not valid JSON: ${reason}`);
+  }
+
+  if (!isRecord(value)) {
+    throw new Error("Stored chat selection must be an object");
+  }
+
+  if (value.kind === "draft") {
+    return {
+      kind: "draft",
+      draftId: parseChatIdentifier(
+        value.draftId,
+        "Stored chat selection draftId",
+      ),
+    };
+  }
+  if (value.kind === "session") {
+    return {
+      kind: "session",
+      sessionId: parseChatIdentifier(
+        value.sessionId,
+        "Stored chat selection sessionId",
+      ),
+    };
+  }
+
+  throw new Error("Stored chat selection kind must be draft or session");
+};
+
+export const readChatSelection = (
+  storage: Storage,
+  scope: ChatSelectionScope,
+): ChatTarget | null => {
+  const rawValue = storage.getItem(getChatSelectionStorageKey(scope));
+  return rawValue === null ? null : parseStoredChatTarget(rawValue);
+};
+
+export const writeChatSelection = (
+  storage: Storage,
+  scope: ChatSelectionScope,
+  target: ChatTarget,
+): void => {
+  const validTarget = target.kind === "draft"
+    ? {
+      kind: "draft" as const,
+      draftId: parseChatIdentifier(
+        target.draftId,
+        "Chat selection draftId",
+      ),
+    }
+    : {
+      kind: "session" as const,
+      sessionId: parseChatIdentifier(
+        target.sessionId,
+        "Chat selection sessionId",
+      ),
+    };
+
+  storage.setItem(
+    getChatSelectionStorageKey(scope),
+    JSON.stringify(validTarget),
+  );
+};
+
+export const readChatSessionTargetFromSearchParams = (
+  searchParams: URLSearchParams,
+): ChatTarget | null => {
+  const sessionValues = searchParams.getAll("session");
+  if (sessionValues.length === 0) {
+    return null;
+  }
+  if (sessionValues.length !== 1) {
+    throw new Error("Chat URL must contain at most one session query parameter");
+  }
+
+  return {
+    kind: "session",
+    sessionId: parseChatIdentifier(
+      sessionValues[0],
+      "Chat URL session query parameter",
+    ),
+  };
+};
+
+export const buildChatTargetUrl = (
+  target: ChatTarget,
+): string => {
+  if (target.kind === "draft") {
+    parseChatIdentifier(target.draftId, "Chat draft target draftId");
+    return "/chat";
+  }
+
+  const sessionId = parseChatIdentifier(
+    target.sessionId,
+    "Chat session target sessionId",
+  );
+  const searchParams = new URLSearchParams({ session: sessionId });
+  return `/chat?${searchParams.toString()}`;
+};

--- a/apps/web/src/ui/chat/workspace/chatSessionSummaryTransport.test.ts
+++ b/apps/web/src/ui/chat/workspace/chatSessionSummaryTransport.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  mergeChatSessionSummaries,
+  parseChatSessionSummaryPage,
+  readChatSessionSummaryPageResponse,
+  type ChatSessionSummary,
+} from "./chatSessionSummaryTransport";
+
+const VALID_SERVER_CURSOR =
+  "eyJsYXN0TWVzc2FnZUF0IjoiMjAyNi0wNy0yNlQxNjo0MjowMC4wMDAxMjNaIiwic2Vzc2lvbklkIjoic2Vzc2lvbi0xIn0";
+
+const createSummary = (
+  overrides: Readonly<Partial<ChatSessionSummary>>,
+): ChatSessionSummary => ({
+  sessionId: "session-1",
+  title: "First chat",
+  lastMessageAt: "2026-07-26T12:00:00.000Z",
+  status: "idle",
+  mainContentInvalidationVersion: 0,
+  ...overrides,
+});
+
+test("parseChatSessionSummaryPage validates and returns the catalog contract", (): void => {
+  const page = parseChatSessionSummaryPage({
+    sessions: [
+      {
+        ...createSummary({ status: "running" }),
+        unrelatedServerField: "ignored",
+      },
+    ],
+    nextCursor: VALID_SERVER_CURSOR,
+    unrelatedEnvelopeField: true,
+  });
+
+  assert.deepEqual(page, {
+    sessions: [createSummary({ status: "running" })],
+    nextCursor: VALID_SERVER_CURSOR,
+  });
+  assert.deepEqual(
+    parseChatSessionSummaryPage({ sessions: [], nextCursor: null }),
+    { sessions: [], nextCursor: null },
+  );
+});
+
+test("parseChatSessionSummaryPage rejects noncanonical cursor encodings", (): void => {
+  const invalidCursors = [
+    "A",
+    "AB",
+    "YQ==",
+    "++8",
+  ];
+
+  for (const nextCursor of invalidCursors) {
+    assert.throws(
+      () => parseChatSessionSummaryPage({
+        sessions: [],
+        nextCursor,
+      }),
+      /nextCursor must (?:be null or a non-empty base64url string|use canonical base64url encoding)/u,
+    );
+  }
+});
+
+test("parseChatSessionSummaryPage rejects every malformed catalog field", (): void => {
+  const validSummary = createSummary({});
+  const malformedResponses: ReadonlyArray<Readonly<{
+    payload: unknown;
+    expectedMessage: RegExp;
+  }>> = [
+    {
+      payload: { sessions: [{ ...validSummary, sessionId: "" }], nextCursor: null },
+      expectedMessage: /sessions\[0\]\.sessionId must contain 1-200 characters/u,
+    },
+    {
+      payload: {
+        sessions: [{ ...validSummary, lastMessageAt: "2026-07-26T12:00:00Z" }],
+        nextCursor: null,
+      },
+      expectedMessage: /sessions\[0\]\.lastMessageAt must be a canonical UTC timestamp/u,
+    },
+    {
+      payload: { sessions: [{ ...validSummary, status: "queued" }], nextCursor: null },
+      expectedMessage: /sessions\[0\]\.status must be idle, running, or interrupted/u,
+    },
+    {
+      payload: {
+        sessions: [{ ...validSummary, mainContentInvalidationVersion: -1 }],
+        nextCursor: null,
+      },
+      expectedMessage: /sessions\[0\]\.mainContentInvalidationVersion must be a non-negative safe integer/u,
+    },
+    {
+      payload: { sessions: [validSummary], nextCursor: "not+a+cursor" },
+      expectedMessage: /nextCursor must be null or a non-empty base64url string/u,
+    },
+  ];
+
+  for (const malformedResponse of malformedResponses) {
+    assert.throws(
+      () => parseChatSessionSummaryPage(malformedResponse.payload),
+      malformedResponse.expectedMessage,
+    );
+  }
+});
+
+test("parseChatSessionSummaryPage reports a malformed row instead of discarding it", (): void => {
+  assert.throws(
+    () => parseChatSessionSummaryPage({
+      sessions: [createSummary({ sessionId: "session-1" }), null],
+      nextCursor: null,
+    }),
+    /sessions\[1\] must be an object/u,
+  );
+});
+
+test("mergeChatSessionSummaries preserves page order and deduplicates by session id", (): void => {
+  const current = [
+    createSummary({ sessionId: "session-1", title: "First" }),
+    createSummary({ sessionId: "session-2", title: "Second" }),
+    createSummary({ sessionId: "session-1", title: "First updated" }),
+  ];
+  const next = [
+    createSummary({
+      sessionId: "session-2",
+      title: "Second updated",
+      status: "running",
+    }),
+    createSummary({ sessionId: "session-3", title: "Third" }),
+  ];
+
+  const merged = mergeChatSessionSummaries(current, next);
+
+  assert.deepEqual(
+    merged.map((summary) => summary.sessionId),
+    ["session-1", "session-2", "session-3"],
+  );
+  assert.equal(merged[0]?.title, "First updated");
+  assert.equal(merged[1]?.title, "Second updated");
+  assert.equal(merged[1]?.status, "running");
+});
+
+test("readChatSessionSummaryPageResponse exposes HTTP and JSON failures", async (): Promise<void> => {
+  await assert.rejects(
+    readChatSessionSummaryPageResponse(
+      new Response("catalog unavailable", { status: 503 }),
+    ),
+    /status=503, responseBody=catalog unavailable/u,
+  );
+  await assert.rejects(
+    readChatSessionSummaryPageResponse(
+      new Response("not-json", { status: 200 }),
+    ),
+    /response was not valid JSON.*Response body: not-json/u,
+  );
+});

--- a/apps/web/src/ui/chat/workspace/chatSessionSummaryTransport.ts
+++ b/apps/web/src/ui/chat/workspace/chatSessionSummaryTransport.ts
@@ -1,0 +1,312 @@
+import { fetchWithCsrf } from "@/lib/csrf";
+
+export type ChatSessionStatus = "idle" | "running" | "interrupted";
+
+export type ChatSessionSummary = Readonly<{
+  sessionId: string;
+  title: string;
+  lastMessageAt: string;
+  status: ChatSessionStatus;
+  mainContentInvalidationVersion: number;
+}>;
+
+export type ChatSessionSummaryPage = Readonly<{
+  sessions: ReadonlyArray<ChatSessionSummary>;
+  nextCursor: string | null;
+}>;
+
+const MAX_SESSION_ID_LENGTH = 200;
+const MAX_TITLE_LENGTH = 200;
+const MAX_CURSOR_LENGTH = 2048;
+const MIN_PAGE_LIMIT = 1;
+const MAX_PAGE_LIMIT = 100;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001F\u007F-\u009F]/u;
+const CANONICAL_UTC_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
+const BASE64_URL_PATTERN = /^[A-Za-z0-9_-]+$/u;
+
+const isRecord = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasCodePointLengthBetween = (
+  value: string,
+  minimumLength: number,
+  maximumLength: number,
+): boolean => {
+  const length = Array.from(value).length;
+  return length >= minimumLength && length <= maximumLength;
+};
+
+export const parseChatIdentifier = (
+  value: unknown,
+  context: string,
+): string => {
+  if (typeof value !== "string") {
+    throw new Error(`${context} must be a string`);
+  }
+  if (!value.isWellFormed()) {
+    throw new Error(`${context} must be well-formed Unicode`);
+  }
+  if (!hasCodePointLengthBetween(value, 1, MAX_SESSION_ID_LENGTH)) {
+    throw new Error(
+      `${context} must contain 1-${MAX_SESSION_ID_LENGTH} characters`,
+    );
+  }
+  if (CONTROL_CHARACTER_PATTERN.test(value)) {
+    throw new Error(`${context} must not contain control characters`);
+  }
+
+  return value;
+};
+
+export const parseChatSessionTimestamp = (
+  value: unknown,
+  context: string,
+): string => {
+  if (
+    typeof value !== "string"
+    || !CANONICAL_UTC_TIMESTAMP_PATTERN.test(value)
+    || value.startsWith("0000-")
+  ) {
+    throw new Error(
+      `${context} must be a canonical UTC timestamp with millisecond precision`,
+    );
+  }
+
+  const timestamp = Date.parse(value);
+  if (
+    Number.isNaN(timestamp)
+    || new Date(timestamp).toISOString() !== value
+  ) {
+    throw new Error(
+      `${context} must be a valid canonical UTC timestamp with millisecond precision`,
+    );
+  }
+
+  return value;
+};
+
+const parseTitle = (
+  value: unknown,
+  context: string,
+): string => {
+  if (
+    typeof value !== "string"
+    || !value.isWellFormed()
+    || !hasCodePointLengthBetween(value, 1, MAX_TITLE_LENGTH)
+  ) {
+    throw new Error(`${context} must contain 1-${MAX_TITLE_LENGTH} Unicode characters`);
+  }
+
+  return value;
+};
+
+const parseStatus = (
+  value: unknown,
+  context: string,
+): ChatSessionStatus => {
+  if (value !== "idle" && value !== "running" && value !== "interrupted") {
+    throw new Error(`${context} must be idle, running, or interrupted`);
+  }
+
+  return value;
+};
+
+const parseInvalidationVersion = (
+  value: unknown,
+  context: string,
+): number => {
+  if (
+    typeof value !== "number"
+    || !Number.isSafeInteger(value)
+    || value < 0
+  ) {
+    throw new Error(`${context} must be a non-negative safe integer`);
+  }
+
+  return value;
+};
+
+const isCanonicalBase64Url = (value: string): boolean => {
+  if (value.length % 4 === 1) {
+    return false;
+  }
+
+  const base64Value = value
+    .replace(/-/gu, "+")
+    .replace(/_/gu, "/")
+    .padEnd(value.length + ((4 - (value.length % 4)) % 4), "=");
+
+  try {
+    const decodedValue = atob(base64Value);
+    const reencodedValue = btoa(decodedValue)
+      .replace(/\+/gu, "-")
+      .replace(/\//gu, "_")
+      .replace(/=+$/u, "");
+    return reencodedValue === value;
+  } catch {
+    return false;
+  }
+};
+
+const parseCursor = (
+  value: unknown,
+  context: string,
+): string | null => {
+  if (value === null) {
+    return null;
+  }
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || value.length > MAX_CURSOR_LENGTH
+    || !BASE64_URL_PATTERN.test(value)
+  ) {
+    throw new Error(
+      `${context} must be null or a non-empty base64url string no longer than ${MAX_CURSOR_LENGTH} characters`,
+    );
+  }
+  if (!isCanonicalBase64Url(value)) {
+    throw new Error(`${context} must use canonical base64url encoding`);
+  }
+
+  return value;
+};
+
+const parseSummary = (
+  value: unknown,
+  index: number,
+): ChatSessionSummary => {
+  const context = `Invalid chat session catalog response sessions[${index}]`;
+  if (!isRecord(value)) {
+    throw new Error(`${context} must be an object`);
+  }
+
+  return {
+    sessionId: parseChatIdentifier(value.sessionId, `${context}.sessionId`),
+    title: parseTitle(value.title, `${context}.title`),
+    lastMessageAt: parseChatSessionTimestamp(
+      value.lastMessageAt,
+      `${context}.lastMessageAt`,
+    ),
+    status: parseStatus(value.status, `${context}.status`),
+    mainContentInvalidationVersion: parseInvalidationVersion(
+      value.mainContentInvalidationVersion,
+      `${context}.mainContentInvalidationVersion`,
+    ),
+  };
+};
+
+export const parseChatSessionSummaryPage = (
+  value: unknown,
+): ChatSessionSummaryPage => {
+  if (!isRecord(value)) {
+    throw new Error("Invalid chat session catalog response: response must be an object");
+  }
+  if (!Array.isArray(value.sessions)) {
+    throw new Error("Invalid chat session catalog response: sessions must be an array");
+  }
+
+  return {
+    sessions: value.sessions.map(parseSummary),
+    nextCursor: parseCursor(
+      value.nextCursor,
+      "Invalid chat session catalog response nextCursor",
+    ),
+  };
+};
+
+export const mergeChatSessionSummaries = (
+  currentSummaries: ReadonlyArray<ChatSessionSummary>,
+  nextSummaries: ReadonlyArray<ChatSessionSummary>,
+): ReadonlyArray<ChatSessionSummary> => {
+  const mergedSummaries: Array<ChatSessionSummary> = [];
+  const summaryIndexes = new Map<string, number>();
+
+  for (const summary of [...currentSummaries, ...nextSummaries]) {
+    const existingIndex = summaryIndexes.get(summary.sessionId);
+    if (existingIndex === undefined) {
+      summaryIndexes.set(summary.sessionId, mergedSummaries.length);
+      mergedSummaries.push(summary);
+      continue;
+    }
+
+    mergedSummaries[existingIndex] = summary;
+  }
+
+  return mergedSummaries;
+};
+
+const requirePageLimit = (limit: number): number => {
+  if (
+    !Number.isSafeInteger(limit)
+    || limit < MIN_PAGE_LIMIT
+    || limit > MAX_PAGE_LIMIT
+  ) {
+    throw new Error(
+      `Chat session catalog limit must be an integer between ${MIN_PAGE_LIMIT} and ${MAX_PAGE_LIMIT}`,
+    );
+  }
+
+  return limit;
+};
+
+const requireRequestCursor = (cursor: string | null): string | null =>
+  parseCursor(cursor, "Chat session catalog cursor");
+
+export const readChatSessionSummaryPageResponse = async (
+  response: Response,
+): Promise<ChatSessionSummaryPage> => {
+  const responseBody = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `Chat session catalog request failed: status=${response.status}, responseBody=${responseBody}`,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(responseBody) as unknown;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Chat session catalog response was not valid JSON: ${reason}. Response body: ${responseBody}`,
+    );
+  }
+
+  try {
+    return parseChatSessionSummaryPage(payload);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `${reason}. Response body: ${responseBody}`,
+    );
+  }
+};
+
+export const fetchChatSessionSummaryPage = async (
+  limit: number,
+  cursor: string | null,
+  signal: AbortSignal,
+): Promise<ChatSessionSummaryPage> => {
+  const searchParams = new URLSearchParams({
+    limit: String(requirePageLimit(limit)),
+  });
+  const validCursor = requireRequestCursor(cursor);
+  if (validCursor !== null) {
+    searchParams.set("cursor", validCursor);
+  }
+
+  const response = await fetchWithCsrf(
+    `/api/chat/sessions?${searchParams.toString()}`,
+    {
+      method: "GET",
+      cache: "no-store",
+      signal,
+    },
+  );
+
+  return readChatSessionSummaryPageResponse(response);
+};

--- a/apps/web/src/ui/chat/workspace/chatWorkspaceState.test.ts
+++ b/apps/web/src/ui/chat/workspace/chatWorkspaceState.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  appendChatSessionCatalogPage,
+  createChatWorkspaceState,
+  failChatSessionCatalogLoad,
+  findChatSessionInvalidationIncrements,
+  getRunningChatSessionCount,
+  replaceChatSessionCatalog,
+  selectChatWorkspaceTarget,
+  startChatSessionCatalogLoad,
+} from "./chatWorkspaceState";
+import type { ChatSessionSummary } from "./chatSessionSummaryTransport";
+
+const createSummary = (
+  sessionId: string,
+  status: ChatSessionSummary["status"],
+  mainContentInvalidationVersion: number,
+): ChatSessionSummary => ({
+  sessionId,
+  title: sessionId,
+  lastMessageAt: "2026-07-26T12:00:00.000Z",
+  status,
+  mainContentInvalidationVersion,
+});
+
+test("chat workspace state keeps an explicit target and selection reason", (): void => {
+  const draftState = createChatWorkspaceState(
+    { kind: "draft", draftId: "draft-1" },
+    "automatic",
+  );
+  const sessionState = selectChatWorkspaceTarget(
+    draftState,
+    { kind: "session", sessionId: "session-1" },
+    "explicit",
+  );
+
+  assert.deepEqual(draftState.target, { kind: "draft", draftId: "draft-1" });
+  assert.deepEqual(sessionState.target, {
+    kind: "session",
+    sessionId: "session-1",
+  });
+  assert.equal(sessionState.selectionReason, "explicit");
+});
+
+test("catalog page state preserves ordering, pagination, and known summaries on failure", (): void => {
+  const initialState = startChatSessionCatalogLoad(
+    createChatWorkspaceState(
+      { kind: "draft", draftId: "draft-1" },
+      "automatic",
+    ),
+  );
+  const firstPageState = replaceChatSessionCatalog(initialState, {
+    sessions: [
+      createSummary("session-1", "idle", 0),
+      createSummary("session-2", "running", 2),
+    ],
+    nextCursor: "cursor-1",
+  });
+  const nextPageState = appendChatSessionCatalogPage(firstPageState, {
+    sessions: [
+      createSummary("session-2", "idle", 3),
+      createSummary("session-3", "interrupted", 0),
+    ],
+    nextCursor: null,
+  });
+  const failedState = failChatSessionCatalogLoad(
+    startChatSessionCatalogLoad(nextPageState),
+    "Chat session catalog request failed: status=503",
+  );
+
+  assert.deepEqual(
+    failedState.summaries.map((summary) => summary.sessionId),
+    ["session-1", "session-2", "session-3"],
+  );
+  assert.equal(failedState.summaries[1]?.status, "idle");
+  assert.deepEqual(failedState.pagination, {
+    hasLoadedFirstPage: true,
+    nextCursor: null,
+  });
+  assert.deepEqual(failedState.catalogRequest, {
+    isLoading: false,
+    errorMessage: "Chat session catalog request failed: status=503",
+  });
+});
+
+test("running count is derived across all catalog summaries", (): void => {
+  assert.equal(
+    getRunningChatSessionCount([
+      createSummary("session-1", "running", 0),
+      createSummary("session-2", "idle", 0),
+      createSummary("session-3", "running", 0),
+      createSummary("session-4", "interrupted", 0),
+    ]),
+    2,
+  );
+});
+
+test("invalidation comparison detects increments for selected and unselected sessions", (): void => {
+  const selectedState = replaceChatSessionCatalog(
+    createChatWorkspaceState(
+      { kind: "session", sessionId: "session-selected" },
+      "explicit",
+    ),
+    {
+      sessions: [
+        createSummary("session-selected", "running", 2),
+        createSummary("session-background", "running", 4),
+      ],
+      nextCursor: null,
+    },
+  );
+
+  const increments = findChatSessionInvalidationIncrements(
+    selectedState.mainContentInvalidationVersions,
+    [
+      createSummary("session-selected", "running", 3),
+      createSummary("session-background", "running", 6),
+      createSummary("session-new", "idle", 5),
+    ],
+  );
+
+  assert.deepEqual(increments, [
+    {
+      sessionId: "session-selected",
+      previousVersion: 2,
+      nextVersion: 3,
+    },
+    {
+      sessionId: "session-background",
+      previousVersion: 4,
+      nextVersion: 6,
+    },
+  ]);
+});
+
+test("first catalog observation establishes invalidation baselines without increments", (): void => {
+  const increments = findChatSessionInvalidationIncrements(
+    new Map<string, number>(),
+    [createSummary("session-1", "idle", 8)],
+  );
+
+  assert.deepEqual(increments, []);
+});

--- a/apps/web/src/ui/chat/workspace/chatWorkspaceState.ts
+++ b/apps/web/src/ui/chat/workspace/chatWorkspaceState.ts
@@ -1,0 +1,210 @@
+import {
+  mergeChatSessionSummaries,
+  parseChatIdentifier,
+  type ChatSessionSummary,
+  type ChatSessionSummaryPage,
+} from "./chatSessionSummaryTransport";
+
+export type ChatTarget =
+  | Readonly<{ kind: "draft"; draftId: string }>
+  | Readonly<{ kind: "session"; sessionId: string }>;
+
+export type ChatSelectionReason = "automatic" | "explicit";
+
+export type ChatCatalogPaginationState = Readonly<{
+  hasLoadedFirstPage: boolean;
+  nextCursor: string | null;
+}>;
+
+export type ChatCatalogRequestState = Readonly<{
+  isLoading: boolean;
+  errorMessage: string | null;
+}>;
+
+export type ChatWorkspaceState = Readonly<{
+  summaries: ReadonlyArray<ChatSessionSummary>;
+  target: ChatTarget;
+  selectionReason: ChatSelectionReason;
+  mainContentInvalidationVersions: ReadonlyMap<string, number>;
+  pagination: ChatCatalogPaginationState;
+  catalogRequest: ChatCatalogRequestState;
+}>;
+
+export type ChatSessionInvalidationIncrement = Readonly<{
+  sessionId: string;
+  previousVersion: number;
+  nextVersion: number;
+}>;
+
+const requireChatTarget = (
+  target: ChatTarget,
+): ChatTarget =>
+  target.kind === "draft"
+    ? {
+      kind: "draft",
+      draftId: parseChatIdentifier(target.draftId, "Chat draft target draftId"),
+    }
+    : {
+      kind: "session",
+      sessionId: parseChatIdentifier(
+        target.sessionId,
+        "Chat session target sessionId",
+      ),
+    };
+
+const requireErrorMessage = (errorMessage: string): string => {
+  if (errorMessage.trim().length === 0) {
+    throw new Error("Chat session catalog error message must not be empty");
+  }
+
+  return errorMessage;
+};
+
+export const createChatWorkspaceState = (
+  target: ChatTarget,
+  selectionReason: ChatSelectionReason,
+): ChatWorkspaceState => ({
+  summaries: [],
+  target: requireChatTarget(target),
+  selectionReason,
+  mainContentInvalidationVersions: new Map<string, number>(),
+  pagination: {
+    hasLoadedFirstPage: false,
+    nextCursor: null,
+  },
+  catalogRequest: {
+    isLoading: false,
+    errorMessage: null,
+  },
+});
+
+export const selectChatWorkspaceTarget = (
+  state: ChatWorkspaceState,
+  target: ChatTarget,
+  selectionReason: ChatSelectionReason,
+): ChatWorkspaceState => ({
+  ...state,
+  target: requireChatTarget(target),
+  selectionReason,
+});
+
+export const startChatSessionCatalogLoad = (
+  state: ChatWorkspaceState,
+): ChatWorkspaceState => ({
+  ...state,
+  catalogRequest: {
+    isLoading: true,
+    errorMessage: null,
+  },
+});
+
+export const updateChatSessionInvalidationVersions = (
+  currentVersions: ReadonlyMap<string, number>,
+  summaries: ReadonlyArray<ChatSessionSummary>,
+): ReadonlyMap<string, number> => {
+  const nextVersions = new Map(currentVersions);
+  for (const summary of mergeChatSessionSummaries([], summaries)) {
+    const currentVersion = nextVersions.get(summary.sessionId);
+    if (
+      currentVersion === undefined
+      || summary.mainContentInvalidationVersion > currentVersion
+    ) {
+      nextVersions.set(
+        summary.sessionId,
+        summary.mainContentInvalidationVersion,
+      );
+    }
+  }
+
+  return nextVersions;
+};
+
+export const findChatSessionInvalidationIncrements = (
+  currentVersions: ReadonlyMap<string, number>,
+  summaries: ReadonlyArray<ChatSessionSummary>,
+): ReadonlyArray<ChatSessionInvalidationIncrement> => {
+  const increments: Array<ChatSessionInvalidationIncrement> = [];
+  for (const summary of mergeChatSessionSummaries([], summaries)) {
+    const currentVersion = currentVersions.get(summary.sessionId);
+    if (
+      currentVersion !== undefined
+      && summary.mainContentInvalidationVersion > currentVersion
+    ) {
+      increments.push({
+        sessionId: summary.sessionId,
+        previousVersion: currentVersion,
+        nextVersion: summary.mainContentInvalidationVersion,
+      });
+    }
+  }
+
+  return increments;
+};
+
+const createLoadedCatalogState = (
+  state: ChatWorkspaceState,
+  summaries: ReadonlyArray<ChatSessionSummary>,
+  nextCursor: string | null,
+): ChatWorkspaceState => ({
+  ...state,
+  summaries,
+  mainContentInvalidationVersions: updateChatSessionInvalidationVersions(
+    state.mainContentInvalidationVersions,
+    summaries,
+  ),
+  pagination: {
+    hasLoadedFirstPage: true,
+    nextCursor,
+  },
+  catalogRequest: {
+    isLoading: false,
+    errorMessage: null,
+  },
+});
+
+export const replaceChatSessionCatalog = (
+  state: ChatWorkspaceState,
+  page: ChatSessionSummaryPage,
+): ChatWorkspaceState =>
+  createLoadedCatalogState(
+    state,
+    mergeChatSessionSummaries([], page.sessions),
+    page.nextCursor,
+  );
+
+export const appendChatSessionCatalogPage = (
+  state: ChatWorkspaceState,
+  page: ChatSessionSummaryPage,
+): ChatWorkspaceState => {
+  if (!state.pagination.hasLoadedFirstPage) {
+    throw new Error(
+      "Cannot append a chat session catalog page before loading the first page",
+    );
+  }
+
+  return createLoadedCatalogState(
+    state,
+    mergeChatSessionSummaries(state.summaries, page.sessions),
+    page.nextCursor,
+  );
+};
+
+export const failChatSessionCatalogLoad = (
+  state: ChatWorkspaceState,
+  errorMessage: string,
+): ChatWorkspaceState => ({
+  ...state,
+  catalogRequest: {
+    isLoading: false,
+    errorMessage: requireErrorMessage(errorMessage),
+  },
+});
+
+export const getRunningChatSessionCount = (
+  summaries: ReadonlyArray<ChatSessionSummary>,
+): number =>
+  summaries.reduce(
+    (count, summary): number =>
+      summary.status === "running" ? count + 1 : count,
+    0,
+  );


### PR DESCRIPTION
## Summary
- add strict chat workspace target, catalog, pagination, and invalidation state
- add canonical catalog transport and per-tab selection storage
- add six-hour activity policy without UI/controller activation

## Validation
- 23 focused item-04 tests
- npm run lint
- npm run build
- git diff checks and exhaustive short cursor parity check