### PR TITLE
Add durable exact chat turn cancellation

### DIFF
--- a/apps/web/src/app/api/chat/stop/route.test.ts
+++ b/apps/web/src/app/api/chat/stop/route.test.ts
@@ -1,7 +1,19 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { stopChatRouteWithDeps } from "@/app/api/chat/stop/route";
-import type { ChatSessionSnapshot } from "@/server/chat/store";
+import {
+  clearActiveChatRunForTests,
+  createActiveChatRunForTests,
+  hasActiveChatSessionRun,
+  markActiveChatRunCancellationPersisted,
+  releaseChatRunStartReservation,
+  reserveChatRunStart,
+  stopActiveChatRun,
+} from "@/server/chat/runtime/runtime";
+import {
+  ChatSessionNotFoundError,
+  type ChatSessionSnapshot,
+} from "@/server/chat/store";
 
 type StopChatRouteDependencies = Parameters<typeof stopChatRouteWithDeps>[1];
 
@@ -14,11 +26,15 @@ const createHeaders = (): Headers =>
 
 const createStopRequest = (
   sessionId: string,
+  turnId: string | null,
 ): Request =>
   new Request("http://localhost/api/chat/stop", {
     method: "POST",
     headers: createHeaders(),
-    body: JSON.stringify({ sessionId }),
+    body: JSON.stringify({
+      sessionId,
+      ...(turnId === null ? {} : { turnId }),
+    }),
   });
 
 const createSnapshot = (
@@ -44,7 +60,7 @@ const createStopDependencies = (
     sessionId,
   ): Promise<ChatSessionSnapshot> => createSnapshot(sessionId ?? "session-1")),
   stopActiveChatRun: overrides.stopActiveChatRun ?? (() => ({ stopped: false })),
-  cancelActiveChatRunByUser: overrides.cancelActiveChatRunByUser ?? (async () => "not_running"),
+  cancelChatTurnByUser: overrides.cancelChatTurnByUser ?? (async () => "cancellation_recorded"),
   markActiveChatRunCancellationPersisted:
     overrides.markActiveChatRunCancellationPersisted ?? (() => undefined),
   hasActiveChatSessionRun: overrides.hasActiveChatSessionRun ?? (() => false),
