### PR TITLE
Fix chat session stop ownership

### DIFF
--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.test.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.test.ts
@@ -10,6 +10,8 @@ import {
   ensureWritableChatSession,
   fetchChatSessionSnapshot,
   isChatSnapshotRequestCurrent,
+  isChatStopSettlementOwned,
+  isChatStreamControllerOwnedByStop,
   isUnavailableChatSessionSnapshotError,
   prepareChatSendRequest,
   resolveChatSnapshotFailureDisposition,
@@ -268,6 +270,171 @@ test("a rejected stale generation waits for a later successful owner", async ():
     kind: "superseded",
     snapshot: authoritativeSnapshot,
   });
+});
+
+test("a pre-Stop running poll cannot overwrite the idle Stop snapshot", async (): Promise<void> => {
+  type RaceSnapshot = ChatSessionSnapshot & Readonly<{
+    message: string;
+  }>;
+
+  let coordinator = createChatSnapshotRequestCoordinator();
+  let controllerState = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "server_session_created", sessionId: "session-a" },
+  );
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "run_started",
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "stop_requested",
+    sessionId: "session-a",
+  });
+  let appliedMessage = "";
+  const preStopPoll = Promise.withResolvers<RaceSnapshot>();
+  const stopSnapshot = Promise.withResolvers<RaceSnapshot>();
+
+  const preStopRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    preStopPoll.promise,
+  );
+  coordinator = preStopRequest.coordinator;
+  const applySnapshot = async (
+    request: typeof preStopRequest.request,
+    snapshotPromise: Promise<RaceSnapshot>,
+  ): Promise<void> => {
+    const snapshot = await snapshotPromise;
+    if (!isChatSnapshotRequestCurrent(coordinator, request)) {
+      return;
+    }
+    controllerState = reduceChatSessionControllerState(controllerState, {
+      type: "snapshot_applied",
+      sessionId: request.sessionId,
+      runState: snapshot.runState,
+      updatedAt: snapshot.updatedAt,
+      mainContentInvalidationVersion: snapshot.updatedAt,
+    });
+    appliedMessage = snapshot.message;
+  };
+  const preStopApplyPromise = applySnapshot(
+    preStopRequest.request,
+    preStopPoll.promise,
+  );
+
+  const stopRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    stopSnapshot.promise,
+  );
+  coordinator = stopRequest.coordinator;
+  const stopApplyPromise = applySnapshot(
+    stopRequest.request,
+    stopSnapshot.promise,
+  );
+  stopSnapshot.resolve({
+    sessionId: "session-a",
+    runState: "idle",
+    updatedAt: 20,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+    message: "stopped transcript",
+  });
+  await stopApplyPromise;
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "stop_completed",
+    sessionId: "session-a",
+  });
+
+  preStopPoll.resolve({
+    sessionId: "session-a",
+    runState: "running",
+    updatedAt: 10,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+    message: "stale running transcript",
+  });
+  await preStopApplyPromise;
+
+  assert.equal(controllerState.runState, "idle");
+  assert.equal(controllerState.lastSnapshotUpdatedAt, 20);
+  assert.equal(controllerState.isHistoryLoaded, false);
+  assert.equal(selectIsAssistantRunActive(controllerState), false);
+  assert.equal(selectComposerAction(controllerState), "send");
+  assert.equal(appliedMessage, "stopped transcript");
+});
+
+test("a deferred Stop cannot abort, disconnect, or adopt into a newer session stream", async (): Promise<void> => {
+  const stopRequest = Promise.withResolvers<void>();
+  const stoppedRunController = new AbortController();
+  const newerRunController = new AbortController();
+  let currentSessionId = "session-a";
+  let activeStreamController: AbortController | null = stoppedRunController;
+  let disconnectCount = 0;
+  let adoptedSnapshotSessionId: string | null = null;
+
+  const stopSettlement = (async (): Promise<void> => {
+    const stoppedSessionId = currentSessionId;
+    const stopStreamController = activeStreamController;
+    await stopRequest.promise;
+
+    stopStreamController?.abort();
+    if (!isChatStopSettlementOwned(
+      stoppedSessionId,
+      currentSessionId,
+      stopStreamController,
+      activeStreamController,
+    )) {
+      return;
+    }
+
+    activeStreamController = null;
+    disconnectCount += 1;
+    if (isChatStopSettlementOwned(
+      stoppedSessionId,
+      currentSessionId,
+      null,
+      activeStreamController,
+    )) {
+      adoptedSnapshotSessionId = stoppedSessionId;
+    }
+  })();
+
+  currentSessionId = "session-b";
+  activeStreamController = newerRunController;
+  stopRequest.resolve();
+  await stopSettlement;
+
+  assert.equal(stoppedRunController.signal.aborted, true);
+  assert.equal(newerRunController.signal.aborted, false);
+  assert.equal(activeStreamController, newerRunController);
+  assert.equal(disconnectCount, 0);
+  assert.equal(adoptedSnapshotSessionId, null);
+  assert.equal(
+    isChatStopSettlementOwned(
+      "session-a",
+      "session-a",
+      stoppedRunController,
+      stoppedRunController,
+    ),
+    true,
+  );
+  assert.equal(
+    isChatStopSettlementOwned("session-a", "session-a", null, null),
+    true,
+  );
+  assert.equal(
+    isChatStreamControllerOwnedByStop(
+      stoppedRunController,
+      stoppedRunController,
+    ),
+    true,
+  );
+  assert.equal(
+    isChatStreamControllerOwnedByStop(null, newerRunController),
+    false,
+  );
 });
 
 test("snapshot transport preserves response status for safe URL recovery", async (): Promise<void> => {

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
@@ -483,12 +483,18 @@ export const fetchChatSessionSnapshot = async (
 
 export const postStopChatSession = async (
   sessionId: string,
+  t: ChatTranslation,
 ): Promise<void> => {
-  await fetchWithCsrf("/api/chat/stop", {
+  const response = await fetchWithCsrf("/api/chat/stop", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ sessionId }),
   });
+
+  if (!response.ok) {
+    const rawError = await response.text();
+    throw new Error(`Error ${response.status}: ${sanitizeChatRouteErrorText(response.status, rawError, t)}`);
+  }
 };
 
 export const createChatSession = async (
@@ -540,6 +546,29 @@ export const deleteChatConversation = async (
 
   return response.json() as Promise<ChatClearConversationResponse>;
 };
+
+export const isChatStreamControllerOwnedByStop = (
+  stopStreamController: AbortController | null,
+  activeStreamController: AbortController | null,
+): boolean =>
+  stopStreamController !== null
+  && stopStreamController === activeStreamController;
+
+export const isChatStopSettlementOwned = (
+  stoppedSessionId: string,
+  currentSessionId: string | null,
+  stopStreamController: AbortController | null,
+  activeStreamController: AbortController | null,
+): boolean =>
+  stoppedSessionId === currentSessionId
+  && (
+    stopStreamController === null
+      ? activeStreamController === null
+      : isChatStreamControllerOwnedByStop(
+        stopStreamController,
+        activeStreamController,
+      )
+  );
 
 const readStreamChunkWithTimeout = async (
   reader: ReadableStreamDefaultReader<Uint8Array>,

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerState.test.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerState.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   createInitialChatSessionControllerState,
   reduceChatSessionControllerState,
+  selectIsSelectedSessionStopping,
   shouldRefreshMainContentForVersion,
 } from "./chatSessionControllerState";
 
@@ -30,4 +31,101 @@ test("initial historical snapshot does not refresh without an invalidation basel
   const state = createInitialChatSessionControllerState();
 
   assert.equal(shouldRefreshMainContentForVersion(state, "snapshot", 1), false);
+});
+
+test("stop suppression is scoped to the explicitly stopped session", (): void => {
+  const selectedA = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "server_session_created", sessionId: "session-a" },
+  );
+  const stoppingA = reduceChatSessionControllerState(selectedA, {
+    type: "stop_requested",
+    sessionId: "session-a",
+  });
+
+  assert.equal(stoppingA.stoppedSessionIds.has("session-a"), true);
+  assert.equal(stoppingA.stoppedSessionIds.has("session-b"), false);
+});
+
+test("a delayed failed Stop for A does not mutate B stop state", (): void => {
+  const selectedA = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "server_session_created", sessionId: "session-a" },
+  );
+  const stoppingA = reduceChatSessionControllerState(selectedA, {
+    type: "stop_requested",
+    sessionId: "session-a",
+  });
+  const selectedB = reduceChatSessionControllerState(stoppingA, {
+    type: "server_session_created",
+    sessionId: "session-b",
+  });
+  const stoppingB = reduceChatSessionControllerState(selectedB, {
+    type: "stop_requested",
+    sessionId: "session-b",
+  });
+  const failedA = reduceChatSessionControllerState(stoppingB, {
+    type: "stop_failed",
+    sessionId: "session-a",
+  });
+
+  assert.equal(failedA.currentSessionId, "session-b");
+  assert.equal(failedA.stoppedSessionIds.has("session-a"), false);
+  assert.equal(failedA.stoppingSessionIds.has("session-a"), false);
+  assert.equal(failedA.stoppedSessionIds.has("session-b"), true);
+  assert.equal(failedA.stoppingSessionIds.has("session-b"), true);
+  assert.equal(selectIsSelectedSessionStopping(failedA), true);
+});
+
+test("idle snapshot retains a pending Stop marker until explicit completion", (): void => {
+  const selectedA = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "server_session_created", sessionId: "session-a" },
+  );
+  const stoppingA = reduceChatSessionControllerState(selectedA, {
+    type: "stop_requested",
+    sessionId: "session-a",
+  });
+  const idleA = reduceChatSessionControllerState(stoppingA, {
+    type: "snapshot_applied",
+    sessionId: "session-a",
+    runState: "idle",
+    updatedAt: 10,
+    mainContentInvalidationVersion: 0,
+  });
+  const completedA = reduceChatSessionControllerState(idleA, {
+    type: "stop_completed",
+    sessionId: "session-a",
+  });
+  const runningA = reduceChatSessionControllerState(completedA, {
+    type: "snapshot_applied",
+    sessionId: "session-a",
+    runState: "running",
+    updatedAt: 11,
+    mainContentInvalidationVersion: 0,
+  });
+
+  assert.equal(idleA.stoppedSessionIds.has("session-a"), false);
+  assert.equal(idleA.stoppingSessionIds.has("session-a"), true);
+  assert.equal(selectIsSelectedSessionStopping(idleA), true);
+  assert.equal(completedA.stoppingSessionIds.has("session-a"), false);
+  assert.equal(runningA.runState, "running");
+});
+
+test("completed Stop clears suppression for later cross-tab runs", (): void => {
+  const selectedA = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "server_session_created", sessionId: "session-a" },
+  );
+  const stoppingA = reduceChatSessionControllerState(selectedA, {
+    type: "stop_requested",
+    sessionId: "session-a",
+  });
+  const stoppedA = reduceChatSessionControllerState(stoppingA, {
+    type: "stop_completed",
+    sessionId: "session-a",
+  });
+
+  assert.equal(stoppedA.stoppedSessionIds.has("session-a"), false);
+  assert.equal(stoppedA.stoppingSessionIds.has("session-a"), false);
 });

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerState.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerState.ts
@@ -18,10 +18,10 @@ export type ChatSessionControllerState = Readonly<{
   currentSessionId: string | null;
   runState: ChatRunState;
   isLiveStreamConnected: boolean;
-  isStopping: boolean;
   lastSnapshotUpdatedAt: number | null;
   lastMainContentInvalidationVersion: number | null;
   stoppedSessionIds: ReadonlySet<string>;
+  stoppingSessionIds: ReadonlySet<string>;
 }>;
 
 export type ChatSessionControllerAction =
