### PR TITLE
06.3A: Coordinate and fence chat snapshots

### DIFF
--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.test.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.test.ts
@@ -1,10 +1,26 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { ChatSessionSnapshot } from "../bootstrap/chatSessionSnapshot";
 import {
+  beginChatSnapshotRequest,
   buildChatSendRequestBody,
+  ChatSessionSnapshotRequestError,
+  createChatSnapshotRequestCoordinator,
+  createSingleFlightChatSnapshotPoller,
   ensureWritableChatSession,
+  fetchChatSessionSnapshot,
+  isChatSnapshotRequestCurrent,
+  isUnavailableChatSessionSnapshotError,
   prepareChatSendRequest,
+  resolveChatSnapshotFailureDisposition,
+  resolveChatSnapshotRequest,
 } from "./chatSessionControllerRuntime";
+import {
+  createInitialChatSessionControllerState,
+  reduceChatSessionControllerState,
+  selectComposerAction,
+  selectIsAssistantRunActive,
+} from "./chatSessionControllerState";
 
 test("ensureWritableChatSession creates a session for a fresh local chat", async (): Promise<void> => {
   let createCallCount = 0;
@@ -48,6 +64,355 @@ test("buildChatSendRequestBody serializes explicit session ids", (): void => {
 
   assert.equal(parsedRequestBody.sessionId, "session-4");
   assert.deepEqual(parsedRequestBody.content, [{ type: "text", text: "Hello" }]);
+});
+
+test("slow snapshot polling stays single-flight until the active poll settles", async (): Promise<void> => {
+  const slowPoll = Promise.withResolvers<void>();
+  let pollCallCount = 0;
+  const pollSnapshot = createSingleFlightChatSnapshotPoller(
+    (): Promise<void> => {
+      pollCallCount += 1;
+      return pollCallCount === 1
+        ? slowPoll.promise
+        : Promise.resolve();
+    },
+  );
+
+  const activePoll = pollSnapshot();
+  const overlappingPoll = pollSnapshot();
+
+  assert.equal(overlappingPoll, activePoll);
+  assert.equal(pollCallCount, 1);
+
+  slowPoll.resolve();
+  await activePoll;
+
+  const nextPoll = pollSnapshot();
+  assert.notEqual(nextPoll, activePoll);
+  assert.equal(pollCallCount, 2);
+  await nextPoll;
+});
+
+test("a superseded idle snapshot cannot overwrite a newer running snapshot", async (): Promise<void> => {
+  type RaceSnapshot = ChatSessionSnapshot & Readonly<{
+    message: string;
+  }>;
+
+  let coordinator = createChatSnapshotRequestCoordinator();
+  let controllerState = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "bootstrap_succeeded" },
+  );
+  let appliedMessage = "";
+  const olderSnapshot = Promise.withResolvers<RaceSnapshot>();
+  const newerSnapshot = Promise.withResolvers<RaceSnapshot>();
+
+  const olderRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    olderSnapshot.promise,
+  );
+  coordinator = olderRequest.coordinator;
+  const applySnapshot = async (
+    request: typeof olderRequest.request,
+    snapshotPromise: Promise<RaceSnapshot>,
+  ): Promise<void> => {
+    const snapshot = await snapshotPromise;
+    if (!isChatSnapshotRequestCurrent(coordinator, request)) {
+      return;
+    }
+    controllerState = reduceChatSessionControllerState(controllerState, {
+      type: "snapshot_applied",
+      sessionId: request.sessionId,
+      runState: snapshot.runState,
+      updatedAt: snapshot.updatedAt,
+      mainContentInvalidationVersion: snapshot.updatedAt,
+    });
+    appliedMessage = snapshot.message;
+  };
+  const olderApplyPromise = applySnapshot(
+    olderRequest.request,
+    olderSnapshot.promise,
+  );
+
+  const newerRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    newerSnapshot.promise,
+  );
+  coordinator = newerRequest.coordinator;
+  const newerApplyPromise = applySnapshot(
+    newerRequest.request,
+    newerSnapshot.promise,
+  );
+  newerSnapshot.resolve({
+    sessionId: "session-a",
+    runState: "running",
+    updatedAt: 20,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+    message: "newer running transcript",
+  });
+  await newerApplyPromise;
+
+  olderSnapshot.resolve({
+    sessionId: "session-a",
+    runState: "idle",
+    updatedAt: 10,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+    message: "older idle transcript",
+  });
+  await olderApplyPromise;
+
+  assert.equal(controllerState.runState, "running");
+  assert.equal(controllerState.lastSnapshotUpdatedAt, 20);
+  assert.equal(controllerState.isHistoryLoaded, true);
+  assert.equal(selectIsAssistantRunActive(controllerState), true);
+  assert.equal(selectComposerAction(controllerState), "stop");
+  assert.equal(appliedMessage, "newer running transcript");
+});
+
+test("a superseded rejected snapshot follows a newer successful owner", async (): Promise<void> => {
+  const olderSnapshot = Promise.withResolvers<ChatSessionSnapshot>();
+  const newerSnapshot = Promise.withResolvers<ChatSessionSnapshot>();
+  let coordinator = createChatSnapshotRequestCoordinator();
+  const olderRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    olderSnapshot.promise,
+  );
+  coordinator = olderRequest.coordinator;
+  const olderResolution = resolveChatSnapshotRequest(
+    () => coordinator,
+    {
+      request: olderRequest.request,
+      snapshot: olderSnapshot.promise,
+    },
+  );
+  const newerRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    newerSnapshot.promise,
+  );
+  coordinator = newerRequest.coordinator;
+  const newerResolution = resolveChatSnapshotRequest(
+    () => coordinator,
+    {
+      request: newerRequest.request,
+      snapshot: newerSnapshot.promise,
+    },
+  );
+  const authoritativeSnapshot: ChatSessionSnapshot = {
+    sessionId: "session-a",
+    runState: "running",
+    updatedAt: 20,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  };
+
+  newerSnapshot.resolve(authoritativeSnapshot);
+  assert.deepEqual(await newerResolution, {
+    kind: "current",
+    snapshot: authoritativeSnapshot,
+  });
+  olderSnapshot.reject(new Error("stale poll failed"));
+
+  assert.deepEqual(await olderResolution, {
+    kind: "superseded",
+    snapshot: authoritativeSnapshot,
+  });
+});
+
+test("a rejected stale generation waits for a later successful owner", async (): Promise<void> => {
+  const olderSnapshot = Promise.withResolvers<ChatSessionSnapshot>();
+  const newerSnapshot = Promise.withResolvers<ChatSessionSnapshot>();
+  let coordinator = createChatSnapshotRequestCoordinator();
+  const olderRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    olderSnapshot.promise,
+  );
+  coordinator = olderRequest.coordinator;
+  const olderResolution = resolveChatSnapshotRequest(
+    () => coordinator,
+    {
+      request: olderRequest.request,
+      snapshot: olderSnapshot.promise,
+    },
+  );
+  const newerRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    newerSnapshot.promise,
+  );
+  coordinator = newerRequest.coordinator;
+  olderSnapshot.reject(new Error("stale poll failed"));
+  await Promise.resolve();
+  const authoritativeSnapshot: ChatSessionSnapshot = {
+    sessionId: "session-a",
+    runState: "idle",
+    updatedAt: 30,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  };
+  newerSnapshot.resolve(authoritativeSnapshot);
+
+  assert.deepEqual(await olderResolution, {
+    kind: "superseded",
+    snapshot: authoritativeSnapshot,
+  });
+});
+
+test("snapshot transport preserves response status for safe URL recovery", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (): Promise<Response> =>
+      new Response("Chat session not found", { status: 404 }),
+  });
+
+  try {
+    await assert.rejects(
+      async (): Promise<void> => {
+        await fetchChatSessionSnapshot(
+          "missing-session",
+          undefined,
+          (key: string): string => key,
+        );
+      },
+      (error: unknown): boolean =>
+        error instanceof ChatSessionSnapshotRequestError
+        && error.status === 404
+        && error.kind === "not_found"
+        && error.message.includes("Chat session not found"),
+    );
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("snapshot recovery distinguishes missing sessions from valid 409 contracts", (): void => {
+  const missingSessionError = new ChatSessionSnapshotRequestError(
+    404,
+    "Error 404: Chat session not found: session-missing",
+    "not_found",
+  );
+  const activeRunConflict = new ChatSessionSnapshotRequestError(
+    409,
+    "Error 409: Chat session already has an active response",
+    "active_response_conflict",
+  );
+  const workspaceReload = new ChatSessionSnapshotRequestError(
+    409,
+    "Error 409: Active workspace is unavailable. Reload to re-establish workspace context.",
+    "workspace_reload_required",
+  );
+
+  assert.equal(
+    isUnavailableChatSessionSnapshotError(missingSessionError),
+    true,
+  );
+  assert.equal(
+    isUnavailableChatSessionSnapshotError(activeRunConflict),
+    false,
+  );
+  assert.equal(
+    isUnavailableChatSessionSnapshotError(workspaceReload),
+    false,
+  );
+  assert.equal(
+    resolveChatSnapshotFailureDisposition(missingSessionError),
+    "recover_unavailable",
+  );
+  assert.equal(
+    resolveChatSnapshotFailureDisposition(activeRunConflict),
+    "retry_active_response",
+  );
+  assert.equal(
+    resolveChatSnapshotFailureDisposition(workspaceReload),
+    "block_workspace_reload",
+  );
+  assert.match(activeRunConflict.message, /active response/u);
+  assert.match(workspaceReload.message, /Reload/u);
+});
+
+test("snapshot transport classifies each server 409 without treating it as unavailable", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+
+  try {
+    for (const expected of [
+      {
+        body: "Chat session already has an active response",
+        kind: "active_response_conflict",
+        disposition: "retry_active_response",
+      },
+      {
+        body: "Active workspace is unavailable. Reload to re-establish workspace context.",
+        kind: "workspace_reload_required",
+        disposition: "block_workspace_reload",
+      },
+    ] as const) {
+      Object.defineProperty(globalThis, "fetch", {
+        configurable: true,
+        value: async (): Promise<Response> =>
+          new Response(expected.body, { status: 409 }),
+      });
+
+      await assert.rejects(
+        async (): Promise<void> => {
+          await fetchChatSessionSnapshot(
+            "valid-session",
+            undefined,
+            (key: string): string => key,
+          );
+        },
+        (error: unknown): boolean =>
+          error instanceof ChatSessionSnapshotRequestError
+          && error.status === 409
+          && error.kind === expected.kind
+          && !isUnavailableChatSessionSnapshotError(error)
+          && resolveChatSnapshotFailureDisposition(error)
+            === expected.disposition,
+      );
+    }
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
 });
 
 test("prepareChatSendRequest sends prepared JPEGs as image parts", (): void => {

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
@@ -206,6 +206,256 @@ export const buildChatSendRequestBody = (
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   } satisfies ChatSendRequestBody);
 
+export type ChatSessionSnapshotRequestErrorKind =
+  | "not_found"
+  | "active_response_conflict"
+  | "workspace_reload_required"
+  | "other";
+
+export type ChatSnapshotFailureDisposition =
+  | "recover_unavailable"
+  | "retry_active_response"
+  | "block_workspace_reload"
+  | "fail";
+
+export type ChatSnapshotRequestToken = Readonly<{
+  sessionId: string;
+  selectionEpoch: number;
+  generation: number;
+}>;
+
+export type ChatSnapshotRequestResult = Readonly<{
+  request: ChatSnapshotRequestToken;
+  snapshot: Promise<ChatSessionSnapshot>;
+}>;
+
+export type ChatSnapshotRequestResolution =
+  | Readonly<{
+    kind: "current";
+    snapshot: ChatSessionSnapshot;
+  }>
+  | Readonly<{
+    kind: "superseded";
+    snapshot: ChatSessionSnapshot | null;
+  }>;
+
+export type ChatSnapshotRequestCoordinator = Readonly<{
+  lastGeneration: number;
+  latestRequest: ChatSnapshotRequestToken | null;
+  latestResult: ChatSnapshotRequestResult | null;
+}>;
+
+export const createChatSnapshotRequestCoordinator =
+  (): ChatSnapshotRequestCoordinator => ({
+    lastGeneration: 0,
+    latestRequest: null,
+    latestResult: null,
+  });
+
+export const createSingleFlightChatSnapshotPoller = (
+  pollSnapshot: () => Promise<void>,
+): (() => Promise<void>) => {
+  let activePoll: Promise<void> | null = null;
+
+  return (): Promise<void> => {
+    if (activePoll !== null) {
+      return activePoll;
+    }
+
+    activePoll = pollSnapshot().finally((): void => {
+      activePoll = null;
+    });
+    return activePoll;
+  };
+};
+
+export const beginChatSnapshotRequest = (
+  coordinator: ChatSnapshotRequestCoordinator,
+  sessionId: string,
+  selectionEpoch: number,
+  snapshot: Promise<ChatSessionSnapshot>,
+): Readonly<{
+  coordinator: ChatSnapshotRequestCoordinator;
+  request: ChatSnapshotRequestToken;
+}> => {
+  const request: ChatSnapshotRequestToken = {
+    sessionId,
+    selectionEpoch,
+    generation: coordinator.lastGeneration + 1,
+  };
+  return {
+    coordinator: {
+      lastGeneration: request.generation,
+      latestRequest: request,
+      latestResult: {
+        request,
+        snapshot,
+      },
+    },
+    request,
+  };
+};
+
+export const isChatSnapshotRequestCurrent = (
+  coordinator: ChatSnapshotRequestCoordinator,
+  request: ChatSnapshotRequestToken,
+): boolean =>
+  coordinator.latestRequest?.sessionId === request.sessionId
+  && coordinator.latestRequest.selectionEpoch === request.selectionEpoch
+  && coordinator.latestRequest.generation === request.generation;
+
+export const selectSupersedingChatSnapshotRequestResult = (
+  coordinator: ChatSnapshotRequestCoordinator,
+  request: ChatSnapshotRequestToken,
+): ChatSnapshotRequestResult | null =>
+  isChatSnapshotRequestCurrent(coordinator, request)
+    ? null
+    : coordinator.latestResult;
+
+const areChatSnapshotRequestTokensEqual = (
+  first: ChatSnapshotRequestToken,
+  second: ChatSnapshotRequestToken,
+): boolean =>
+  first.sessionId === second.sessionId
+  && first.selectionEpoch === second.selectionEpoch
+  && first.generation === second.generation;
+
+export const resolveChatSnapshotRequest = async (
+  getCoordinator: () => ChatSnapshotRequestCoordinator,
+  initialResult: ChatSnapshotRequestResult,
+): Promise<ChatSnapshotRequestResolution> => {
+  let candidate = initialResult;
+
+  while (true) {
+    let snapshot: ChatSessionSnapshot;
+    try {
+      snapshot = await candidate.snapshot;
+    } catch (error) {
+      const coordinator = getCoordinator();
+      if (isChatSnapshotRequestCurrent(coordinator, candidate.request)) {
+        if (areChatSnapshotRequestTokensEqual(
+          candidate.request,
+          initialResult.request,
+        )) {
+          throw error;
+        }
+        return {
+          kind: "superseded",
+          snapshot: null,
+        };
+      }
+
+      const supersedingResult = selectSupersedingChatSnapshotRequestResult(
+        coordinator,
+        candidate.request,
+      );
+      if (supersedingResult === null) {
+        return {
+          kind: "superseded",
+          snapshot: null,
+        };
+      }
+      candidate = supersedingResult;
+      continue;
+    }
+
+    const coordinator = getCoordinator();
+    if (isChatSnapshotRequestCurrent(coordinator, candidate.request)) {
+      return areChatSnapshotRequestTokensEqual(
+        candidate.request,
+        initialResult.request,
+      )
+        ? {
+          kind: "current",
+          snapshot,
+        }
+        : {
+          kind: "superseded",
+          snapshot,
+        };
+    }
+
+    const supersedingResult = selectSupersedingChatSnapshotRequestResult(
+      coordinator,
+      candidate.request,
+    );
+    if (supersedingResult === null) {
+      return {
+        kind: "superseded",
+        snapshot: null,
+      };
+    }
+    candidate = supersedingResult;
+  }
+};
+
+const ACTIVE_RESPONSE_CONFLICT_MESSAGE =
+  "Chat session already has an active response";
+const WORKSPACE_RELOAD_MESSAGE =
+  "Active workspace is unavailable. Reload to re-establish workspace context.";
+
+const classifyChatSessionSnapshotRequestError = (
+  status: number,
+  rawError: string,
+): ChatSessionSnapshotRequestErrorKind => {
+  if (status === 404) {
+    return "not_found";
+  }
+  if (status !== 409) {
+    return "other";
+  }
+
+  const message = rawError.trim();
+  if (message === ACTIVE_RESPONSE_CONFLICT_MESSAGE) {
+    return "active_response_conflict";
+  }
+  if (message === WORKSPACE_RELOAD_MESSAGE) {
+    return "workspace_reload_required";
+  }
+  return "other";
+};
+
+export class ChatSessionSnapshotRequestError extends Error {
+  public readonly status: number;
+  public readonly kind: ChatSessionSnapshotRequestErrorKind;
+
+  public constructor(
+    status: number,
+    message: string,
+    kind: ChatSessionSnapshotRequestErrorKind,
+  ) {
+    super(message);
+    this.name = "ChatSessionSnapshotRequestError";
+    this.status = status;
+    this.kind = kind;
+  }
+}
+
+export const isUnavailableChatSessionSnapshotError = (
+  error: unknown,
+): error is ChatSessionSnapshotRequestError =>
+  error instanceof ChatSessionSnapshotRequestError
+  && error.kind === "not_found";
+
+export const resolveChatSnapshotFailureDisposition = (
+  error: unknown,
+): ChatSnapshotFailureDisposition => {
+  if (!(error instanceof ChatSessionSnapshotRequestError)) {
+    return "fail";
+  }
+
+  switch (error.kind) {
+    case "not_found":
+      return "recover_unavailable";
+    case "active_response_conflict":
+      return "retry_active_response";
+    case "workspace_reload_required":
+      return "block_workspace_reload";
+    case "other":
+      return "fail";
+  }
+};
+
 export const fetchChatSessionSnapshot = async (
   sessionId: string | undefined,
   signal: AbortSignal | undefined,
@@ -221,7 +471,11 @@ export const fetchChatSessionSnapshot = async (
 
   if (!response.ok) {
     const rawError = await response.text();
-    throw new Error(`Error ${response.status}: ${sanitizeChatRouteErrorText(response.status, rawError, t)}`);
+    throw new ChatSessionSnapshotRequestError(
+      response.status,
+      `Error ${response.status}: ${sanitizeChatRouteErrorText(response.status, rawError, t)}`,
+      classifyChatSessionSnapshotRequestError(response.status, rawError),
+    );
   }
 
   return response.json() as Promise<ChatSessionSnapshot>;

--- a/apps/web/src/ui/chat/session/controller/useChatSessionController.ts
+++ b/apps/web/src/ui/chat/session/controller/useChatSessionController.ts
@@ -31,12 +31,16 @@ import {
   type ChatRunState,
 } from "../../stream/streamRecovery";
 import {
+  beginChatSnapshotRequest,
   buildChatSendRequestBody,
   createChatSession,
+  createChatSnapshotRequestCoordinator,
+  createSingleFlightChatSnapshotPoller,
   deleteChatConversation,
   fetchChatSessionSnapshot,
   postStopChatSession,
   prepareChatSendRequest,
+  resolveChatSnapshotRequest,
   streamChatResponse,
 } from "./chatSessionControllerRuntime";
 import {
@@ -89,6 +93,24 @@ type NormalizedChatSessionSnapshot = Readonly<{
   messages: ChatSessionSnapshot["messages"];
 }>;
 
+type ChatSnapshotLoadResult =
+  | Readonly<{
+    kind: "applied";
+    snapshot: NormalizedChatSessionSnapshot;
+  }>
+  | Readonly<{
+    kind: "superseded";
+    snapshot: NormalizedChatSessionSnapshot | null;
+  }>;
+
+const assertValidChatSessionSnapshot = (
+  snapshot: ChatSessionSnapshot,
+): void => {
+  if (typeof snapshot.sessionId !== "string" || snapshot.sessionId.trim() === "") {
+    throw new Error("Chat session snapshot did not include a sessionId");
+  }
+};
+
 export const useChatSessionController = (
   params: UseChatSessionControllerParams,
 ): ChatSessionController => {
@@ -117,6 +139,9 @@ export const useChatSessionController = (
   const abortRef = useRef<AbortController | null>(null);
   const pendingSessionIdRef = useRef<Promise<string> | null>(null);
   const invalidationSourceIdRef = useRef<string | null>(null);
+  const snapshotRequestCoordinatorRef = useRef(
+    createChatSnapshotRequestCoordinator(),
+  );
 
   const dispatchAction = useCallback((
     action: ChatSessionControllerAction,
@@ -182,8 +207,46 @@ export const useChatSessionController = (
     sessionId: string | undefined,
     signal: AbortSignal | undefined,
     replaceHistory: boolean,
-  ): Promise<NormalizedChatSessionSnapshot> => {
-    const payload = await fetchChatSessionSnapshot(sessionId, signal, t);
+  ): Promise<ChatSnapshotLoadResult> => {
+    const snapshotPromise = fetchChatSessionSnapshot(sessionId, signal, t);
+    const snapshotRequest = beginChatSnapshotRequest(
+      snapshotRequestCoordinatorRef.current,
+      sessionId ?? stateRef.current.currentSessionId ?? workspaceId,
+      0,
+      snapshotPromise,
+    );
+    snapshotRequestCoordinatorRef.current = snapshotRequest.coordinator;
+
+    const resolution = await resolveChatSnapshotRequest(
+      () => snapshotRequestCoordinatorRef.current,
+      {
+        request: snapshotRequest.request,
+        snapshot: snapshotPromise,
+      },
+    );
+    if (resolution.snapshot === null) {
+      return {
+        kind: "superseded",
+        snapshot: null,
+      };
+    }
+
+    const payload = resolution.snapshot;
+    assertValidChatSessionSnapshot(payload);
+    if (resolution.kind === "superseded") {
+      return {
+        kind: "superseded",
+        snapshot: {
+          ...payload,
+          runState: selectEffectiveSnapshotRunState(
+            stateRef.current,
+            payload.sessionId,
+            payload.runState,
+          ),
+        },
+      };
+    }
+
     const currentState = stateRef.current;
     const shouldRefresh = shouldRefreshMainContentForVersion(
       currentState,
@@ -215,10 +278,13 @@ export const useChatSessionController = (
     }
 
     return {
-      ...payload,
-      runState: effectiveRunState,
+      kind: "applied",
+      snapshot: {
+        ...payload,
+        runState: effectiveRunState,
+      },
     };
-  }, [dispatchAction, refreshMainContent, replaceMessages, t]);
+  }, [dispatchAction, refreshMainContent, replaceMessages, t, workspaceId]);
 
   useEffect(() => {
     if (!state.isHistoryLoaded) {
@@ -366,16 +432,27 @@ export const useChatSessionController = (
       return;
     }
 
-    const intervalId = setInterval(() => {
-      void loadChatSnapshot(state.currentSessionId ?? undefined, undefined, true).catch((error) => {
-        if (stateRef.current.isLiveStreamConnected) {
-          return;
-        }
+    const pollSnapshot = createSingleFlightChatSnapshotPoller(
+      async (): Promise<void> => {
+        try {
+          await loadChatSnapshot(
+            state.currentSessionId ?? undefined,
+            undefined,
+            true,
+          );
+        } catch (error) {
+          if (stateRef.current.isLiveStreamConnected) {
+            return;
+          }
 
-        const message = error instanceof Error ? error.message : String(error);
-        markAssistantError(t("chat.errorFailed", { message }));
-        dispatchAction({ type: "run_interrupted" });
-      });
+          const message = error instanceof Error ? error.message : String(error);
+          markAssistantError(t("chat.errorFailed", { message }));
+          dispatchAction({ type: "run_interrupted" });
+        }
+      },
+    );
+    const intervalId = setInterval(() => {
+      void pollSnapshot();
     }, ACTIVE_RUN_SNAPSHOT_POLL_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
@@ -516,8 +593,15 @@ export const useChatSessionController = (
     const sessionIdToReload = streamResult.responseSessionId ?? stateRef.current.currentSessionId ?? undefined;
     if (!streamResult.wasAborted && sessionIdToReload !== undefined) {
       try {
-        const snapshot = await loadChatSnapshot(sessionIdToReload, undefined, true);
-        if (shouldSuppressStreamFailure(snapshot)) {
+        const snapshotResult = await loadChatSnapshot(
+          sessionIdToReload,
+          undefined,
+          true,
+        );
+        if (snapshotResult.snapshot === null) {
+          return;
+        }
+        if (shouldSuppressStreamFailure(snapshotResult.snapshot)) {
           return;
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- classify snapshot request failures and coordinate monotonic request generations
- fence reducer, history, and invalidation adoption to the latest snapshot owner
- keep active-run snapshot polling single-flight so slow polls cannot starve

## Validation
- focused controller tests: 15/15
- direct TypeScript check
- git diff --check
- npm run lint
- npm run build (40/40 pages)