@@ -53,9 +69,10 @@ const createStopDependencies = (
 
 test("stopChatRouteWithDeps returns public stop state and marks the stopped local run persisted", async (): Promise<void> => {
   let markedRun: ReadonlyArray<string> | null = null;
+  const calls: Array<string> = [];
 
   const response = await stopChatRouteWithDeps(
-    createStopRequest("client-session"),
+    createStopRequest("client-session", null),
     createStopDependencies({
       getChatSessionSnapshot: async (_userId, _workspaceId, sessionId): Promise<ChatSessionSnapshot> => {
         assert.equal(sessionId, "client-session");
@@ -68,17 +85,20 @@ test("stopChatRouteWithDeps returns public stop state and marks the stopped loca
       stopActiveChatRun: (sessionId, activeRunId) => {
         assert.equal(sessionId, "session-1");
         assert.equal(activeRunId, "run-stopped");
+        calls.push("runtime");
         return { stopped: true, activeRunId: "run-stopped" };
       },
-      cancelActiveChatRunByUser: async (userId, workspaceId, sessionId, activeRunId) => {
+      cancelChatTurnByUser: async (userId, workspaceId, sessionId, activeRunId) => {
         assert.equal(userId, "user-1");
         assert.equal(workspaceId, "workspace-1");
         assert.equal(sessionId, "session-1");
         assert.equal(activeRunId, "run-stopped");
-        return "cancelled";
+        calls.push("persisted");
+        return "active_run_cancelled";
       },
       markActiveChatRunCancellationPersisted: (sessionId, activeRunId) => {
         markedRun = [sessionId, activeRunId];
+        calls.push("marked");
       },
       hasActiveChatSessionRun: (sessionId) => {
         assert.equal(sessionId, "session-1");
@@ -95,16 +115,16 @@ test("stopChatRouteWithDeps returns public stop state and marks the stopped loca
     stillRunning: false,
   });
   assert.deepEqual(markedRun, ["session-1", "run-stopped"]);
+  assert.deepEqual(calls, ["persisted", "runtime", "marked"]);
 });
 
 test("stopChatRouteWithDeps reports stillRunning from session-level local state", async (): Promise<void> => {
   let markCalled = false;
 
   const response = await stopChatRouteWithDeps(
-    createStopRequest("session-1"),
+    createStopRequest("session-1", null),
     createStopDependencies({
       stopActiveChatRun: () => ({ stopped: false }),
-      cancelActiveChatRunByUser: async () => "not_running",
       markActiveChatRunCancellationPersisted: () => {
         markCalled = true;
       },
@@ -120,4 +140,316 @@ test("stopChatRouteWithDeps reports stillRunning from session-level local state"
     stillRunning: true,
   });
   assert.equal(markCalled, false);
+});
+
+test("stopChatRouteWithDeps durably cancels an exact turn before stopping its local runtime", async (): Promise<void> => {
+  const turnId = "00000000-0000-4000-8000-000000000101";
+  const calls: Array<string> = [];
+
+  const response = await stopChatRouteWithDeps(
+    createStopRequest("session-1", turnId),
+    createStopDependencies({
+      cancelChatTurnByUser: async (
+        userId,
+        workspaceId,
+        sessionId,
+        requestedTurnId,
+      ) => {
+        assert.equal(userId, "user-1");
+        assert.equal(workspaceId, "workspace-1");
+        assert.equal(sessionId, "session-1");
+        assert.equal(requestedTurnId, turnId);
+        calls.push("persisted");
+        return "active_run_cancelled";
+      },
+      stopActiveChatRun: (sessionId, requestedTurnId) => {
+        assert.equal(sessionId, "session-1");
+        assert.equal(requestedTurnId, turnId);
+        calls.push("runtime");
+        return { stopped: true, activeRunId: turnId };
+      },
+      markActiveChatRunCancellationPersisted: (sessionId, activeRunId) => {
+        assert.equal(sessionId, "session-1");
+        assert.equal(activeRunId, turnId);
+        calls.push("marked");
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(calls, ["persisted", "runtime", "marked"]);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    sessionId: "session-1",
+    turnId,
+    cancellationConfirmed: true,
+    stopped: true,
+    stillRunning: false,
+  });
+});
+
+test("stopChatRouteWithDeps confirms an idempotently recorded exact cancellation", async (): Promise<void> => {
+  const turnId = "00000000-0000-4000-8000-000000000102";
+
+  const response = await stopChatRouteWithDeps(
+    createStopRequest("session-1", turnId),
+    createStopDependencies({
+      cancelChatTurnByUser: async () => "already_cancelled",
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    sessionId: "session-1",
+    turnId,
+    cancellationConfirmed: true,
+    stopped: false,
+    stillRunning: false,
+  });
+});
+
+test("stopChatRouteWithDeps rejects an invalid exact turn ID", async (): Promise<void> => {
+  const response = await stopChatRouteWithDeps(
+    createStopRequest("session-1", "invalid-turn-id"),
+    createStopDependencies({}),
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(await response.text(), "turnId must be a UUID");
+});
+
+test("stopChatRouteWithDeps canonicalizes an exact turn ID before cancellation", async (): Promise<void> => {
+  const uppercaseTurnId = "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA";
+  const canonicalTurnId = uppercaseTurnId.toLowerCase();
+  let cancelledTurnId: string | null = null;
+  let stoppedTurnId: string | null = null;
+
+  const response = await stopChatRouteWithDeps(
+    createStopRequest("session-1", uppercaseTurnId),
+    createStopDependencies({
+      cancelChatTurnByUser: async (
+        _userId,
+        _workspaceId,
+        _sessionId,
+        turnId,
+      ) => {
+        cancelledTurnId = turnId;
+        return "active_run_cancelled";
+      },
+      stopActiveChatRun: (_sessionId, turnId) => {
+        stoppedTurnId = turnId;
+        return { stopped: false };
+      },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(cancelledTurnId, canonicalTurnId);
+  assert.equal(stoppedTurnId, canonicalTurnId);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    sessionId: "session-1",
+    turnId: canonicalTurnId,
+    cancellationConfirmed: true,
+    stopped: true,
+    stillRunning: false,
+  });
+});
+
+test("stopChatRouteWithDeps aborts an authorized exact local run when durable cancellation fails", async (): Promise<void> => {
+  const sessionId = "session-exact-persistence-failure";
+  const turnId = "00000000-0000-4000-8000-000000000103";
+  const persistenceError = new Error("durable cancellation failed");
+  let markedPersisted = false;
+  const logLines: Array<string> = [];
+  const originalLog = console.log;
+  console.log = (message?: unknown): void => {
+    logLines.push(String(message));
+  };
+  createActiveChatRunForTests(sessionId, turnId);
+
+  try {
+    const response = await stopChatRouteWithDeps(
+      createStopRequest(sessionId, turnId),
+      createStopDependencies({
+        getChatSessionSnapshot: async (
+          userId,
+          workspaceId,
+          requestedSessionId,
+        ) => {
+          assert.equal(userId, "user-1");
+          assert.equal(workspaceId, "workspace-1");
+          assert.equal(requestedSessionId, sessionId);
+          return createSnapshot(sessionId, {
+            runState: "running",
+            activeRunId: turnId,
+            activeRunHeartbeatAt: 1_000,
+          });
+        },
+        cancelChatTurnByUser: async () => {
+          assert.equal(hasActiveChatSessionRun(sessionId), true);
+          throw persistenceError;
+        },
+        stopActiveChatRun,
+        markActiveChatRunCancellationPersisted: () => {
+          markedPersisted = true;
+        },
+      }),
+    );
+
+    assert.equal(response.status, 500);
+    assert.equal(await response.text(), "Chat stop failed");
+    assert.equal(hasActiveChatSessionRun(sessionId), false);
+    assert.equal(markedPersisted, false);
+    assert.equal(
+      logLines.some((line) => line.includes(persistenceError.message)),
+      true,
+    );
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+    console.log = originalLog;
+  }
+});
+
+test("stopChatRouteWithDeps releases an already-requested local run after a successful durable retry", async (): Promise<void> => {
+  const sessionId = "session-exact-persistence-retry";
+  const turnId = "00000000-0000-4000-8000-000000000106";
+  const nextTurnId = "00000000-0000-4000-8000-000000000107";
+  let persistenceAttemptCount = 0;
+  let persistedMarkerCount = 0;
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  createActiveChatRunForTests(sessionId, turnId);
+  const dependencies = createStopDependencies({
+    getChatSessionSnapshot: async () => createSnapshot(sessionId, {
+      runState: "running",
+      activeRunId: turnId,
+      activeRunHeartbeatAt: 1_000,
+    }),
+    cancelChatTurnByUser: async () => {
+      persistenceAttemptCount += 1;
+      if (persistenceAttemptCount === 1) {
+        throw new Error("durable cancellation failed");
+      }
+      return "active_run_cancelled";
+    },
+    stopActiveChatRun,
+    markActiveChatRunCancellationPersisted: (
+      requestedSessionId,
+      requestedTurnId,
+    ) => {
+      persistedMarkerCount += 1;
+      markActiveChatRunCancellationPersisted(
+        requestedSessionId,
+        requestedTurnId,
+      );
+    },
+  });
+
+  try {
+    const failedResponse = await stopChatRouteWithDeps(
+      createStopRequest(sessionId, turnId),
+      dependencies,
+    );
+
+    assert.equal(failedResponse.status, 500);
+    assert.equal(persistedMarkerCount, 0);
+    assert.deepEqual(
+      reserveChatRunStart(sessionId, nextTurnId),
+      { kind: "conflict" },
+    );
+
+    const retryResponse = await stopChatRouteWithDeps(
+      createStopRequest(sessionId, turnId),
+      dependencies,
+    );
+
+    assert.equal(retryResponse.status, 200);
+    assert.deepEqual(await retryResponse.json(), {
+      ok: true,
+      sessionId,
+      turnId,
+      cancellationConfirmed: true,
+      stopped: true,
+      stillRunning: false,
+    });
+    assert.equal(persistedMarkerCount, 1);
+
+    const nextReservation = reserveChatRunStart(sessionId, nextTurnId);
+    assert.equal(nextReservation.kind, "reserved");
+    if (nextReservation.kind === "reserved") {
+      releaseChatRunStartReservation(nextReservation.reservation);
+    }
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+    console.log = originalLog;
+  }
+});
+
+test("stopChatRouteWithDeps aborts an authorized legacy local run when durable cancellation fails", async (): Promise<void> => {
+  const sessionId = "session-legacy-persistence-failure";
+  const turnId = "00000000-0000-4000-8000-000000000104";
+  let markedPersisted = false;
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  createActiveChatRunForTests(sessionId, turnId);
+
+  try {
+    const response = await stopChatRouteWithDeps(
+      createStopRequest(sessionId, null),
+      createStopDependencies({
+        getChatSessionSnapshot: async () => createSnapshot(sessionId, {
+          runState: "running",
+          activeRunId: turnId,
+          activeRunHeartbeatAt: 1_000,
+        }),
+        cancelChatTurnByUser: async () => {
+          assert.equal(hasActiveChatSessionRun(sessionId), true);
+          throw new Error("legacy durable cancellation failed");
+        },
+        stopActiveChatRun,
+        markActiveChatRunCancellationPersisted: () => {
+          markedPersisted = true;
+        },
+      }),
+    );
+
+    assert.equal(response.status, 500);
+    assert.equal(await response.text(), "Chat stop failed");
+    assert.equal(hasActiveChatSessionRun(sessionId), false);
+    assert.equal(markedPersisted, false);
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+    console.log = originalLog;
+  }
+});
+
+test("stopChatRouteWithDeps does not abort a local run when exact Stop authorization fails", async (): Promise<void> => {
+  const sessionId = "session-exact-unauthorized";
+  const turnId = "00000000-0000-4000-8000-000000000105";
+  let localStopCalled = false;
+  createActiveChatRunForTests(sessionId, turnId);
+
+  try {
+    const response = await stopChatRouteWithDeps(
+      createStopRequest(sessionId, turnId),
+      createStopDependencies({
+        getChatSessionSnapshot: async () => {
+          throw new ChatSessionNotFoundError(sessionId);
+        },
+        stopActiveChatRun: (requestedSessionId, requestedTurnId) => {
+          localStopCalled = true;
+          return stopActiveChatRun(requestedSessionId, requestedTurnId);
+        },
+      }),
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal(await response.text(), `Chat session not found: ${sessionId}`);
+    assert.equal(localStopCalled, false);
+    assert.equal(hasActiveChatSessionRun(sessionId), true);
+  } finally {
+    clearActiveChatRunForTests(sessionId);
+  }
 });

--- a/apps/web/src/app/api/chat/stop/route.ts
+++ b/apps/web/src/app/api/chat/stop/route.ts
@@ -4,18 +4,27 @@ import {
   hasActiveChatSessionRun,
   markActiveChatRunCancellationPersisted,
   stopActiveChatRun,
+  type StopActiveChatRunResult,
 } from "@/server/chat/runtime/runtime";
 import {
-  cancelActiveChatRunByUser,
+  cancelChatTurnByUser,
   ChatSessionNotFoundError,
   getChatSessionSnapshot,
+  type ChatSessionSnapshot,
+  type UserCancelChatTurnResult,
 } from "@/server/chat/store";
 import { log } from "@/server/logger";
 import { extractUserId, extractWorkspaceId } from "@/server/userId";
+import { z } from "zod";
 
 type StopChatRequestBody = Readonly<{
   sessionId: string;
+  turnId: string | null;
 }>;
+
+const CHAT_TURN_ID_SCHEMA = z.uuid().transform(
+  (turnId): string => turnId.toLowerCase(),
+);
 
 const parseStopChatRequestBody = (body: unknown): StopChatRequestBody => {
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
@@ -26,8 +35,19 @@ const parseStopChatRequestBody = (body: unknown): StopChatRequestBody => {
   if (typeof candidate.sessionId !== "string" || candidate.sessionId.length === 0) {
     throw new ApiRouteError(400, "sessionId must be a non-empty string");
   }
+  let turnId: string | null = null;
+  if (candidate.turnId !== undefined) {
+    const parsedTurnId = CHAT_TURN_ID_SCHEMA.safeParse(candidate.turnId);
+    if (!parsedTurnId.success) {
+      throw new ApiRouteError(400, "turnId must be a UUID");
+    }
+    turnId = parsedTurnId.data;
+  }
 
-  return { sessionId: candidate.sessionId };
+  return {
+    sessionId: candidate.sessionId,
+    turnId,
+  };
 };
 
 const extractChatRequestContext = (request: Request): Readonly<{
@@ -41,19 +61,71 @@ const extractChatRequestContext = (request: Request): Readonly<{
 type StopChatRouteDependencies = Readonly<{
   getChatSessionSnapshot: typeof getChatSessionSnapshot;
   stopActiveChatRun: typeof stopActiveChatRun;
-  cancelActiveChatRunByUser: typeof cancelActiveChatRunByUser;
+  cancelChatTurnByUser: typeof cancelChatTurnByUser;
   markActiveChatRunCancellationPersisted: typeof markActiveChatRunCancellationPersisted;
   hasActiveChatSessionRun: typeof hasActiveChatSessionRun;
   log: typeof log;
 }>;
 
+type AuthorizedChatTurnCancellationResult = Readonly<{
+  persistedCancelResult: UserCancelChatTurnResult;
+  stoppedRuntimeRun: StopActiveChatRunResult;
+}>;
+
 const DEFAULT_STOP_CHAT_ROUTE_DEPENDENCIES: StopChatRouteDependencies = {
   getChatSessionSnapshot,
   stopActiveChatRun,
-  cancelActiveChatRunByUser,
+  cancelChatTurnByUser,
   markActiveChatRunCancellationPersisted,
   hasActiveChatSessionRun,
   log,
+};
+
+const getAuthorizedChatSessionSnapshot = async (
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  dependencies: StopChatRouteDependencies,
+): Promise<ChatSessionSnapshot> => {
+  try {
+    return await dependencies.getChatSessionSnapshot(
+      userId,
+      workspaceId,
+      sessionId,
+    );
+  } catch (error) {
+    if (error instanceof ChatSessionNotFoundError) {
+      throw new ApiRouteError(404, error.message);
+    }
+    throw error;
+  }
+};
+
+const cancelAuthorizedChatTurnAndStopLocal = async (
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  turnId: string,
+  dependencies: StopChatRouteDependencies,
+): Promise<AuthorizedChatTurnCancellationResult> => {
+  let persistedCancelResult: UserCancelChatTurnResult;
+  let stoppedRuntimeRun: StopActiveChatRunResult = { stopped: false };
+  try {
+    persistedCancelResult = await dependencies.cancelChatTurnByUser(
+      userId,
+      workspaceId,
+      sessionId,
+      turnId,
+    );
+  } finally {
+    stoppedRuntimeRun = dependencies.stopActiveChatRun(sessionId, turnId);
+  }
+
+  dependencies.markActiveChatRunCancellationPersisted(sessionId, turnId);
+  return {
+    persistedCancelResult,
+    stoppedRuntimeRun,
+  };
 };
 
 export const stopChatRouteWithDeps = async (
@@ -66,44 +138,78 @@ export const stopChatRouteWithDeps = async (
       const context = extractChatRequestContext(request);
       const body = parseStopChatRequestBody(await request.json());
 
-      let sessionId: string;
-      let expectedActiveRunId: string | null = null;
-      try {
-        const snapshot = await dependencies.getChatSessionSnapshot(
+      if (body.turnId !== null) {
+        const snapshot = await getAuthorizedChatSessionSnapshot(
           context.userId,
           context.workspaceId,
           body.sessionId,
+          dependencies,
         );
-        sessionId = snapshot.sessionId;
-        if (snapshot.runState === "running" && snapshot.activeRunId === null) {
-          throw new Error(`Chat stop failed: running session has no activeRunId, sessionId=${sessionId}`);
+        let cancelResult: AuthorizedChatTurnCancellationResult;
+        try {
+          cancelResult = await cancelAuthorizedChatTurnAndStopLocal(
+            context.userId,
+            context.workspaceId,
+            snapshot.sessionId,
+            body.turnId,
+            dependencies,
+          );
+        } catch (error) {
+          if (error instanceof ChatSessionNotFoundError) {
+            throw new ApiRouteError(404, error.message);
+          }
+          throw error;
         }
-        expectedActiveRunId = snapshot.runState === "running"
-          ? snapshot.activeRunId
-          : null;
-      } catch (error) {
-        if (error instanceof ChatSessionNotFoundError) {
-          throw new ApiRouteError(404, error.message);
-        }
-        throw error;
+
+        const stopped = cancelResult.stoppedRuntimeRun.stopped
+          || cancelResult.persistedCancelResult === "active_run_cancelled";
+        dependencies.log({
+          domain: "chat",
+          action: "run_cancel_requested",
+          vendor: "openai",
+          sessionId: snapshot.sessionId,
+          userId: context.userId,
+          workspaceId: context.workspaceId,
+        });
+        return Response.json({
+          ok: true,
+          sessionId: snapshot.sessionId,
+          turnId: body.turnId,
+          cancellationConfirmed: true,
+          stopped,
+          stillRunning: dependencies.hasActiveChatSessionRun(snapshot.sessionId),
+        });
       }
 
-      const stoppedRuntimeRun = expectedActiveRunId === null
-        ? { stopped: false } as const
-        : dependencies.stopActiveChatRun(sessionId, expectedActiveRunId);
-      const persistedCancelResult = expectedActiveRunId === null
-        ? "not_running"
-        : await dependencies.cancelActiveChatRunByUser(
+      const snapshot = await getAuthorizedChatSessionSnapshot(
+        context.userId,
+        context.workspaceId,
+        body.sessionId,
+        dependencies,
+      );
+      const sessionId = snapshot.sessionId;
+      if (snapshot.runState === "running" && snapshot.activeRunId === null) {
+        throw new Error(`Chat stop failed: running session has no activeRunId, sessionId=${sessionId}`);
+      }
+      const expectedActiveRunId = snapshot.runState === "running"
+        ? snapshot.activeRunId
+        : null;
+
+      let persistedStop = false;
+      let stoppedRuntimeRun: StopActiveChatRunResult = { stopped: false };
+      if (expectedActiveRunId !== null) {
+        const cancelResult = await cancelAuthorizedChatTurnAndStopLocal(
           context.userId,
           context.workspaceId,
           sessionId,
           expectedActiveRunId,
+          dependencies,
         );
-      if (stoppedRuntimeRun.stopped) {
-        dependencies.markActiveChatRunCancellationPersisted(sessionId, stoppedRuntimeRun.activeRunId);
+        persistedStop = cancelResult.persistedCancelResult === "active_run_cancelled";
+        stoppedRuntimeRun = cancelResult.stoppedRuntimeRun;
       }
 
-      const stopped = stoppedRuntimeRun.stopped || persistedCancelResult === "cancelled";
+      const stopped = stoppedRuntimeRun.stopped || persistedStop;
       if (stopped) {
         dependencies.log({
           domain: "chat",

--- a/apps/web/src/lib/chatHistory.ts
+++ b/apps/web/src/lib/chatHistory.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/server/chat/types";
 
 export type StoredMessage = Readonly<{
+  messageId?: string;
   role: "user" | "assistant";
   content: ReadonlyArray<ContentPart>;
   timestamp: number;

--- a/apps/web/src/server/chat/http/freshSessionRoute.test.ts
+++ b/apps/web/src/server/chat/http/freshSessionRoute.test.ts
@@ -56,6 +56,7 @@ const createPreparedRun = (
 
 const createReservation = (): ChatRunStartReservation => ({
   sessionId: "session-1",
+  activeRunId: "run-1",
   reservationId: Symbol("session-1"),
 });
 
@@ -65,7 +66,10 @@ const createDependencies = (
   getLocaleFromRequest: overrides.getLocaleFromRequest
     ?? (() => "en" as SupportedLocale),
   reserveChatRunStart: overrides.reserveChatRunStart
-    ?? (() => createReservation()),
+    ?? (() => ({
+      kind: "reserved",
+      reservation: createReservation(),
+    })),
   releaseChatRunStartReservation: overrides.releaseChatRunStartReservation
     ?? (() => undefined),
   prepareFreshChatRun: overrides.prepareFreshChatRun
@@ -289,7 +293,10 @@ test("POST /api/chat/new returns session then safe error after persisting a runt
           timezone: "Europe/Madrid",
         }),
         createDependencies({
-          reserveChatRunStart: () => reservation,
+          reserveChatRunStart: () => ({
+            kind: "reserved",
+            reservation,
+          }),
           releaseChatRunStartReservation: (released) => {
             releasedReservation = released;
           },

--- a/apps/web/src/server/chat/http/freshSessionRoute.ts
+++ b/apps/web/src/server/chat/http/freshSessionRoute.ts
@@ -20,6 +20,7 @@ import {
   releaseChatRunStartReservation,
   reserveChatRunStart,
   startPersistedChatRun,
+  type ChatRunStartReservation,
 } from "@/server/chat/runtime/runtime";
 import {
   persistAssistantTerminalError,
@@ -211,15 +212,19 @@ export const postFreshChatSessionRouteWithDeps = async (
         preparedRun.sessionId,
       );
       const events = await (async (): Promise<AsyncGenerator<ChatStreamEvent>> => {
-        let reservation: ReturnType<typeof reserveChatRunStart> = null;
+        let reservation: ChatRunStartReservation | null = null;
         let runtimeStarted = false;
         try {
-          reservation = dependencies.reserveChatRunStart(preparedRun.sessionId);
-          if (reservation === null) {
+          const reservationResult = dependencies.reserveChatRunStart(
+            preparedRun.sessionId,
+            preparedRun.activeRunId,
+          );
+          if (reservationResult.kind !== "reserved") {
             throw new Error(
-              `Fresh chat runtime reservation failed after persistence: sessionId=${preparedRun.sessionId}`,
+              `Fresh chat runtime reservation failed after persistence: sessionId=${preparedRun.sessionId}, result=${reservationResult.kind}`,
             );
           }
+          reservation = reservationResult.reservation;
 
           const startedEvents = dependencies.startPersistedChatRun({
             requestId,

--- a/apps/web/src/server/chat/http/request.ts
+++ b/apps/web/src/server/chat/http/request.ts
@@ -2,12 +2,14 @@ import type {
   ChatSessionRunState,
   ChatSessionSnapshot,
 } from "@/server/chat/store";
+import { z } from "zod";
 import { validateChatAttachments } from "@/server/chat/attachments/validation";
 import type { ContentPart } from "@/server/chat/types";
 import { extractUserId, extractWorkspaceId } from "@/server/userId";
 
 export type ChatRequestBody = Readonly<{
   sessionId: string;
+  turnId: string | null;
   content: ReadonlyArray<ContentPart>;
   model: string;
   timezone: string;
@@ -46,9 +48,11 @@ export type ChatRequestDiagnostics = Readonly<{
 export type ChatHistoryResponse = Readonly<{
   sessionId: string;
   runState: ChatSessionRunState;
+  activeTurnId: string | null;
   updatedAt: number;
   mainContentInvalidationVersion: number;
   messages: ReadonlyArray<Readonly<{
+    messageId: string;
     role: "user" | "assistant";
     content: ReadonlyArray<ContentPart>;
     timestamp: number;
@@ -61,6 +65,10 @@ const LEGACY_CHAT_REQUEST_FIELDS = [
   "chatSessionId",
   "codeInterpreterContainerId",
 ] as const;
+
+const CHAT_TURN_ID_SCHEMA = z.uuid().transform(
+  (turnId): string => turnId.toLowerCase(),
+);
 
 const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -97,12 +105,28 @@ const collectChatAttachmentFileNames = (
 const toChatHistoryMessage = (
   message: ChatSessionSnapshot["messages"][number],
 ): ChatHistoryResponse["messages"][number] => ({
+  messageId: message.itemId,
   role: message.role,
   content: message.content,
   timestamp: message.timestamp,
   isError: message.isError,
   isStopped: message.isStopped,
 });
+
+const getActiveTurnId = (
+  snapshot: ChatSessionSnapshot,
+): string | null => {
+  if (snapshot.runState !== "running") {
+    return null;
+  }
+  if (snapshot.activeRunId === null) {
+    throw new Error(
+      `Running chat snapshot has no active run id: sessionId=${snapshot.sessionId}`,
+    );
+  }
+
+  return snapshot.activeRunId;
+};
 
 export const extractChatRequestContext = (request: Request): ChatRequestContext => ({
   userId: extractUserId(request),
@@ -149,8 +173,18 @@ export const parseChatRequestBody = (body: unknown): ChatRequestBody => {
     throw new Error("sessionId must be a non-empty string");
   }
 
+  let turnId: string | null = null;
+  if (body.turnId !== undefined) {
+    const parsedTurnId = CHAT_TURN_ID_SCHEMA.safeParse(body.turnId);
+    if (!parsedTurnId.success) {
+      throw new Error("turnId must be a UUID");
+    }
+    turnId = parsedTurnId.data;
+  }
+
   return {
     sessionId: body.sessionId,
+    turnId,
     ...parsedBody,
   };
 };
@@ -186,6 +220,7 @@ export const toChatHistoryResponse = (
 ): ChatHistoryResponse => ({
   sessionId: snapshot.sessionId,
   runState: snapshot.runState,
+  activeTurnId: getActiveTurnId(snapshot),
   updatedAt: snapshot.updatedAt,
   mainContentInvalidationVersion: snapshot.mainContentInvalidationVersion,
   messages: snapshot.messages.map(toChatHistoryMessage),

--- a/apps/web/src/server/chat/http/routeHandlers.test.ts
+++ b/apps/web/src/server/chat/http/routeHandlers.test.ts
@@ -7,15 +7,25 @@ import {
   getChatRouteWithDeps,
   postChatRouteWithDeps,
 } from "@/server/chat/http/routeHandlers";
+import { stopChatRouteWithDeps } from "@/app/api/chat/stop/route";
 import type { ChatSessionSnapshot, PreparedChatRun } from "@/server/chat/store";
 import {
   ChatSessionConflictError,
   ChatSessionNotFoundError,
+  ChatTurnCancelledError,
 } from "@/server/chat/store";
-import type { ChatRunStartReservation } from "@/server/chat/runtime/runtime";
+import {
+  clearActiveChatRunForTests,
+  createActiveChatRunForTests,
+  markActiveChatRunCancellationPersisted,
+  reserveChatRunStart,
+  stopActiveChatRun,
+  type ChatRunStartReservation,
+} from "@/server/chat/runtime/runtime";
 import type { ChatStreamEvent, ContentPart } from "@/server/chat/types";
 
 const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
+const TURN_ID = "00000000-0000-4000-8000-000000000001";
 const HEIC_BASE64_PREFIX = "AAAAGGZ0eXBoZWljAAAAAA==";
 const HEIC_COMPATIBLE_BRAND_BASE64 = "AAAAFGZ0eXBpc29tAAAAAGhlaWM=";
 const HEIC_UNPADDED_BASE64_PREFIX = HEIC_BASE64_PREFIX.slice(0, -2);
@@ -45,7 +55,7 @@ const createPreparedRun = (
   sessionId: string,
 ): PreparedChatRun => ({
   sessionId,
-  activeRunId: `run-${sessionId}`,
+  activeRunId: TURN_ID,
   assistantItem: {
     itemId: "assistant-1",
     sessionId,
@@ -65,6 +75,7 @@ const createReservation = (
   sessionId: string,
 ): ChatRunStartReservation => ({
   sessionId,
+  activeRunId: TURN_ID,
   reservationId: Symbol(sessionId),
 });
 
@@ -75,7 +86,11 @@ const createChatRequest = (
   new Request(init?.url ?? "http://localhost/api/chat", {
     method: init?.method ?? "POST",
     headers: init?.headers ?? createHeaders(),
-    body: JSON.stringify(body),
+    body: JSON.stringify(
+      typeof body === "object" && body !== null && !Array.isArray(body)
+        ? { turnId: TURN_ID, ...body }
+        : body,
+    ),
   });
 
 const createPostDependencies = (
@@ -83,14 +98,24 @@ const createPostDependencies = (
 ): Parameters<typeof postChatRouteWithDeps>[1] => ({
   getLocaleFromRequest: overrides.getLocaleFromRequest ?? (() => "en" as SupportedLocale),
   resolveSnapshotWithRunRecovery: overrides.resolveSnapshotWithRunRecovery ?? (async () => createSnapshot()),
-  reserveChatRunStart: overrides.reserveChatRunStart ?? ((sessionId) => createReservation(sessionId)),
+  reserveChatRunStart: overrides.reserveChatRunStart ?? ((sessionId) => ({
+    kind: "reserved",
+    reservation: createReservation(sessionId),
+  })),
   releaseChatRunStartReservation: overrides.releaseChatRunStartReservation ?? (() => undefined),
   prepareChatRun: overrides.prepareChatRun ?? (async (
     _userId: string,
     _workspaceId: string,
     sessionId: string | undefined,
     _content: ReadonlyArray<ContentPart>,
-  ) => createPreparedRun(sessionId ?? "session-1")),
+    _turnId: string,
+  ) => ({
+    kind: "started",
+    preparedRun: createPreparedRun(sessionId ?? "session-1"),
+  })),
+  admitChatRunStart: overrides.admitChatRunStart ?? (async () => undefined),
+  requireAcceptedChatTurn:
+    overrides.requireAcceptedChatTurn ?? (async () => undefined),
   startPersistedChatRun: overrides.startPersistedChatRun ?? (() => (async function* (): AsyncGenerator<ChatStreamEvent> {
     yield { type: "done" };
   })()),
@@ -132,6 +157,166 @@ test("postChatRouteWithDeps returns 400 for invalid request bodies", async (): P
   });
 });
 
+test("postChatRouteWithDeps rejects non-UUID turn identities before persistence", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        turnId: "not-a-uuid",
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies(),
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(await response.text(), "turnId must be a UUID");
+  });
+});
+
+test("postChatRouteWithDeps preserves legacy requests without turn identities", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    let reservedTurnId: string | null = null;
+    let preparedTurnId: string | null = null;
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        turnId: undefined,
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies({
+        reserveChatRunStart: (sessionId, turnId) => {
+          reservedTurnId = turnId;
+          return {
+            kind: "reserved",
+            reservation: {
+              sessionId,
+              activeRunId: turnId,
+              reservationId: Symbol(sessionId),
+            },
+          };
+        },
+        prepareChatRun: async (
+          _userId,
+          _workspaceId,
+          sessionId,
+          _content,
+          turnId,
+        ) => {
+          preparedTurnId = turnId;
+          return {
+            kind: "started",
+            preparedRun: {
+              ...createPreparedRun(sessionId ?? "session-1"),
+              activeRunId: turnId,
+            },
+          };
+        },
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.notEqual(reservedTurnId, null);
+    assert.equal(preparedTurnId, reservedTurnId);
+    assert.match(reservedTurnId ?? "", /^[0-9a-f-]{36}$/u);
+  });
+});
+
+test("postChatRouteWithDeps canonicalizes mixed-case turn identities across retries", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    const uppercaseTurnId = "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA";
+    const canonicalTurnId = uppercaseTurnId.toLowerCase();
+    let acceptedTurnId: string | null = null;
+    let runtimeStartCount = 0;
+    const observedTurnIds: Array<string> = [];
+    const dependencies = createPostDependencies({
+      reserveChatRunStart: (sessionId, turnId) => {
+        observedTurnIds.push(turnId);
+        if (acceptedTurnId !== null) {
+          assert.equal(turnId, acceptedTurnId);
+          return { kind: "same_turn_accepted" };
+        }
+        return {
+          kind: "reserved",
+          reservation: {
+            sessionId,
+            activeRunId: turnId,
+            reservationId: Symbol(sessionId),
+          },
+        };
+      },
+      prepareChatRun: async (
+        _userId,
+        _workspaceId,
+        sessionId,
+        _content,
+        turnId,
+      ) => {
+        observedTurnIds.push(turnId);
+        acceptedTurnId = turnId;
+        return {
+          kind: "started",
+          preparedRun: {
+            ...createPreparedRun(sessionId ?? "session-1"),
+            activeRunId: turnId,
+          },
+        };
+      },
+      admitChatRunStart: async (
+        _userId,
+        _workspaceId,
+        _sessionId,
+        turnId,
+      ) => {
+        observedTurnIds.push(turnId);
+      },
+      requireAcceptedChatTurn: async (
+        _userId,
+        _workspaceId,
+        _sessionId,
+        turnId,
+      ) => {
+        observedTurnIds.push(turnId);
+        assert.equal(turnId, acceptedTurnId);
+      },
+      startPersistedChatRun: (params, reservation) => {
+        observedTurnIds.push(params.activeRunId, reservation.activeRunId);
+        runtimeStartCount += 1;
+        return (async function* (): AsyncGenerator<ChatStreamEvent> {
+          yield { type: "done" };
+        })();
+      },
+    });
+    const requestBody = {
+      sessionId: "session-1",
+      content: [{ type: "text" as const, text: "Hello" }],
+      model: CHAT_MODEL_ID,
+      timezone: "Europe/Madrid",
+    };
+
+    const firstResponse = await postChatRouteWithDeps(
+      createChatRequest({ ...requestBody, turnId: uppercaseTurnId }),
+      dependencies,
+    );
+    const retryResponse = await postChatRouteWithDeps(
+      createChatRequest({ ...requestBody, turnId: canonicalTurnId }),
+      dependencies,
+    );
+
+    assert.equal(firstResponse.status, 200);
+    assert.equal(retryResponse.status, 202);
+    assert.equal(acceptedTurnId, canonicalTurnId);
+    assert.equal(runtimeStartCount, 1);
+    assert.deepEqual(
+      observedTurnIds,
+      Array.from({ length: observedTurnIds.length }, () => canonicalTurnId),
+    );
+  });
+});
+
 test("postChatRouteWithDeps rejects unsupported images before reserving or persisting a run", async (): Promise<void> => {
   await withOpenAiApiKey("test-key", async (): Promise<void> => {
     let snapshotCallCount = 0;
@@ -156,11 +341,17 @@ test("postChatRouteWithDeps rejects unsupported images before reserving or persi
         },
         reserveChatRunStart: (sessionId) => {
           reservationCallCount += 1;
-          return createReservation(sessionId);
+          return {
+            kind: "reserved",
+            reservation: createReservation(sessionId),
+          };
         },
         prepareChatRun: async () => {
           prepareCallCount += 1;
-          return createPreparedRun("session-1");
+          return {
+            kind: "started",
+            preparedRun: createPreparedRun("session-1"),
+          };
         },
         startPersistedChatRun: () => {
           modelStartCallCount += 1;
@@ -213,11 +404,17 @@ test("postChatRouteWithDeps rejects generic HEIC signatures before persistence",
           },
           reserveChatRunStart: (sessionId) => {
             reservationCallCount += 1;
-            return createReservation(sessionId);
+            return {
+              kind: "reserved",
+              reservation: createReservation(sessionId),
+            };
           },
           prepareChatRun: async () => {
             prepareCallCount += 1;
-            return createPreparedRun("session-1");
+            return {
+              kind: "started",
+              preparedRun: createPreparedRun("session-1"),
+            };
           },
           startPersistedChatRun: () => {
             modelStartCallCount += 1;
@@ -326,10 +523,13 @@ test("postChatRouteWithDeps returns 409 without preparing DB run when local rese
         timezone: "Europe/Madrid",
       }),
       createPostDependencies({
-        reserveChatRunStart: () => null,
-        prepareChatRun: async (): Promise<PreparedChatRun> => {
+        reserveChatRunStart: () => ({ kind: "conflict" }),
+        prepareChatRun: async () => {
           prepareCalled = true;
-          return createPreparedRun("session-1");
+          return {
+            kind: "started" as const,
+            preparedRun: createPreparedRun("session-1"),
+          };
         },
       }),
     );
@@ -337,6 +537,155 @@ test("postChatRouteWithDeps returns 409 without preparing DB run when local rese
     assert.equal(response.status, 409);
     assert.equal(await response.text(), "Chat session already has an active response");
     assert.equal(prepareCalled, false);
+  });
+});
+
+test("postChatRouteWithDeps reports same-turn pending as retryable acceptance-unknown", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    let prepareCalled = false;
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies({
+        reserveChatRunStart: () => ({ kind: "same_turn_pending" }),
+        prepareChatRun: async () => {
+          prepareCalled = true;
+          return {
+            kind: "started" as const,
+            preparedRun: createPreparedRun("session-1"),
+          };
+        },
+      }),
+    );
+
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get("X-Chat-Request-Acceptance"), "unknown");
+    assert.equal(prepareCalled, false);
+  });
+});
+
+test("postChatRouteWithDeps returns accepted for an already-running matching turn", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    let prepareCalled = false;
+    let acceptedTurnChecked = false;
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies({
+        reserveChatRunStart: () => ({ kind: "same_turn_accepted" }),
+        prepareChatRun: async () => {
+          prepareCalled = true;
+          return {
+            kind: "started" as const,
+            preparedRun: createPreparedRun("session-1"),
+          };
+        },
+        requireAcceptedChatTurn: async (
+          userId,
+          workspaceId,
+          sessionId,
+          turnId,
+        ) => {
+          assert.equal(userId, "user-1");
+          assert.equal(workspaceId, "workspace-1");
+          assert.equal(sessionId, "session-1");
+          assert.equal(turnId, TURN_ID);
+          acceptedTurnChecked = true;
+        },
+      }),
+    );
+
+    assert.equal(response.status, 202);
+    assert.equal(response.headers.get("X-Chat-Request-Acceptance"), "accepted");
+    assert.equal(response.headers.get("X-Chat-Session-Id"), "session-1");
+    assert.equal(prepareCalled, false);
+    assert.equal(acceptedTurnChecked, true);
+  });
+});
+
+test("postChatRouteWithDeps rejects a stopped same-turn retry while its local runtime entry remains", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    createActiveChatRunForTests("session-1", TURN_ID);
+    try {
+      assert.deepEqual(stopActiveChatRun("session-1", TURN_ID), {
+        stopped: true,
+        activeRunId: TURN_ID,
+      });
+      markActiveChatRunCancellationPersisted("session-1", TURN_ID);
+
+      const response = await postChatRouteWithDeps(
+        createChatRequest({
+          sessionId: "session-1",
+          content: [{ type: "text", text: "Hello" }],
+          model: CHAT_MODEL_ID,
+          timezone: "Europe/Madrid",
+        }),
+        createPostDependencies({
+          reserveChatRunStart,
+          requireAcceptedChatTurn: async (
+            _userId,
+            _workspaceId,
+            sessionId,
+            turnId,
+          ) => {
+            throw new ChatTurnCancelledError(sessionId, turnId);
+          },
+        }),
+      );
+
+      assert.equal(response.status, 409);
+      assert.match(await response.text(), /Chat turn was cancelled/u);
+    } finally {
+      clearActiveChatRunForTests("session-1");
+    }
+  });
+});
+
+test("postChatRouteWithDeps suppresses a cross-instance duplicate after atomic persistence", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    const reservation = createReservation("session-1");
+    let releasedReservation: ChatRunStartReservation | null = null;
+    let runtimeStartCount = 0;
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies({
+        reserveChatRunStart: () => ({
+          kind: "reserved",
+          reservation,
+        }),
+        releaseChatRunStartReservation: (released) => {
+          releasedReservation = released;
+        },
+        prepareChatRun: async () => ({
+          kind: "already_accepted",
+          sessionId: "session-1",
+        }),
+        startPersistedChatRun: () => {
+          runtimeStartCount += 1;
+          return (async function* (): AsyncGenerator<ChatStreamEvent> {
+            yield { type: "done" };
+          })();
+        },
+      }),
+    );
+
+    assert.equal(response.status, 202);
+    assert.equal(response.headers.get("X-Chat-Request-Acceptance"), "accepted");
+    assert.equal(releasedReservation, reservation);
+    assert.equal(runtimeStartCount, 0);
   });
 });
 
@@ -352,11 +701,14 @@ test("postChatRouteWithDeps releases the local reservation when DB prepare fails
         timezone: "Europe/Madrid",
       }),
       createPostDependencies({
-        reserveChatRunStart: () => reservation,
+        reserveChatRunStart: () => ({
+          kind: "reserved",
+          reservation,
+        }),
         releaseChatRunStartReservation: (released) => {
           releasedReservation = released;
         },
-        prepareChatRun: async (): Promise<PreparedChatRun> => {
+        prepareChatRun: async () => {
           throw new ChatSessionConflictError("session-1");
         },
       }),
@@ -365,6 +717,225 @@ test("postChatRouteWithDeps releases the local reservation when DB prepare fails
     assert.equal(response.status, 409);
     assert.equal(await response.text(), "Chat session already has an active response");
     assert.equal(releasedReservation, reservation);
+  });
+});
+
+test("postChatRouteWithDeps definitively rejects a tombstoned turn before runtime execution", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    const reservation = createReservation("session-1");
+    let releasedReservation: ChatRunStartReservation | null = null;
+    let runtimeStartCount = 0;
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        content: [{ type: "text", text: "Cancelled request" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies({
+        reserveChatRunStart: () => ({
+          kind: "reserved",
+          reservation,
+        }),
+        releaseChatRunStartReservation: (released) => {
+          releasedReservation = released;
+        },
+        prepareChatRun: async () => {
+          throw new ChatTurnCancelledError("session-1", TURN_ID);
+        },
+        startPersistedChatRun: () => {
+          runtimeStartCount += 1;
+          return (async function* (): AsyncGenerator<ChatStreamEvent> {
+            yield { type: "done" };
+          })();
+        },
+      }),
+    );
+
+    assert.equal(response.status, 409);
+    assert.match(await response.text(), /Chat turn was cancelled/u);
+    assert.equal(releasedReservation, reservation);
+    assert.equal(runtimeStartCount, 0);
+  });
+});
+
+test("postChatRouteWithDeps does not start runtime when remote Stop wins after prepare commits", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    const prepareCommitted = Promise.withResolvers<void>();
+    const releasePreparedRun = Promise.withResolvers<void>();
+    const reservation = createReservation("session-1");
+    let remoteStopCommitted = false;
+    let releasedReservation: ChatRunStartReservation | null = null;
+    let runtimeStartCount = 0;
+    const responsePromise = postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        content: [{ type: "text", text: "Cancelled request" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createPostDependencies({
+        reserveChatRunStart: () => ({
+          kind: "reserved",
+          reservation,
+        }),
+        releaseChatRunStartReservation: (released) => {
+          releasedReservation = released;
+        },
+        prepareChatRun: async () => {
+          prepareCommitted.resolve();
+          await releasePreparedRun.promise;
+          return {
+            kind: "started",
+            preparedRun: createPreparedRun("session-1"),
+          };
+        },
+        admitChatRunStart: async (
+          _userId,
+          _workspaceId,
+          sessionId,
+          turnId,
+        ) => {
+          assert.equal(remoteStopCommitted, true);
+          throw new ChatTurnCancelledError(sessionId, turnId);
+        },
+        startPersistedChatRun: () => {
+          runtimeStartCount += 1;
+          return (async function* (): AsyncGenerator<ChatStreamEvent> {
+            yield { type: "done" };
+          })();
+        },
+      }),
+    );
+
+    await prepareCommitted.promise;
+    remoteStopCommitted = true;
+    releasePreparedRun.resolve();
+    const response = await responsePromise;
+
+    assert.equal(response.status, 409);
+    assert.match(await response.text(), /Chat turn was cancelled/u);
+    assert.equal(releasedReservation, reservation);
+    assert.equal(runtimeStartCount, 0);
+  });
+});
+
+test("legacy Stop durably tombstones a prepared turn before admission and later retry", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    const prepareCommitted = Promise.withResolvers<void>();
+    const releasePreparedRun = Promise.withResolvers<void>();
+    let prepareCallCount = 0;
+    let tombstoned = false;
+    let runtimeStartCount = 0;
+    const postDependencies = createPostDependencies({
+      reserveChatRunStart: (sessionId, turnId) => ({
+        kind: "reserved",
+        reservation: {
+          sessionId,
+          activeRunId: turnId,
+          reservationId: Symbol(sessionId),
+        },
+      }),
+      prepareChatRun: async (
+        _userId,
+        _workspaceId,
+        sessionId,
+        _content,
+        turnId,
+      ) => {
+        prepareCallCount += 1;
+        if (prepareCallCount === 1) {
+          prepareCommitted.resolve();
+          await releasePreparedRun.promise;
+        }
+        if (tombstoned) {
+          throw new ChatTurnCancelledError(sessionId ?? "session-1", turnId);
+        }
+        return {
+          kind: "started",
+          preparedRun: {
+            ...createPreparedRun(sessionId ?? "session-1"),
+            activeRunId: turnId,
+          },
+        };
+      },
+      admitChatRunStart: async (
+        _userId,
+        _workspaceId,
+        sessionId,
+        turnId,
+      ) => {
+        if (tombstoned) {
+          throw new ChatTurnCancelledError(sessionId, turnId);
+        }
+      },
+      startPersistedChatRun: () => {
+        runtimeStartCount += 1;
+        return (async function* (): AsyncGenerator<ChatStreamEvent> {
+          yield { type: "done" };
+        })();
+      },
+    });
+    const requestBody = {
+      sessionId: "session-1",
+      content: [{ type: "text" as const, text: "Hello" }],
+      model: CHAT_MODEL_ID,
+      timezone: "Europe/Madrid",
+    };
+    const firstResponsePromise = postChatRouteWithDeps(
+      createChatRequest(requestBody),
+      postDependencies,
+    );
+
+    await prepareCommitted.promise;
+    const stopResponse = await stopChatRouteWithDeps(
+      new Request("http://localhost/api/chat/stop", {
+        method: "POST",
+        headers: createHeaders(),
+        body: JSON.stringify({ sessionId: "session-1" }),
+      }),
+      {
+        getChatSessionSnapshot: async () => createSnapshot({
+          runState: "running",
+          activeRunId: TURN_ID,
+          activeRunHeartbeatAt: 100,
+        }),
+        cancelChatTurnByUser: async (
+          _userId,
+          _workspaceId,
+          _sessionId,
+          turnId,
+        ) => {
+          assert.equal(turnId, TURN_ID);
+          tombstoned = true;
+          return "active_run_cancelled";
+        },
+        stopActiveChatRun: () => ({ stopped: false }),
+        markActiveChatRunCancellationPersisted: () => undefined,
+        hasActiveChatSessionRun: () => false,
+        log: () => undefined,
+      },
+    );
+    assert.equal(stopResponse.status, 200);
+    assert.deepEqual(await stopResponse.json(), {
+      ok: true,
+      sessionId: "session-1",
+      stopped: true,
+      stillRunning: false,
+    });
+
+    releasePreparedRun.resolve();
+    const firstResponse = await firstResponsePromise;
+    const retryResponse = await postChatRouteWithDeps(
+      createChatRequest(requestBody),
+      postDependencies,
+    );
+
+    assert.equal(firstResponse.status, 409);
+    assert.match(await firstResponse.text(), /Chat turn was cancelled/u);
+    assert.equal(retryResponse.status, 409);
+    assert.match(await retryResponse.text(), /Chat turn was cancelled/u);
+    assert.equal(runtimeStartCount, 0);
   });
 });
 
@@ -384,11 +955,17 @@ test("postChatRouteWithDeps consumes the reservation when runtime starts success
         timezone: "Europe/Madrid",
       }),
       createPostDependencies({
-        reserveChatRunStart: () => reservation,
+        reserveChatRunStart: () => ({
+          kind: "reserved",
+          reservation,
+        }),
         releaseChatRunStartReservation: () => {
           released = true;
         },
-        prepareChatRun: async () => createPreparedRun("session-1"),
+        prepareChatRun: async () => ({
+          kind: "started",
+          preparedRun: createPreparedRun("session-1"),
+        }),
         startPersistedChatRun: (params, startReservation) => {
           startedWith = {
             activeRunId: params.activeRunId,
@@ -403,7 +980,7 @@ test("postChatRouteWithDeps consumes the reservation when runtime starts success
 
     assert.equal(response.status, 200);
     assert.deepEqual(startedWith, {
-      activeRunId: "run-session-1",
+      activeRunId: TURN_ID,
       reservation,
     });
     assert.equal(released, false);
@@ -443,7 +1020,7 @@ test("getChatRouteWithDeps maps missing sessions to 404", async (): Promise<void
   assert.equal(await response.text(), "Chat session not found: missing");
 });
 
-test("getChatRouteWithDeps does not serialize internal active run fields", async (): Promise<void> => {
+test("getChatRouteWithDeps exposes exact active turn identity without internal heartbeat fields", async (): Promise<void> => {
   const publicContent: ReadonlyArray<ContentPart> = [{ type: "text", text: "Hello" }];
   const response = await getChatRouteWithDeps(
     new Request("http://localhost/api/chat?sessionId=session-1", {
@@ -481,9 +1058,11 @@ test("getChatRouteWithDeps does not serialize internal active run fields", async
   assert.deepEqual(body, {
     sessionId: "session-1",
     runState: "running",
+    activeTurnId: "run-1",
     updatedAt: 100,
     mainContentInvalidationVersion: 0,
     messages: [{
+      messageId: "assistant-1",
       role: "assistant",
       content: publicContent,
       timestamp: 123,

--- a/apps/web/src/server/chat/http/routeHandlers.ts
+++ b/apps/web/src/server/chat/http/routeHandlers.ts
@@ -26,13 +26,16 @@ import {
   startPersistedChatRun,
 } from "@/server/chat/runtime/runtime";
 import {
+  admitChatRunStart,
   ChatSessionConflictError,
   ChatSessionNotFoundError,
+  ChatTurnCancelledError,
   type ChatSessionSnapshot,
   createFreshChatSession,
   getChatSessionSnapshot,
   getLatestChatSessionId,
   prepareChatRun,
+  requireAcceptedChatTurn,
 } from "@/server/chat/store";
 import { log } from "@/server/logger";
 import {
@@ -50,6 +53,8 @@ type PostChatRouteDependencies = Readonly<{
   reserveChatRunStart: typeof reserveChatRunStart;
   releaseChatRunStartReservation: typeof releaseChatRunStartReservation;
   prepareChatRun: typeof prepareChatRun;
+  admitChatRunStart: typeof admitChatRunStart;
+  requireAcceptedChatTurn: typeof requireAcceptedChatTurn;
   startPersistedChatRun: typeof startPersistedChatRun;
   isServerDraining: typeof isServerDraining;
   log: typeof log;
@@ -71,6 +76,8 @@ const DEFAULT_POST_CHAT_ROUTE_DEPENDENCIES: PostChatRouteDependencies = {
   reserveChatRunStart,
   releaseChatRunStartReservation,
   prepareChatRun,
+  admitChatRunStart,
+  requireAcceptedChatTurn,
   startPersistedChatRun,
   isServerDraining,
   log,
@@ -83,6 +90,26 @@ const DEFAULT_CHAT_DELETE_ROUTE_DEPENDENCIES: ChatDeleteRouteDependencies = {
 };
 
 export const CHAT_STREAM_DRAINING_ERROR = CHAT_SERVER_DRAINING_MESSAGE;
+export const CHAT_REQUEST_ACCEPTANCE_HEADER = "X-Chat-Request-Acceptance";
+
+const createAcceptedChatTurnResponse = (
+  sessionId: string,
+): Response =>
+  new Response(null, {
+    status: 202,
+    headers: {
+      [CHAT_REQUEST_ACCEPTANCE_HEADER]: "accepted",
+      "X-Chat-Session-Id": sessionId,
+    },
+  });
+
+const createPendingChatTurnResponse = (): Response =>
+  new Response("Chat turn acceptance is still pending", {
+    status: 503,
+    headers: {
+      [CHAT_REQUEST_ACCEPTANCE_HEADER]: "unknown",
+    },
+  });
 
 export const getChatRouteWithDeps = async (
   request: Request,
@@ -139,7 +166,9 @@ export const postChatRouteWithDeps = async (
   if (apiKey === undefined || apiKey === "") {
     const diagnostics = buildChatRequestDiagnostics(requestId, body.model, body.content);
     dependencies.log(createChatErrorLogEvent(diagnostics, "config", `${envKey} environment variable is not set`));
-    return new Response(`${envKey} environment variable is not set`, { status: 500 });
+    return new Response(`${envKey} environment variable is not set`, {
+      status: 500,
+    });
   }
 
   let context: ChatRequestContext;
@@ -167,19 +196,47 @@ export const postChatRouteWithDeps = async (
       context.workspaceId,
       snapshot.sessionId,
     );
+    const turnId = body.turnId ?? crypto.randomUUID();
 
-    const reservation = dependencies.reserveChatRunStart(snapshot.sessionId);
-    if (reservation === null) {
+    const reservationResult = dependencies.reserveChatRunStart(
+      snapshot.sessionId,
+      turnId,
+    );
+    if (reservationResult.kind === "same_turn_pending") {
+      return createPendingChatTurnResponse();
+    }
+    if (reservationResult.kind === "same_turn_accepted") {
+      await dependencies.requireAcceptedChatTurn(
+        context.userId,
+        context.workspaceId,
+        snapshot.sessionId,
+        turnId,
+      );
+      return createAcceptedChatTurnResponse(snapshot.sessionId);
+    }
+    if (reservationResult.kind === "conflict") {
       throw new ChatSessionConflictError(snapshot.sessionId);
     }
+    const reservation = reservationResult.reservation;
 
     let runtimeStarted = false;
     try {
-      const preparedRun = await dependencies.prepareChatRun(
+      const prepareResult = await dependencies.prepareChatRun(
         context.userId,
         context.workspaceId,
         snapshot.sessionId,
         body.content,
+        turnId,
+      );
+      if (prepareResult.kind === "already_accepted") {
+        return createAcceptedChatTurnResponse(prepareResult.sessionId);
+      }
+      const preparedRun = prepareResult.preparedRun;
+      await dependencies.admitChatRunStart(
+        context.userId,
+        context.workspaceId,
+        preparedRun.sessionId,
+        preparedRun.activeRunId,
       );
       const locale = dependencies.getLocaleFromRequest(request);
       const runtimeParams = {
@@ -232,15 +289,16 @@ export const postChatRouteWithDeps = async (
     if (
       error instanceof ChatSessionNotFoundError
       || error instanceof ChatSessionConflictError
+      || error instanceof ChatTurnCancelledError
     ) {
       return new Response(
         error instanceof ChatSessionConflictError
           ? "Chat session already has an active response"
           : error.message,
         {
-          status: error instanceof ChatSessionConflictError
-            ? 409
-            : 404,
+          status: error instanceof ChatSessionNotFoundError
+            ? 404
+            : 409,
         },
       );
     }

--- a/apps/web/src/server/chat/openai/loop.test.ts
+++ b/apps/web/src/server/chat/openai/loop.test.ts
@@ -24,6 +24,7 @@ const createLoopParams = (): StartOpenAILoopParams => ({
   userId: "user-1",
   workspaceId: "workspace-1",
   sessionId: "session-1",
+  turnId: "turn-1",
   locale: "en",
   timezone: "Europe/Madrid",
   localMessages: [],
@@ -223,6 +224,10 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
   const toolOutput = "{\"ok\":true}";
   let modelCallCount = 0;
   const openAIRequests: Array<OpenAIResponsesRequest> = [];
+  let executedToolScope: Readonly<{
+    sessionId: string;
+    turnId: string;
+  }> | null = null;
 
   const completion = await runOpenAILoopWithDeps(
     params,
@@ -256,19 +261,29 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
           toolStates: createToolCallStateMap(),
         };
       },
-      runOneToolCall: async (): Promise<Readonly<{
+      runOneToolCall: async (toolParams): Promise<Readonly<{
         output: string;
         isMutating: boolean;
         succeeded: boolean;
-      }>> => ({
-        output: toolOutput,
-        isMutating: false,
-        succeeded: true,
-      }),
+      }>> => {
+        executedToolScope = {
+          sessionId: toolParams.sessionId,
+          turnId: toolParams.turnId,
+        };
+        return {
+          output: toolOutput,
+          isMutating: false,
+          succeeded: true,
+        };
+      },
     }),
   );
 
   assert.equal(modelCallCount, 2);
+  assert.deepEqual(executedToolScope, {
+    sessionId: params.sessionId,
+    turnId: params.turnId,
+  });
   assert.deepEqual(
     openAIRequests.map((request) => request.safety_identifier),
     [

--- a/apps/web/src/server/chat/openai/loop.ts
+++ b/apps/web/src/server/chat/openai/loop.ts
@@ -102,6 +102,7 @@ export type StartOpenAILoopParams = Readonly<{
   userId: string;
   workspaceId: string;
   sessionId: string;
+  turnId: string;
   locale: SupportedLocale;
   timezone: string;
   localMessages: ReadonlyArray<ServerChatMessage>;
@@ -413,6 +414,8 @@ const runLoopWithDeps = async (
         item: functionCall,
         userId: params.userId,
         workspaceId: params.workspaceId,
+        sessionId: params.sessionId,
+        turnId: params.turnId,
         rootObservation: params.rootObservation,
       });
       const update = applyToolCallOutput(

--- a/apps/web/src/server/chat/openai/tooling/toolExecutor.ts
+++ b/apps/web/src/server/chat/openai/tooling/toolExecutor.ts
@@ -24,6 +24,8 @@ export const runOneToolCall = async (
     item: OpenAI.Responses.ResponseFunctionToolCall;
     userId: string;
     workspaceId: string;
+    sessionId: string;
+    turnId: string;
     rootObservation: LangfuseObservation | null;
   }>,
 ): Promise<ExecutedChatToolCall> => {
@@ -51,6 +53,8 @@ export const runOneToolCall = async (
       {
         userId: params.userId,
         workspaceId: params.workspaceId,
+        sessionId: params.sessionId,
+        turnId: params.turnId,
       },
     );
     toolObservation?.updateOtelSpanAttributes({

--- a/apps/web/src/server/chat/openai/tooling/tools.test.ts
+++ b/apps/web/src/server/chat/openai/tooling/tools.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  executeChatToolCallWithDependencies,
+  type OpenAIToolContext,
+} from "./tools";
+
+test("query_database forwards the exact session and turn scope to SQL execution", async (): Promise<void> => {
+  const context: OpenAIToolContext = {
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    sessionId: "session-1",
+    turnId: "turn-1",
+  };
+  let receivedContext: OpenAIToolContext | null = null;
+
+  const result = await executeChatToolCallWithDependencies(
+    "query_database",
+    JSON.stringify({ sql: "SELECT account_id FROM accounts" }),
+    context,
+    {
+      execQuery: async (_sql, executionContext) => {
+        receivedContext = executionContext;
+        return {
+          json: JSON.stringify({ statements: [] }),
+        };
+      },
+    },
+  );
+
+  assert.equal(result.succeeded, true);
+  assert.equal(result.isMutating, false);
+  assert.deepEqual(receivedContext, context);
+});

--- a/apps/web/src/server/chat/openai/tooling/tools.ts
+++ b/apps/web/src/server/chat/openai/tooling/tools.ts
@@ -6,7 +6,17 @@ import { TOOL_DESCRIPTION, execQuery } from "@/server/chat/shared";
 export type OpenAIToolContext = Readonly<{
   userId: string;
   workspaceId: string;
+  sessionId: string;
+  turnId: string;
 }>;
+
+type ChatToolDependencies = Readonly<{
+  execQuery: typeof execQuery;
+}>;
+
+const DEFAULT_CHAT_TOOL_DEPENDENCIES: ChatToolDependencies = {
+  execQuery,
+};
 
 type ToolSuccessPayload = Readonly<Record<string, unknown>>;
 
@@ -138,10 +148,11 @@ export const OPENAI_CHAT_TOOLS: ReadonlyArray<OpenAI.Responses.FunctionTool> = [
   },
 }];
 
-export const executeChatToolCall = async (
+export const executeChatToolCallWithDependencies = async (
   toolName: string,
   rawArguments: string,
   context: OpenAIToolContext,
+  dependencies: ChatToolDependencies,
 ): Promise<ExecutedChatToolCall> => {
   /**
    * This function is the canonical source of tool completion metadata consumed
@@ -158,7 +169,7 @@ export const executeChatToolCall = async (
 
   try {
     const parsed = queryDatabaseInputSchema.parse(JSON.parse(rawArguments));
-    const result = await execQuery(parsed.sql, context.userId, context.workspaceId);
+    const result = await dependencies.execQuery(parsed.sql, context);
     return {
       output: createToolSuccessResult("query_database", {
         sql: parsed.sql,
@@ -179,3 +190,15 @@ export const executeChatToolCall = async (
     };
   }
 };
+
+export const executeChatToolCall = async (
+  toolName: string,
+  rawArguments: string,
+  context: OpenAIToolContext,
+): Promise<ExecutedChatToolCall> =>
+  executeChatToolCallWithDependencies(
+    toolName,
+    rawArguments,
+    context,
+    DEFAULT_CHAT_TOOL_DEPENDENCIES,
+  );

--- a/apps/web/src/server/chat/runtime/runtime.test.ts
+++ b/apps/web/src/server/chat/runtime/runtime.test.ts
@@ -69,13 +69,16 @@ const resolvesWithin = async (
 
 const requireReservation = (
   sessionId: string,
+  activeRunId: string,
 ): ChatRunStartReservation => {
-  const reservation = reserveChatRunStart(sessionId);
-  if (reservation === null) {
-    throw new Error(`Expected chat run start reservation for sessionId=${sessionId}`);
+  const result = reserveChatRunStart(sessionId, activeRunId);
+  if (result.kind !== "reserved") {
+    throw new Error(
+      `Expected chat run start reservation for sessionId=${sessionId}, result=${result.kind}`,
+    );
   }
 
-  return reservation;
+  return result.reservation;
 };
 
 const createRunParams = (
@@ -162,8 +165,9 @@ const createRuntimeDependencies = (
     workspaceId,
     sessionId,
     activeRunId,
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     recorded.heartbeatPayloads.push({ userId, workspaceId, sessionId, activeRunId });
+    return true;
   }),
   updateAssistantMessageItem: overrides.updateAssistantMessageItem ?? (async (
     _userId,
@@ -215,11 +219,13 @@ test("runPersistedChatSessionWithDeps persists stopped state for user aborts wit
       createRuntimeDependencies(
         {
           runOpenAILoop: async (
-            _loopParams,
+            loopParams,
             onEvent,
           ): Promise<Readonly<{
             openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
           }>> => {
+            assert.equal(loopParams.sessionId, params.sessionId);
+            assert.equal(loopParams.turnId, params.activeRunId);
             await onEvent(createDeltaEvent("Partial answer"));
             assert.deepEqual(stopActiveChatRun(sessionId, params.activeRunId), {
               stopped: true,
@@ -316,7 +322,7 @@ test("startPersistedChatRunWithDeps persists and streams recovery for poisoned H
   try {
     const events = startPersistedChatRunWithDeps(
       params,
-      requireReservation(sessionId),
+      requireReservation(sessionId, params.activeRunId),
       createRuntimeDependencies(
         {
           runOpenAILoop: async (loopParams): Promise<Readonly<{
@@ -479,12 +485,18 @@ test("reserveChatRunStart rejects active and requested local runs before DB prep
   createActiveChatRunForTests(sessionId, activeRunId);
 
   try {
-    assert.equal(reserveChatRunStart(sessionId), null);
+    assert.deepEqual(
+      reserveChatRunStart(sessionId, "run-other"),
+      { kind: "conflict" },
+    );
     assert.deepEqual(stopActiveChatRun(sessionId, activeRunId), {
       stopped: true,
       activeRunId,
     });
-    assert.equal(reserveChatRunStart(sessionId), null);
+    assert.deepEqual(
+      reserveChatRunStart(sessionId, "run-other"),
+      { kind: "conflict" },
+    );
   } finally {
     clearActiveChatRunForTests(sessionId);
   }
@@ -492,12 +504,50 @@ test("reserveChatRunStart rejects active and requested local runs before DB prep
 
 test("reserveChatRunStart can be released before runtime start", (): void => {
   const sessionId = "session-reserve-release";
-  const reservation = requireReservation(sessionId);
+  const activeRunId = `run-${sessionId}`;
+  const reservation = requireReservation(sessionId, activeRunId);
 
   releaseChatRunStartReservation(reservation);
 
-  const secondReservation = requireReservation(sessionId);
+  const secondReservation = requireReservation(sessionId, activeRunId);
   releaseChatRunStartReservation(secondReservation);
+});
+
+test("reserveChatRunStart correlates same-turn retries without admitting duplicate runs", (): void => {
+  const pendingSessionId = "session-same-turn-pending";
+  const pendingActiveRunId = `run-${pendingSessionId}`;
+  const pendingReservation = requireReservation(
+    pendingSessionId,
+    pendingActiveRunId,
+  );
+  try {
+    assert.deepEqual(
+      reserveChatRunStart(pendingSessionId, pendingReservation.activeRunId),
+      { kind: "same_turn_pending" },
+    );
+    assert.deepEqual(
+      reserveChatRunStart(pendingSessionId, "run-other"),
+      { kind: "conflict" },
+    );
+  } finally {
+    releaseChatRunStartReservation(pendingReservation);
+  }
+
+  const activeSessionId = "session-same-turn-active";
+  const activeRunId = "run-active";
+  createActiveChatRunForTests(activeSessionId, activeRunId);
+  try {
+    assert.deepEqual(
+      reserveChatRunStart(activeSessionId, activeRunId),
+      { kind: "same_turn_accepted" },
+    );
+    assert.deepEqual(
+      reserveChatRunStart(activeSessionId, "run-other"),
+      { kind: "conflict" },
+    );
+  } finally {
+    clearActiveChatRunForTests(activeSessionId);
+  }
 });
 
 test("cancelling the session-prefixed SSE stream unsubscribes a pending read without aborting the backend run", async (): Promise<void> => {
@@ -515,7 +565,7 @@ test("cancelling the session-prefixed SSE stream unsubscribes a pending read wit
   };
   const runtimeEvents = startPersistedChatRunWithDeps(
     params,
-    requireReservation(sessionId),
+    requireReservation(sessionId, params.activeRunId),
     createRuntimeDependencies(
       {
         runOpenAILoop: async (): Promise<Readonly<{
@@ -687,7 +737,10 @@ test("startPersistedChatRunWithDeps replaces persisted local stop state without 
     });
     markActiveChatRunCancellationPersisted(sessionId, oldParams.activeRunId);
 
-    const newReservation = requireReservation(sessionId);
+    const newReservation = requireReservation(
+      sessionId,
+      newParams.activeRunId,
+    );
     const newEvents = startPersistedChatRunWithDeps(
       newParams,
       newReservation,
@@ -782,7 +835,10 @@ test("late done from a replaced run does not close the newer stream", async (): 
     });
     markActiveChatRunCancellationPersisted(sessionId, oldParams.activeRunId);
 
-    const newReservation = requireReservation(sessionId);
+    const newReservation = requireReservation(
+      sessionId,
+      newParams.activeRunId,
+    );
     const newEvents = startPersistedChatRunWithDeps(
       newParams,
       newReservation,
@@ -872,6 +928,111 @@ test("runPersistedChatSessionWithDeps passes the same active run id to heartbeat
   assert.equal((recorded.completedPayload as { sessionId: string }).sessionId, params.sessionId);
   assert.equal(recorded.cancelledPayload, null);
   assert.equal(recorded.terminalErrorPayload, null);
+});
+
+test("runPersistedChatSessionWithDeps does not enter OpenAI when startup admission is lost", async (): Promise<void> => {
+  const params = createRunParams("session-startup-admission-lost");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  let openAILoopCallCount = 0;
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          touchChatSessionHeartbeat: async (): Promise<boolean> => false,
+          runOpenAILoop: async (): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            openAILoopCallCount += 1;
+            return { openaiItems: [] };
+          },
+        },
+        recorded,
+      ),
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.equal(openAILoopCallCount, 0);
+  assert.equal(recorded.completedPayload, null);
+  assert.equal(recorded.cancelledPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+});
+
+test("runPersistedChatSessionWithDeps logs startup store errors without terminalizing the accepted run", async (): Promise<void> => {
+  const params = createRunParams("session-startup-store-error");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const storeError = new Error("heartbeat store unavailable");
+  const logLines: Array<string> = [];
+  let openAILoopCallCount = 0;
+  const originalLog = console.log;
+  console.log = (message?: unknown): void => {
+    logLines.push(String(message));
+  };
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          touchChatSessionHeartbeat: async (): Promise<boolean> => {
+            throw storeError;
+          },
+          runOpenAILoop: async (): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            openAILoopCallCount += 1;
+            return { openaiItems: [] };
+          },
+        },
+        recorded,
+      ),
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.equal(openAILoopCallCount, 0);
+  assert.equal(recorded.completedPayload, null);
+  assert.equal(recorded.cancelledPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(logLines.length, 1);
+  assert.deepEqual(JSON.parse(logLines[0]), {
+    domain: "chat",
+    action: "error",
+    vendor: "openai",
+    stage: "stream",
+    error: storeError.message,
+    requestId: params.requestId,
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    sessionId: params.sessionId,
+    model: params.diagnostics.model,
+    messageCount: params.diagnostics.messageCount,
+    hasAttachments: params.diagnostics.hasAttachments,
+    attachmentFileNames: params.diagnostics.attachmentFileNames,
+    errorClass: "Error",
+  });
 });
 
 test("runPersistedChatSessionWithDeps skips terminal error persistence when completion lost the active-run race", async (): Promise<void> => {

--- a/apps/web/src/server/chat/runtime/runtime.ts
+++ b/apps/web/src/server/chat/runtime/runtime.ts
@@ -88,8 +88,18 @@ export type StopActiveChatRunResult =
 
 export type ChatRunStartReservation = Readonly<{
   sessionId: string;
+  activeRunId: string;
   reservationId: symbol;
 }>;
+
+export type ChatRunStartReservationResult =
+  | Readonly<{
+    kind: "reserved";
+    reservation: ChatRunStartReservation;
+  }>
+  | Readonly<{ kind: "same_turn_pending" }>
+  | Readonly<{ kind: "same_turn_accepted" }>
+  | Readonly<{ kind: "conflict" }>;
 
 export type ChatRuntimeDependencies = Readonly<{
   runOpenAILoop: typeof runOpenAILoop;
@@ -105,7 +115,13 @@ export type ChatRuntimeDependencies = Readonly<{
 }>;
 
 const activeChatRuns = new Map<string, ActiveChatRun>();
-const chatRunStartReservations = new Map<string, symbol>();
+const chatRunStartReservations = new Map<
+  string,
+  Readonly<{
+    activeRunId: string;
+    reservationId: symbol;
+  }>
+>();
 
 const DEFAULT_CHAT_RUNTIME_DEPENDENCIES: ChatRuntimeDependencies = {
   runOpenAILoop,
@@ -264,8 +280,11 @@ const getCurrentActiveChatRun = (
 const consumeChatRunStartReservation = (
   reservation: ChatRunStartReservation,
 ): void => {
-  const currentReservationId = chatRunStartReservations.get(reservation.sessionId);
-  if (currentReservationId !== reservation.reservationId) {
+  const currentReservation = chatRunStartReservations.get(reservation.sessionId);
+  if (
+    currentReservation?.reservationId !== reservation.reservationId
+    || currentReservation.activeRunId !== reservation.activeRunId
+  ) {
     throw new Error(`Chat run start reservation is not active: sessionId=${reservation.sessionId}`);
   }
 
@@ -567,12 +586,25 @@ export const runPersistedChatSessionWithDeps = async (
 
   try {
     await dependencies.beginTaskProtection();
-    await dependencies.touchChatSessionHeartbeat(
-      params.userId,
-      params.workspaceId,
-      params.sessionId,
-      params.activeRunId,
-    );
+    let heartbeatTouched: boolean;
+    try {
+      heartbeatTouched = await dependencies.touchChatSessionHeartbeat(
+        params.userId,
+        params.workspaceId,
+        params.sessionId,
+        params.activeRunId,
+      );
+    } catch (error) {
+      logChatRunError(params.diagnostics, "stream", error);
+      return;
+    }
+    if (!heartbeatTouched) {
+      throw new ChatSessionRunTransitionError({
+        sessionId: params.sessionId,
+        activeRunId: params.activeRunId,
+        operation: "admit runtime start",
+      });
+    }
 
     await dependencies.startChatTurnObservation(
       {
@@ -656,6 +688,7 @@ export const runPersistedChatSessionWithDeps = async (
           userId: params.userId,
           workspaceId: params.workspaceId,
           sessionId: params.sessionId,
+          turnId: params.activeRunId,
           locale: params.locale,
           timezone: params.timezone,
           localMessages: params.localMessages,
@@ -768,15 +801,24 @@ export const hasActiveChatSessionRun = (sessionId: string): boolean =>
 
 export const reserveChatRunStart = (
   sessionId: string,
-): ChatRunStartReservation | null => {
-  if (chatRunStartReservations.has(sessionId)) {
-    return null;
+  activeRunId: string,
+): ChatRunStartReservationResult => {
+  const existingReservation = chatRunStartReservations.get(sessionId);
+  if (existingReservation !== undefined) {
+    return {
+      kind: existingReservation.activeRunId === activeRunId
+        ? "same_turn_pending"
+        : "conflict",
+    };
   }
 
   const existingRun = activeChatRuns.get(sessionId);
   if (existingRun !== undefined) {
+    if (existingRun.activeRunId === activeRunId) {
+      return { kind: "same_turn_accepted" };
+    }
     if (existingRun.cancellationState !== "persisted") {
-      return null;
+      return { kind: "conflict" };
     }
 
     closeRunSubscribers(existingRun);
@@ -784,14 +826,29 @@ export const reserveChatRunStart = (
   }
 
   const reservationId = Symbol(sessionId);
-  chatRunStartReservations.set(sessionId, reservationId);
-  return { sessionId, reservationId };
+  const reservation: ChatRunStartReservation = {
+    sessionId,
+    activeRunId,
+    reservationId,
+  };
+  chatRunStartReservations.set(sessionId, {
+    activeRunId,
+    reservationId,
+  });
+  return {
+    kind: "reserved",
+    reservation,
+  };
 };
 
 export const releaseChatRunStartReservation = (
   reservation: ChatRunStartReservation,
 ): void => {
-  if (chatRunStartReservations.get(reservation.sessionId) !== reservation.reservationId) {
+  const currentReservation = chatRunStartReservations.get(reservation.sessionId);
+  if (
+    currentReservation?.reservationId !== reservation.reservationId
+    || currentReservation.activeRunId !== reservation.activeRunId
+  ) {
     return;
   }
 
@@ -803,6 +860,11 @@ export const startPersistedChatRunWithDeps = (
   reservation: ChatRunStartReservation,
   dependencies: ChatRuntimeDependencies,
 ): AsyncGenerator<ChatStreamEvent> => {
+  if (params.activeRunId !== reservation.activeRunId) {
+    throw new Error(
+      `Chat run start reservation belongs to another run: sessionId=${params.sessionId}, activeRunId=${params.activeRunId}`,
+    );
+  }
   consumeChatRunStartReservation(reservation);
 
   const existingRun = activeChatRuns.get(params.sessionId);

--- a/apps/web/src/server/chat/shared.test.ts
+++ b/apps/web/src/server/chat/shared.test.ts
@@ -1,12 +1,152 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { execQuery } from "@/server/chat/shared";
+import type { QueryResult as PgQueryResult } from "pg";
+import {
+  execQuery,
+  execQueryWithDependencies,
+  type ExecQueryDependencies,
+} from "@/server/chat/shared";
+import { ChatTurnCancelledError } from "@/server/chat/store";
+import type { QueryFn } from "@/server/db/contextRunner";
+
+const createQueryResult = (
+  command: string,
+  rows: ReadonlyArray<Readonly<Record<string, string>>>,
+): PgQueryResult => ({
+  command,
+  rowCount: rows.length,
+  oid: 0,
+  fields: [],
+  rows: [...rows],
+});
+
+const createUnusedRestrictedRunner = (): ExecQueryDependencies["withRestrictedUserContext"] =>
+  async <T>(
+    _userId: string,
+    _workspaceId: string,
+    _statementTimeoutMs: number,
+    _callback: (queryFn: QueryFn) => Promise<T>,
+  ): Promise<T> => {
+    throw new Error("Restricted read transaction was not expected");
+  };
 
 test("execQuery rejects function calls before reaching the database", async (): Promise<void> => {
   await assert.rejects(
-    () => execQuery("SELECT now()", "user-1", "workspace-1"),
+    () => execQuery("SELECT now()", {
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+    }),
     (error: unknown) =>
       error instanceof Error
       && error.message === "Only allowlisted functions are supported in chat queries: SUM, COUNT, MIN, MAX, AVG, and COALESCE",
   );
+});
+
+test("cancel-first exact turn fencing rejects before mutating chat SQL", async (): Promise<void> => {
+  let mutationCount = 0;
+  const queryFn: QueryFn = async (sql): Promise<PgQueryResult> => {
+    if (sql.startsWith("DELETE ")) {
+      mutationCount += 1;
+    }
+    return createQueryResult("SELECT", []);
+  };
+
+  await assert.rejects(
+    () => execQueryWithDependencies(
+      "DELETE FROM ledger_entries WHERE entry_id = 'entry-1'",
+      {
+        userId: "user-1",
+        workspaceId: "workspace-1",
+        sessionId: "session-1",
+        turnId: "turn-1",
+      },
+      {
+        withUserContext: async <T>(
+          _userId: string,
+          _workspaceId: string,
+          callback: (transactionQueryFn: QueryFn) => Promise<T>,
+        ): Promise<T> => callback(queryFn),
+        withRestrictedUserContext: createUnusedRestrictedRunner(),
+        lockUncancelledChatTurnForMutationWithQuery:
+          async (): Promise<void> => {
+            throw new ChatTurnCancelledError("session-1", "turn-1");
+          },
+      },
+    ),
+    ChatTurnCancelledError,
+  );
+
+  assert.equal(mutationCount, 0);
+});
+
+test("SQL-first exact turn fencing holds the session lock until mutation commit", async (): Promise<void> => {
+  const mutationMayCommit = Promise.withResolvers<void>();
+  const mutationStarted = Promise.withResolvers<void>();
+  let transactionTail = Promise.resolve();
+  let mutationCommitted = false;
+  let cancellationConfirmed = false;
+
+  const withSerializedSessionTransaction: ExecQueryDependencies["withUserContext"] =
+    async <T>(
+      _userId: string,
+      _workspaceId: string,
+      callback: (queryFn: QueryFn) => Promise<T>,
+    ): Promise<T> => {
+      const previousTransaction = transactionTail;
+      const transactionFinished = Promise.withResolvers<void>();
+      transactionTail = previousTransaction.then(
+        (): Promise<void> => transactionFinished.promise,
+      );
+      await previousTransaction;
+      const queryFn: QueryFn = async (sql): Promise<PgQueryResult> => {
+        if (sql.startsWith("DELETE ")) {
+          mutationStarted.resolve();
+          await mutationMayCommit.promise;
+          mutationCommitted = true;
+          return createQueryResult("DELETE", []);
+        }
+        return createQueryResult("SELECT", []);
+      };
+      try {
+        return await callback(queryFn);
+      } finally {
+        transactionFinished.resolve();
+      }
+    };
+
+  const mutation = execQueryWithDependencies(
+    "DELETE FROM ledger_entries WHERE entry_id = 'entry-1'",
+    {
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+    },
+    {
+      withUserContext: withSerializedSessionTransaction,
+      withRestrictedUserContext: createUnusedRestrictedRunner(),
+      lockUncancelledChatTurnForMutationWithQuery:
+        async (): Promise<void> => {},
+    },
+  );
+
+  await mutationStarted.promise;
+  const cancellation = withSerializedSessionTransaction(
+    "user-1",
+    "workspace-1",
+    async (): Promise<void> => {
+      cancellationConfirmed = true;
+    },
+  );
+  await Promise.resolve();
+  assert.equal(cancellationConfirmed, false);
+
+  mutationMayCommit.resolve();
+  await mutation;
+  await cancellation;
+
+  assert.equal(mutationCommitted, true);
+  assert.equal(cancellationConfirmed, true);
 });

--- a/apps/web/src/server/chat/shared.ts
+++ b/apps/web/src/server/chat/shared.ts
@@ -1,6 +1,13 @@
-import { MAX_SQL_ROWS, SqlPolicyError, validateExpenseSql } from "@expense-budget-tracker/agent-shared/sql-policy";
+import {
+  MAX_SQL_ROWS,
+  SqlPolicyError,
+  validateExpenseSql,
+  type ValidatedExpenseSqlStatement,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
 import type { ContentPart } from "@/server/chat/types";
-import { withRestrictedUserContext } from "@/server/db";
+import { withRestrictedUserContext, withUserContext } from "@/server/db";
+import type { QueryFn } from "@/server/db/contextRunner";
+import { lockUncancelledChatTurnForMutationWithQuery } from "@/server/chat/store/turnCancellationStore";
 
 export const MAX_ROWS = MAX_SQL_ROWS;
 export const STATEMENT_TIMEOUT_MS = 10_000;
@@ -331,10 +338,64 @@ export type QueryResult = Readonly<{
   json: string;
 }>;
 
-export const execQuery = async (
-  sql: string,
+export type ChatSqlExecutionContext = Readonly<{
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+  turnId: string;
+}>;
+
+type UserContextRunner = <T>(
   userId: string,
   workspaceId: string,
+  callback: (queryFn: QueryFn) => Promise<T>,
+) => Promise<T>;
+
+type RestrictedUserContextRunner = <T>(
+  userId: string,
+  workspaceId: string,
+  statementTimeoutMs: number,
+  callback: (queryFn: QueryFn) => Promise<T>,
+) => Promise<T>;
+
+export type ExecQueryDependencies = Readonly<{
+  withUserContext: UserContextRunner;
+  withRestrictedUserContext: RestrictedUserContextRunner;
+  lockUncancelledChatTurnForMutationWithQuery: typeof lockUncancelledChatTurnForMutationWithQuery;
+}>;
+
+const DEFAULT_EXEC_QUERY_DEPENDENCIES: ExecQueryDependencies = {
+  withUserContext,
+  withRestrictedUserContext,
+  lockUncancelledChatTurnForMutationWithQuery,
+};
+
+const executeValidatedChatSql = async (
+  queryFn: QueryFn,
+  statements: ReadonlyArray<ValidatedExpenseSqlStatement>,
+): Promise<ReadonlyArray<Readonly<Record<string, unknown>>>> => {
+  const results: Array<Readonly<Record<string, unknown>>> = [];
+  for (const statement of statements) {
+    const result = await queryFn(statement.sql, []);
+    const rows = result.rows.slice(0, MAX_ROWS);
+    results.push({
+      sql: statement.sql,
+      command: result.command,
+      rows,
+      rowCount: rows.length > 0 ? rows.length : (result.rowCount ?? 0),
+      returnedRowCount: rows.length,
+      totalRowCount: result.rows.length > 0 ? result.rows.length : (result.rowCount ?? 0),
+      truncated: result.rows.length > rows.length,
+      referencedRelations: statement.referencedRelations,
+    });
+  }
+  return results;
+};
+
+export const execQueryWithDependencies = async (
+  sql: string,
+  context: ChatSqlExecutionContext,
+  dependencies: ExecQueryDependencies,
 ): Promise<QueryResult> => {
   let validated;
   try {
@@ -346,32 +407,39 @@ export const execQuery = async (
     throw error;
   }
 
-  const statements = await withRestrictedUserContext(
-    userId,
-    workspaceId,
-    STATEMENT_TIMEOUT_MS,
-    async (queryFn) => {
-      const results: Array<Readonly<Record<string, unknown>>> = [];
-      for (const statement of validated.statements) {
-        const result = await queryFn(statement.sql, []);
-        const rows = result.rows.slice(0, MAX_ROWS);
-        results.push({
-          sql: statement.sql,
-          command: result.command,
-          rows,
-          rowCount: rows.length > 0 ? rows.length : (result.rowCount ?? 0),
-          returnedRowCount: rows.length,
-          totalRowCount: result.rows.length > 0 ? result.rows.length : (result.rowCount ?? 0),
-          truncated: result.rows.length > rows.length,
-          referencedRelations: statement.referencedRelations,
-        });
-      }
-      return results;
-    },
-  );
+  const isMutating = validated.statements.some((statement) => statement.isMutating);
+  const statements = isMutating
+    ? await dependencies.withUserContext(
+      context.userId,
+      context.workspaceId,
+      async (queryFn) => {
+        await queryFn("SELECT set_config('statement_timeout', $1, true)", [
+          String(STATEMENT_TIMEOUT_MS),
+        ]);
+        await dependencies.lockUncancelledChatTurnForMutationWithQuery(
+          queryFn,
+          context.sessionId,
+          context.turnId,
+        );
+        await queryFn("SET LOCAL ROLE api_sql_executor", []);
+        return executeValidatedChatSql(queryFn, validated.statements);
+      },
+    )
+    : await dependencies.withRestrictedUserContext(
+      context.userId,
+      context.workspaceId,
+      STATEMENT_TIMEOUT_MS,
+      async (queryFn) => executeValidatedChatSql(queryFn, validated.statements),
+    );
 
   return { json: JSON.stringify({ statements }) };
 };
+
+export const execQuery = async (
+  sql: string,
+  context: ChatSqlExecutionContext,
+): Promise<QueryResult> =>
+  execQueryWithDependencies(sql, context, DEFAULT_EXEC_QUERY_DEPENDENCIES);
 
 export const extractText = (content: ReadonlyArray<ContentPart>): string =>
   content

--- a/apps/web/src/server/chat/store.ts
+++ b/apps/web/src/server/chat/store.ts
@@ -4,8 +4,10 @@ export type {
   ChatSessionTerminalState,
   ChatSessionSnapshot,
   PersistedChatMessageItem,
+  PrepareChatRunResult,
   PreparedChatRun,
   UserCancelChatRunResult,
+  UserCancelChatTurnResult,
 } from "./store/shared";
 
 export type {
@@ -21,6 +23,7 @@ export {
   ChatSessionConflictError,
   ChatSessionNotFoundError,
   ChatSessionRunTransitionError,
+  ChatTurnCancelledError,
   FAILED_TOOL_CALL_OUTPUT,
   INTERRUPTED_TOOL_CALL_OUTPUT,
   STOPPED_BY_USER_TOOL_OUTPUT,
@@ -53,10 +56,14 @@ export {
 export { getChatSessionSnapshot } from "./store/snapshotStore";
 
 export {
+  admitChatRunStart,
+  admitChatRunStartWithQuery,
   buildUserStoppedAssistantContent,
   buildUserStoppedChatRunUpdatePlan,
   cancelActiveChatRunByUser,
   cancelActiveChatRunByUserWithQuery,
+  cancelChatTurnByUser,
+  cancelChatTurnByUserWithQuery,
   completeChatRun,
   completeChatRunWithQuery,
   markChatSessionInterrupted,
@@ -66,4 +73,6 @@ export {
   prepareFreshChatRun,
   recoverStaleChatSession,
   recoverStaleChatSessionWithQuery,
+  requireAcceptedChatTurn,
+  requireAcceptedChatTurnWithQuery,
 } from "./store/lifecycleStore";

--- a/apps/web/src/server/chat/store/lifecycleStore.test.ts
+++ b/apps/web/src/server/chat/store/lifecycleStore.test.ts
@@ -2,18 +2,22 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { QueryResult } from "pg";
 import {
+  admitChatRunStartWithQuery,
   cancelActiveChatRunByUserWithQuery,
+  cancelChatTurnByUserWithQuery,
   completeChatRunWithQuery,
   persistAssistantCancelledWithQuery,
   persistAssistantTerminalErrorWithQuery,
   prepareChatRunWithQuery,
   prepareFreshChatRunWithQuery,
   recoverStaleChatSessionWithQuery,
+  requireAcceptedChatTurnWithQuery,
 } from "@/server/chat/store/lifecycleStore";
 import { updateAssistantMessageItemWithQuery } from "@/server/chat/store/messageStore";
 import {
   ChatSessionConflictError,
   ChatSessionRunTransitionError,
+  ChatTurnCancelledError,
 } from "@/server/chat/store/shared";
 import type { QueryFn } from "@/server/db/contextRunner";
 
@@ -190,7 +194,7 @@ const createFreshRunQueryFn = (
   }
 
   if (text.includes("INSERT INTO public.chat_items")) {
-    const payload = JSON.parse(String(params[2])) as Readonly<{
+    const payload = JSON.parse(String(params[3])) as Readonly<{
       role: "user" | "assistant";
       content: ReadonlyArray<Readonly<{ type: "text"; text: string }>>;
     }>;
@@ -198,9 +202,9 @@ const createFreshRunQueryFn = (
       throw new Error("assistant insert failed");
     }
     return createQueryResult([{
-      item_id: `${payload.role}-1`,
+      item_id: params[0] === null ? `${payload.role}-1` : String(params[0]),
       session_id: "session-1",
-      state: String(params[1]),
+      state: String(params[2]),
       payload,
       created_at: "2026-05-02T13:00:00.000Z",
       updated_at: "2026-05-02T13:00:00.000Z",
@@ -302,6 +306,12 @@ test("prepareChatRunWithQuery explicitly rejects a second run in the same sessio
     if (text.includes("FROM public.chat_sessions")) {
       return createQueryResult([createSessionRow("running", "run-1")]);
     }
+    if (text.includes("FROM public.chat_turn_cancellations")) {
+      return createQueryResult([]);
+    }
+    if (text.includes("FROM public.chat_items")) {
+      return createQueryResult([]);
+    }
     throw new Error(`Unexpected query: ${text}`);
   };
 
@@ -312,15 +322,228 @@ test("prepareChatRunWithQuery explicitly rejects a second run in the same sessio
       "workspace-1",
       "session-1",
       [{ type: "text", text: "Another message" }],
+      "00000000-0000-4000-8000-000000000002",
     ),
     (error: unknown): boolean =>
       error instanceof ChatSessionConflictError
       && error.message.includes("session-1"),
   );
 
-  assert.equal(recordedQueries.length, 2);
+  assert.equal(recordedQueries.length, 4);
   assert.equal(
     recordedQueries.some((query) => query.text.includes("INSERT INTO public.chat_items")),
+    false,
+  );
+});
+
+test("prepareChatRunWithQuery treats a persisted matching turn as already accepted", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const turnId = "00000000-0000-4000-8000-000000000003";
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions")) {
+      return createQueryResult([createSessionRow("running", turnId)]);
+    }
+    if (text.includes("FROM public.chat_turn_cancellations")) {
+      return createQueryResult([]);
+    }
+    if (text.includes("FROM public.chat_items")) {
+      return createQueryResult([{ item_id: turnId }]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  const result = await prepareChatRunWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    "session-1",
+    [{ type: "text", text: "Same message" }],
+    turnId,
+  );
+
+  assert.deepEqual(result, {
+    kind: "already_accepted",
+    sessionId: "session-1",
+  });
+  assert.equal(
+    recordedQueries.some((query) => query.text.includes("INSERT INTO public.chat_items")),
+    false,
+  );
+  assert.equal(
+    recordedQueries.some((query) => query.text.includes("UPDATE public.chat_sessions")),
+    false,
+  );
+});
+
+test("prepareChatRunWithQuery rejects a durably cancelled turn before reading or writing chat items", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const turnId = "00000000-0000-4000-8000-000000000004";
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions")) {
+      return createQueryResult([createSessionRow("idle", null)]);
+    }
+    if (text.includes("FROM public.chat_turn_cancellations")) {
+      return createQueryResult([{ turn_id: turnId }]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  await assert.rejects(
+    prepareChatRunWithQuery(
+      queryFn,
+      "user-1",
+      "workspace-1",
+      "session-1",
+      [{ type: "text", text: "Cancelled message" }],
+      turnId,
+    ),
+    ChatTurnCancelledError,
+  );
+
+  assert.match(recordedQueries[1].text, /FOR UPDATE/);
+  assert.equal(
+    recordedQueries[2].text.includes("FROM public.chat_turn_cancellations"),
+    true,
+  );
+  assert.equal(
+    recordedQueries.some((query) => query.text.includes("public.chat_items")),
+    false,
+  );
+  assert.equal(
+    recordedQueries.some((query) => query.text.includes("UPDATE public.chat_sessions")),
+    false,
+  );
+});
+
+test("admitChatRunStartWithQuery locks and admits only the exact uncancelled run", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const turnId = "00000000-0000-4000-8000-000000000005";
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions") && text.includes("FOR UPDATE")) {
+      return createQueryResult([createSessionRow("running", turnId)]);
+    }
+    if (text.includes("FROM public.chat_turn_cancellations")) {
+      return createQueryResult([]);
+    }
+    if (text.includes("SET active_run_heartbeat_at")) {
+      return createQueryResult([createSessionRow("running", turnId)]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  await admitChatRunStartWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    "session-1",
+    turnId,
+  );
+
+  assert.equal(recordedQueries.length, 3);
+  assert.match(recordedQueries[0].text, /FOR UPDATE/u);
+  assert.deepEqual(recordedQueries[0].params, [
+    "user-1",
+    "workspace-1",
+    "session-1",
+  ]);
+  assert.match(recordedQueries[1].text, /chat_turn_cancellations/u);
+  assert.match(recordedQueries[2].text, /active_run_heartbeat_at/u);
+  assert.equal(recordedQueries[2].params[0], "session-1");
+  assert.equal(recordedQueries[2].params[1], turnId);
+});
+
+test("admitChatRunStartWithQuery rejects a tombstone before touching the runtime heartbeat", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const turnId = "00000000-0000-4000-8000-000000000006";
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions") && text.includes("FOR UPDATE")) {
+      return createQueryResult([createSessionRow("idle", null)]);
+    }
+    if (text.includes("FROM public.chat_turn_cancellations")) {
+      return createQueryResult([{ turn_id: turnId }]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  await assert.rejects(
+    admitChatRunStartWithQuery(
+      queryFn,
+      "user-1",
+      "workspace-1",
+      "session-1",
+      turnId,
+    ),
+    ChatTurnCancelledError,
+  );
+
+  assert.equal(recordedQueries.length, 2);
+  assert.match(recordedQueries[0].text, /FOR UPDATE/u);
+  assert.match(recordedQueries[1].text, /chat_turn_cancellations/u);
+});
+
+test("requireAcceptedChatTurnWithQuery confirms an uncancelled persisted user turn", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const turnId = "00000000-0000-4000-8000-000000000007";
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions") && text.includes("FOR UPDATE")) {
+      return createQueryResult([createSessionRow("running", turnId)]);
+    }
+    if (text.includes("FROM public.chat_turn_cancellations")) {
+      return createQueryResult([]);
+    }
+    if (text.includes("FROM public.chat_items")) {
+      return createQueryResult([{ item_id: turnId }]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  await requireAcceptedChatTurnWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    "session-1",
+    turnId,
+  );
+
+  assert.equal(recordedQueries.length, 3);
+  assert.match(recordedQueries[0].text, /FOR UPDATE/u);
+  assert.match(recordedQueries[1].text, /chat_turn_cancellations/u);
+  assert.match(recordedQueries[2].text, /public\.chat_items/u);
+});
+
+test("requireAcceptedChatTurnWithQuery rejects a tombstone before accepting the persisted user turn", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const turnId = "00000000-0000-4000-8000-000000000008";
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions") && text.includes("FOR UPDATE")) {
+      return createQueryResult([createSessionRow("idle", null)]);
+    }
+    if (text.includes("FROM public.chat_turn_cancellations")) {
+      return createQueryResult([{ turn_id: turnId }]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  await assert.rejects(
+    requireAcceptedChatTurnWithQuery(
+      queryFn,
+      "user-1",
+      "workspace-1",
+      "session-1",
+      turnId,
+    ),
+    ChatTurnCancelledError,
+  );
+
+  assert.equal(recordedQueries.length, 2);
+  assert.equal(
+    recordedQueries.some((query) => query.text.includes("public.chat_items")),
     false,
   );
 });
@@ -439,6 +662,128 @@ test("cancelActiveChatRunByUserWithQuery skips item writes when the session is n
   assert.equal(recordedQueries.some((query) => query.text.includes("FROM public.chat_items")), false);
   assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_items")), false);
   assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE public.chat_sessions")), false);
+});
+
+test("cancelChatTurnByUserWithQuery records a tombstone before an unpersisted turn can prepare", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const turnId = "00000000-0000-4000-8000-000000000105";
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions") && text.includes("FOR UPDATE")) {
+      return createQueryResult([createSessionRow("idle", null)]);
+    }
+    if (text.includes("INSERT INTO public.chat_turn_cancellations")) {
+      return createQueryResult([{ turn_id: turnId }]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  const result = await cancelChatTurnByUserWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    "session-1",
+    turnId,
+  );
+
+  assert.equal(result, "cancellation_recorded");
+  assert.match(recordedQueries[0].text, /FOR UPDATE/);
+  assert.deepEqual(recordedQueries[1].params, ["session-1", turnId]);
+  assert.equal(
+    recordedQueries.some((query) => query.text.includes("public.chat_items")),
+    false,
+  );
+});
+
+test("cancelChatTurnByUserWithQuery stops the exact run when send persistence wins the session lock first", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const turnId = "00000000-0000-4000-8000-000000000106";
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions") && text.includes("FOR UPDATE")) {
+      return createQueryResult([createSessionRow("running", turnId)]);
+    }
+    if (text.includes("INSERT INTO public.chat_turn_cancellations")) {
+      return createQueryResult([{ turn_id: turnId }]);
+    }
+    if (text.includes("FROM public.chat_items")) {
+      return createQueryResult([createChatItemRow("in_progress")]);
+    }
+    if (text.includes("UPDATE public.chat_items")) {
+      return createQueryResult([createChatItemRow("cancelled")]);
+    }
+    if (text.includes("UPDATE public.chat_sessions")) {
+      return createQueryResult([createSessionRow("idle", null)]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  const result = await cancelChatTurnByUserWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    "session-1",
+    turnId,
+  );
+
+  assert.equal(result, "active_run_cancelled");
+  assert.match(recordedQueries[0].text, /FOR UPDATE/);
+  assert.equal(
+    recordedQueries[1].text.includes("INSERT INTO public.chat_turn_cancellations"),
+    true,
+  );
+  assert.equal(
+    recordedQueries.some((query) => query.text.includes("UPDATE public.chat_items")),
+    true,
+  );
+  assert.deepEqual(recordedQueries.at(-1)?.params, [
+    "session-1",
+    turnId,
+    "idle",
+  ]);
+});
+
+test("cancelChatTurnByUserWithQuery is idempotent across repeated server instances", async (): Promise<void> => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const turnId = "00000000-0000-4000-8000-000000000107";
+  let cancellationRecorded = false;
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions") && text.includes("FOR UPDATE")) {
+      return createQueryResult([createSessionRow("idle", null)]);
+    }
+    if (text.includes("INSERT INTO public.chat_turn_cancellations")) {
+      if (cancellationRecorded) {
+        return createQueryResult([]);
+      }
+      cancellationRecorded = true;
+      return createQueryResult([{ turn_id: turnId }]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  const firstResult = await cancelChatTurnByUserWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    "session-1",
+    turnId,
+  );
+  const secondResult = await cancelChatTurnByUserWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    "session-1",
+    turnId,
+  );
+
+  assert.equal(firstResult, "cancellation_recorded");
+  assert.equal(secondResult, "already_cancelled");
+  assert.equal(
+    recordedQueries.filter((query) =>
+      query.text.includes("INSERT INTO public.chat_turn_cancellations")).length,
+    2,
+  );
 });
 
 test("recoverStaleChatSessionWithQuery interrupts stale in-progress assistant messages", async (): Promise<void> => {

--- a/apps/web/src/server/chat/store/lifecycleStore.ts
+++ b/apps/web/src/server/chat/store/lifecycleStore.ts
@@ -6,6 +6,8 @@ import type { ContentPart } from "@/server/chat/types";
 import { log } from "@/server/logger";
 import {
   ChatSessionConflictError,
+  ChatSessionRunTransitionError,
+  ChatTurnCancelledError,
   FAILED_TOOL_CALL_OUTPUT,
   INCOMPLETE_TOOL_CALL_PROVIDER_STATUS,
   INTERRUPTED_TOOL_CALL_OUTPUT,
@@ -14,11 +16,14 @@ import {
   type PersistAssistantCancelledParams,
   type PersistedChatMessageItem,
   type PersistAssistantTerminalErrorParams,
+  type PrepareChatRunResult,
   type PreparedChatRun,
   type UserCancelChatRunResult,
+  type UserCancelChatTurnResult,
   type UserStoppedChatRunUpdatePlan,
 } from "./shared";
 import {
+  hasChatUserTurnWithQuery,
   insertChatItemWithQuery,
   listChatMessagesWithQuery,
   updateChatItemWithQuery,
@@ -35,7 +40,13 @@ import {
   resolveLatestOrCreateChatSessionWithQuery,
   resolveRequestedChatSessionWithQuery,
   startChatSessionRunWithQuery,
+  touchChatSessionHeartbeatWithQuery,
+  type ChatSessionRow,
 } from "./sessionStore";
+import {
+  hasChatTurnCancellationWithQuery,
+  insertChatTurnCancellationWithQuery,
+} from "./turnCancellationStore";
 
 export const buildUserStoppedAssistantContent = (
   content: ReadonlyArray<ContentPart>,
@@ -84,18 +95,28 @@ export const prepareChatRunWithQuery = async (
   workspaceId: string,
   requestedSessionId: string | undefined,
   content: ReadonlyArray<ContentPart>,
-): Promise<PreparedChatRun> => {
+  turnId: string,
+): Promise<PrepareChatRunResult> => {
   const sessionRow = requestedSessionId === undefined
     ? await resolveLatestOrCreateChatSessionWithQuery(queryFn, userId, workspaceId)
     : await resolveRequestedChatSessionWithQuery(queryFn, userId, workspaceId, requestedSessionId);
 
   const lockedSession = await lockChatSessionWithQuery(queryFn, sessionRow.session_id);
+  if (await hasChatTurnCancellationWithQuery(queryFn, sessionRow.session_id, turnId)) {
+    throw new ChatTurnCancelledError(sessionRow.session_id, turnId);
+  }
+  if (await hasChatUserTurnWithQuery(queryFn, sessionRow.session_id, turnId)) {
+    return {
+      kind: "already_accepted",
+      sessionId: sessionRow.session_id,
+    };
+  }
   if (lockedSession.status === "running") {
     throw new ChatSessionConflictError(sessionRow.session_id);
   }
 
-  const activeRunId = randomUUID();
   await insertChatItemWithQuery(queryFn, {
+    itemId: turnId,
     sessionId: sessionRow.session_id,
     role: "user",
     state: "completed",
@@ -104,20 +125,24 @@ export const prepareChatRunWithQuery = async (
 
   const persistedMessages = await listChatMessagesWithQuery(queryFn, sessionRow.session_id);
   const assistantItem = await insertChatItemWithQuery(queryFn, {
+    itemId: null,
     sessionId: sessionRow.session_id,
     role: "assistant",
     state: "in_progress",
     content: [],
   });
 
-  await startChatSessionRunWithQuery(queryFn, sessionRow.session_id, activeRunId, new Date());
+  await startChatSessionRunWithQuery(queryFn, sessionRow.session_id, turnId, new Date());
 
   return {
-    sessionId: sessionRow.session_id,
-    activeRunId,
-    assistantItem,
-    localMessages: buildLocalChatMessages(persistedMessages),
-    turnInput: content,
+    kind: "started",
+    preparedRun: {
+      sessionId: sessionRow.session_id,
+      activeRunId: turnId,
+      assistantItem,
+      localMessages: buildLocalChatMessages(persistedMessages),
+      turnInput: content,
+    },
   };
 };
 
@@ -126,9 +151,128 @@ export const prepareChatRun = async (
   workspaceId: string,
   requestedSessionId: string | undefined,
   content: ReadonlyArray<ContentPart>,
-): Promise<PreparedChatRun> =>
+  turnId: string,
+): Promise<PrepareChatRunResult> =>
   withUserContext(userId, workspaceId, async (queryFn) =>
-    prepareChatRunWithQuery(queryFn, userId, workspaceId, requestedSessionId, content));
+    prepareChatRunWithQuery(queryFn, userId, workspaceId, requestedSessionId, content, turnId));
+
+const lockUncancelledRequestedChatTurnWithQuery = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  turnId: string,
+): Promise<ChatSessionRow> => {
+  const lockedSession = await lockRequestedChatSessionWithQuery(
+    queryFn,
+    userId,
+    workspaceId,
+    sessionId,
+  );
+  if (await hasChatTurnCancellationWithQuery(queryFn, sessionId, turnId)) {
+    throw new ChatTurnCancelledError(sessionId, turnId);
+  }
+
+  return lockedSession;
+};
+
+export const admitChatRunStartWithQuery = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  turnId: string,
+): Promise<void> => {
+  const lockedSession = await lockUncancelledRequestedChatTurnWithQuery(
+    queryFn,
+    userId,
+    workspaceId,
+    sessionId,
+    turnId,
+  );
+  if (
+    lockedSession.status !== "running"
+    || lockedSession.active_run_id !== turnId
+  ) {
+    throw new ChatSessionRunTransitionError({
+      sessionId,
+      activeRunId: turnId,
+      operation: "admit runtime start",
+    });
+  }
+
+  const heartbeatTouched = await touchChatSessionHeartbeatWithQuery(
+    queryFn,
+    sessionId,
+    turnId,
+    new Date(),
+  );
+  if (!heartbeatTouched) {
+    throw new ChatSessionRunTransitionError({
+      sessionId,
+      activeRunId: turnId,
+      operation: "admit runtime start",
+    });
+  }
+};
+
+export const admitChatRunStart = async (
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  turnId: string,
+): Promise<void> =>
+  withUserContext(userId, workspaceId, async (queryFn) =>
+    admitChatRunStartWithQuery(
+      queryFn,
+      userId,
+      workspaceId,
+      sessionId,
+      turnId,
+    ));
+
+export const requireAcceptedChatTurnWithQuery = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  turnId: string,
+): Promise<void> => {
+  await lockUncancelledRequestedChatTurnWithQuery(
+    queryFn,
+    userId,
+    workspaceId,
+    sessionId,
+    turnId,
+  );
+  const userTurnExists = await hasChatUserTurnWithQuery(
+    queryFn,
+    sessionId,
+    turnId,
+  );
+  if (!userTurnExists) {
+    throw new ChatSessionRunTransitionError({
+      sessionId,
+      activeRunId: turnId,
+      operation: "confirm accepted chat turn",
+    });
+  }
+};
+
+export const requireAcceptedChatTurn = async (
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  turnId: string,
+): Promise<void> =>
+  withUserContext(userId, workspaceId, async (queryFn) =>
+    requireAcceptedChatTurnWithQuery(
+      queryFn,
+      userId,
+      workspaceId,
+      sessionId,
+      turnId,
+    ));
 
 export const prepareFreshChatRunWithQuery = async (
   queryFn: QueryFn,
@@ -145,6 +289,7 @@ export const prepareFreshChatRunWithQuery = async (
     deriveChatSessionTitle(content),
   );
   await insertChatItemWithQuery(queryFn, {
+    itemId: activeRunId,
     sessionId: sessionRow.session_id,
     role: "user",
     state: "completed",
@@ -153,6 +298,7 @@ export const prepareFreshChatRunWithQuery = async (
 
   const persistedMessages = await listChatMessagesWithQuery(queryFn, sessionRow.session_id);
   const assistantItem = await insertChatItemWithQuery(queryFn, {
+    itemId: null,
     sessionId: sessionRow.session_id,
     role: "assistant",
     state: "in_progress",
@@ -244,6 +390,7 @@ export const persistAssistantTerminalErrorWithQuery = async (
       assistantOpenAIItems: params.assistantOpenAIItems,
     });
     await insertChatItemWithQuery(queryFn, {
+      itemId: null,
       sessionId: params.sessionId,
       role: "assistant",
       state: "error",
@@ -351,6 +498,65 @@ export const cancelActiveChatRunByUser = async (
   withUserContext(userId, workspaceId, async (queryFn) =>
     cancelActiveChatRunByUserWithQuery(queryFn, userId, workspaceId, sessionId, expectedActiveRunId));
 
+export const cancelChatTurnByUserWithQuery = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  turnId: string,
+): Promise<UserCancelChatTurnResult> => {
+  const lockedSession = await lockRequestedChatSessionWithQuery(
+    queryFn,
+    userId,
+    workspaceId,
+    sessionId,
+  );
+  const cancellationInserted = await insertChatTurnCancellationWithQuery(
+    queryFn,
+    sessionId,
+    turnId,
+  );
+  if (!cancellationInserted) {
+    return "already_cancelled";
+  }
+
+  if (
+    lockedSession.status !== "running"
+    || lockedSession.active_run_id !== turnId
+  ) {
+    return "cancellation_recorded";
+  }
+
+  const messages = await listChatMessagesWithQuery(queryFn, sessionId);
+  const updatePlan = buildUserStoppedChatRunUpdatePlan(messages);
+  if (updatePlan.assistantItem !== null && updatePlan.assistantContent !== null) {
+    await updateChatItemWithQuery(queryFn, {
+      sessionId,
+      itemId: updatePlan.assistantItem.itemId,
+      content: updatePlan.assistantContent,
+      state: "cancelled",
+      assistantOpenAIItems: updatePlan.assistantOpenAIItems ?? undefined,
+    });
+  }
+
+  await completeChatSessionRunWithQuery(
+    queryFn,
+    sessionId,
+    turnId,
+    updatePlan.sessionState,
+  );
+  return "active_run_cancelled";
+};
+
+export const cancelChatTurnByUser = async (
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  turnId: string,
+): Promise<UserCancelChatTurnResult> =>
+  withUserContext(userId, workspaceId, async (queryFn) =>
+    cancelChatTurnByUserWithQuery(queryFn, userId, workspaceId, sessionId, turnId));
+
 export type StaleChatSessionRecoveryResult =
   | "interrupted"
   | "completed_recovered"
@@ -408,6 +614,7 @@ export const recoverStaleChatSessionWithQuery = async (
         state: "completed",
       });
       await insertChatItemWithQuery(queryFn, {
+        itemId: null,
         sessionId: params.sessionId,
         role: "assistant",
         state: "error",

--- a/apps/web/src/server/chat/store/messageStore.test.ts
+++ b/apps/web/src/server/chat/store/messageStore.test.ts
@@ -38,25 +38,27 @@ test("insertChatItemWithQuery records user activity but not an empty assistant p
   }>> = [];
   const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
     recordedQueries.push({ text, params });
-    const payload = JSON.parse(String(params[2])) as Readonly<{
+    const payload = JSON.parse(String(params[3])) as Readonly<{
       role: "user" | "assistant";
       content: ReadonlyArray<Readonly<{ type: "text"; text: string }>>;
     }>;
     return createQueryResult(
       payload.role,
-      String(params[1]) as "in_progress" | "completed",
+      String(params[2]) as "in_progress" | "completed",
       payload.content,
       undefined,
     );
   };
 
   await insertChatItemWithQuery(queryFn, {
+    itemId: "turn-1",
     sessionId: "session-1",
     role: "user",
     state: "completed",
     content: [{ type: "text", text: "Hello" }],
   });
   await insertChatItemWithQuery(queryFn, {
+    itemId: null,
     sessionId: "session-1",
     role: "assistant",
     state: "in_progress",
@@ -64,8 +66,10 @@ test("insertChatItemWithQuery records user activity but not an empty assistant p
   });
 
   assert.match(recordedQueries[0].text, /last_message_at = CASE/);
-  assert.equal(recordedQueries[0].params[3], true);
-  assert.equal(recordedQueries[1].params[3], false);
+  assert.equal(recordedQueries[0].params[0], "turn-1");
+  assert.equal(recordedQueries[0].params[4], true);
+  assert.equal(recordedQueries[1].params[0], null);
+  assert.equal(recordedQueries[1].params[4], false);
   assert.equal(recordedQueries.some((query) => query.text.includes("title =")), false);
 });
 

--- a/apps/web/src/server/chat/store/messageStore.ts
+++ b/apps/web/src/server/chat/store/messageStore.ts
@@ -50,20 +50,21 @@ const LIST_CHAT_ITEMS_SQL = `
 const INSERT_CHAT_ITEM_SQL = `
   WITH inserted_item AS (
     INSERT INTO public.chat_items (
+      item_id,
       session_id,
       item_kind,
       state,
       payload,
       updated_at
     )
-    VALUES ($1, 'message', $2, $3::jsonb, now())
+    VALUES (COALESCE($1, gen_random_uuid()::text), $2, 'message', $3, $4::jsonb, now())
     RETURNING item_id, session_id, state, payload, created_at, updated_at
   ),
   touched_session AS (
     UPDATE public.chat_sessions AS session
     SET updated_at = inserted_item.updated_at,
         last_message_at = CASE
-          WHEN $4 THEN inserted_item.updated_at
+          WHEN $5 THEN inserted_item.updated_at
           ELSE session.last_message_at
         END
     FROM inserted_item
@@ -71,6 +72,15 @@ const INSERT_CHAT_ITEM_SQL = `
   )
   SELECT item_id, session_id, state, payload, created_at, updated_at
   FROM inserted_item
+`;
+
+const HAS_CHAT_USER_TURN_SQL = `
+  SELECT item_id
+  FROM public.chat_items
+  WHERE item_id = $1
+    AND session_id = $2
+    AND item_kind = 'message'
+    AND payload->>'role' = 'user'
 `;
 
 const UPDATE_CHAT_ITEM_SQL = `
@@ -190,6 +200,7 @@ export const insertChatItemWithQuery = async (
   params: InsertChatItemParams,
 ): Promise<PersistedChatMessageItem> => {
   const result = await queryFn(INSERT_CHAT_ITEM_SQL, [
+    params.itemId,
     params.sessionId,
     params.state,
     JSON.stringify(toChatItemPayload(params.role, params.content, params.assistantOpenAIItems)),
@@ -199,6 +210,15 @@ export const insertChatItemWithQuery = async (
   return mapChatItemRow(
     requireChatItemRow(result.rows[0] as ChatItemRow | undefined, "insert"),
   );
+};
+
+export const hasChatUserTurnWithQuery = async (
+  queryFn: QueryFn,
+  sessionId: string,
+  turnId: string,
+): Promise<boolean> => {
+  const result = await queryFn(HAS_CHAT_USER_TURN_SQL, [turnId, sessionId]);
+  return result.rows.length > 0;
 };
 
 export const updateChatItemWithQuery = async (

--- a/apps/web/src/server/chat/store/sessionStore.ts
+++ b/apps/web/src/server/chat/store/sessionStore.ts
@@ -34,6 +34,13 @@ const SELECT_SESSION_FOR_UPDATE_SQL = `
   FOR UPDATE
 `;
 
+const SELECT_SESSION_FOR_SHARE_SQL = `
+  SELECT session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
+  FROM public.chat_sessions
+  WHERE session_id = $1
+  FOR SHARE
+`;
+
 const SELECT_REQUESTED_SESSION_FOR_UPDATE_SQL = `
   SELECT session_id, status, active_run_id, active_run_heartbeat_at, main_content_invalidation_version, updated_at
   FROM public.chat_sessions
@@ -280,6 +287,17 @@ export const lockChatSessionWithQuery = async (
   return requireSessionRow(result.rows[0] as ChatSessionRow | undefined, "lock");
 };
 
+export const lockChatSessionForSnapshotWithQuery = async (
+  queryFn: QueryFn,
+  sessionId: string,
+): Promise<ChatSessionRow> => {
+  const result = await queryFn(SELECT_SESSION_FOR_SHARE_SQL, [sessionId]);
+  return requireSessionRow(
+    result.rows[0] as ChatSessionRow | undefined,
+    "snapshot lock",
+  );
+};
+
 export const lockRequestedChatSessionWithQuery = async (
   queryFn: QueryFn,
   userId: string,
@@ -394,10 +412,11 @@ export const touchChatSessionHeartbeat = async (
   workspaceId: string,
   sessionId: string,
   activeRunId: string,
-): Promise<void> => {
-  await queryAs(userId, workspaceId, TOUCH_CHAT_SESSION_HEARTBEAT_SQL, [
+): Promise<boolean> => {
+  const result = await queryAs(userId, workspaceId, TOUCH_CHAT_SESSION_HEARTBEAT_SQL, [
     sessionId,
     activeRunId,
     new Date().toISOString(),
   ]);
+  return result.rows.length > 0;
 };

--- a/apps/web/src/server/chat/store/shared.ts
+++ b/apps/web/src/server/chat/store/shared.ts
@@ -27,6 +27,13 @@ export class ChatSessionConflictError extends Error {
   }
 }
 
+export class ChatTurnCancelledError extends Error {
+  public constructor(sessionId: string, turnId: string) {
+    super(`Chat turn was cancelled: sessionId=${sessionId}, turnId=${turnId}`);
+    this.name = "ChatTurnCancelledError";
+  }
+}
+
 export class ChatSessionRunTransitionError extends Error {
   public readonly sessionId: string;
   public readonly activeRunId: string;
@@ -84,7 +91,18 @@ export type PreparedChatRun = Readonly<{
   turnInput: ReadonlyArray<ContentPart>;
 }>;
 
+export type PrepareChatRunResult =
+  | Readonly<{
+    kind: "started";
+    preparedRun: PreparedChatRun;
+  }>
+  | Readonly<{
+    kind: "already_accepted";
+    sessionId: string;
+  }>;
+
 export type InsertChatItemParams = Readonly<{
+  itemId: string | null;
   sessionId: string;
   role: "user" | "assistant";
   state: ChatItemState;
@@ -153,6 +171,11 @@ export type UserCancelChatRunResult =
   | "cancelled"
   | "not_running"
   | "run_changed";
+
+export type UserCancelChatTurnResult =
+  | "active_run_cancelled"
+  | "cancellation_recorded"
+  | "already_cancelled";
 
 export const parseMainContentInvalidationVersion = (
   rawValue: string,

--- a/apps/web/src/server/chat/store/snapshotStore.test.ts
+++ b/apps/web/src/server/chat/store/snapshotStore.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { QueryResult } from "pg";
+import type { QueryFn } from "@/server/db/contextRunner";
+import { getChatSessionSnapshotWithQuery } from "./snapshotStore";
+
+type RecordedQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<unknown>;
+}>;
+
+const createQueryResult = (
+  rows: ReadonlyArray<unknown>,
+): QueryResult => ({
+  command: "SELECT",
+  rowCount: rows.length,
+  oid: 0,
+  fields: [],
+  rows: [...rows],
+});
+
+const createSessionRow = (
+  status: "idle" | "running",
+  activeRunId: string | null,
+): Readonly<Record<string, string | null>> => ({
+  session_id: "session-1",
+  status,
+  active_run_id: activeRunId,
+  active_run_heartbeat_at: activeRunId === null
+    ? null
+    : "2026-07-27T10:00:01.000Z",
+  main_content_invalidation_version: "0",
+  updated_at: activeRunId === null
+    ? "2026-07-27T10:00:00.000Z"
+    : "2026-07-27T10:00:01.000Z",
+});
+
+test("snapshot locks the session before reading messages and uses the locked run state", async (): Promise<void> => {
+  const turnId = "00000000-0000-4000-8000-000000000001";
+  const recordedQueries: Array<RecordedQuery> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    if (text.includes("FROM public.chat_sessions") && text.includes("FOR SHARE")) {
+      return createQueryResult([createSessionRow("running", turnId)]);
+    }
+    if (text.includes("FROM public.chat_sessions")) {
+      return createQueryResult([createSessionRow("idle", null)]);
+    }
+    if (text.includes("FROM public.chat_items")) {
+      return createQueryResult([{
+        item_id: turnId,
+        session_id: "session-1",
+        state: "completed",
+        payload: {
+          role: "user",
+          content: [{ type: "text", text: "Persisted request" }],
+        },
+        created_at: "2026-07-27T10:00:01.000Z",
+        updated_at: "2026-07-27T10:00:01.000Z",
+      }]);
+    }
+    throw new Error(`Unexpected query: ${text}`);
+  };
+
+  const snapshot = await getChatSessionSnapshotWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    "session-1",
+  );
+
+  assert.equal(snapshot.runState, "running");
+  assert.equal(snapshot.activeRunId, turnId);
+  assert.equal(snapshot.messages[0]?.itemId, turnId);
+  assert.equal(recordedQueries.length, 3);
+  assert.match(recordedQueries[1].text, /FOR SHARE/);
+  assert.match(recordedQueries[2].text, /FROM public\.chat_items/);
+  assert.deepEqual(recordedQueries[1].params, ["session-1"]);
+  assert.deepEqual(recordedQueries[2].params, ["session-1"]);
+});

--- a/apps/web/src/server/chat/store/snapshotStore.ts
+++ b/apps/web/src/server/chat/store/snapshotStore.ts
@@ -1,15 +1,17 @@
 import { withUserContext } from "@/server/db";
+import type { QueryFn } from "@/server/db/contextRunner";
 import type { ServerChatMessage } from "@/server/chat/openai/responses/replayItems";
 import {
   type ChatSessionSnapshot,
   type PersistedChatMessageItem,
 } from "./shared";
 import {
+  lockChatSessionForSnapshotWithQuery,
   mapSessionRow,
   resolveLatestOrCreateChatSessionWithQuery,
   resolveRequestedChatSessionWithQuery,
 } from "./sessionStore";
-import { listChatMessages } from "./messageStore";
+import { listChatMessagesWithQuery } from "./messageStore";
 
 export const buildLocalChatMessages = (
   messages: ReadonlyArray<PersistedChatMessageItem>,
@@ -24,16 +26,44 @@ export const getChatSessionSnapshot = async (
   userId: string,
   workspaceId: string,
   sessionId?: string,
+): Promise<ChatSessionSnapshot> =>
+  withUserContext(userId, workspaceId, async (queryFn) =>
+    getChatSessionSnapshotWithQuery(
+      queryFn,
+      userId,
+      workspaceId,
+      sessionId,
+    ));
+
+export const getChatSessionSnapshotWithQuery = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  sessionId: string | undefined,
 ): Promise<ChatSessionSnapshot> => {
   const sessionRow = sessionId === undefined
-    ? await withUserContext(userId, workspaceId, async (queryFn) =>
-      resolveLatestOrCreateChatSessionWithQuery(queryFn, userId, workspaceId))
-    : await withUserContext(userId, workspaceId, async (queryFn) =>
-      resolveRequestedChatSessionWithQuery(queryFn, userId, workspaceId, sessionId));
-  const messages = await listChatMessages(userId, workspaceId, sessionRow.session_id);
+    ? await resolveLatestOrCreateChatSessionWithQuery(
+      queryFn,
+      userId,
+      workspaceId,
+    )
+    : await resolveRequestedChatSessionWithQuery(
+      queryFn,
+      userId,
+      workspaceId,
+      sessionId,
+    );
+  const lockedSessionRow = await lockChatSessionForSnapshotWithQuery(
+    queryFn,
+    sessionRow.session_id,
+  );
+  const messages = await listChatMessagesWithQuery(
+    queryFn,
+    lockedSessionRow.session_id,
+  );
 
   return {
-    ...mapSessionRow(sessionRow),
+    ...mapSessionRow(lockedSessionRow),
     messages,
   };
 };

--- a/apps/web/src/server/chat/store/turnCancellationStore.test.ts
+++ b/apps/web/src/server/chat/store/turnCancellationStore.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { QueryResult } from "pg";
+import type { QueryFn } from "@/server/db/contextRunner";
+import {
+  ChatSessionRunTransitionError,
+  ChatTurnCancelledError,
+} from "./shared";
+import { lockUncancelledChatTurnForMutationWithQuery } from "./turnCancellationStore";
+
+const createQueryResult = (
+  rows: ReadonlyArray<Readonly<Record<string, string | null>>>,
+): QueryResult => ({
+  command: "SELECT",
+  rowCount: rows.length,
+  oid: 0,
+  fields: [],
+  rows: [...rows],
+});
+
+test("mutating SQL fencing locks the exact active turn before checking cancellation", async (): Promise<void> => {
+  const queries: Array<string> = [];
+  const queryFn: QueryFn = async (sql): Promise<QueryResult> => {
+    queries.push(sql);
+    if (queries.length === 1) {
+      return createQueryResult([{
+        session_id: "session-1",
+        status: "running",
+        active_run_id: "turn-1",
+        active_run_heartbeat_at: "2026-07-27T10:00:00.000Z",
+        main_content_invalidation_version: "0",
+        updated_at: "2026-07-27T10:00:00.000Z",
+      }]);
+    }
+    return createQueryResult([]);
+  };
+
+  await lockUncancelledChatTurnForMutationWithQuery(
+    queryFn,
+    "session-1",
+    "turn-1",
+  );
+
+  assert.match(queries[0], /FOR UPDATE/u);
+  assert.match(queries[1], /chat_turn_cancellations/u);
+});
+
+test("mutating SQL fencing rejects a tombstoned active turn", async (): Promise<void> => {
+  let queryCount = 0;
+  const queryFn: QueryFn = async (): Promise<QueryResult> => {
+    queryCount += 1;
+    return queryCount === 1
+      ? createQueryResult([{
+        session_id: "session-1",
+        status: "running",
+        active_run_id: "turn-1",
+        active_run_heartbeat_at: "2026-07-27T10:00:00.000Z",
+        main_content_invalidation_version: "0",
+        updated_at: "2026-07-27T10:00:00.000Z",
+      }])
+      : createQueryResult([{ turn_id: "turn-1" }]);
+  };
+
+  await assert.rejects(
+    () => lockUncancelledChatTurnForMutationWithQuery(
+      queryFn,
+      "session-1",
+      "turn-1",
+    ),
+    ChatTurnCancelledError,
+  );
+});
+
+test("a remote runtime reaching SQL after cancellation cannot mutate a terminal turn", async (): Promise<void> => {
+  let queryCount = 0;
+  const queryFn: QueryFn = async (): Promise<QueryResult> => {
+    queryCount += 1;
+    return createQueryResult([]);
+  };
+
+  await assert.rejects(
+    () => lockUncancelledChatTurnForMutationWithQuery(
+      queryFn,
+      "session-1",
+      "turn-1",
+    ),
+    ChatSessionRunTransitionError,
+  );
+  assert.equal(queryCount, 1);
+});

--- a/apps/web/src/server/chat/store/turnCancellationStore.ts
+++ b/apps/web/src/server/chat/store/turnCancellationStore.ts
@@ -1,0 +1,64 @@
+import type { QueryFn } from "@/server/db/contextRunner";
+import {
+  ChatTurnCancelledError,
+} from "./shared";
+import {
+  lockActiveChatSessionRunWithQuery,
+} from "./sessionStore";
+
+const HAS_CHAT_TURN_CANCELLATION_SQL = `
+  SELECT turn_id
+  FROM public.chat_turn_cancellations
+  WHERE session_id = $1
+    AND turn_id = $2
+`;
+
+const INSERT_CHAT_TURN_CANCELLATION_SQL = `
+  INSERT INTO public.chat_turn_cancellations (
+    session_id,
+    turn_id
+  )
+  VALUES ($1, $2)
+  ON CONFLICT (session_id, turn_id) DO NOTHING
+  RETURNING turn_id
+`;
+
+export const hasChatTurnCancellationWithQuery = async (
+  queryFn: QueryFn,
+  sessionId: string,
+  turnId: string,
+): Promise<boolean> => {
+  const result = await queryFn(HAS_CHAT_TURN_CANCELLATION_SQL, [
+    sessionId,
+    turnId,
+  ]);
+  return result.rows.length > 0;
+};
+
+export const insertChatTurnCancellationWithQuery = async (
+  queryFn: QueryFn,
+  sessionId: string,
+  turnId: string,
+): Promise<boolean> => {
+  const result = await queryFn(INSERT_CHAT_TURN_CANCELLATION_SQL, [
+    sessionId,
+    turnId,
+  ]);
+  return result.rows.length > 0;
+};
+
+export const lockUncancelledChatTurnForMutationWithQuery = async (
+  queryFn: QueryFn,
+  sessionId: string,
+  turnId: string,
+): Promise<void> => {
+  await lockActiveChatSessionRunWithQuery(
+    queryFn,
+    sessionId,
+    turnId,
+    "execute mutating chat SQL",
+  );
+  if (await hasChatTurnCancellationWithQuery(queryFn, sessionId, turnId)) {
+    throw new ChatTurnCancelledError(sessionId, turnId);
+  }
+};


### PR DESCRIPTION
## Summary

- add backward-compatible exact chat turn identity across server, store, runtime, tools, and snapshots
- add durable, idempotent exact-turn cancellation and cross-instance mutating-SQL fencing
- preserve legacy/cached send and Stop behavior while keeping the mounted client unchanged

## Validation

- direct TypeScript check
- C2 server/store/runtime/tool/API matrix: 124/124
- untracked-inclusive diff check
- web lint
- old-client production build: 40 pages

## Deployment

C1 migration 0065 is already live in production. This C2 server release remains backward compatible with old and cached clients. C3 client activation stays gated until C2 is deployed successfully and old tasks have drained.