### PR TITLE
Add transcription server compatibility bridge

### DIFF
--- a/apps/web/src/app/api/chat/transcriptions/route.test.ts
+++ b/apps/web/src/app/api/chat/transcriptions/route.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+
 import { transcribeChatRouteWithDeps } from "@/app/api/chat/transcriptions/route";
-import { ChatSessionNotFoundError } from "@/server/chat/store";
+import type { ChatTranscriptionTelemetryContext } from "@/server/chat/transcriptions";
+import { WorkspaceAccessError } from "@/server/workspaceErrors";
 
 const createHeaders = (): Headers =>
   new Headers({
@@ -15,24 +17,109 @@ const createTranscriptionRequest = (): Request =>
     headers: createHeaders(),
   });
 
-test("transcribeChatRouteWithDeps returns 404 for missing sessions", async (): Promise<void> => {
+test("transcription succeeds without a persisted chat session", async (): Promise<void> => {
+  const telemetryContexts: Array<ChatTranscriptionTelemetryContext> = [];
+  const membershipChecks: Array<Readonly<{
+    userId: string;
+    workspaceId: string;
+  }>> = [];
   const response = await transcribeChatRouteWithDeps(
     createTranscriptionRequest(),
     {
-      getChatSessionSnapshot: async () => {
-        throw new ChatSessionNotFoundError("missing");
+      ensureUserProvisioned: async (userId, workspaceId) => {
+        membershipChecks.push({ userId, workspaceId });
       },
       parseChatTranscriptionUpload: async () => ({
         file: new File(["audio"], "audio.webm", { type: "audio/webm" }),
         source: "web",
-        sessionId: "missing",
+        sessionId: null,
       }),
+      transcribeChatAudioUpload: async (_upload, context) => {
+        telemetryContexts.push(context);
+        return "transcribed text";
+      },
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { text: "transcribed text" });
+  assert.deepEqual(membershipChecks, [{
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  }]);
+  assert.equal(telemetryContexts[0]?.userId, "user-1");
+  assert.equal(telemetryContexts[0]?.workspaceId, "workspace-1");
+  assert.equal(typeof telemetryContexts[0]?.requestId, "string");
+});
+
+test("transcription echoes a legacy client session id without validating it", async (): Promise<void> => {
+  const response = await transcribeChatRouteWithDeps(
+    createTranscriptionRequest(),
+    {
+      ensureUserProvisioned: async () => undefined,
+      parseChatTranscriptionUpload: async () => ({
+        file: new File(["audio"], "audio.webm", { type: "audio/webm" }),
+        source: "web",
+        sessionId: "session-legacy",
+      }),
+      transcribeChatAudioUpload: async () => "legacy transcription",
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    text: "legacy transcription",
+    sessionId: "session-legacy",
+  });
+});
+
+test("transcription still rejects missing workspace authentication", async (): Promise<void> => {
+  const response = await transcribeChatRouteWithDeps(
+    new Request("http://localhost/api/chat/transcriptions", {
+      method: "POST",
+      headers: new Headers({ "x-user-id": "user-1" }),
+    }),
+    {
+      ensureUserProvisioned: async () => {
+        throw new Error("should not validate membership");
+      },
+      parseChatTranscriptionUpload: async () => {
+        throw new Error("should not parse");
+      },
       transcribeChatAudioUpload: async () => {
         throw new Error("should not transcribe");
       },
     },
   );
 
-  assert.equal(response.status, 404);
-  assert.equal(await response.text(), "Chat session not found: missing");
+  assert.equal(response.status, 401);
+});
+
+test("transcription rejects inaccessible workspaces before parsing or provider use", async (): Promise<void> => {
+  let uploadParsed = false;
+  let providerCalled = false;
+  const response = await transcribeChatRouteWithDeps(
+    createTranscriptionRequest(),
+    {
+      ensureUserProvisioned: async (userId, workspaceId) => {
+        throw new WorkspaceAccessError(userId, workspaceId);
+      },
+      parseChatTranscriptionUpload: async () => {
+        uploadParsed = true;
+        return {
+          file: new File(["audio"], "audio.webm", { type: "audio/webm" }),
+          source: "web",
+          sessionId: null,
+        };
+      },
+      transcribeChatAudioUpload: async () => {
+        providerCalled = true;
+        return "must not transcribe";
+      },
+    },
+  );
+
+  assert.equal(response.status, 409);
+  assert.equal(uploadParsed, false);
+  assert.equal(providerCalled, false);
 });

--- a/apps/web/src/app/api/chat/transcriptions/route.ts
+++ b/apps/web/src/app/api/chat/transcriptions/route.ts
@@ -2,28 +2,24 @@ import { randomUUID } from "node:crypto";
 import { handleRoute } from "@/server/api/handleRoute";
 import { ApiRouteError } from "@/server/api/errors";
 import {
-  ChatSessionNotFoundError,
-  getChatSessionSnapshot,
-} from "@/server/chat/store";
-import {
   parseChatTranscriptionUpload,
   transcribeChatAudioUpload,
 } from "@/server/chat/transcriptions";
+import { ensureUserProvisioned } from "@/server/db";
 import { extractUserId, extractWorkspaceId } from "@/server/userId";
 
-type ChatTranscriptionRouteResponse = Readonly<{
-  text: string;
-  sessionId: string;
-}>;
+type ChatTranscriptionRouteResponse =
+  | Readonly<{ text: string }>
+  | Readonly<{ text: string; sessionId: string }>;
 
 type ChatTranscriptionsRouteDependencies = Readonly<{
-  getChatSessionSnapshot: typeof getChatSessionSnapshot;
+  ensureUserProvisioned: typeof ensureUserProvisioned;
   parseChatTranscriptionUpload: typeof parseChatTranscriptionUpload;
   transcribeChatAudioUpload: typeof transcribeChatAudioUpload;
 }>;
 
 const DEFAULT_CHAT_TRANSCRIPTIONS_ROUTE_DEPENDENCIES: ChatTranscriptionsRouteDependencies = {
-  getChatSessionSnapshot,
+  ensureUserProvisioned,
   parseChatTranscriptionUpload,
   transcribeChatAudioUpload,
 };
@@ -52,34 +48,21 @@ export const transcribeChatRouteWithDeps = async (
       assertAuthenticatedChatRequest(request);
       const userId = extractUserId(request);
       const workspaceId = extractWorkspaceId(request);
+      await dependencies.ensureUserProvisioned(userId, workspaceId);
       const upload = await dependencies.parseChatTranscriptionUpload(request);
-      let sessionId: string;
-      try {
-        sessionId = await dependencies.getChatSessionSnapshot(
-          userId,
-          workspaceId,
-          upload.sessionId,
-        ).then((snapshot) => snapshot.sessionId);
-      } catch (error) {
-        if (error instanceof ChatSessionNotFoundError) {
-          throw new ApiRouteError(404, error.message);
-        }
-
-        throw error;
-      }
       const text = await dependencies.transcribeChatAudioUpload(upload, {
         requestId: randomUUID(),
         userId,
-        sessionId,
+        workspaceId,
         source: upload.source,
         fileName: upload.file.name,
         mediaType: upload.file.type.trim().toLowerCase(),
         fileSize: upload.file.size,
       });
-      return Response.json({
-        text,
-        sessionId,
-      } satisfies ChatTranscriptionRouteResponse);
+      const responseBody: ChatTranscriptionRouteResponse = upload.sessionId === null
+        ? { text }
+        : { text, sessionId: upload.sessionId };
+      return Response.json(responseBody);
     },
   );
 

--- a/apps/web/src/server/chat/openai/langfuse.ts
+++ b/apps/web/src/server/chat/openai/langfuse.ts
@@ -20,7 +20,7 @@ type ChatTraceMetadata = Readonly<{
 export type ChatTranscriptionTraceMetadata = Readonly<{
   requestId: string;
   userId: string;
-  sessionId: string;
+  workspaceId: string;
   source: "web";
   fileName: string;
   mediaType: string;
@@ -78,7 +78,7 @@ const buildChatTranscriptionTraceMetadata = (
 ): TelemetryMetadata => ({
   requestId: metadataValue(params.requestId),
   userId: metadataValue(params.userId),
-  sessionId: metadataValue(params.sessionId),
+  workspaceId: metadataValue(params.workspaceId),
   source: metadataValue(params.source),
   fileName: metadataValue(params.fileName),
   mediaType: metadataValue(params.mediaType),
@@ -149,7 +149,7 @@ export const sanitizeChatTranscriptionForTelemetry = (
   params: ChatTranscriptionTraceMetadata,
 ): Readonly<{
   upload: Readonly<{
-    sessionId: string;
+    workspaceId: string;
     source: string;
     fileName: string;
     mediaType: string;
@@ -157,7 +157,7 @@ export const sanitizeChatTranscriptionForTelemetry = (
   }>;
 }> => ({
   upload: {
-    sessionId: params.sessionId,
+    workspaceId: params.workspaceId,
     source: params.source,
     fileName: params.fileName,
     mediaType: params.mediaType,

--- a/apps/web/src/server/chat/transcriptions.test.ts
+++ b/apps/web/src/server/chat/transcriptions.test.ts
@@ -14,20 +14,31 @@ const createTranscriptionRequest = (
     body: formData,
   });
 
-test("parseChatTranscriptionUpload requires a session id", async (): Promise<void> => {
+test("parseChatTranscriptionUpload accepts audio without a session id", async (): Promise<void> => {
   const formData = new FormData();
   formData.append("file", new File(["audio"], "audio.webm", { type: "audio/webm" }));
   formData.append("source", "web");
 
-  await assert.rejects(
-    async (): Promise<void> => {
-      await parseChatTranscriptionUpload(createTranscriptionRequest(formData));
-    },
-    (error: unknown) =>
-      error instanceof ApiRouteError
-      && error.status === 400
-      && error.message === "sessionId is required",
+  const upload = await parseChatTranscriptionUpload(
+    createTranscriptionRequest(formData),
   );
+
+  assert.equal(upload.file.name, "audio.webm");
+  assert.equal(upload.source, "web");
+  assert.equal(upload.sessionId, null);
+});
+
+test("parseChatTranscriptionUpload preserves an optional legacy session id", async (): Promise<void> => {
+  const formData = new FormData();
+  formData.append("file", new File(["audio"], "audio.webm", { type: "audio/webm" }));
+  formData.append("source", "web");
+  formData.append("sessionId", " session-legacy ");
+
+  const upload = await parseChatTranscriptionUpload(
+    createTranscriptionRequest(formData),
+  );
+
+  assert.equal(upload.sessionId, "session-legacy");
 });
 
 test("parseChatTranscriptionUpload rejects audio above the transcription size limit", async (): Promise<void> => {
@@ -41,7 +52,6 @@ test("parseChatTranscriptionUpload rejects audio above the transcription size li
     ),
   );
   formData.append("source", "web");
-  formData.append("sessionId", "session-1");
 
   await assert.rejects(
     async (): Promise<void> => {

--- a/apps/web/src/server/chat/transcriptions.ts
+++ b/apps/web/src/server/chat/transcriptions.ts
@@ -26,7 +26,7 @@ type OpenAITranscriptionClient = Readonly<{
 export type ChatTranscriptionUpload = Readonly<{
   file: File;
   source: ChatTranscriptionSource;
-  sessionId: string;
+  sessionId: string | null;
 }>;
 
 export type ChatTranscriptionTelemetryContext = ChatTranscriptionTraceMetadata;
@@ -121,22 +121,19 @@ export const parseChatTranscriptionUpload = async (request: Request): Promise<Ch
     throw new ApiRouteError(400, "source must be web");
   }
 
+  const sessionValue = formData.get("sessionId");
+  if (sessionValue !== null && typeof sessionValue !== "string") {
+    throw new ApiRouteError(400, "sessionId must be a string when provided");
+  }
+  const sessionId = sessionValue?.trim() ?? null;
+  if (sessionId === "") {
+    throw new ApiRouteError(400, "sessionId must not be empty when provided");
+  }
+
   return {
     file: fileValue,
     source: sourceValue,
-    sessionId: (() => {
-      const sessionValue = formData.get("sessionId");
-      if (typeof sessionValue !== "string") {
-        throw new ApiRouteError(400, "sessionId is required");
-      }
-
-      const normalizedSessionId = sessionValue.trim();
-      if (normalizedSessionId === "") {
-        throw new ApiRouteError(400, "sessionId is required");
-      }
-
-      return normalizedSessionId;
-    })(),
+    sessionId,
   };
 };
 
@@ -206,7 +203,7 @@ const logChatTranscriptionFailure = (
     vendor: "openai",
     requestId: telemetryContext.requestId,
     userId: telemetryContext.userId,
-    sessionId: telemetryContext.sessionId,
+    workspaceId: telemetryContext.workspaceId,
     source: upload.source,
     fileName: upload.file.name,
     fileSize: upload.file.size,

--- a/apps/web/src/server/logger.ts
+++ b/apps/web/src/server/logger.ts
@@ -164,7 +164,7 @@ type ChatTranscriptionEvent = Readonly<{
   vendor: ChatVendor;
   requestId: string;
   userId: string;
-  sessionId: string;
+  workspaceId: string;
   source: "web";
   fileName: string;
   fileSize: number;


### PR DESCRIPTION
## Summary
- accept transcription uploads without a persisted chat session
- authorize workspace access before provider use
- preserve optional legacy session IDs in responses and workspace-scoped telemetry

## Validation
- focused transcription tests: 7/7 passed
- TypeScript `--noEmit`: passed
- `git diff --check`: passed
- independent review: no P0-P4 findings