@@ -42,7 +42,8 @@ export type ChatSessionControllerAction =
   | Readonly<{ type: "run_finished" }>
   | Readonly<{ type: "run_interrupted" }>
   | Readonly<{ type: "stop_requested"; sessionId: string }>
-  | Readonly<{ type: "stop_completed" }>
+  | Readonly<{ type: "stop_completed"; sessionId: string }>
+  | Readonly<{ type: "stop_failed"; sessionId: string }>
   | Readonly<{ type: "stopped_session_cleared"; sessionId: string }>
   | Readonly<{ type: "conversation_cleared"; sessionId: string }>
   | Readonly<{ type: "server_session_accepted"; sessionId: string }>
@@ -56,17 +57,17 @@ const mergeInvalidationVersion = (
     ? nextVersion
     : Math.max(previousVersion, nextVersion);
 
-const removeStoppedSession = (
-  stoppedSessionIds: ReadonlySet<string>,
+const removeSessionId = (
+  sessionIds: ReadonlySet<string>,
   sessionId: string,
 ): ReadonlySet<string> => {
-  if (!stoppedSessionIds.has(sessionId)) {
-    return stoppedSessionIds;
+  if (!sessionIds.has(sessionId)) {
+    return sessionIds;
   }
 
-  const nextStoppedSessionIds = new Set(stoppedSessionIds);
-  nextStoppedSessionIds.delete(sessionId);
-  return nextStoppedSessionIds;
+  const nextSessionIds = new Set(sessionIds);
+  nextSessionIds.delete(sessionId);
+  return nextSessionIds;
 };
 
 export const createInitialChatSessionControllerState = (): ChatSessionControllerState => ({
@@ -74,10 +75,10 @@ export const createInitialChatSessionControllerState = (): ChatSessionController
   currentSessionId: null,
   runState: "idle",
   isLiveStreamConnected: false,
-  isStopping: false,
   lastSnapshotUpdatedAt: null,
   lastMainContentInvalidationVersion: null,
   stoppedSessionIds: new Set<string>(),
+  stoppingSessionIds: new Set<string>(),
 });
 
 export const reduceChatSessionControllerState = (
@@ -93,20 +94,25 @@ export const reduceChatSessionControllerState = (
         ...state,
         isHistoryLoaded: true,
       };
-    case "snapshot_applied":
+    case "snapshot_applied": {
+      const stoppedSessionIds = action.runState === "idle"
+        ? removeSessionId(state.stoppedSessionIds, action.sessionId)
+        : state.stoppedSessionIds;
       return {
         ...state,
         currentSessionId: action.sessionId,
         runState: getEffectiveSnapshotRunState(
           action.runState,
-          state.stoppedSessionIds.has(action.sessionId),
+          stoppedSessionIds.has(action.sessionId),
         ),
+        stoppedSessionIds,
         lastSnapshotUpdatedAt: action.updatedAt,
         lastMainContentInvalidationVersion: mergeInvalidationVersion(
           state.lastMainContentInvalidationVersion,
           action.mainContentInvalidationVersion,
         ),
       };
+    }
     case "main_content_invalidation_observed":
       return {
         ...state,
@@ -130,7 +136,12 @@ export const reduceChatSessionControllerState = (
         ...state,
         runState: "running",
         isLiveStreamConnected: false,
-        stoppedSessionIds: new Set<string>(),
+        stoppedSessionIds: state.currentSessionId === null
+          ? state.stoppedSessionIds
+          : removeSessionId(
+            state.stoppedSessionIds,
+            state.currentSessionId,
+          ),
       };
     case "run_finished":
       return {
@@ -147,18 +158,37 @@ export const reduceChatSessionControllerState = (
     case "stop_requested":
       return {
         ...state,
-        isStopping: true,
         stoppedSessionIds: new Set([...state.stoppedSessionIds, action.sessionId]),
+        stoppingSessionIds: new Set([...state.stoppingSessionIds, action.sessionId]),
       };
     case "stop_completed":
       return {
         ...state,
-        isStopping: false,
+        stoppedSessionIds: removeSessionId(
+          state.stoppedSessionIds,
+          action.sessionId,
+        ),
+        stoppingSessionIds: removeSessionId(
+          state.stoppingSessionIds,
+          action.sessionId,
+        ),
+      };
+    case "stop_failed":
+      return {
+        ...state,
+        stoppedSessionIds: removeSessionId(
+          state.stoppedSessionIds,
+          action.sessionId,
+        ),
+        stoppingSessionIds: removeSessionId(
+          state.stoppingSessionIds,
+          action.sessionId,
+        ),
       };
     case "stopped_session_cleared":
       return {
         ...state,
-        stoppedSessionIds: removeStoppedSession(state.stoppedSessionIds, action.sessionId),
+        stoppedSessionIds: removeSessionId(state.stoppedSessionIds, action.sessionId),
       };
     case "conversation_cleared":
       return {
@@ -166,11 +196,13 @@ export const reduceChatSessionControllerState = (
         currentSessionId: action.sessionId,
         runState: "idle",
         isLiveStreamConnected: false,
-        isStopping: false,
         lastMainContentInvalidationVersion: 0,
         stoppedSessionIds: state.currentSessionId === null
           ? state.stoppedSessionIds
-          : removeStoppedSession(state.stoppedSessionIds, state.currentSessionId),
+          : removeSessionId(state.stoppedSessionIds, state.currentSessionId),
+        stoppingSessionIds: state.currentSessionId === null
+          ? state.stoppingSessionIds
+          : removeSessionId(state.stoppingSessionIds, state.currentSessionId),
       };
     case "server_session_accepted":
       return {
@@ -223,6 +255,12 @@ export const selectIsAssistantRunActive = (
   state: ChatSessionControllerState,
 ): boolean =>
   isChatRunActive(state.runState);
+
+export const selectIsSelectedSessionStopping = (
+  state: ChatSessionControllerState,
+): boolean =>
+  state.currentSessionId !== null
+  && state.stoppingSessionIds.has(state.currentSessionId);
 
 export const selectComposerAction = (
   state: ChatSessionControllerState,

--- a/apps/web/src/ui/chat/session/controller/useChatSessionController.ts
+++ b/apps/web/src/ui/chat/session/controller/useChatSessionController.ts
@@ -38,6 +38,7 @@ import {
   createSingleFlightChatSnapshotPoller,
   deleteChatConversation,
   fetchChatSessionSnapshot,
+  isChatStopSettlementOwned,
   postStopChatSession,
   prepareChatSendRequest,
   resolveChatSnapshotRequest,
@@ -49,6 +50,7 @@ import {
   selectComposerAction,
   selectEffectiveSnapshotRunState,
   selectIsAssistantRunActive,
+  selectIsSelectedSessionStopping,
   shouldRefreshMainContentForVersion,
   shouldReplaceHistoryForSnapshot,
   type ChatMainContentInvalidationSource,
@@ -102,6 +104,8 @@ type ChatSnapshotLoadResult =
     kind: "superseded";
     snapshot: NormalizedChatSessionSnapshot | null;
   }>;
+
+const shouldAlwaysAdoptChatSnapshot = (): boolean => true;
 
 const assertValidChatSessionSnapshot = (
   snapshot: ChatSessionSnapshot,
@@ -207,6 +211,7 @@ export const useChatSessionController = (
     sessionId: string | undefined,
     signal: AbortSignal | undefined,
     replaceHistory: boolean,
+    shouldAdoptSnapshot: () => boolean,
   ): Promise<ChatSnapshotLoadResult> => {
     const snapshotPromise = fetchChatSessionSnapshot(sessionId, signal, t);
     const snapshotRequest = beginChatSnapshotRequest(
@@ -244,6 +249,12 @@ export const useChatSessionController = (
             payload.runState,
           ),
         },
+      };
+    }
+    if (!shouldAdoptSnapshot()) {
+      return {
+        kind: "superseded",
+        snapshot: null,
       };
     }
 
@@ -336,7 +347,12 @@ export const useChatSessionController = (
           return;
         }
 
-        await loadChatSnapshot(undefined, abortController.signal, true);
+        await loadChatSnapshot(
+          undefined,
+          abortController.signal,
+          true,
+          shouldAlwaysAdoptChatSnapshot,
+        );
       } catch (error) {
         if (abortController.signal.aborted) {
           return;
@@ -374,7 +390,7 @@ export const useChatSessionController = (
         !currentState.isHistoryLoaded
         || selectIsAssistantRunActive(currentState)
         || currentState.isLiveStreamConnected
-        || currentState.isStopping
+        || selectIsSelectedSessionStopping(currentState)
       ) {
         return;
       }
@@ -420,7 +436,12 @@ export const useChatSessionController = (
         return;
       }
 
-      void loadChatSnapshot(nextLocalState.sessionId, undefined, true).catch(() => undefined);
+      void loadChatSnapshot(
+        nextLocalState.sessionId,
+        undefined,
+        true,
+        shouldAlwaysAdoptChatSnapshot,
+      ).catch(() => undefined);
     };
 
     window.addEventListener("storage", handleStorage);
@@ -439,6 +460,7 @@ export const useChatSessionController = (
             state.currentSessionId ?? undefined,
             undefined,
             true,
+            shouldAlwaysAdoptChatSnapshot,
           );
         } catch (error) {
           if (stateRef.current.isLiveStreamConnected) {
@@ -500,7 +522,7 @@ export const useChatSessionController = (
     sendParams: SendChatMessageParams,
   ): Promise<void> => {
     const currentState = stateRef.current;
-    if (selectIsAssistantRunActive(currentState) || currentState.isLiveStreamConnected || currentState.isStopping) {
+    if (selectIsAssistantRunActive(currentState) || currentState.isLiveStreamConnected || selectIsSelectedSessionStopping(currentState)) {
       return;
     }
 
@@ -597,6 +619,7 @@ export const useChatSessionController = (
           sessionIdToReload,
           undefined,
           true,
+          shouldAlwaysAdoptChatSnapshot,
         );
         if (snapshotResult.snapshot === null) {
           return;
@@ -634,35 +657,55 @@ export const useChatSessionController = (
 
   const stopMessage = useCallback(async (): Promise<void> => {
     const currentState = stateRef.current;
-    if (currentState.currentSessionId === null || !selectIsAssistantRunActive(currentState) || currentState.isStopping) {
+    if (currentState.currentSessionId === null || !selectIsAssistantRunActive(currentState) || selectIsSelectedSessionStopping(currentState)) {
       return;
     }
+    const stoppedSessionId = currentState.currentSessionId;
+    const stopStreamController = abortRef.current;
 
     dispatchAction({
       type: "stop_requested",
-      sessionId: currentState.currentSessionId,
+      sessionId: stoppedSessionId,
     });
 
     try {
-      await postStopChatSession(currentState.currentSessionId);
+      await postStopChatSession(stoppedSessionId, t);
     } catch {
       // The stop request is best-effort, but we still abort the local stream below.
     } finally {
-      if (abortRef.current !== null) {
-        abortRef.current.abort();
+      stopStreamController?.abort();
+      if (isChatStopSettlementOwned(
+        stoppedSessionId,
+        stateRef.current.currentSessionId,
+        stopStreamController,
+        abortRef.current,
+      )) {
         abortRef.current = null;
-      }
-      dispatchAction({ type: "live_stream_disconnected" });
+        dispatchAction({ type: "live_stream_disconnected" });
+        const shouldAdoptStopSnapshot = (): boolean =>
+          isChatStopSettlementOwned(
+            stoppedSessionId,
+            stateRef.current.currentSessionId,
+            null,
+            abortRef.current,
+          );
 
-      try {
-        await loadChatSnapshot(currentState.currentSessionId, undefined, true);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        markAssistantError(t("chat.errorFailed", { message }));
-        dispatchAction({ type: "run_interrupted" });
-      } finally {
-        dispatchAction({ type: "stop_completed" });
+        try {
+          await loadChatSnapshot(
+            stoppedSessionId,
+            undefined,
+            true,
+            shouldAdoptStopSnapshot,
+          );
+        } catch (error) {
+          if (shouldAdoptStopSnapshot()) {
+            const message = error instanceof Error ? error.message : String(error);
+            markAssistantError(t("chat.errorFailed", { message }));
+            dispatchAction({ type: "run_interrupted" });
+          }
+        }
       }
+      dispatchAction({ type: "stop_completed", sessionId: stoppedSessionId });
     }
   }, [dispatchAction, loadChatSnapshot, markAssistantError, t]);
 
@@ -670,7 +713,7 @@ export const useChatSessionController = (
     const currentState = stateRef.current;
     if (currentState.currentSessionId !== null && selectIsAssistantRunActive(currentState)) {
       try {
-        await postStopChatSession(currentState.currentSessionId);
+        await postStopChatSession(currentState.currentSessionId, t);
       } catch {
         // Continue clearing the UI even if stop fails.
       }
@@ -682,8 +725,11 @@ export const useChatSessionController = (
     }
 
     dispatchAction({ type: "live_stream_disconnected" });
-    dispatchAction({ type: "stop_completed" });
     if (currentState.currentSessionId !== null) {
+      dispatchAction({
+        type: "stop_completed",
+        sessionId: currentState.currentSessionId,
+      });
       dispatchAction({
         type: "stopped_session_cleared",
         sessionId: currentState.currentSessionId,
@@ -716,7 +762,7 @@ export const useChatSessionController = (
     isHistoryLoaded: state.isHistoryLoaded,
     isAssistantRunActive,
     isLiveStreamConnected: state.isLiveStreamConnected,
-    isStopping: state.isStopping,
+    isStopping: selectIsSelectedSessionStopping(state),
     currentSessionId: state.currentSessionId,
     composerAction,
     acceptServerSessionId,


### PR DESCRIPTION
## Summary
- scope Stop suppression and stopping state by chat session
- fence delayed Stop settlement and snapshot adoption by session/controller ownership
- validate Stop responses and cover snapshot/Stop ownership races

## Validation
- focused controller tests: 21/21 passed
- direct TypeScript: passed
- npm run lint: passed
- npm run build: passed
- git diff --check: passed