### PR TITLE
Activate chat turn reconciliation

### DIFF
--- a/apps/web/src/ui/chat/session/bootstrap/chatSessionSnapshot.ts
+++ b/apps/web/src/ui/chat/session/bootstrap/chatSessionSnapshot.ts
@@ -6,6 +6,7 @@ import type { ChatRunState } from "../../stream/streamRecovery";
 export type ChatSessionSnapshot = Readonly<{
   sessionId: string;
   runState: ChatRunState;
+  activeTurnId: string | null;
   updatedAt: number;
   mainContentInvalidationVersion: number;
   messages: ReadonlyArray<StoredMessage>;

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.test.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.test.ts
@@ -2,27 +2,82 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { ChatSessionSnapshot } from "../bootstrap/chatSessionSnapshot";
 import {
+  assertCanonicalChatTurnId,
+  assertValidChatSessionSnapshot,
   beginChatSnapshotRequest,
   buildChatSendRequestBody,
+  buildFailedChatSendHistory,
+  buildPendingChatSendHistory,
+  buildStoppedChatSendHistory,
+  type ChatClearOperationOwner,
+  type ChatTurnCancellationResolution,
+  ChatSessionSnapshotSchemaError,
   ChatSessionSnapshotRequestError,
+  ChatSessionSnapshotTransportError,
+  ChatTurnCancellationRequestError,
+  classifyConfirmedChatStopSnapshotFailure,
+  completeChatTurnCancellation,
   createChatSnapshotRequestCoordinator,
+  createSingleFlightChatClearOperationRunner,
+  createSingleFlightChatSendReconciliationRunner,
   createSingleFlightChatSnapshotPoller,
+  createSingleFlightChatTurnCancellationRunner,
   ensureWritableChatSession,
   fetchChatSessionSnapshot,
+  isChatClearOperationOwnerCurrent,
+  isChatPreSessionSendOwnerCurrent,
+  isCanonicalChatUuid,
+  isChatSnapshotPollingOwnerCurrent,
   isChatSnapshotRequestCurrent,
+  isChatSendReconciliationOwnerCurrent,
   isChatStopSettlementOwned,
+  isChatStopOperationOwnerCurrent,
   isChatStreamControllerOwnedByStop,
+  isChatTurnCancellationSettlementOwned,
+  isChatTurnOwnerForSession,
+  isDefinitiveChatRequestRejection,
   isUnavailableChatSessionSnapshotError,
+  postStopChatSession,
   prepareChatSendRequest,
+  reconcileChatTurnCancellation,
+  reconcileConfirmedChatStopSnapshot,
+  resolveChatExactTurnOwnership,
+  resolveChatPreSessionSendAdoption,
+  resolveChatSendReconciliationDisposition,
+  resolveDefinitiveChatSendSnapshotFailureHistory,
+  resolveConfirmedChatStopSnapshotDisposition,
+  resolveConfirmedChatTurnStopHistory,
   resolveChatSnapshotFailureDisposition,
   resolveChatSnapshotRequest,
+  restorePendingChatTurnAfterCancellationRejection,
+  selectSupersedingChatSnapshotRequestResult,
+  shouldRestoreChatRunAfterSnapshotFailure,
+  shouldRestoreChatTurnAfterCancellationRejection,
+  streamChatResponse,
 } from "./chatSessionControllerRuntime";
 import {
   createInitialChatSessionControllerState,
   reduceChatSessionControllerState,
   selectComposerAction,
   selectIsAssistantRunActive,
+  selectIsSelectedSessionStopping,
 } from "./chatSessionControllerState";
+
+const TURN_ID = "00000000-0000-4000-8000-000000000001";
+const NEWER_TURN_ID = "00000000-0000-4000-8000-000000000002";
+
+const createUnreadableResponse = (
+  status: number,
+  statusText: string,
+): Response =>
+  new Response(
+    new ReadableStream<Uint8Array>({
+      start: (controller): void => {
+        controller.error(new Error("response body read failed"));
+      },
+    }),
+    { status, statusText },
+  );
 
 test("ensureWritableChatSession creates a session for a fresh local chat", async (): Promise<void> => {
   let createCallCount = 0;
@@ -58,14 +113,578 @@ test("buildChatSendRequestBody serializes explicit session ids", (): void => {
   const requestBody = buildChatSendRequestBody(
     [{ type: "text", text: "Hello" }],
     "session-4",
+    TURN_ID,
   );
   const parsedRequestBody = JSON.parse(requestBody) as Readonly<{
     sessionId: string;
+    turnId: string;
     content: ReadonlyArray<Readonly<{ type: string; text?: string }>>;
   }>;
 
   assert.equal(parsedRequestBody.sessionId, "session-4");
+  assert.equal(parsedRequestBody.turnId, TURN_ID);
   assert.deepEqual(parsedRequestBody.content, [{ type: "text", text: "Hello" }]);
+});
+
+test("client, active-turn, and persisted-message identities match canonical Zod UUID semantics", (): void => {
+  const validIds = [
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    "aaaaaaaa-aaaa-1aaa-8aaa-aaaaaaaaaaaa",
+    "aaaaaaaa-aaaa-8aaa-baaa-aaaaaaaaaaaa",
+    "00000000-0000-0000-0000-000000000000",
+    "ffffffff-ffff-ffff-ffff-ffffffffffff",
+  ];
+  for (const validId of validIds) {
+    assert.equal(isCanonicalChatUuid(validId), true);
+    assert.doesNotThrow((): void => {
+      assertCanonicalChatTurnId(validId);
+    });
+    assert.doesNotThrow((): void => {
+      assertValidChatSessionSnapshot({
+        sessionId: "session-valid-active-identity",
+        runState: "running",
+        activeTurnId: validId,
+        updatedAt: 10,
+        mainContentInvalidationVersion: 0,
+        messages: [],
+      });
+    });
+    assert.doesNotThrow((): void => {
+      assertValidChatSessionSnapshot({
+        sessionId: "session-valid-message-identity",
+        runState: "idle",
+        activeTurnId: null,
+        updatedAt: 10,
+        mainContentInvalidationVersion: 0,
+        messages: [{
+          messageId: validId,
+          role: "user",
+          content: [{ type: "text", text: "Valid identity" }],
+          timestamp: 10,
+          isError: false,
+          isStopped: false,
+        }],
+      });
+    });
+  }
+
+  const invalidIds = [
+    "aaaaaaaa-aaaa-0aaa-8aaa-aaaaaaaaaaaa",
+    "aaaaaaaa-aaaa-9aaa-8aaa-aaaaaaaaaaaa",
+    "aaaaaaaa-aaaa-4aaa-7aaa-aaaaaaaaaaaa",
+    "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA",
+    "not-a-uuid",
+  ];
+  for (const invalidId of invalidIds) {
+    assert.equal(isCanonicalChatUuid(invalidId), false);
+    assert.throws((): void => {
+      assertCanonicalChatTurnId(invalidId);
+    }, /canonical lowercase UUID/u);
+    assert.throws((): void => {
+      assertValidChatSessionSnapshot({
+        sessionId: "session-invalid-active-identity",
+        runState: "running",
+        activeTurnId: invalidId,
+        updatedAt: 10,
+        mainContentInvalidationVersion: 0,
+        messages: [],
+      });
+    }, ChatSessionSnapshotSchemaError);
+    assert.throws((): void => {
+      assertValidChatSessionSnapshot({
+        sessionId: "session-invalid-message-identity",
+        runState: "idle",
+        activeTurnId: null,
+        updatedAt: 10,
+        mainContentInvalidationVersion: 0,
+        messages: [{
+          messageId: invalidId,
+          role: "user",
+          content: [{ type: "text", text: "Invalid identity" }],
+          timestamp: 10,
+          isError: false,
+          isStopped: false,
+        }],
+      });
+    }, ChatSessionSnapshotSchemaError);
+  }
+});
+
+test("fresh-session send ownership blocks every invalidated continuation", (): void => {
+  const activeSignal = new AbortController().signal;
+  const owner = {
+    ownerId: Symbol("pre-session-owner"),
+    initialSessionId: null,
+    turnId: TURN_ID,
+  };
+  const supersedingOwner = {
+    ownerId: Symbol("superseding-owner"),
+    initialSessionId: null,
+    turnId: "00000000-0000-4000-8000-000000000002",
+  };
+
+  assert.equal(isChatPreSessionSendOwnerCurrent(owner, owner, null), true);
+  for (const invalidatedOwner of [
+    null,
+    supersedingOwner,
+  ]) {
+    assert.equal(
+      isChatPreSessionSendOwnerCurrent(owner, invalidatedOwner, null),
+      false,
+    );
+  }
+  assert.equal(
+    isChatPreSessionSendOwnerCurrent(owner, owner, "session-switched"),
+    false,
+  );
+  assert.equal(
+    resolveChatPreSessionSendAdoption(
+      owner,
+      owner,
+      null,
+      "session-created",
+      activeSignal,
+    )?.sessionId,
+    "session-created",
+  );
+  assert.equal(
+    resolveChatPreSessionSendAdoption(
+      owner,
+      null,
+      null,
+      "session-created",
+      activeSignal,
+    ),
+    null,
+  );
+  assert.equal(
+    resolveChatPreSessionSendAdoption(
+      owner,
+      supersedingOwner,
+      null,
+      "session-created",
+      activeSignal,
+    ),
+    null,
+  );
+  assert.equal(
+    resolveChatPreSessionSendAdoption(
+      owner,
+      owner,
+      "session-switched",
+      "session-created",
+      activeSignal,
+    ),
+    null,
+  );
+
+  let currentOwner: typeof owner | null = owner;
+  let postCount = 0;
+  const adoptAndPost = (): void => {
+    const adoptedOwner = resolveChatPreSessionSendAdoption(
+      owner,
+      currentOwner,
+      null,
+      "session-created",
+      activeSignal,
+    );
+    if (adoptedOwner === null) {
+      return;
+    }
+    currentOwner = null;
+    postCount += 1;
+  };
+  adoptAndPost();
+  adoptAndPost();
+  assert.equal(postCount, 1);
+
+  const stoppedController = new AbortController();
+  stoppedController.abort();
+  assert.equal(
+    resolveChatPreSessionSendAdoption(
+      owner,
+      owner,
+      null,
+      "session-created",
+      stoppedController.signal,
+    ),
+    null,
+  );
+});
+
+test("accepted and restored snapshots preserve exact active turn ownership until terminal", (): void => {
+  const pendingOwner = {
+    ownerId: Symbol("pending-owner"),
+    sessionId: "session-1",
+    turnId: TURN_ID,
+  };
+  const acceptedActiveSnapshot: ChatSessionSnapshot = {
+    sessionId: "session-1",
+    runState: "running",
+    activeTurnId: TURN_ID,
+    updatedAt: 10,
+    mainContentInvalidationVersion: 0,
+    messages: [{
+      messageId: TURN_ID,
+      role: "user",
+      content: [{ type: "text", text: "Persisted" }],
+      timestamp: 10,
+      isError: false,
+      isStopped: false,
+    }],
+  };
+
+  const acceptedOwnership = resolveChatExactTurnOwnership(
+    acceptedActiveSnapshot,
+    pendingOwner,
+    null,
+    null,
+  );
+  assert.equal(acceptedOwnership.pendingTurn, null);
+  assert.equal(acceptedOwnership.activeTurn?.ownerId, pendingOwner.ownerId);
+
+  const restoredOwnership = resolveChatExactTurnOwnership(
+    acceptedActiveSnapshot,
+    null,
+    null,
+    null,
+  );
+  assert.equal(restoredOwnership.activeTurn?.sessionId, "session-1");
+  assert.equal(restoredOwnership.activeTurn?.turnId, TURN_ID);
+
+  const terminalOwnership = resolveChatExactTurnOwnership(
+    {
+      ...acceptedActiveSnapshot,
+      runState: "idle",
+      activeTurnId: null,
+      updatedAt: 20,
+    },
+    null,
+    acceptedOwnership.activeTurn,
+    null,
+  );
+  assert.equal(terminalOwnership.activeTurn, null);
+});
+
+test("ambiguous cancellation keeps the exact active turn fenced through terminal snapshots", (): void => {
+  const activeOwner = {
+    ownerId: Symbol("active-owner"),
+    sessionId: "session-1",
+    turnId: TURN_ID,
+  };
+  const terminalSnapshot: ChatSessionSnapshot = {
+    sessionId: "session-1",
+    runState: "idle",
+    activeTurnId: null,
+    updatedAt: 20,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  };
+
+  const ownership = resolveChatExactTurnOwnership(
+    terminalSnapshot,
+    null,
+    activeOwner,
+    activeOwner,
+  );
+
+  assert.equal(ownership.activeTurn?.ownerId, activeOwner.ownerId);
+  assert.equal(
+    isChatTurnCancellationSettlementOwned(
+      activeOwner,
+      activeOwner,
+      ownership.activeTurn,
+      "session-1",
+    ),
+    true,
+  );
+});
+
+test("a superseding active snapshot makes stale cancellation settlement non-owning", (): void => {
+  const staleOwner = {
+    ownerId: Symbol("stale-owner"),
+    sessionId: "session-1",
+    turnId: TURN_ID,
+  };
+  const newerTurnId = "00000000-0000-4000-8000-000000000002";
+  const ownership = resolveChatExactTurnOwnership(
+    {
+      sessionId: "session-1",
+      runState: "running",
+      activeTurnId: newerTurnId,
+      updatedAt: 30,
+      mainContentInvalidationVersion: 0,
+      messages: [],
+    },
+    null,
+    staleOwner,
+    staleOwner,
+  );
+
+  assert.equal(ownership.activeTurn?.turnId, newerTurnId);
+  assert.equal(
+    isChatTurnCancellationSettlementOwned(
+      staleOwner,
+      staleOwner,
+      ownership.activeTurn,
+      "session-1",
+    ),
+    false,
+  );
+});
+
+test("owned rejected Stop restores a masked running turn and keeps Send fenced", (): void => {
+  const activeTurn = {
+    ownerId: Symbol("active-turn"),
+    sessionId: "session-1",
+    turnId: TURN_ID,
+  };
+  const rejection = new ChatTurnCancellationRequestError(
+    "Request rejected",
+    403,
+    "rejected",
+  );
+  let controllerState = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "server_session_created", sessionId: activeTurn.sessionId },
+  );
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "run_started",
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "stop_requested",
+    sessionId: activeTurn.sessionId,
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "snapshot_applied",
+    sessionId: activeTurn.sessionId,
+    runState: "running",
+    updatedAt: 10,
+    mainContentInvalidationVersion: 0,
+  });
+
+  assert.equal(controllerState.runState, "idle");
+  assert.equal(
+    shouldRestoreChatTurnAfterCancellationRejection(
+      rejection,
+      activeTurn,
+      activeTurn,
+      controllerState.currentSessionId,
+    ),
+    true,
+  );
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "run_started",
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "stop_failed",
+    sessionId: activeTurn.sessionId,
+  });
+
+  assert.equal(controllerState.runState, "running");
+  assert.equal(selectIsAssistantRunActive(controllerState), true);
+  assert.equal(selectComposerAction(controllerState), "stop");
+  assert.equal(
+    isChatTurnOwnerForSession(
+      activeTurn,
+      controllerState.currentSessionId,
+    ),
+    true,
+  );
+
+  const newerTurn = {
+    ownerId: Symbol("newer-turn"),
+    sessionId: activeTurn.sessionId,
+    turnId: "00000000-0000-4000-8000-000000000002",
+  };
+  assert.equal(
+    shouldRestoreChatTurnAfterCancellationRejection(
+      rejection,
+      activeTurn,
+      newerTurn,
+      activeTurn.sessionId,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldRestoreChatTurnAfterCancellationRejection(
+      rejection,
+      activeTurn,
+      activeTurn,
+      "session-switched",
+    ),
+    false,
+  );
+  assert.equal(
+    isChatTurnOwnerForSession(activeTurn, "session-switched"),
+    false,
+  );
+});
+
+test("permanent Stop or Clear snapshot failure restores running only for the current exact turn", (): void => {
+  const stoppedTurn = {
+    ownerId: Symbol("stopped-turn"),
+    sessionId: "session-restore-running",
+    turnId: TURN_ID,
+  };
+  const authoritativeActiveTurn = {
+    ownerId: Symbol("authoritative-active-turn"),
+    sessionId: stoppedTurn.sessionId,
+    turnId: stoppedTurn.turnId,
+  };
+  let controllerState = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "server_session_created", sessionId: stoppedTurn.sessionId },
+  );
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "run_started",
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "stop_requested",
+    sessionId: stoppedTurn.sessionId,
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "snapshot_applied",
+    sessionId: stoppedTurn.sessionId,
+    runState: "running",
+    updatedAt: 10,
+    mainContentInvalidationVersion: 0,
+  });
+  assert.equal(controllerState.runState, "idle");
+
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "stop_failed",
+    sessionId: stoppedTurn.sessionId,
+  });
+  if (shouldRestoreChatRunAfterSnapshotFailure(
+    stoppedTurn,
+    authoritativeActiveTurn,
+    controllerState.currentSessionId,
+  )) {
+    controllerState = reduceChatSessionControllerState(controllerState, {
+      type: "run_started",
+    });
+  }
+  assert.equal(controllerState.runState, "running");
+  assert.equal(selectComposerAction(controllerState), "stop");
+
+  for (const staleOwnership of [
+    {
+      activeTurn: {
+        ownerId: Symbol("superseding-turn"),
+        sessionId: stoppedTurn.sessionId,
+        turnId: NEWER_TURN_ID,
+      },
+      currentSessionId: stoppedTurn.sessionId,
+    },
+    {
+      activeTurn: null,
+      currentSessionId: stoppedTurn.sessionId,
+    },
+    {
+      activeTurn: authoritativeActiveTurn,
+      currentSessionId: "session-switched",
+    },
+  ]) {
+    assert.equal(
+      shouldRestoreChatRunAfterSnapshotFailure(
+        stoppedTurn,
+        staleOwnership.activeTurn,
+        staleOwnership.currentSessionId,
+      ),
+      false,
+    );
+  }
+});
+
+test("owned definitive cancellation rejection renews the identical pending Send without overlap", async (): Promise<void> => {
+  const requestBody = buildChatSendRequestBody(
+    [{ type: "text", text: "Retry this exact turn" }],
+    "session-rejected-cancellation",
+    TURN_ID,
+  );
+  const pendingTurn = {
+    ownerId: Symbol("rejected-cancellation-pending-turn"),
+    sessionId: "session-rejected-cancellation",
+    turnId: TURN_ID,
+    requestBody,
+    retryAbortController: new AbortController(),
+  };
+  const rejection = new ChatTurnCancellationRequestError(
+    "Cancellation was rejected",
+    409,
+    "rejected",
+  );
+  const firstAttemptStarted = Promise.withResolvers<void>();
+  const attemptedBodies: Array<string> = [];
+  const attemptedTurnIds: Array<string> = [];
+  let activeAttemptCount = 0;
+  let maximumActiveAttemptCount = 0;
+  const runner = createSingleFlightChatSendReconciliationRunner<
+    typeof pendingTurn
+  >(
+    async (attemptedTurn, attemptAbortController): Promise<void> => {
+      attemptedBodies.push(attemptedTurn.requestBody);
+      attemptedTurnIds.push(attemptedTurn.turnId);
+      activeAttemptCount += 1;
+      maximumActiveAttemptCount = Math.max(
+        maximumActiveAttemptCount,
+        activeAttemptCount,
+      );
+      try {
+        if (attemptedBodies.length === 1) {
+          firstAttemptStarted.resolve();
+          await new Promise<void>((resolve) => {
+            const finish = (): void => {
+              attemptAbortController.signal.removeEventListener("abort", finish);
+              resolve();
+            };
+            if (attemptAbortController.signal.aborted) {
+              finish();
+              return;
+            }
+            attemptAbortController.signal.addEventListener(
+              "abort",
+              finish,
+              { once: true },
+            );
+          });
+        }
+      } finally {
+        activeAttemptCount -= 1;
+      }
+    },
+  );
+
+  const firstAttempt = runner.run(pendingTurn);
+  await firstAttemptStarted.promise;
+  pendingTurn.retryAbortController.abort();
+  runner.cancel(pendingTurn);
+  await firstAttempt;
+
+  const restoredTurn = restorePendingChatTurnAfterCancellationRejection(
+    rejection,
+    pendingTurn,
+    pendingTurn,
+    pendingTurn.sessionId,
+  );
+  assert.notEqual(restoredTurn, null);
+  assert.equal(restoredTurn?.ownerId, pendingTurn.ownerId);
+  assert.equal(restoredTurn?.turnId, pendingTurn.turnId);
+  assert.equal(restoredTurn?.requestBody, pendingTurn.requestBody);
+  assert.equal(restoredTurn?.retryAbortController.signal.aborted, false);
+
+  if (restoredTurn === null) {
+    throw new Error("Expected an owned rejected cancellation to restore the pending turn");
+  }
+  const firstRetry = runner.run(restoredTurn);
+  const overlappingRetry = runner.run(restoredTurn);
+  assert.equal(firstRetry, overlappingRetry);
+  await firstRetry;
+
+  assert.deepEqual(attemptedBodies, [requestBody, requestBody]);
+  assert.deepEqual(attemptedTurnIds, [TURN_ID, TURN_ID]);
+  assert.equal(maximumActiveAttemptCount, 1);
 });
 
 test("slow snapshot polling stays single-flight until the active poll settles", async (): Promise<void> => {
@@ -93,6 +712,1624 @@ test("slow snapshot polling stays single-flight until the active poll settles", 
   assert.notEqual(nextPoll, activePoll);
   assert.equal(pollCallCount, 2);
   await nextPoll;
+});
+
+test("poll ownership rejects late snapshots after session switch, Clear, and unmount", async (): Promise<void> => {
+  const runLateSnapshotScenario = async (
+    invalidate: (
+      abortController: AbortController,
+      selectSession: (sessionId: string | null) => void,
+    ) => void,
+  ): Promise<void> => {
+    const requestedSessionId = "session-polling";
+    const abortController = new AbortController();
+    const snapshot = Promise.withResolvers<ChatSessionSnapshot>();
+    let currentSessionId: string | null = requestedSessionId;
+    let appliedSessionId: string | null = null;
+    const adoption = (async (): Promise<void> => {
+      const payload = await snapshot.promise;
+      if (
+        payload.sessionId === requestedSessionId
+        && isChatSnapshotPollingOwnerCurrent(
+          requestedSessionId,
+          currentSessionId,
+          abortController.signal,
+        )
+      ) {
+        appliedSessionId = payload.sessionId;
+      }
+    })();
+
+    invalidate(
+      abortController,
+      (sessionId): void => {
+        currentSessionId = sessionId;
+      },
+    );
+    snapshot.resolve({
+      sessionId: requestedSessionId,
+      runState: "idle",
+      activeTurnId: null,
+      updatedAt: 10,
+      mainContentInvalidationVersion: 0,
+      messages: [],
+    });
+    await adoption;
+
+    assert.equal(appliedSessionId, null);
+  };
+
+  await runLateSnapshotScenario((
+    _abortController,
+    selectSession,
+  ): void => {
+    selectSession("session-selected");
+  });
+  await runLateSnapshotScenario((
+    abortController,
+    selectSession,
+  ): void => {
+    selectSession("session-after-clear");
+    abortController.abort();
+  });
+  await runLateSnapshotScenario((
+    abortController,
+    _selectSession,
+  ): void => {
+    abortController.abort();
+  });
+});
+
+test("ambiguous send retries remain single-flight and reuse the exact request identity", async (): Promise<void> => {
+  type RetryOwner = Readonly<{
+    ownerId: symbol;
+    sessionId: string;
+    turnId: string;
+    requestBody: string;
+  }>;
+  const firstAttempt = Promise.withResolvers<void>();
+  const requestBody = buildChatSendRequestBody(
+    [{ type: "text", text: "Retry safely" }],
+    "session-retry",
+    TURN_ID,
+  );
+  const owner: RetryOwner = {
+    ownerId: Symbol("retry-owner"),
+    sessionId: "session-retry",
+    turnId: TURN_ID,
+    requestBody,
+  };
+  const attemptedBodies: Array<string> = [];
+  let attemptCount = 0;
+  const runner = createSingleFlightChatSendReconciliationRunner<RetryOwner>(
+    async (attemptOwner): Promise<void> => {
+      attemptCount += 1;
+      attemptedBodies.push(attemptOwner.requestBody);
+      if (attemptCount === 1) {
+        await firstAttempt.promise;
+      }
+    },
+  );
+
+  const activeAttempt = runner.run(owner);
+  const overlappingAttempt = runner.run(owner);
+
+  assert.equal(overlappingAttempt, activeAttempt);
+  assert.equal(attemptCount, 1);
+  firstAttempt.resolve();
+  await activeAttempt;
+
+  await runner.run(owner);
+
+  assert.equal(attemptCount, 2);
+  assert.deepEqual(attemptedBodies, [requestBody, requestBody]);
+  assert.equal(
+    (JSON.parse(attemptedBodies[1]) as { turnId: string }).turnId,
+    TURN_ID,
+  );
+});
+
+test("superseding send ownership aborts stale work and blocks stale session results", async (): Promise<void> => {
+  const firstAttemptStarted = Promise.withResolvers<void>();
+  const firstAttemptAborted = Promise.withResolvers<void>();
+  const secondAttempt = Promise.withResolvers<void>();
+  const firstOwner = {
+    ownerId: Symbol("first-owner"),
+    sessionId: "session-a",
+    turnId: TURN_ID,
+  };
+  const secondOwner = {
+    ownerId: Symbol("second-owner"),
+    sessionId: "session-b",
+    turnId: "00000000-0000-4000-8000-000000000002",
+  };
+  const runner = createSingleFlightChatSendReconciliationRunner(
+    async (owner, abortController): Promise<void> => {
+      if (owner.ownerId === firstOwner.ownerId) {
+        abortController.signal.addEventListener("abort", () => {
+          firstAttemptAborted.resolve();
+        }, { once: true });
+        firstAttemptStarted.resolve();
+        await firstAttemptAborted.promise;
+        return;
+      }
+      await secondAttempt.promise;
+    },
+  );
+
+  const staleAttempt = runner.run(firstOwner);
+  await firstAttemptStarted.promise;
+  const currentAttempt = runner.run(secondOwner);
+  await firstAttemptAborted.promise;
+
+  assert.equal(
+    isChatSendReconciliationOwnerCurrent(
+      firstOwner,
+      secondOwner,
+      secondOwner.sessionId,
+    ),
+    false,
+  );
+  assert.equal(
+    isChatSendReconciliationOwnerCurrent(
+      secondOwner,
+      secondOwner,
+      secondOwner.sessionId,
+    ),
+    true,
+  );
+
+  secondAttempt.resolve();
+  await Promise.all([staleAttempt, currentAttempt]);
+});
+
+test("Clear is single-flight and only the current owner applies success or failure", async (): Promise<void> => {
+  type ClearOutcome =
+    | Readonly<{ kind: "success"; nextSessionId: string }>
+    | Readonly<{ kind: "failure"; error: Error }>;
+  const owner = {
+    ownerId: Symbol("clear-owner"),
+    targetSessionId: "session-a",
+  };
+  const settlement = Promise.withResolvers<ClearOutcome>();
+  let currentOwner = owner;
+  let currentSessionId: string | null = owner.targetSessionId;
+  let clearCallCount = 0;
+  let visibleSessionId = currentSessionId;
+  let visibleError: string | null = null;
+  const runner = createSingleFlightChatClearOperationRunner(
+    async (attemptOwner): Promise<void> => {
+      clearCallCount += 1;
+      const outcome = await settlement.promise;
+      if (!isChatClearOperationOwnerCurrent(
+        attemptOwner,
+        currentOwner,
+        currentSessionId,
+      )) {
+        return;
+      }
+      if (outcome.kind === "success") {
+        visibleSessionId = outcome.nextSessionId;
+        return;
+      }
+      visibleError = outcome.error.message;
+    },
+  );
+
+  const firstClear = runner.run(owner);
+  const overlappingClear = runner.run(owner);
+  assert.equal(overlappingClear, firstClear);
+  assert.equal(clearCallCount, 1);
+
+  settlement.resolve({
+    kind: "success",
+    nextSessionId: "session-after-clear",
+  });
+  await firstClear;
+
+  assert.equal(visibleSessionId, "session-after-clear");
+  assert.equal(visibleError, null);
+
+  const failedOwner = {
+    ownerId: Symbol("failed-clear-owner"),
+    targetSessionId: "session-after-clear",
+  };
+  const failedSettlement = Promise.withResolvers<ClearOutcome>();
+  currentOwner = failedOwner;
+  currentSessionId = failedOwner.targetSessionId;
+  const failedRunner = createSingleFlightChatClearOperationRunner(
+    async (attemptOwner): Promise<void> => {
+      const outcome = await failedSettlement.promise;
+      if (!isChatClearOperationOwnerCurrent(
+        attemptOwner,
+        currentOwner,
+        currentSessionId,
+      )) {
+        return;
+      }
+      if (outcome.kind === "failure") {
+        visibleError = outcome.error.message;
+      }
+    },
+  );
+
+  const failedClear = failedRunner.run(failedOwner);
+  failedSettlement.resolve({
+    kind: "failure",
+    error: new Error("Clear failed"),
+  });
+  await failedClear;
+
+  assert.equal(visibleSessionId, "session-after-clear");
+  assert.equal(visibleError, "Clear failed");
+});
+
+test("superseding Clear and session switches block stale success and failure", async (): Promise<void> => {
+  type ClearOutcome =
+    | Readonly<{ kind: "success"; nextSessionId: string }>
+    | Readonly<{ kind: "failure"; error: Error }>;
+  const firstOwner = {
+    ownerId: Symbol("first-clear-owner"),
+    targetSessionId: "session-a",
+  };
+  const secondOwner = {
+    ownerId: Symbol("second-clear-owner"),
+    targetSessionId: "session-b",
+  };
+  const firstSettlement = Promise.withResolvers<ClearOutcome>();
+  const secondSettlement = Promise.withResolvers<ClearOutcome>();
+  const settlements = new Map<symbol, Promise<ClearOutcome>>([
+    [firstOwner.ownerId, firstSettlement.promise],
+    [secondOwner.ownerId, secondSettlement.promise],
+  ]);
+  let currentOwner: ChatClearOperationOwner | null = firstOwner;
+  let currentSessionId: string | null = firstOwner.targetSessionId;
+  let visibleSessionId = currentSessionId;
+  let visibleError: string | null = null;
+  const runner = createSingleFlightChatClearOperationRunner(
+    async (attemptOwner): Promise<void> => {
+      const settlementPromise = settlements.get(attemptOwner.ownerId);
+      if (settlementPromise === undefined) {
+        throw new Error("Clear settlement was not configured");
+      }
+      const outcome = await settlementPromise;
+      if (!isChatClearOperationOwnerCurrent(
+        attemptOwner,
+        currentOwner,
+        currentSessionId,
+      )) {
+        return;
+      }
+      if (outcome.kind === "success") {
+        visibleSessionId = outcome.nextSessionId;
+        return;
+      }
+      visibleError = outcome.error.message;
+    },
+  );
+
+  const staleClear = runner.run(firstOwner);
+  currentOwner = secondOwner;
+  currentSessionId = secondOwner.targetSessionId;
+  visibleSessionId = secondOwner.targetSessionId;
+  const currentClear = runner.run(secondOwner);
+
+  firstSettlement.resolve({
+    kind: "success",
+    nextSessionId: "stale-session",
+  });
+  await staleClear;
+  assert.equal(visibleSessionId, "session-b");
+  assert.equal(visibleError, null);
+
+  currentOwner = null;
+  currentSessionId = "session-c";
+  visibleSessionId = currentSessionId;
+  runner.cancel(secondOwner);
+  secondSettlement.resolve({
+    kind: "failure",
+    error: new Error("Stale clear failed"),
+  });
+  await currentClear;
+
+  assert.equal(visibleSessionId, "session-c");
+  assert.equal(visibleError, null);
+});
+
+test("network ambiguity converges through a same-body accepted retry", async (): Promise<void> => {
+  type RetryOwner = Readonly<{
+    ownerId: symbol;
+    sessionId: string;
+    turnId: string;
+    requestBody: string;
+  }>;
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  const requestBody = buildChatSendRequestBody(
+    [{ type: "text", text: "Apply once" }],
+    "session-retry",
+    TURN_ID,
+  );
+  const owner: RetryOwner = {
+    ownerId: Symbol("network-retry-owner"),
+    sessionId: "session-retry",
+    turnId: TURN_ID,
+    requestBody,
+  };
+  const attemptedBodies: Array<string> = [];
+  const acceptances: Array<string> = [];
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      attemptedBodies.push(String(init?.body));
+      if (attemptedBodies.length === 1) {
+        throw new TypeError("network unavailable");
+      }
+      return new Response(null, {
+        status: 202,
+        headers: {
+          "X-Chat-Request-Acceptance": "accepted",
+          "X-Chat-Session-Id": owner.sessionId,
+        },
+      });
+    },
+  });
+  const runner = createSingleFlightChatSendReconciliationRunner<RetryOwner>(
+    async (attemptOwner, abortController): Promise<void> => {
+      const result = await streamChatResponse({
+        requestBody: attemptOwner.requestBody,
+        signal: abortController.signal,
+        abortStream: (): void => {
+          abortController.abort();
+        },
+        t: (key: string): string => key,
+        handlers: {
+          appendAssistantChunk: (): void => {},
+          upsertReasoningSummary: (): void => {},
+          upsertToolCall: (): void => {},
+          markAssistantError: (): void => {},
+          applyMainContentInvalidationVersion: (): void => {},
+        },
+        onSessionIdReceived: (): void => {},
+        onLiveStreamConnected: (): void => {},
+      });
+      acceptances.push(result.requestAcceptance);
+    },
+  );
+
+  try {
+    await runner.run(owner);
+    await runner.run(owner);
+
+    assert.deepEqual(acceptances, ["unknown", "accepted"]);
+    assert.deepEqual(attemptedBodies, [requestBody, requestBody]);
+    const optimisticHistory = buildPendingChatSendHistory(
+      [],
+      [{ type: "text", text: "Apply once" }],
+      10,
+    );
+    assert.equal(
+      optimisticHistory.filter((message) => message.role === "user").length,
+      1,
+    );
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("missing CSRF definitively rejects Send before issuing a request", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  let requestCount = 0;
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (): Promise<Response> => {
+      requestCount += 1;
+      throw new Error("fetch must not be called");
+    },
+  });
+
+  try {
+    const result = await streamChatResponse({
+      requestBody: "{}",
+      signal: new AbortController().signal,
+      abortStream: (): void => {},
+      t: (key: string): string => key,
+      handlers: {
+        appendAssistantChunk: (): void => {},
+        upsertReasoningSummary: (): void => {},
+        upsertToolCall: (): void => {},
+        markAssistantError: (): void => {},
+        applyMainContentInvalidationVersion: (): void => {},
+      },
+      onSessionIdReceived: (): void => {},
+      onLiveStreamConnected: (): void => {},
+    });
+
+    assert.equal(requestCount, 0);
+    assert.equal(result.requestAcceptance, "rejected");
+    assert.equal(result.failureStage, "request");
+    assert.equal(isDefinitiveChatRequestRejection(result), true);
+    assert.match(
+      result.streamFailure?.message ?? "",
+      /Missing CSRF token cookie/u,
+    );
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("session-level Stop accepts the legacy response without exact-turn fields", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  let attemptedBody = "";
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      attemptedBody = String(init?.body);
+      return Response.json({
+        ok: true,
+        sessionId: "session-legacy",
+        stopped: true,
+        stillRunning: false,
+      });
+    },
+  });
+
+  try {
+    const result = await postStopChatSession(
+      "session-legacy",
+      null,
+      undefined,
+      (key: string): string => key,
+    );
+
+    assert.deepEqual(JSON.parse(attemptedBody), {
+      sessionId: "session-legacy",
+    });
+    assert.deepEqual(result, {
+      ok: true,
+      sessionId: "session-legacy",
+      stopped: true,
+      stillRunning: false,
+    });
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("missing CSRF definitively rejects cancellation without requesting or retrying", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  let requestCount = 0;
+  let retryCount = 0;
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (): Promise<Response> => {
+      requestCount += 1;
+      throw new Error("fetch must not be called");
+    },
+  });
+
+  try {
+    await assert.rejects(
+      reconcileChatTurnCancellation({
+        signal: new AbortController().signal,
+        isOwnerCurrent: (): boolean => true,
+        requestCancellation: (signal) =>
+          postStopChatSession(
+            "session-1",
+            TURN_ID,
+            signal,
+            (key: string): string => key,
+          ),
+        waitForRetry: async (): Promise<void> => {
+          retryCount += 1;
+        },
+      }),
+      (error: unknown): boolean =>
+        error instanceof ChatTurnCancellationRequestError
+        && error.kind === "rejected"
+        && error.status === null
+        && error.message.includes("Missing CSRF token cookie"),
+    );
+    assert.equal(requestCount, 0);
+    assert.equal(retryCount, 0);
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("ambiguous exact-turn cancellation retries the same intent until confirmed", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  const attemptedBodies: Array<string> = [];
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      attemptedBodies.push(String(init?.body));
+      if (attemptedBodies.length === 1) {
+        throw new TypeError("network unavailable");
+      }
+      if (attemptedBodies.length === 2) {
+        return new Response("temporarily unavailable", { status: 503 });
+      }
+      return Response.json({
+        ok: true,
+        sessionId: "session-1",
+        turnId: TURN_ID,
+        cancellationConfirmed: true,
+        stopped: false,
+        stillRunning: false,
+      });
+    },
+  });
+
+  try {
+    const abortController = new AbortController();
+    const resolution = await reconcileChatTurnCancellation({
+      signal: abortController.signal,
+      isOwnerCurrent: (): boolean => true,
+      requestCancellation: (signal) =>
+        postStopChatSession(
+          "session-1",
+          TURN_ID,
+          signal,
+          (key: string): string => key,
+        ),
+      waitForRetry: async (): Promise<void> => undefined,
+    });
+
+    assert.equal(resolution.kind, "confirmed");
+    assert.equal(attemptedBodies.length, 3);
+    for (const body of attemptedBodies) {
+      assert.deepEqual(JSON.parse(body), {
+        sessionId: "session-1",
+        turnId: TURN_ID,
+      });
+    }
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("definitive cancellation rejection stays explicit and does not retry", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  let requestCount = 0;
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (): Promise<Response> => {
+      requestCount += 1;
+      return new Response("turnId must be a UUID", {
+        status: 400,
+        headers: {
+          "X-Chat-Request-Acceptance": "unknown",
+        },
+      });
+    },
+  });
+
+  try {
+    await assert.rejects(
+      reconcileChatTurnCancellation({
+        signal: new AbortController().signal,
+        isOwnerCurrent: (): boolean => true,
+        requestCancellation: (signal) =>
+          postStopChatSession(
+            "session-1",
+            TURN_ID,
+            signal,
+            (key: string): string => key,
+          ),
+        waitForRetry: async (): Promise<void> => undefined,
+      }),
+      (error: unknown): boolean =>
+        error instanceof ChatTurnCancellationRequestError
+        && error.kind === "rejected"
+        && error.status === 400,
+    );
+    assert.equal(requestCount, 1);
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("an unreadable cancellation 4xx remains definitive and is not retried", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  let requestCount = 0;
+  let retryCount = 0;
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (): Promise<Response> => {
+      requestCount += 1;
+      return createUnreadableResponse(409, "Conflict");
+    },
+  });
+
+  try {
+    await assert.rejects(
+      reconcileChatTurnCancellation({
+        signal: new AbortController().signal,
+        isOwnerCurrent: (): boolean => true,
+        requestCancellation: (signal) =>
+          postStopChatSession(
+            "session-1",
+            TURN_ID,
+            signal,
+            (key: string): string => key,
+          ),
+        waitForRetry: async (): Promise<void> => {
+          retryCount += 1;
+        },
+      }),
+      (error: unknown): boolean =>
+        error instanceof ChatTurnCancellationRequestError
+        && error.kind === "rejected"
+        && error.status === 409
+        && error.message.includes("Conflict")
+        && error.message.includes("response body could not be read"),
+    );
+    assert.equal(requestCount, 1);
+    assert.equal(retryCount, 0);
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("an unreadable cancellation 5xx retries the identical intent", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  const attemptedBodies: Array<string> = [];
+  let retryCount = 0;
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      attemptedBodies.push(String(init?.body));
+      if (attemptedBodies.length === 1) {
+        return createUnreadableResponse(503, "Service Unavailable");
+      }
+      return Response.json({
+        ok: true,
+        sessionId: "session-1",
+        turnId: TURN_ID,
+        cancellationConfirmed: true,
+        stopped: false,
+        stillRunning: false,
+      });
+    },
+  });
+
+  try {
+    const resolution = await reconcileChatTurnCancellation({
+      signal: new AbortController().signal,
+      isOwnerCurrent: (): boolean => true,
+      requestCancellation: (signal) =>
+        postStopChatSession(
+          "session-1",
+          TURN_ID,
+          signal,
+          (key: string): string => key,
+        ),
+      waitForRetry: async (): Promise<void> => {
+        retryCount += 1;
+      },
+    });
+
+    assert.equal(resolution.kind, "confirmed");
+    assert.equal(retryCount, 1);
+    assert.equal(attemptedBodies.length, 2);
+    assert.equal(attemptedBodies[0], attemptedBodies[1]);
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("unreadable and malformed cancellation success stays fenced until exact confirmation", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  const attemptedBodies: Array<string> = [];
+  let retryCount = 0;
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      attemptedBodies.push(String(init?.body));
+      if (attemptedBodies.length === 1) {
+        return createUnreadableResponse(200, "OK");
+      }
+      if (attemptedBodies.length === 2) {
+        return Response.json({
+          ok: true,
+          sessionId: "different-session",
+          turnId: TURN_ID,
+          cancellationConfirmed: true,
+          stopped: false,
+          stillRunning: false,
+        });
+      }
+      if (attemptedBodies.length === 3) {
+        return Response.json({
+          ok: true,
+          sessionId: "session-1",
+          turnId: "00000000-0000-4000-8000-000000000002",
+          cancellationConfirmed: true,
+          stopped: false,
+          stillRunning: false,
+        });
+      }
+      return Response.json({
+        ok: true,
+        sessionId: "session-1",
+        turnId: TURN_ID,
+        cancellationConfirmed: true,
+        stopped: false,
+        stillRunning: false,
+      });
+    },
+  });
+
+  try {
+    const resolution = await reconcileChatTurnCancellation({
+      signal: new AbortController().signal,
+      isOwnerCurrent: (): boolean => true,
+      requestCancellation: (signal) =>
+        postStopChatSession(
+          "session-1",
+          TURN_ID,
+          signal,
+          (key: string): string => key,
+        ),
+      waitForRetry: async (): Promise<void> => {
+        retryCount += 1;
+      },
+    });
+
+    assert.equal(resolution.kind, "confirmed");
+    assert.equal(retryCount, 3);
+    assert.equal(attemptedBodies.length, 4);
+    assert.equal(attemptedBodies[0], attemptedBodies[1]);
+    assert.equal(attemptedBodies[1], attemptedBodies[2]);
+    assert.equal(attemptedBodies[2], attemptedBodies[3]);
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("exact-turn cancellation is single-flight and stale ownership cannot confirm it", async (): Promise<void> => {
+  const response = Promise.withResolvers<Readonly<{
+    ok: true;
+    sessionId: string;
+    turnId: string;
+    cancellationConfirmed: true;
+    stopped: false;
+    stillRunning: false;
+  }>>();
+  const owner = {
+    ownerId: Symbol("cancellation-owner"),
+    sessionId: "session-1",
+    turnId: TURN_ID,
+  };
+  let ownerCurrent = true;
+  let requestCount = 0;
+  const runner = createSingleFlightChatTurnCancellationRunner(
+    async (_owner, abortController) =>
+      reconcileChatTurnCancellation({
+        signal: abortController.signal,
+        isOwnerCurrent: (): boolean => ownerCurrent,
+        requestCancellation: async () => {
+          requestCount += 1;
+          return response.promise;
+        },
+        waitForRetry: async (): Promise<void> => undefined,
+      }),
+  );
+
+  const activeCancellation = runner.run(owner);
+  const overlappingCancellation = runner.run(owner);
+  assert.equal(activeCancellation, overlappingCancellation);
+  assert.equal(requestCount, 1);
+  assert.equal(
+    isChatTurnCancellationSettlementOwned(
+      owner,
+      owner,
+      owner,
+      owner.sessionId,
+    ),
+    true,
+  );
+  assert.equal(
+    isChatTurnCancellationSettlementOwned(
+      owner,
+      owner,
+      {
+        ownerId: Symbol("newer-owner"),
+        sessionId: owner.sessionId,
+        turnId: "00000000-0000-4000-8000-000000000002",
+      },
+      owner.sessionId,
+    ),
+    false,
+  );
+
+  ownerCurrent = false;
+  response.resolve({
+    ok: true,
+    sessionId: "session-1",
+    turnId: TURN_ID,
+    cancellationConfirmed: true,
+    stopped: false,
+    stillRunning: false,
+  });
+
+  assert.deepEqual(await activeCancellation, { kind: "superseded" });
+
+  const unmountedController = new AbortController();
+  unmountedController.abort();
+  let unmountedRequestCount = 0;
+  assert.deepEqual(
+    await reconcileChatTurnCancellation({
+      signal: unmountedController.signal,
+      isOwnerCurrent: (): boolean => true,
+      requestCancellation: async () => {
+        unmountedRequestCount += 1;
+        return response.promise;
+      },
+      waitForRetry: async (): Promise<void> => undefined,
+    }),
+    { kind: "superseded" },
+  );
+  assert.equal(unmountedRequestCount, 0);
+});
+
+test("Stop and Clear share one complete cancellation settlement in either order", async (): Promise<void> => {
+  for (const firstCaller of ["stop", "clear"] as const) {
+    const owner = {
+      ownerId: Symbol(`${firstCaller}-first-owner`),
+      sessionId: `session-${firstCaller}-first`,
+      turnId: TURN_ID,
+    };
+    const response = Promise.withResolvers<Readonly<{
+      ok: true;
+      sessionId: string;
+      turnId: string;
+      cancellationConfirmed: true;
+      stopped: true;
+      stillRunning: false;
+    }>>();
+    let cancellationAttempt: typeof owner | null = owner;
+    let exactTurn: typeof owner | null = owner;
+    let requestCount = 0;
+    let ownershipCleanupCount = 0;
+    let attemptCleanupCount = 0;
+    let deleteCount = 0;
+    const runner = createSingleFlightChatTurnCancellationRunner(
+      async (cancellation, abortController) =>
+        completeChatTurnCancellation({
+          signal: abortController.signal,
+          isOwnerCurrent: (): boolean =>
+            cancellationAttempt?.ownerId === cancellation.ownerId
+            && exactTurn?.ownerId === cancellation.ownerId,
+          requestCancellation: async () => {
+            requestCount += 1;
+            return response.promise;
+          },
+          waitForRetry: async (): Promise<void> => undefined,
+          clearCancellationAttempt: (): void => {
+            if (cancellationAttempt?.ownerId === cancellation.ownerId) {
+              cancellationAttempt = null;
+              attemptCleanupCount += 1;
+            }
+          },
+          clearExactTurnOwnership: (): void => {
+            if (exactTurn?.ownerId === cancellation.ownerId) {
+              exactTurn = null;
+              ownershipCleanupCount += 1;
+            }
+          },
+        }),
+    );
+    const cancelForStop = (): Promise<ChatTurnCancellationResolution> =>
+      runner.run(owner);
+    const cancelForClear =
+      async (): Promise<ChatTurnCancellationResolution> => {
+      const resolution = await runner.run(owner);
+      if (resolution.kind === "confirmed") {
+        deleteCount += 1;
+      }
+      return resolution;
+    };
+
+    const firstPromise = firstCaller === "stop"
+      ? cancelForStop()
+      : cancelForClear();
+    const secondPromise = firstCaller === "stop"
+      ? cancelForClear()
+      : cancelForStop();
+
+    assert.equal(requestCount, 1);
+    response.resolve({
+      ok: true,
+      sessionId: owner.sessionId,
+      turnId: owner.turnId,
+      cancellationConfirmed: true,
+      stopped: true,
+      stillRunning: false,
+    });
+
+    const resolutions = await Promise.all([firstPromise, secondPromise]);
+    assert.deepEqual(
+      resolutions.map((resolution) => resolution.kind),
+      ["confirmed", "confirmed"],
+    );
+    assert.equal(deleteCount, 1);
+    assert.equal(ownershipCleanupCount, 1);
+    assert.equal(attemptCleanupCount, 1);
+    assert.equal(exactTurn, null);
+    assert.equal(cancellationAttempt, null);
+  }
+});
+
+test("concurrent exact-cancellation callers receive the same confirmed settlement", async (): Promise<void> => {
+  const owner = {
+    ownerId: Symbol("shared-complete-cancellation"),
+    sessionId: "session-shared-complete-cancellation",
+    turnId: TURN_ID,
+  };
+  const response = Promise.withResolvers<Readonly<{
+    ok: true;
+    sessionId: string;
+    turnId: string;
+    cancellationConfirmed: true;
+    stopped: true;
+    stillRunning: false;
+  }>>();
+  let cancellationAttempt: typeof owner | null = owner;
+  let exactTurn: typeof owner | null = owner;
+  const runner = createSingleFlightChatTurnCancellationRunner(
+    async (cancellation, abortController) =>
+      completeChatTurnCancellation({
+        signal: abortController.signal,
+        isOwnerCurrent: (): boolean =>
+          cancellationAttempt?.ownerId === cancellation.ownerId
+          && exactTurn?.ownerId === cancellation.ownerId,
+        requestCancellation: async () => response.promise,
+        waitForRetry: async (): Promise<void> => undefined,
+        clearCancellationAttempt: (): void => {
+          cancellationAttempt = null;
+        },
+        clearExactTurnOwnership: (): void => {
+          exactTurn = null;
+        },
+      }),
+  );
+
+  const firstCancellation = runner.run(owner);
+  const secondCancellation = runner.run(owner);
+  assert.equal(firstCancellation, secondCancellation);
+
+  response.resolve({
+    ok: true,
+    sessionId: owner.sessionId,
+    turnId: owner.turnId,
+    cancellationConfirmed: true,
+    stopped: true,
+    stillRunning: false,
+  });
+
+  assert.equal((await firstCancellation).kind, "confirmed");
+  assert.equal((await secondCancellation).kind, "confirmed");
+});
+
+test("definitive cancellation rejection clears only its attempt and permits explicit retry", async (): Promise<void> => {
+  const owner = {
+    ownerId: Symbol("definitive-retry-owner"),
+    sessionId: "session-definitive-retry",
+    turnId: TURN_ID,
+  };
+  let cancellationAttempt: typeof owner | null = owner;
+  let exactTurn: typeof owner | null = owner;
+  let requestCount = 0;
+  const runner = createSingleFlightChatTurnCancellationRunner(
+    async (cancellation, abortController) =>
+      completeChatTurnCancellation({
+        signal: abortController.signal,
+        isOwnerCurrent: (): boolean =>
+          cancellationAttempt?.ownerId === cancellation.ownerId
+          && exactTurn?.ownerId === cancellation.ownerId,
+        requestCancellation: async () => {
+          requestCount += 1;
+          if (requestCount === 1) {
+            throw new ChatTurnCancellationRequestError(
+              "Cancellation was rejected",
+              409,
+              "rejected",
+            );
+          }
+          return {
+            ok: true,
+            sessionId: cancellation.sessionId,
+            turnId: cancellation.turnId,
+            cancellationConfirmed: true,
+            stopped: true,
+            stillRunning: false,
+          };
+        },
+        waitForRetry: async (): Promise<void> => undefined,
+        clearCancellationAttempt: (): void => {
+          if (cancellationAttempt?.ownerId === cancellation.ownerId) {
+            cancellationAttempt = null;
+          }
+        },
+        clearExactTurnOwnership: (): void => {
+          if (exactTurn?.ownerId === cancellation.ownerId) {
+            exactTurn = null;
+          }
+        },
+      }),
+  );
+
+  await assert.rejects(
+    runner.run(owner),
+    (error: unknown): boolean =>
+      error instanceof ChatTurnCancellationRequestError
+      && error.kind === "rejected",
+  );
+  assert.equal(cancellationAttempt, null);
+  assert.equal(exactTurn?.ownerId, owner.ownerId);
+
+  cancellationAttempt = owner;
+  assert.equal((await runner.run(owner)).kind, "confirmed");
+  assert.equal(requestCount, 2);
+  assert.equal(cancellationAttempt, null);
+  assert.equal(exactTurn, null);
+});
+
+test("a stale definitive cancellation error cannot clear newer ownership", async (): Promise<void> => {
+  const staleOwner = {
+    ownerId: Symbol("stale-definitive-owner"),
+    sessionId: "session-stale-definitive",
+    turnId: TURN_ID,
+  };
+  const currentOwner = {
+    ownerId: Symbol("current-definitive-owner"),
+    sessionId: "session-current-definitive",
+    turnId: "00000000-0000-4000-8000-000000000002",
+  };
+  const staleResponse = Promise.withResolvers<never>();
+  const currentResponse = Promise.withResolvers<Readonly<{
+    ok: true;
+    sessionId: string;
+    turnId: string;
+    cancellationConfirmed: true;
+    stopped: true;
+    stillRunning: false;
+  }>>();
+  let cancellationAttempt: typeof staleOwner | typeof currentOwner | null =
+    staleOwner;
+  let exactTurn: typeof staleOwner | typeof currentOwner | null = staleOwner;
+  const runner = createSingleFlightChatTurnCancellationRunner(
+    async (cancellation, abortController) =>
+      completeChatTurnCancellation({
+        signal: abortController.signal,
+        isOwnerCurrent: (): boolean =>
+          cancellationAttempt?.ownerId === cancellation.ownerId
+          && exactTurn?.ownerId === cancellation.ownerId,
+        requestCancellation: async () =>
+          cancellation.ownerId === staleOwner.ownerId
+            ? staleResponse.promise
+            : currentResponse.promise,
+        waitForRetry: async (): Promise<void> => undefined,
+        clearCancellationAttempt: (): void => {
+          if (cancellationAttempt?.ownerId === cancellation.ownerId) {
+            cancellationAttempt = null;
+          }
+        },
+        clearExactTurnOwnership: (): void => {
+          if (exactTurn?.ownerId === cancellation.ownerId) {
+            exactTurn = null;
+          }
+        },
+      }),
+  );
+
+  const staleCancellation = runner.run(staleOwner);
+  cancellationAttempt = currentOwner;
+  exactTurn = currentOwner;
+  const currentCancellation = runner.run(currentOwner);
+  staleResponse.reject(new ChatTurnCancellationRequestError(
+    "Stale cancellation was rejected",
+    409,
+    "rejected",
+  ));
+
+  assert.deepEqual(await staleCancellation, { kind: "superseded" });
+  assert.equal(cancellationAttempt?.ownerId, currentOwner.ownerId);
+  assert.equal(exactTurn?.ownerId, currentOwner.ownerId);
+
+  currentResponse.resolve({
+    ok: true,
+    sessionId: currentOwner.sessionId,
+    turnId: currentOwner.turnId,
+    cancellationConfirmed: true,
+    stopped: true,
+    stillRunning: false,
+  });
+  assert.equal((await currentCancellation).kind, "confirmed");
+  assert.equal(cancellationAttempt, null);
+  assert.equal(exactTurn, null);
+});
+
+test("confirmed exact cancellation preserves stillRunning and releases Stop to a newer active turn", async (): Promise<void> => {
+  const cancelledTurn = {
+    ownerId: Symbol("cancelled-turn"),
+    sessionId: "session-newer-turn",
+    turnId: TURN_ID,
+  };
+  let cancellationAttempt: typeof cancelledTurn | null = cancelledTurn;
+  let exactTurn: typeof cancelledTurn | null = cancelledTurn;
+  const cancellation = await completeChatTurnCancellation({
+    signal: new AbortController().signal,
+    isOwnerCurrent: (): boolean =>
+      cancellationAttempt?.ownerId === cancelledTurn.ownerId
+      && exactTurn?.ownerId === cancelledTurn.ownerId,
+    requestCancellation: async () => ({
+      ok: true,
+      sessionId: cancelledTurn.sessionId,
+      turnId: cancelledTurn.turnId,
+      cancellationConfirmed: true,
+      stopped: false,
+      stillRunning: true,
+    }),
+    waitForRetry: async (): Promise<void> => undefined,
+    clearCancellationAttempt: (): void => {
+      cancellationAttempt = null;
+    },
+    clearExactTurnOwnership: (): void => {
+      exactTurn = null;
+    },
+  });
+  assert.equal(cancellation.kind, "confirmed");
+  if (cancellation.kind !== "confirmed") {
+    return;
+  }
+  assert.equal(cancellation.response.stillRunning, true);
+
+  const newerSnapshot: ChatSessionSnapshot = {
+    sessionId: cancelledTurn.sessionId,
+    runState: "running",
+    activeTurnId: NEWER_TURN_ID,
+    updatedAt: 30,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  };
+  assert.equal(
+    resolveConfirmedChatStopSnapshotDisposition(
+      cancelledTurn.turnId,
+      newerSnapshot,
+    ),
+    "superseded",
+  );
+  const exactOwnership = resolveChatExactTurnOwnership(
+    newerSnapshot,
+    null,
+    null,
+    null,
+  );
+  assert.equal(exactOwnership.pendingTurn, null);
+  assert.equal(exactOwnership.activeTurn?.turnId, NEWER_TURN_ID);
+
+  let controllerState = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    {
+      type: "server_session_created",
+      sessionId: cancelledTurn.sessionId,
+    },
+  );
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "run_started",
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "stop_requested",
+    sessionId: cancelledTurn.sessionId,
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "snapshot_applied",
+    sessionId: cancelledTurn.sessionId,
+    runState: newerSnapshot.runState,
+    updatedAt: newerSnapshot.updatedAt,
+    mainContentInvalidationVersion: 0,
+  });
+  assert.equal(controllerState.runState, "idle");
+  assert.equal(selectIsSelectedSessionStopping(controllerState), true);
+
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "stop_completed",
+    sessionId: cancelledTurn.sessionId,
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "run_started",
+  });
+  assert.equal(controllerState.runState, "running");
+  assert.equal(selectIsSelectedSessionStopping(controllerState), false);
+  assert.equal(selectComposerAction(controllerState), "stop");
+});
+
+test("Clear preserves a newer authoritative turn instead of aborting or deleting it", async (): Promise<void> => {
+  const newerSnapshot: ChatSessionSnapshot = {
+    sessionId: "session-clear-newer-turn",
+    runState: "running",
+    activeTurnId: NEWER_TURN_ID,
+    updatedAt: 30,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  };
+  const reconciliation = await reconcileConfirmedChatStopSnapshot({
+    signal: new AbortController().signal,
+    isOwnerCurrent: (): boolean => true,
+    loadSnapshot: async () => newerSnapshot,
+    resolveSnapshot: (snapshot) =>
+      resolveConfirmedChatStopSnapshotDisposition(TURN_ID, snapshot),
+    classifyFailure: classifyConfirmedChatStopSnapshotFailure,
+    waitForRetry: async (): Promise<void> => undefined,
+  });
+  let deleteCount = 0;
+  let newerTurnAbortCount = 0;
+  let cancellationMarker: string | null = TURN_ID;
+  if (reconciliation.kind === "settled") {
+    newerTurnAbortCount += 1;
+    deleteCount += 1;
+  } else if (reconciliation.snapshot !== null) {
+    cancellationMarker = null;
+  }
+
+  assert.deepEqual(reconciliation, {
+    kind: "superseded",
+    snapshot: newerSnapshot,
+  });
+  assert.equal(cancellationMarker, null);
+  assert.equal(newerTurnAbortCount, 0);
+  assert.equal(deleteCount, 0);
+  assert.equal(newerSnapshot.activeTurnId, NEWER_TURN_ID);
+  assert.equal(newerSnapshot.runState, "running");
+});
+
+test("confirmed cancellation keeps reconciling the same active turn until terminal", async (): Promise<void> => {
+  const snapshots: ReadonlyArray<ChatSessionSnapshot> = [{
+    sessionId: "session-same-turn",
+    runState: "running",
+    activeTurnId: TURN_ID,
+    updatedAt: 20,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  }, {
+    sessionId: "session-same-turn",
+    runState: "idle",
+    activeTurnId: null,
+    updatedAt: 30,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  }];
+  let loadCount = 0;
+  let retryCount = 0;
+  const reconciliation = await reconcileConfirmedChatStopSnapshot({
+    signal: new AbortController().signal,
+    isOwnerCurrent: (): boolean => true,
+    loadSnapshot: async (): Promise<ChatSessionSnapshot> => {
+      const snapshot = snapshots[loadCount];
+      if (snapshot === undefined) {
+        throw new Error("Snapshot sequence was exhausted");
+      }
+      loadCount += 1;
+      return snapshot;
+    },
+    resolveSnapshot: (snapshot) =>
+      resolveConfirmedChatStopSnapshotDisposition(TURN_ID, snapshot),
+    classifyFailure: classifyConfirmedChatStopSnapshotFailure,
+    waitForRetry: async (): Promise<void> => {
+      retryCount += 1;
+    },
+  });
+
+  assert.deepEqual(reconciliation, {
+    kind: "settled",
+    snapshot: snapshots[1],
+  });
+  assert.equal(loadCount, 2);
+  assert.equal(retryCount, 1);
+});
+
+test("superseded cancellation clears only its matching attempt marker", async (): Promise<void> => {
+  const cancelledTurn = {
+    ownerId: Symbol("superseded-cancelled-turn"),
+    sessionId: "session-superseded-cancellation",
+    turnId: TURN_ID,
+  };
+  const newerTurn = {
+    ownerId: Symbol("newer-turn"),
+    sessionId: cancelledTurn.sessionId,
+    turnId: NEWER_TURN_ID,
+  };
+  const response = Promise.withResolvers<Readonly<{
+    ok: true;
+    sessionId: string;
+    turnId: string;
+    cancellationConfirmed: true;
+    stopped: false;
+    stillRunning: true;
+  }>>();
+  let cancellationAttempt: typeof cancelledTurn | null = cancelledTurn;
+  let exactTurn: typeof cancelledTurn | typeof newerTurn | null =
+    cancelledTurn;
+  const cancellationPromise = completeChatTurnCancellation({
+    signal: new AbortController().signal,
+    isOwnerCurrent: (): boolean =>
+      cancellationAttempt?.ownerId === cancelledTurn.ownerId
+      && exactTurn?.ownerId === cancelledTurn.ownerId,
+    requestCancellation: async () => response.promise,
+    waitForRetry: async (): Promise<void> => undefined,
+    clearCancellationAttempt: (): void => {
+      if (cancellationAttempt?.ownerId === cancelledTurn.ownerId) {
+        cancellationAttempt = null;
+      }
+    },
+    clearExactTurnOwnership: (): void => {
+      if (exactTurn?.ownerId === cancelledTurn.ownerId) {
+        exactTurn = null;
+      }
+    },
+  });
+
+  exactTurn = newerTurn;
+  response.resolve({
+    ok: true,
+    sessionId: cancelledTurn.sessionId,
+    turnId: cancelledTurn.turnId,
+    cancellationConfirmed: true,
+    stopped: false,
+    stillRunning: true,
+  });
+
+  assert.deepEqual(await cancellationPromise, { kind: "superseded" });
+  assert.equal(cancellationAttempt, null);
+  assert.equal(exactTurn?.ownerId, newerTurn.ownerId);
+});
+
+test("confirmed Stop retries network, 5xx, and active-response snapshot failures", async (): Promise<void> => {
+  const failures: ReadonlyArray<Error> = [
+    new ChatSessionSnapshotTransportError(
+      "Network request failed",
+      "network",
+    ),
+    new ChatSessionSnapshotRequestError(
+      503,
+      "Error 503: Service unavailable",
+      "other",
+    ),
+    new ChatSessionSnapshotRequestError(
+      409,
+      "Error 409: Chat session already has an active response",
+      "active_response_conflict",
+    ),
+  ];
+  const terminalSnapshot: ChatSessionSnapshot = {
+    sessionId: "session-transient-stop",
+    runState: "idle",
+    activeTurnId: null,
+    updatedAt: 30,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  };
+  let loadCount = 0;
+  let retryCount = 0;
+  const reconciliation = await reconcileConfirmedChatStopSnapshot({
+    signal: new AbortController().signal,
+    isOwnerCurrent: (): boolean => true,
+    loadSnapshot: async (): Promise<ChatSessionSnapshot> => {
+      const failure = failures[loadCount];
+      loadCount += 1;
+      if (failure !== undefined) {
+        throw failure;
+      }
+      return terminalSnapshot;
+    },
+    resolveSnapshot: (snapshot) =>
+      resolveConfirmedChatStopSnapshotDisposition(TURN_ID, snapshot),
+    classifyFailure: classifyConfirmedChatStopSnapshotFailure,
+    waitForRetry: async (): Promise<void> => {
+      retryCount += 1;
+    },
+  });
+
+  assert.deepEqual(reconciliation, {
+    kind: "settled",
+    snapshot: terminalSnapshot,
+  });
+  assert.equal(loadCount, 4);
+  assert.equal(retryCount, 3);
+});
+
+test("confirmed Stop propagates permanent snapshot failures to owned stop_failed settlement", async (): Promise<void> => {
+  const failures: ReadonlyArray<Error> = [
+    new ChatSessionSnapshotTransportError(
+      "Snapshot request was rejected before sending",
+      "preflight_rejected",
+    ),
+    new ChatSessionSnapshotRequestError(
+      404,
+      "Error 404: Chat session not found",
+      "not_found",
+    ),
+    new ChatSessionSnapshotRequestError(
+      409,
+      "Error 409: Active workspace is unavailable. Reload to re-establish workspace context.",
+      "workspace_reload_required",
+    ),
+    new SyntaxError("Unexpected token while parsing snapshot JSON"),
+    new Error("Chat snapshot schema was invalid"),
+  ];
+
+  for (const failure of failures) {
+    let retryCount = 0;
+    let stopFailedCount = 0;
+    const isOwnerCurrent = (): boolean => true;
+    try {
+      await reconcileConfirmedChatStopSnapshot({
+        signal: new AbortController().signal,
+        isOwnerCurrent,
+        loadSnapshot: async (): Promise<ChatSessionSnapshot> => {
+          throw failure;
+        },
+        resolveSnapshot: (snapshot) =>
+          resolveConfirmedChatStopSnapshotDisposition(TURN_ID, snapshot),
+        classifyFailure: classifyConfirmedChatStopSnapshotFailure,
+        waitForRetry: async (): Promise<void> => {
+          retryCount += 1;
+        },
+      });
+      assert.fail("Permanent snapshot failure unexpectedly reconciled");
+    } catch (error) {
+      assert.equal(error, failure);
+      if (isOwnerCurrent()) {
+        stopFailedCount += 1;
+      }
+    }
+
+    assert.equal(retryCount, 0);
+    assert.equal(stopFailedCount, 1);
+  }
 });
 
 test("a superseded idle snapshot cannot overwrite a newer running snapshot", async (): Promise<void> => {
@@ -152,6 +2389,7 @@ test("a superseded idle snapshot cannot overwrite a newer running snapshot", asy
   newerSnapshot.resolve({
     sessionId: "session-a",
     runState: "running",
+    activeTurnId: TURN_ID,
     updatedAt: 20,
     mainContentInvalidationVersion: 0,
     messages: [],
@@ -162,6 +2400,7 @@ test("a superseded idle snapshot cannot overwrite a newer running snapshot", asy
   olderSnapshot.resolve({
     sessionId: "session-a",
     runState: "idle",
+    activeTurnId: null,
     updatedAt: 10,
     mainContentInvalidationVersion: 0,
     messages: [],
@@ -212,6 +2451,7 @@ test("a superseded rejected snapshot follows a newer successful owner", async ()
   const authoritativeSnapshot: ChatSessionSnapshot = {
     sessionId: "session-a",
     runState: "running",
+    activeTurnId: TURN_ID,
     updatedAt: 20,
     mainContentInvalidationVersion: 0,
     messages: [],
@@ -260,6 +2500,7 @@ test("a rejected stale generation waits for a later successful owner", async ():
   const authoritativeSnapshot: ChatSessionSnapshot = {
     sessionId: "session-a",
     runState: "idle",
+    activeTurnId: null,
     updatedAt: 30,
     mainContentInvalidationVersion: 0,
     messages: [],
@@ -270,6 +2511,217 @@ test("a rejected stale generation waits for a later successful owner", async ():
     kind: "superseded",
     snapshot: authoritativeSnapshot,
   });
+});
+
+test("confirmed Stop rebuilds a missing turn from a superseding same-session terminal poll", async (): Promise<void> => {
+  const stopSnapshot = Promise.withResolvers<ChatSessionSnapshot>();
+  const pollSnapshot = Promise.withResolvers<ChatSessionSnapshot>();
+  let coordinator = createChatSnapshotRequestCoordinator();
+  let stopSnapshotResolutionKind:
+    "current" | "superseded" | null = null;
+  let retryWaitCount = 0;
+
+  const stopReconciliation = reconcileConfirmedChatStopSnapshot({
+    signal: new AbortController().signal,
+    isOwnerCurrent: (): boolean => true,
+    loadSnapshot: async (): Promise<ChatSessionSnapshot | null> => {
+      const stopRequest = beginChatSnapshotRequest(
+        coordinator,
+        "session-a",
+        4,
+        stopSnapshot.promise,
+      );
+      coordinator = stopRequest.coordinator;
+      const resolution = await resolveChatSnapshotRequest(
+        () => coordinator,
+        {
+          request: stopRequest.request,
+          snapshot: stopSnapshot.promise,
+        },
+      );
+      stopSnapshotResolutionKind = resolution.kind;
+      return resolution.snapshot;
+    },
+    resolveSnapshot: (snapshot) =>
+      snapshot.sessionId === "session-a"
+        ? resolveConfirmedChatStopSnapshotDisposition(TURN_ID, snapshot)
+        : "retry",
+    classifyFailure: (): "fail" => "fail",
+    waitForRetry: async (): Promise<void> => {
+      retryWaitCount += 1;
+    },
+  });
+
+  const pollRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    pollSnapshot.promise,
+  );
+  coordinator = pollRequest.coordinator;
+  const pollResolutionPromise = resolveChatSnapshotRequest(
+    () => coordinator,
+    {
+      request: pollRequest.request,
+      snapshot: pollSnapshot.promise,
+    },
+  );
+  const terminalSnapshot: ChatSessionSnapshot = {
+    sessionId: "session-a",
+    runState: "idle",
+    activeTurnId: null,
+    updatedAt: 30,
+    mainContentInvalidationVersion: 0,
+    messages: [{
+      messageId: "00000000-0000-4000-8000-000000000099",
+      role: "assistant",
+      content: [{ type: "text", text: "Existing history" }],
+      timestamp: 10,
+      isError: false,
+      isStopped: false,
+    }],
+  };
+  pollSnapshot.resolve(terminalSnapshot);
+  const pollResolution = await pollResolutionPromise;
+  assert.equal(pollResolution.kind, "current");
+  assert.deepEqual(pollResolution.snapshot?.messages, terminalSnapshot.messages);
+
+  stopSnapshot.reject(new Error("Stop snapshot request lost the race"));
+  const reconciliation = await stopReconciliation;
+
+  assert.equal(stopSnapshotResolutionKind, "superseded");
+  assert.equal(retryWaitCount, 0);
+  assert.equal(reconciliation.kind, "settled");
+  if (reconciliation.kind !== "settled") {
+    return;
+  }
+
+  const submittedContent = [{
+    type: "text" as const,
+    text: "Stop this pending import",
+  }, {
+    type: "image" as const,
+    mediaType: "image/png",
+    base64Data: "aW1hZ2U=",
+  }, {
+    type: "file" as const,
+    mediaType: "application/pdf",
+    base64Data: "cGRm",
+    fileName: "full-receipt.pdf",
+  }];
+  assert.deepEqual(
+    resolveConfirmedChatTurnStopHistory(
+      reconciliation.snapshot,
+      {
+        turnId: TURN_ID,
+        authoritativeMessages: terminalSnapshot.messages,
+        submittedContent,
+      },
+      40,
+    ),
+    [
+      ...terminalSnapshot.messages,
+      {
+        role: "user",
+        content: submittedContent,
+        timestamp: 40,
+        isError: false,
+        isStopped: false,
+      },
+      {
+        role: "assistant",
+        content: [],
+        timestamp: 40,
+        isError: false,
+        isStopped: true,
+      },
+    ],
+  );
+});
+
+test("confirmed Stop retries transient missing snapshots until terminal convergence", async (): Promise<void> => {
+  let loadCount = 0;
+  let retryWaitCount = 0;
+  const terminalSnapshot: ChatSessionSnapshot = {
+    sessionId: "session-a",
+    runState: "interrupted",
+    activeTurnId: null,
+    updatedAt: 30,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  };
+
+  const reconciliation = await reconcileConfirmedChatStopSnapshot({
+    signal: new AbortController().signal,
+    isOwnerCurrent: (): boolean => true,
+    loadSnapshot: async (): Promise<ChatSessionSnapshot | null> => {
+      loadCount += 1;
+      if (loadCount === 1) {
+        throw new Error("Transient snapshot failure");
+      }
+      if (loadCount === 2) {
+        return null;
+      }
+      return terminalSnapshot;
+    },
+    resolveSnapshot: (snapshot) =>
+      resolveConfirmedChatStopSnapshotDisposition(TURN_ID, snapshot),
+    classifyFailure: (): "retry" => "retry",
+    waitForRetry: async (): Promise<void> => {
+      retryWaitCount += 1;
+    },
+  });
+
+  assert.deepEqual(reconciliation, {
+    kind: "settled",
+    snapshot: terminalSnapshot,
+  });
+  assert.equal(loadCount, 3);
+  assert.equal(retryWaitCount, 2);
+});
+
+test("a session-switched Stop owner cannot reconstruct or retry snapshots", async (): Promise<void> => {
+  const ownerId = Symbol("stop-session-a");
+  const abortController = new AbortController();
+  const firstSnapshot = Promise.withResolvers<ChatSessionSnapshot | null>();
+  let currentOwnerId: symbol | null = ownerId;
+  let currentSessionId: string | null = "session-a";
+  let loadCount = 0;
+  let retryWaitCount = 0;
+  let didReconstruct = false;
+
+  const reconciliationPromise = reconcileConfirmedChatStopSnapshot({
+    signal: abortController.signal,
+    isOwnerCurrent: (): boolean =>
+      currentOwnerId === ownerId
+      && currentSessionId === "session-a",
+    loadSnapshot: (): Promise<ChatSessionSnapshot | null> => {
+      loadCount += 1;
+      return firstSnapshot.promise;
+    },
+    resolveSnapshot: (): "settled" => "settled",
+    classifyFailure: (): "fail" => "fail",
+    waitForRetry: async (): Promise<void> => {
+      retryWaitCount += 1;
+    },
+  });
+
+  currentOwnerId = null;
+  currentSessionId = "session-b";
+  abortController.abort();
+  firstSnapshot.reject(new Error("Session changed"));
+  const reconciliation = await reconciliationPromise;
+  if (reconciliation.kind === "settled") {
+    didReconstruct = true;
+  }
+
+  assert.deepEqual(reconciliation, {
+    kind: "superseded",
+    snapshot: null,
+  });
+  assert.equal(loadCount, 1);
+  assert.equal(retryWaitCount, 0);
+  assert.equal(didReconstruct, false);
 });
 
 test("a pre-Stop running poll cannot overwrite the idle Stop snapshot", async (): Promise<void> => {
@@ -336,6 +2788,7 @@ test("a pre-Stop running poll cannot overwrite the idle Stop snapshot", async ()
   stopSnapshot.resolve({
     sessionId: "session-a",
     runState: "idle",
+    activeTurnId: null,
     updatedAt: 20,
     mainContentInvalidationVersion: 0,
     messages: [],
@@ -350,6 +2803,7 @@ test("a pre-Stop running poll cannot overwrite the idle Stop snapshot", async ()
   preStopPoll.resolve({
     sessionId: "session-a",
     runState: "running",
+    activeTurnId: TURN_ID,
     updatedAt: 10,
     mainContentInvalidationVersion: 0,
     messages: [],
@@ -363,6 +2817,90 @@ test("a pre-Stop running poll cannot overwrite the idle Stop snapshot", async ()
   assert.equal(selectIsAssistantRunActive(controllerState), false);
   assert.equal(selectComposerAction(controllerState), "send");
   assert.equal(appliedMessage, "stopped transcript");
+});
+
+test("a superseded ambiguous reconciliation cannot roll back its accepted owner", async (): Promise<void> => {
+  const acceptedMessages: ChatSessionSnapshot["messages"] = [{
+    messageId: TURN_ID,
+    role: "user",
+    content: [{ type: "text", text: "Persisted request" }],
+    timestamp: 20,
+    isError: false,
+    isStopped: false,
+  }];
+  const olderSnapshot = Promise.withResolvers<ChatSessionSnapshot>();
+  const newerSnapshot = Promise.withResolvers<ChatSessionSnapshot>();
+  let coordinator = createChatSnapshotRequestCoordinator();
+  const olderRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    olderSnapshot.promise,
+  );
+  coordinator = olderRequest.coordinator;
+  const newerRequest = beginChatSnapshotRequest(
+    coordinator,
+    "session-a",
+    4,
+    newerSnapshot.promise,
+  );
+  coordinator = newerRequest.coordinator;
+  let controllerState = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "server_session_created", sessionId: "session-a" },
+  );
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "run_started",
+  });
+  let appliedMessages: ChatSessionSnapshot["messages"] = [];
+
+  newerSnapshot.resolve({
+    sessionId: "session-a",
+    runState: "running",
+    activeTurnId: TURN_ID,
+    updatedAt: 20,
+    mainContentInvalidationVersion: 0,
+    messages: acceptedMessages,
+  });
+  const authoritativeSnapshot = await newerSnapshot.promise;
+  if (isChatSnapshotRequestCurrent(coordinator, newerRequest.request)) {
+    controllerState = reduceChatSessionControllerState(controllerState, {
+      type: "snapshot_applied",
+      sessionId: authoritativeSnapshot.sessionId,
+      runState: authoritativeSnapshot.runState,
+      updatedAt: authoritativeSnapshot.updatedAt,
+      mainContentInvalidationVersion:
+        authoritativeSnapshot.mainContentInvalidationVersion,
+    });
+    appliedMessages = authoritativeSnapshot.messages;
+  }
+
+  olderSnapshot.resolve({
+    sessionId: "session-a",
+    runState: "idle",
+    activeTurnId: null,
+    updatedAt: 10,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  });
+  await olderSnapshot.promise;
+  const supersedingResult = selectSupersedingChatSnapshotRequestResult(
+    coordinator,
+    olderRequest.request,
+  );
+  assert.notEqual(supersedingResult, null);
+  if (supersedingResult === null) {
+    assert.fail("Expected the newer snapshot request to own reconciliation");
+  }
+  const supersedingSnapshot = await supersedingResult.snapshot;
+  const disposition = resolveChatSendReconciliationDisposition(
+    TURN_ID,
+    supersedingSnapshot,
+  );
+
+  assert.equal(disposition, "preserve_success");
+  assert.deepEqual(appliedMessages, acceptedMessages);
+  assert.equal(controllerState.runState, "running");
 });
 
 test("a deferred Stop cannot abort, disconnect, or adopt into a newer session stream", async (): Promise<void> => {
@@ -437,6 +2975,1079 @@ test("a deferred Stop cannot abort, disconnect, or adopt into a newer session st
   );
 });
 
+test("outer Stop ownership fences every continuation after unmount, session switch, or Clear takeover", async (): Promise<void> => {
+  const invalidations = [
+    {
+      name: "unmount",
+      invalidate: (
+        owner: Readonly<{ abortController: AbortController }>,
+        clearOwner: () => void,
+        _selectSession: (sessionId: string) => void,
+      ): void => {
+        owner.abortController.abort();
+        clearOwner();
+      },
+    },
+    {
+      name: "session switch",
+      invalidate: (
+        owner: Readonly<{ abortController: AbortController }>,
+        clearOwner: () => void,
+        selectSession: (sessionId: string) => void,
+      ): void => {
+        selectSession("session-b");
+        owner.abortController.abort();
+        clearOwner();
+      },
+    },
+    {
+      name: "Clear takeover",
+      invalidate: (
+        owner: Readonly<{ abortController: AbortController }>,
+        clearOwner: () => void,
+        _selectSession: (sessionId: string) => void,
+      ): void => {
+        owner.abortController.abort();
+        clearOwner();
+      },
+    },
+  ];
+
+  for (const invalidation of invalidations) {
+    for (const boundary of ["request", "snapshot"] as const) {
+      const request = Promise.withResolvers<void>();
+      const snapshot = Promise.withResolvers<void>();
+      const snapshotStarted = Promise.withResolvers<void>();
+      const stopOwner = {
+        ownerId: Symbol(`${invalidation.name}-${boundary}`),
+        sessionId: "session-a",
+        abortController: new AbortController(),
+      };
+      let currentOwner: typeof stopOwner | null = stopOwner;
+      let currentSessionId = stopOwner.sessionId;
+      let dispatchCount = 0;
+      let historyMutationCount = 0;
+      let streamMutationCount = 0;
+      let reconciliationStartCount = 0;
+      const isOwnerCurrent = (): boolean =>
+        isChatStopOperationOwnerCurrent(
+          stopOwner,
+          currentOwner,
+          currentSessionId,
+        );
+      const continuation = (async (): Promise<void> => {
+        await request.promise;
+        if (!isOwnerCurrent()) {
+          return;
+        }
+        streamMutationCount += 1;
+        reconciliationStartCount += 1;
+        snapshotStarted.resolve();
+        await snapshot.promise;
+        if (!isOwnerCurrent()) {
+          return;
+        }
+        historyMutationCount += 1;
+        dispatchCount += 1;
+      })();
+      const invalidateOwner = (): void => {
+        currentOwner = null;
+      };
+      const selectSession = (sessionId: string): void => {
+        currentSessionId = sessionId;
+      };
+
+      if (boundary === "request") {
+        invalidation.invalidate(
+          stopOwner,
+          invalidateOwner,
+          selectSession,
+        );
+        request.resolve();
+        snapshot.resolve();
+      } else {
+        request.resolve();
+        await snapshotStarted.promise;
+        invalidation.invalidate(
+          stopOwner,
+          invalidateOwner,
+          selectSession,
+        );
+        snapshot.resolve();
+      }
+      await continuation;
+
+      assert.equal(isOwnerCurrent(), false, invalidation.name);
+      assert.equal(dispatchCount, 0, invalidation.name);
+      assert.equal(historyMutationCount, 0, invalidation.name);
+      assert.equal(
+        streamMutationCount,
+        boundary === "request" ? 0 : 1,
+        invalidation.name,
+      );
+      assert.equal(
+        reconciliationStartCount,
+        boundary === "request" ? 0 : 1,
+        invalidation.name,
+      );
+    }
+  }
+});
+
+test("existing-session transport reconciles ambiguous failures and fast-fails explicit rejection", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  const createParams = (): Parameters<typeof streamChatResponse>[0] => ({
+    requestBody: "{}",
+    signal: new AbortController().signal,
+    abortStream: (): void => {},
+    t: (key: string): string => key,
+    handlers: {
+      appendAssistantChunk: (): void => {},
+      upsertReasoningSummary: (): void => {},
+      upsertToolCall: (): void => {},
+      markAssistantError: (): void => {},
+      applyMainContentInvalidationVersion: (): void => {},
+    },
+    onSessionIdReceived: (): void => {},
+    onLiveStreamConnected: (): void => {},
+  });
+
+  try {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (): Promise<Response> => {
+        throw new TypeError("network unavailable");
+      },
+    });
+    const ambiguousResult = await streamChatResponse(createParams());
+    assert.equal(ambiguousResult.requestAcceptance, "unknown");
+    assert.equal(ambiguousResult.failureStage, "request");
+    assert.equal(isDefinitiveChatRequestRejection(ambiguousResult), false);
+
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (): Promise<Response> =>
+        new Response("Run start failed after persistence", { status: 503 }),
+    });
+    const ambiguousServerResult = await streamChatResponse(createParams());
+    assert.equal(ambiguousServerResult.requestAcceptance, "unknown");
+    assert.equal(ambiguousServerResult.failureStage, "request");
+    assert.equal(
+      isDefinitiveChatRequestRejection(ambiguousServerResult),
+      false,
+    );
+
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (): Promise<Response> =>
+        new Response("Server rejected before persistence", {
+          status: 503,
+          headers: {
+            "X-Chat-Request-Acceptance": "rejected",
+          },
+        }),
+    });
+    const declaredRejectedServerResult = await streamChatResponse(createParams());
+    assert.equal(declaredRejectedServerResult.requestAcceptance, "unknown");
+    assert.equal(
+      isDefinitiveChatRequestRejection(declaredRejectedServerResult),
+      false,
+    );
+
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (): Promise<Response> =>
+        new Response("Request rejected", {
+          status: 400,
+          headers: {
+            "X-Chat-Request-Acceptance": "unknown",
+          },
+        }),
+    });
+    const rejectedResult = await streamChatResponse(createParams());
+    assert.equal(rejectedResult.requestAcceptance, "rejected");
+    assert.equal(rejectedResult.failureStage, "request");
+    assert.equal(isDefinitiveChatRequestRejection(rejectedResult), true);
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("definitive Send snapshot failures settle the exact owner and preserve submitted attachments", (): void => {
+  const submittedContent = [{
+    type: "text" as const,
+    text: "Keep this failed submission",
+  }, {
+    type: "image" as const,
+    mediaType: "image/png",
+    base64Data: "aW1hZ2U=",
+  }, {
+    type: "file" as const,
+    mediaType: "application/pdf",
+    base64Data: "cGRm",
+    fileName: "complete-receipt.pdf",
+  }];
+  const authoritativeMessages = [{
+    messageId: "00000000-0000-4000-8000-000000000099",
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: "Existing message" }],
+    timestamp: 10,
+    isError: false,
+    isStopped: false,
+  }];
+  const pendingTurn = {
+    ownerId: Symbol("definitive-send-snapshot-failure"),
+    sessionId: "session-definitive-send-failure",
+    turnId: TURN_ID,
+    authoritativeMessages,
+    submittedContent,
+  };
+  const expectedHistory = [
+    ...authoritativeMessages,
+    {
+      role: "user" as const,
+      content: submittedContent,
+      timestamp: 20,
+      isError: false,
+      isStopped: false,
+    },
+    {
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: "Snapshot was invalid" }],
+      timestamp: 20,
+      isError: true,
+      isStopped: false,
+    },
+  ];
+
+  for (const definitiveError of [
+    new ChatSessionSnapshotRequestError(
+      400,
+      "Error 400: invalid request",
+      "other",
+    ),
+    new ChatSessionSnapshotRequestError(
+      409,
+      "Error 409: reload workspace",
+      "workspace_reload_required",
+    ),
+    new ChatSessionSnapshotTransportError(
+      "Missing CSRF cookie",
+      "preflight_rejected",
+    ),
+    new SyntaxError("Unexpected token while parsing snapshot JSON"),
+    new ChatSessionSnapshotSchemaError("Snapshot schema was invalid"),
+  ]) {
+    assert.deepEqual(
+      resolveDefinitiveChatSendSnapshotFailureHistory(
+        definitiveError,
+        pendingTurn,
+        pendingTurn,
+        pendingTurn.sessionId,
+        "Snapshot was invalid",
+        20,
+      ),
+      expectedHistory,
+    );
+  }
+
+  for (const retryableError of [
+    new ChatSessionSnapshotTransportError(
+      "Network unavailable",
+      "network",
+    ),
+    new ChatSessionSnapshotRequestError(
+      503,
+      "Error 503: unavailable",
+      "other",
+    ),
+    new ChatSessionSnapshotRequestError(
+      409,
+      "Error 409: active response",
+      "active_response_conflict",
+    ),
+  ]) {
+    assert.equal(
+      resolveDefinitiveChatSendSnapshotFailureHistory(
+        retryableError,
+        pendingTurn,
+        pendingTurn,
+        pendingTurn.sessionId,
+        "Retryable failure",
+        30,
+      ),
+      null,
+    );
+  }
+
+  assert.equal(
+    resolveDefinitiveChatSendSnapshotFailureHistory(
+      new ChatSessionSnapshotSchemaError("Snapshot schema was invalid"),
+      pendingTurn,
+      {
+        ...pendingTurn,
+        ownerId: Symbol("newer-owner"),
+      },
+      pendingTurn.sessionId,
+      "Stale failure",
+      40,
+    ),
+    null,
+  );
+});
+
+test("unchanged snapshots stay ambiguous and definitive rejection preserves submitted attachments", (): void => {
+  const submittedContent = [{
+    type: "text" as const,
+    text: "Please import this receipt",
+  }, {
+    type: "file" as const,
+    mediaType: "application/pdf",
+    base64Data: "cGRm",
+    fileName: "receipt.pdf",
+  }];
+  const disposition = resolveChatSendReconciliationDisposition(
+    TURN_ID,
+    {
+      messages: [],
+    },
+  );
+  const failedHistory = buildFailedChatSendHistory(
+    [],
+    submittedContent,
+    "Network request failed",
+    30,
+  );
+  const retriedHistory = buildPendingChatSendHistory(
+    [],
+    submittedContent,
+    40,
+  );
+
+  assert.equal(
+    disposition,
+    "acceptance_unknown",
+  );
+  assert.deepEqual(failedHistory, [
+    {
+      role: "user",
+      content: submittedContent,
+      timestamp: 30,
+      isError: false,
+      isStopped: false,
+    },
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "Network request failed" }],
+      timestamp: 30,
+      isError: true,
+      isStopped: false,
+    },
+  ]);
+  assert.deepEqual(retriedHistory, [
+    {
+      role: "user",
+      content: submittedContent,
+      timestamp: 40,
+      isError: false,
+      isStopped: false,
+    },
+    {
+      role: "assistant",
+      content: [],
+      timestamp: 40,
+      isError: false,
+      isStopped: false,
+    },
+  ]);
+});
+
+test("pre-session Stop preserves submitted attachments and marks the optimistic assistant stopped", (): void => {
+  const authoritativeMessages = [{
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: "Existing history" }],
+    timestamp: 10,
+    isError: false,
+    isStopped: false,
+  }];
+  const submittedContent = [{
+    type: "text" as const,
+    text: "Keep this request",
+  }, {
+    type: "image" as const,
+    mediaType: "image/png",
+    base64Data: "aW1hZ2U=",
+  }, {
+    type: "file" as const,
+    mediaType: "application/pdf",
+    base64Data: "cGRm",
+    fileName: "receipt.pdf",
+  }];
+
+  const stoppedHistory = buildStoppedChatSendHistory(
+    authoritativeMessages,
+    submittedContent,
+    20,
+  );
+
+  assert.deepEqual(stoppedHistory, [
+    ...authoritativeMessages,
+    {
+      role: "user",
+      content: submittedContent,
+      timestamp: 20,
+      isError: false,
+      isStopped: false,
+    },
+    {
+      role: "assistant",
+      content: [],
+      timestamp: 20,
+      isError: false,
+      isStopped: true,
+    },
+  ]);
+});
+
+test("confirmed Stop rebuilds a tombstoned unpersisted turn and preserves authoritative persisted turns", (): void => {
+  const authoritativeMessages = [{
+    messageId: "00000000-0000-4000-8000-000000000099",
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: "Existing history" }],
+    timestamp: 10,
+    isError: false,
+    isStopped: false,
+  }];
+  const submittedContent = [{
+    type: "text" as const,
+    text: "Stop this pending import",
+  }, {
+    type: "image" as const,
+    mediaType: "image/png",
+    base64Data: "aW1hZ2U=",
+  }, {
+    type: "file" as const,
+    mediaType: "application/pdf",
+    base64Data: "cGRm",
+    fileName: "full-receipt.pdf",
+  }];
+  const pendingTurn = {
+    turnId: TURN_ID,
+    authoritativeMessages,
+    submittedContent,
+  };
+
+  const tombstoneBeforePersistHistory = resolveConfirmedChatTurnStopHistory(
+    {
+      activeTurnId: null,
+      runState: "idle",
+      messages: authoritativeMessages,
+    },
+    pendingTurn,
+    20,
+  );
+  assert.deepEqual(tombstoneBeforePersistHistory, [
+    ...authoritativeMessages,
+    {
+      role: "user",
+      content: submittedContent,
+      timestamp: 20,
+      isError: false,
+      isStopped: false,
+    },
+    {
+      role: "assistant",
+      content: [],
+      timestamp: 20,
+      isError: false,
+      isStopped: true,
+    },
+  ]);
+
+  const newerAuthoritativeMessage = {
+    messageId: "00000000-0000-4000-8000-000000000098",
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: "Newer authoritative history" }],
+    timestamp: 15,
+    isError: false,
+    isStopped: false,
+  };
+  const historyWithNewerSnapshotMessages =
+    resolveConfirmedChatTurnStopHistory(
+      {
+        activeTurnId: null,
+        runState: "idle",
+        messages: [
+          ...authoritativeMessages,
+          newerAuthoritativeMessage,
+        ],
+      },
+      pendingTurn,
+      25,
+    );
+  assert.deepEqual(historyWithNewerSnapshotMessages, [
+    ...authoritativeMessages,
+    newerAuthoritativeMessage,
+    {
+      role: "user",
+      content: submittedContent,
+      timestamp: 25,
+      isError: false,
+      isStopped: false,
+    },
+    {
+      role: "assistant",
+      content: [],
+      timestamp: 25,
+      isError: false,
+      isStopped: true,
+    },
+  ]);
+
+  const authoritativeStoppedMessages = [
+    ...authoritativeMessages,
+    {
+      messageId: TURN_ID,
+      role: "user" as const,
+      content: submittedContent,
+      timestamp: 20,
+      isError: false,
+      isStopped: false,
+    },
+    {
+      role: "assistant" as const,
+      content: [],
+      timestamp: 20,
+      isError: false,
+      isStopped: true,
+    },
+  ];
+  assert.equal(
+    resolveConfirmedChatTurnStopHistory(
+      {
+        activeTurnId: null,
+        runState: "idle",
+        messages: authoritativeStoppedMessages,
+      },
+      pendingTurn,
+      30,
+    ),
+    null,
+  );
+  assert.equal(
+    resolveConfirmedChatTurnStopHistory(
+      {
+        activeTurnId: "00000000-0000-4000-8000-000000000088",
+        runState: "running",
+        messages: authoritativeMessages,
+      },
+      pendingTurn,
+      40,
+    ),
+    null,
+  );
+});
+
+test("an immediate old idle snapshot stays ambiguous until the exact turn is later accepted", (): void => {
+  assert.equal(
+    resolveChatSendReconciliationDisposition(
+      TURN_ID,
+      {
+        messages: [],
+      },
+    ),
+    "acceptance_unknown",
+  );
+  assert.equal(
+    resolveChatSendReconciliationDisposition(
+      TURN_ID,
+      {
+        messages: [{
+          messageId: "00000000-0000-4000-8000-000000000002",
+          role: "user",
+          content: [{ type: "text", text: "Persisted request" }],
+          timestamp: 20,
+          isError: false,
+          isStopped: false,
+        }],
+      },
+    ),
+    "acceptance_unknown",
+  );
+  assert.equal(
+    resolveChatSendReconciliationDisposition(
+      TURN_ID,
+      {
+        messages: [{
+          messageId: TURN_ID,
+          role: "user",
+          content: [{ type: "text", text: "Persisted request" }],
+          timestamp: 20,
+          isError: false,
+          isStopped: false,
+        }],
+      },
+    ),
+    "preserve_success",
+  );
+});
+
+test("snapshot validation requires complete persisted messages and supported content parts", (): void => {
+  const streamPosition = {
+    itemId: "response-item-1",
+    responseIndex: 0,
+    outputIndex: 1,
+    contentIndex: 2,
+    sequenceNumber: 3,
+  };
+  const validMessage = {
+    messageId: TURN_ID,
+    role: "assistant",
+    content: [{
+      type: "text",
+      text: "Rendered text",
+      streamPosition,
+    }, {
+      type: "image",
+      mediaType: "image/png",
+      base64Data: "aW1hZ2U=",
+    }, {
+      type: "file",
+      mediaType: "application/pdf",
+      base64Data: "cGRm",
+      fileName: "receipt.pdf",
+    }, {
+      type: "tool_call",
+      id: "call-1",
+      name: "lookup_transactions",
+      status: "completed",
+      providerStatus: null,
+      input: "{}",
+      output: "[]",
+      streamPosition: {
+        ...streamPosition,
+        contentIndex: null,
+      },
+    }, {
+      type: "reasoning_summary",
+      summary: "Checked the transaction history",
+      streamPosition: {
+        ...streamPosition,
+        contentIndex: null,
+      },
+    }],
+    timestamp: 10,
+    isError: false,
+    isStopped: false,
+  };
+  const validSnapshot = {
+    sessionId: "session-valid-snapshot",
+    runState: "idle",
+    activeTurnId: null,
+    updatedAt: 20,
+    mainContentInvalidationVersion: 1,
+    messages: [validMessage],
+  };
+
+  assert.doesNotThrow((): void => {
+    assertValidChatSessionSnapshot(validSnapshot);
+  });
+
+  const invalidMessages: ReadonlyArray<Readonly<{
+    label: string;
+    message: unknown;
+  }>> = [{
+    label: "missing messageId",
+    message: { ...validMessage, messageId: undefined },
+  }, {
+    label: "non-canonical messageId",
+    message: {
+      ...validMessage,
+      messageId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa".toUpperCase(),
+    },
+  }, {
+    label: "invalid role",
+    message: { ...validMessage, role: "system" },
+  }, {
+    label: "invalid content collection",
+    message: { ...validMessage, content: "not-an-array" },
+  }, {
+    label: "invalid text part",
+    message: {
+      ...validMessage,
+      content: [{ type: "text", text: 42 }],
+    },
+  }, {
+    label: "invalid image part",
+    message: {
+      ...validMessage,
+      content: [{ type: "image", mediaType: "image/png" }],
+    },
+  }, {
+    label: "invalid file part",
+    message: {
+      ...validMessage,
+      content: [{
+        type: "file",
+        mediaType: "application/pdf",
+        base64Data: "cGRm",
+      }],
+    },
+  }, {
+    label: "invalid tool-call part",
+    message: {
+      ...validMessage,
+      content: [{
+        type: "tool_call",
+        name: "lookup_transactions",
+        status: "completed",
+      }],
+    },
+  }, {
+    label: "missing required reasoning stream position",
+    message: {
+      ...validMessage,
+      content: [{
+        type: "reasoning_summary",
+        summary: "Missing chronology",
+      }],
+    },
+  }, {
+    label: "invalid nested stream position",
+    message: {
+      ...validMessage,
+      content: [{
+        type: "text",
+        text: "Invalid chronology",
+        streamPosition: {
+          ...streamPosition,
+          outputIndex: -1,
+        },
+      }],
+    },
+  }, {
+    label: "non-finite timestamp",
+    message: { ...validMessage, timestamp: Number.NaN },
+  }, {
+    label: "invalid error flag",
+    message: { ...validMessage, isError: "false" },
+  }, {
+    label: "missing stopped flag",
+    message: { ...validMessage, isStopped: undefined },
+  }];
+
+  for (const invalid of invalidMessages) {
+    assert.throws(
+      (): void => {
+        assertValidChatSessionSnapshot({
+          ...validSnapshot,
+          messages: [invalid.message],
+        });
+      },
+      ChatSessionSnapshotSchemaError,
+      invalid.label,
+    );
+  }
+});
+
+test("snapshot transport rejects malformed persisted messages as definitive schema failures", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (): Promise<Response> =>
+      Response.json({
+        sessionId: "session-malformed-snapshot",
+        runState: "idle",
+        activeTurnId: null,
+        updatedAt: 10,
+        mainContentInvalidationVersion: 0,
+        messages: [{
+          role: "user",
+          content: [{ type: "text", text: "Missing persisted identity" }],
+          timestamp: 10,
+          isError: false,
+          isStopped: false,
+        }],
+      }),
+  });
+
+  try {
+    await assert.rejects(
+      fetchChatSessionSnapshot(
+        "session-malformed-snapshot",
+        undefined,
+        (key: string): string => key,
+      ),
+      (error: unknown): boolean =>
+        error instanceof ChatSessionSnapshotSchemaError
+        && classifyConfirmedChatStopSnapshotFailure(error) === "fail",
+    );
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("interrupted successful snapshot bodies retry while malformed JSON and schema fail definitively", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  const requestedSessionId = "session-snapshot-read";
+  const terminalSnapshot: ChatSessionSnapshot = {
+    sessionId: requestedSessionId,
+    runState: "idle",
+    activeTurnId: null,
+    updatedAt: 20,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  };
+  let requestCount = 0;
+  let interruptedReadError: unknown = null;
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (): Promise<Response> => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        const response = new Response(null, { status: 200 });
+        Object.defineProperty(response, "json", {
+          configurable: true,
+          value: async (): Promise<never> => {
+            throw new TypeError("terminated while decoding response body");
+          },
+        });
+        return response;
+      }
+      return Response.json(terminalSnapshot);
+    },
+  });
+
+  try {
+    const reconciliation = await reconcileConfirmedChatStopSnapshot({
+      signal: new AbortController().signal,
+      isOwnerCurrent: (): boolean => true,
+      loadSnapshot: async (): Promise<ChatSessionSnapshot> => {
+        try {
+          return await fetchChatSessionSnapshot(
+            requestedSessionId,
+            undefined,
+            (key: string): string => key,
+          );
+        } catch (error) {
+          interruptedReadError = error;
+          throw error;
+        }
+      },
+      resolveSnapshot: (snapshot) =>
+        resolveConfirmedChatStopSnapshotDisposition(TURN_ID, snapshot),
+      classifyFailure: classifyConfirmedChatStopSnapshotFailure,
+      waitForRetry: async (): Promise<void> => {},
+    });
+
+    assert.equal(requestCount, 2);
+    assert.deepEqual(reconciliation, {
+      kind: "settled",
+      snapshot: terminalSnapshot,
+    });
+    assert.equal(
+      interruptedReadError instanceof ChatSessionSnapshotTransportError
+      && interruptedReadError.kind === "network"
+      && interruptedReadError.message.includes(requestedSessionId)
+      && classifyConfirmedChatStopSnapshotFailure(interruptedReadError)
+        === "retry",
+      true,
+    );
+    const pendingTurn = {
+      ownerId: Symbol("interrupted-body-pending-turn"),
+      sessionId: requestedSessionId,
+      turnId: TURN_ID,
+      authoritativeMessages: [],
+      submittedContent: [{
+        type: "file" as const,
+        mediaType: "application/pdf",
+        base64Data: "cGRm",
+        fileName: "preserved.pdf",
+      }],
+    };
+    assert.equal(
+      resolveDefinitiveChatSendSnapshotFailureHistory(
+        interruptedReadError,
+        pendingTurn,
+        pendingTurn,
+        requestedSessionId,
+        "Transient read",
+        30,
+      ),
+      null,
+    );
+
+    const abortedOwner = new AbortController();
+    let abortedRetryCount = 0;
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (): Promise<Response> => {
+        const response = new Response(null, { status: 200 });
+        Object.defineProperty(response, "json", {
+          configurable: true,
+          value: async (): Promise<never> => {
+            abortedOwner.abort();
+            throw new TypeError("body read aborted");
+          },
+        });
+        return response;
+      },
+    });
+    const abortedResolution = await reconcileConfirmedChatStopSnapshot({
+      signal: abortedOwner.signal,
+      isOwnerCurrent: (): boolean => !abortedOwner.signal.aborted,
+      loadSnapshot: (signal) =>
+        fetchChatSessionSnapshot(
+          requestedSessionId,
+          signal,
+          (key: string): string => key,
+        ),
+      resolveSnapshot: (snapshot) =>
+        resolveConfirmedChatStopSnapshotDisposition(TURN_ID, snapshot),
+      classifyFailure: classifyConfirmedChatStopSnapshotFailure,
+      waitForRetry: async (): Promise<void> => {
+        abortedRetryCount += 1;
+      },
+    });
+    assert.deepEqual(abortedResolution, {
+      kind: "superseded",
+      snapshot: null,
+    });
+    assert.equal(abortedRetryCount, 0);
+
+    for (const definitiveResponse of [
+      new Response("{", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+      Response.json({
+        ...terminalSnapshot,
+        messages: [{
+          role: "user",
+          content: [{ type: "text", text: "Missing messageId" }],
+          timestamp: 20,
+          isError: false,
+          isStopped: false,
+        }],
+      }),
+    ]) {
+      Object.defineProperty(globalThis, "fetch", {
+        configurable: true,
+        value: async (): Promise<Response> => definitiveResponse,
+      });
+      await assert.rejects(
+        fetchChatSessionSnapshot(
+          requestedSessionId,
+          undefined,
+          (key: string): string => key,
+        ),
+        (error: unknown): boolean =>
+          error instanceof ChatSessionSnapshotSchemaError
+          && classifyConfirmedChatStopSnapshotFailure(error) === "fail",
+      );
+    }
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("explicit snapshot requests reject a different returned session while latest-session requests accept it", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  const returnedSnapshot: ChatSessionSnapshot = {
+    sessionId: "session-b",
+    runState: "idle",
+    activeTurnId: null,
+    updatedAt: 10,
+    mainContentInvalidationVersion: 0,
+    messages: [],
+  };
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (): Promise<Response> => Response.json(returnedSnapshot),
+  });
+
+  try {
+    await assert.rejects(
+      fetchChatSessionSnapshot(
+        "session-a",
+        undefined,
+        (key: string): string => key,
+      ),
+      (error: unknown): boolean =>
+        error instanceof ChatSessionSnapshotSchemaError
+        && error.message.includes("requestedSessionId=session-a")
+        && error.message.includes("returnedSessionId=session-b")
+        && classifyConfirmedChatStopSnapshotFailure(error) === "fail",
+    );
+    assert.deepEqual(
+      await fetchChatSessionSnapshot(
+        undefined,
+        undefined,
+        (key: string): string => key,
+      ),
+      returnedSnapshot,
+    );
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
 test("snapshot transport preserves response status for safe URL recovery", async (): Promise<void> => {
   const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
   const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
@@ -465,6 +4076,58 @@ test("snapshot transport preserves response status for safe URL recovery", async
         && error.kind === "not_found"
         && error.message.includes("Chat session not found"),
     );
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("snapshot reconciliation classifies unreadable 5xx as retryable and unreadable 4xx as definitive", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+
+  try {
+    for (const expected of [{
+      status: 503,
+      statusText: "Service Unavailable",
+      disposition: "retry",
+    }, {
+      status: 400,
+      statusText: "Bad Request",
+      disposition: "fail",
+    }] as const) {
+      Object.defineProperty(globalThis, "fetch", {
+        configurable: true,
+        value: async (): Promise<Response> =>
+          createUnreadableResponse(expected.status, expected.statusText),
+      });
+
+      await assert.rejects(
+        fetchChatSessionSnapshot(
+          "session-unreadable-snapshot",
+          undefined,
+          (key: string): string => key,
+        ),
+        (error: unknown): boolean =>
+          error instanceof ChatSessionSnapshotRequestError
+          && error.status === expected.status
+          && error.message.includes("response body could not be read")
+          && classifyConfirmedChatStopSnapshotFailure(error)
+            === expected.disposition,
+      );
+    }
   } finally {
     if (originalDocument === undefined) {
       Reflect.deleteProperty(globalThis, "document");

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
@@ -8,6 +8,7 @@ import {
   OPENAI_IMAGE_MIME_TYPES,
 } from "@/lib/chatImageFormats";
 import { CHAT_MODEL_ID } from "@/lib/chatModels";
+import type { StoredMessage } from "@/lib/chatHistory";
 import type { ContentPart } from "@/server/chat/types";
 import type { PendingAttachment } from "../../shell/panel/FileAttachment";
 import type { ChatSessionSnapshot } from "../bootstrap/chatSessionSnapshot";
@@ -29,8 +30,32 @@ type ChatClearConversationResponse = Readonly<{
   sessionId: string;
 }>;
 
+type StopChatSessionResponseBase = Readonly<{
+  ok: true;
+  sessionId: string;
+  stopped: boolean;
+  stillRunning: boolean;
+}>;
+
+export type SessionLevelStopChatSessionResponse =
+  StopChatSessionResponseBase & Readonly<{
+    turnId?: undefined;
+    cancellationConfirmed?: undefined;
+  }>;
+
+export type ExactTurnStopChatSessionResponse =
+  StopChatSessionResponseBase & Readonly<{
+    turnId: string;
+    cancellationConfirmed: true;
+  }>;
+
+export type StopChatSessionResponse =
+  | SessionLevelStopChatSessionResponse
+  | ExactTurnStopChatSessionResponse;
+
 type ChatSendRequestBody = Readonly<{
   sessionId: string;
+  turnId: string;
   model: string;
   content: ReadonlyArray<ContentPart>;
   timezone: string;
@@ -64,6 +89,11 @@ export type StreamChatResponseParams = Readonly<{
 
 export type StreamChatFailureStage = "request" | "stream" | null;
 
+export type ChatRequestAcceptance =
+  | "unknown"
+  | "rejected"
+  | "accepted";
+
 type ChatCreateSessionResponse = Readonly<{
   sessionId: string;
 }>;
@@ -74,13 +104,908 @@ export type StreamChatResponseResult = Readonly<{
   failureStage: StreamChatFailureStage;
   receivedContent: boolean;
   wasAborted: boolean;
+  requestAcceptance: ChatRequestAcceptance;
 }>;
+
+export type ChatSendReconciliationOwner = Readonly<{
+  ownerId: symbol;
+  sessionId: string;
+  turnId: string;
+}>;
+
+export type ChatClearOperationOwner = Readonly<{
+  ownerId: symbol;
+  targetSessionId: string | null;
+}>;
+
+export type ChatStopOperationOwner = Readonly<{
+  ownerId: symbol;
+  sessionId: string;
+  abortController: AbortController;
+}>;
+
+export type ChatPreSessionSendOwner = Readonly<{
+  ownerId: symbol;
+  initialSessionId: string | null;
+  turnId: string;
+}>;
+
+type ChatRequestStartResult =
+  | Readonly<{
+    kind: "started";
+    response: Promise<Response>;
+  }>
+  | Readonly<{
+    kind: "preflight_rejected";
+    error: Error;
+  }>;
+
+const toError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const RFC_CHAT_UUID_PATTERN =
+  /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/u;
+
+export const isCanonicalChatUuid = (value: string): boolean =>
+  value === value.toLowerCase()
+  && RFC_CHAT_UUID_PATTERN.test(value);
+
+export const assertCanonicalChatTurnId = (turnId: string): void => {
+  if (!isCanonicalChatUuid(turnId)) {
+    throw new Error(
+      `Client chat turn identity was not a canonical lowercase UUID: turnId=${turnId}`,
+    );
+  }
+};
+
+const isRecord = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object"
+  && value !== null
+  && !Array.isArray(value);
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === "number"
+  && Number.isInteger(value)
+  && value >= 0;
+
+const isNullableNonNegativeInteger = (
+  value: unknown,
+): value is number | null =>
+  value === null || isNonNegativeInteger(value);
+
+const isValidStreamPosition = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return typeof value.itemId === "string"
+    && value.itemId.trim() !== ""
+    && (
+      value.responseIndex === undefined
+      || isNonNegativeInteger(value.responseIndex)
+    )
+    && isNonNegativeInteger(value.outputIndex)
+    && isNullableNonNegativeInteger(value.contentIndex)
+    && isNullableNonNegativeInteger(value.sequenceNumber);
+};
+
+const hasValidOptionalStreamPosition = (
+  value: Readonly<Record<string, unknown>>,
+): boolean =>
+  value.streamPosition === undefined
+  || isValidStreamPosition(value.streamPosition);
+
+const isValidChatSnapshotContentPart = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  switch (value.type) {
+    case "text":
+      return typeof value.text === "string"
+        && hasValidOptionalStreamPosition(value);
+    case "image":
+      return typeof value.mediaType === "string"
+        && typeof value.base64Data === "string";
+    case "file":
+      return typeof value.mediaType === "string"
+        && typeof value.base64Data === "string"
+        && typeof value.fileName === "string";
+    case "tool_call":
+      return (value.id === undefined || typeof value.id === "string")
+        && typeof value.name === "string"
+        && (value.status === "started" || value.status === "completed")
+        && (
+          value.providerStatus === undefined
+          || value.providerStatus === null
+          || typeof value.providerStatus === "string"
+        )
+        && (value.input === null || typeof value.input === "string")
+        && (value.output === null || typeof value.output === "string")
+        && hasValidOptionalStreamPosition(value);
+    case "reasoning_summary":
+      return typeof value.summary === "string"
+        && isValidStreamPosition(value.streamPosition);
+    default:
+      return false;
+  }
+};
+
+export class ChatSessionSnapshotSchemaError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "ChatSessionSnapshotSchemaError";
+  }
+}
+
+export function assertValidChatSessionSnapshot(
+  snapshot: unknown,
+): asserts snapshot is ChatSessionSnapshot {
+  if (!isRecord(snapshot)) {
+    throw new ChatSessionSnapshotSchemaError(
+      "Chat session snapshot was not an object",
+    );
+  }
+  if (
+    typeof snapshot.sessionId !== "string"
+    || snapshot.sessionId.trim() === ""
+  ) {
+    throw new ChatSessionSnapshotSchemaError(
+      "Chat session snapshot did not include a sessionId",
+    );
+  }
+  if (
+    snapshot.runState !== "idle"
+    && snapshot.runState !== "running"
+    && snapshot.runState !== "interrupted"
+  ) {
+    throw new ChatSessionSnapshotSchemaError(
+      `Chat session snapshot included an invalid runState: sessionId=${snapshot.sessionId}, runState=${String(snapshot.runState)}`,
+    );
+  }
+  if (
+    snapshot.activeTurnId !== null
+    && (
+      typeof snapshot.activeTurnId !== "string"
+      || !isCanonicalChatUuid(snapshot.activeTurnId)
+    )
+  ) {
+    throw new ChatSessionSnapshotSchemaError(
+      `Chat session snapshot included an invalid activeTurnId: sessionId=${snapshot.sessionId}, activeTurnId=${String(snapshot.activeTurnId)}`,
+    );
+  }
+  if (
+    (snapshot.runState === "running") !== (snapshot.activeTurnId !== null)
+  ) {
+    throw new ChatSessionSnapshotSchemaError(
+      `Chat session snapshot run state did not match active turn identity: sessionId=${snapshot.sessionId}, runState=${snapshot.runState}, activeTurnId=${snapshot.activeTurnId ?? "none"}`,
+    );
+  }
+  if (
+    typeof snapshot.updatedAt !== "number"
+    || !Number.isFinite(snapshot.updatedAt)
+    || typeof snapshot.mainContentInvalidationVersion !== "number"
+    || !Number.isFinite(snapshot.mainContentInvalidationVersion)
+    || !Array.isArray(snapshot.messages)
+  ) {
+    throw new ChatSessionSnapshotSchemaError(
+      `Chat session snapshot included invalid metadata: sessionId=${snapshot.sessionId}`,
+    );
+  }
+
+  for (
+    const [messageIndex, message] of snapshot.messages.entries()
+  ) {
+    if (
+      !isRecord(message)
+      || typeof message.messageId !== "string"
+      || !isCanonicalChatUuid(message.messageId)
+    ) {
+      throw new ChatSessionSnapshotSchemaError(
+        `Chat session snapshot included an invalid message identity: sessionId=${snapshot.sessionId}, messageIndex=${String(messageIndex)}`,
+      );
+    }
+    if (
+      (message.role !== "user" && message.role !== "assistant")
+      || !Array.isArray(message.content)
+      || !message.content.every(isValidChatSnapshotContentPart)
+      || typeof message.timestamp !== "number"
+      || !Number.isFinite(message.timestamp)
+      || typeof message.isError !== "boolean"
+      || typeof message.isStopped !== "boolean"
+    ) {
+      throw new ChatSessionSnapshotSchemaError(
+        `Chat session snapshot included an invalid persisted message: sessionId=${snapshot.sessionId}, messageId=${message.messageId}`,
+      );
+    }
+  }
+}
+
+const startChatRequest = (
+  input: RequestInfo | URL,
+  init: RequestInit,
+): ChatRequestStartResult => {
+  try {
+    return {
+      kind: "started",
+      response: fetchWithCsrf(input, init),
+    };
+  } catch (error) {
+    return {
+      kind: "preflight_rejected",
+      error: toError(error),
+    };
+  }
+};
+
+export const isChatPreSessionSendOwnerCurrent = (
+  owner: ChatPreSessionSendOwner,
+  currentOwner: ChatPreSessionSendOwner | null,
+  currentSessionId: string | null,
+): boolean =>
+  currentOwner?.ownerId === owner.ownerId
+  && currentSessionId === owner.initialSessionId;
+
+export const resolveChatPreSessionSendAdoption = (
+  owner: ChatPreSessionSendOwner,
+  currentOwner: ChatPreSessionSendOwner | null,
+  currentSessionId: string | null,
+  writableSessionId: string,
+  signal: AbortSignal,
+): ChatSendReconciliationOwner | null => {
+  if (
+    signal.aborted
+    || !isChatPreSessionSendOwnerCurrent(
+      owner,
+      currentOwner,
+      currentSessionId,
+    )
+  ) {
+    return null;
+  }
+  if (
+    owner.initialSessionId !== null
+    && owner.initialSessionId !== writableSessionId
+  ) {
+    throw new Error(
+      `Chat session changed while preparing a send: expectedSessionId=${owner.initialSessionId}, writableSessionId=${writableSessionId}`,
+    );
+  }
+
+  return {
+    ownerId: owner.ownerId,
+    sessionId: writableSessionId,
+    turnId: owner.turnId,
+  };
+};
+
+type ChatOperationOwner = Readonly<{
+  ownerId: symbol;
+}>;
+
+type ChatSingleFlightRunner<
+  Owner extends ChatOperationOwner,
+  Result,
+> = Readonly<{
+  run: (owner: Owner) => Promise<Result>;
+  cancel: (owner: Owner) => void;
+  cancelActive: () => void;
+}>;
+
+export type ChatSendReconciliationRunner<
+  Owner extends ChatSendReconciliationOwner,
+> = ChatSingleFlightRunner<Owner, void>;
+
+export type ChatTurnCancellationResolution =
+  | Readonly<{
+    kind: "confirmed";
+    response: ExactTurnStopChatSessionResponse;
+  }>
+  | Readonly<{
+    kind: "superseded";
+  }>;
+
+export type ChatTurnCancellationRunner<
+  Owner extends ChatSendReconciliationOwner,
+> = ChatSingleFlightRunner<Owner, ChatTurnCancellationResolution>;
+
+export type ChatClearOperationRunner =
+  ChatSingleFlightRunner<ChatClearOperationOwner, void>;
+
+export const isChatClearOperationOwnerCurrent = (
+  owner: ChatClearOperationOwner,
+  currentOwner: ChatClearOperationOwner | null,
+  currentSessionId: string | null,
+): boolean =>
+  currentOwner?.ownerId === owner.ownerId
+  && currentSessionId === owner.targetSessionId;
+
+export const isChatSendReconciliationOwnerCurrent = (
+  owner: ChatSendReconciliationOwner,
+  currentOwner: ChatSendReconciliationOwner | null,
+  currentSessionId: string | null,
+): boolean =>
+  currentOwner?.ownerId === owner.ownerId
+  && currentSessionId === owner.sessionId;
+
+export const isChatTurnOwnerForSession = (
+  owner: ChatSendReconciliationOwner | null,
+  sessionId: string | null,
+): boolean =>
+  owner !== null
+  && owner.sessionId === sessionId;
+
+export const isChatStopOperationOwnerCurrent = (
+  owner: ChatStopOperationOwner,
+  currentOwner: ChatStopOperationOwner | null,
+  currentSessionId: string | null,
+): boolean =>
+  !owner.abortController.signal.aborted
+  && currentOwner?.ownerId === owner.ownerId
+  && currentSessionId === owner.sessionId;
+
+export const isChatSnapshotPollingOwnerCurrent = (
+  requestedSessionId: string,
+  currentSessionId: string | null,
+  signal: AbortSignal,
+): boolean =>
+  !signal.aborted
+  && currentSessionId === requestedSessionId;
+
+export const isChatTurnCancellationSettlementOwned = (
+  cancellation: ChatSendReconciliationOwner,
+  currentCancellation: ChatSendReconciliationOwner | null,
+  currentExactTurn: ChatSendReconciliationOwner | null,
+  currentSessionId: string | null,
+): boolean =>
+  isChatSendReconciliationOwnerCurrent(
+    cancellation,
+    currentCancellation,
+    currentSessionId,
+  )
+  && currentExactTurn?.ownerId === cancellation.ownerId;
+
+const createSingleFlightChatRunner = <
+  Owner extends ChatOperationOwner,
+  Result,
+>(
+  runCycle: (
+    owner: Owner,
+    abortController: AbortController,
+  ) => Promise<Result>,
+): ChatSingleFlightRunner<Owner, Result> => {
+  let activeCycle: Readonly<{
+    ownerId: symbol;
+    abortController: AbortController;
+    promise: Promise<Result>;
+  }> | null = null;
+
+  const run = (owner: Owner): Promise<Result> => {
+    if (activeCycle?.ownerId === owner.ownerId) {
+      return activeCycle.promise;
+    }
+
+    activeCycle?.abortController.abort();
+    const abortController = new AbortController();
+    let cyclePromise: Promise<Result>;
+    cyclePromise = runCycle(owner, abortController).finally((): void => {
+      if (activeCycle?.promise === cyclePromise) {
+        activeCycle = null;
+      }
+    });
+    activeCycle = {
+      ownerId: owner.ownerId,
+      abortController,
+      promise: cyclePromise,
+    };
+    return cyclePromise;
+  };
+
+  const cancel = (owner: Owner): void => {
+    if (activeCycle?.ownerId === owner.ownerId) {
+      activeCycle.abortController.abort();
+    }
+  };
+
+  const cancelActive = (): void => {
+    activeCycle?.abortController.abort();
+  };
+
+  return {
+    run,
+    cancel,
+    cancelActive,
+  };
+};
+
+export const createSingleFlightChatSendReconciliationRunner = <
+  Owner extends ChatSendReconciliationOwner,
+>(
+  reconcile: (
+    owner: Owner,
+    abortController: AbortController,
+  ) => Promise<void>,
+): ChatSendReconciliationRunner<Owner> =>
+  createSingleFlightChatRunner(reconcile);
+
+export const createSingleFlightChatTurnCancellationRunner = <
+  Owner extends ChatSendReconciliationOwner,
+>(
+  reconcile: (
+    owner: Owner,
+    abortController: AbortController,
+  ) => Promise<ChatTurnCancellationResolution>,
+): ChatTurnCancellationRunner<Owner> =>
+  createSingleFlightChatRunner(reconcile);
+
+export const createSingleFlightChatClearOperationRunner = (
+  clear: (
+    owner: ChatClearOperationOwner,
+    abortController: AbortController,
+  ) => Promise<void>,
+): ChatClearOperationRunner =>
+  createSingleFlightChatRunner(clear);
+
+export type ChatTurnCancellationRequestErrorKind =
+  | "acceptance_unknown"
+  | "rejected";
+
+export class ChatTurnCancellationRequestError extends Error {
+  public readonly status: number | null;
+  public readonly kind: ChatTurnCancellationRequestErrorKind;
+
+  public constructor(
+    message: string,
+    status: number | null,
+    kind: ChatTurnCancellationRequestErrorKind,
+  ) {
+    super(message);
+    this.name = "ChatTurnCancellationRequestError";
+    this.status = status;
+    this.kind = kind;
+  }
+}
+
+export const shouldRestoreChatTurnAfterCancellationRejection = (
+  error: unknown,
+  rejectedTurn: ChatSendReconciliationOwner,
+  currentTurn: ChatSendReconciliationOwner | null,
+  currentSessionId: string | null,
+): boolean =>
+  error instanceof ChatTurnCancellationRequestError
+  && error.kind === "rejected"
+  && isChatSendReconciliationOwnerCurrent(
+    rejectedTurn,
+    currentTurn,
+    currentSessionId,
+  );
+
+export const shouldRestoreChatRunAfterSnapshotFailure = (
+  stoppedTurn: ChatSendReconciliationOwner,
+  activeTurn: ChatSendReconciliationOwner | null,
+  currentSessionId: string | null,
+): boolean =>
+  currentSessionId === stoppedTurn.sessionId
+  && activeTurn?.sessionId === stoppedTurn.sessionId
+  && activeTurn.turnId === stoppedTurn.turnId;
+
+export type ChatPendingTurnRetryOwner =
+  ChatSendReconciliationOwner & Readonly<{
+    requestBody: string;
+    retryAbortController: AbortController;
+  }>;
+
+export const restorePendingChatTurnAfterCancellationRejection = <
+  Owner extends ChatPendingTurnRetryOwner,
+>(
+  error: unknown,
+  rejectedTurn: ChatSendReconciliationOwner,
+  currentTurn: Owner | null,
+  currentSessionId: string | null,
+): Owner | null => {
+  if (
+    currentTurn === null
+    || !currentTurn.retryAbortController.signal.aborted
+    || !shouldRestoreChatTurnAfterCancellationRejection(
+      error,
+      rejectedTurn,
+      currentTurn,
+      currentSessionId,
+    )
+  ) {
+    return null;
+  }
+
+  return {
+    ...currentTurn,
+    retryAbortController: new AbortController(),
+  };
+};
+
+export type ReconcileChatTurnCancellationParams = Readonly<{
+  signal: AbortSignal;
+  isOwnerCurrent: () => boolean;
+  requestCancellation: (
+    signal: AbortSignal,
+  ) => Promise<ExactTurnStopChatSessionResponse>;
+  waitForRetry: (signal: AbortSignal) => Promise<void>;
+}>;
+
+export const reconcileChatTurnCancellation = async (
+  params: ReconcileChatTurnCancellationParams,
+): Promise<ChatTurnCancellationResolution> => {
+  while (!params.signal.aborted && params.isOwnerCurrent()) {
+    try {
+      const response = await params.requestCancellation(params.signal);
+      return params.signal.aborted || !params.isOwnerCurrent()
+        ? { kind: "superseded" }
+        : {
+          kind: "confirmed",
+          response,
+        };
+    } catch (error) {
+      if (params.signal.aborted || !params.isOwnerCurrent()) {
+        return { kind: "superseded" };
+      }
+      if (
+        error instanceof ChatTurnCancellationRequestError
+        && error.kind === "rejected"
+      ) {
+        throw error;
+      }
+      await params.waitForRetry(params.signal);
+    }
+  }
+
+  return { kind: "superseded" };
+};
+
+export type CompleteChatTurnCancellationParams =
+  ReconcileChatTurnCancellationParams & Readonly<{
+    clearCancellationAttempt: () => void;
+    clearExactTurnOwnership: () => void;
+  }>;
+
+export const completeChatTurnCancellation = async (
+  params: CompleteChatTurnCancellationParams,
+): Promise<ChatTurnCancellationResolution> => {
+  let resolution: ChatTurnCancellationResolution;
+  try {
+    resolution = await reconcileChatTurnCancellation(params);
+  } catch (error) {
+    if (
+      error instanceof ChatTurnCancellationRequestError
+      && error.kind === "rejected"
+      && params.isOwnerCurrent()
+    ) {
+      params.clearCancellationAttempt();
+    }
+    throw error;
+  }
+
+  if (resolution.kind !== "confirmed" || !params.isOwnerCurrent()) {
+    params.clearCancellationAttempt();
+    return { kind: "superseded" };
+  }
+
+  params.clearExactTurnOwnership();
+  params.clearCancellationAttempt();
+  return resolution;
+};
+
+export type ChatConfirmedStopSnapshotResolution<Snapshot> =
+  | Readonly<{
+    kind: "settled";
+    snapshot: Snapshot;
+  }>
+  | Readonly<{
+    kind: "superseded";
+    snapshot: Snapshot | null;
+  }>;
+
+export type ChatConfirmedStopSnapshotDisposition =
+  | "retry"
+  | "settled"
+  | "superseded";
+
+export type ChatConfirmedStopSnapshotFailureDisposition =
+  | "retry"
+  | "fail";
+
+export type ReconcileConfirmedChatStopSnapshotParams<Snapshot> = Readonly<{
+  signal: AbortSignal;
+  isOwnerCurrent: () => boolean;
+  loadSnapshot: (signal: AbortSignal) => Promise<Snapshot | null>;
+  resolveSnapshot: (
+    snapshot: Snapshot,
+  ) => ChatConfirmedStopSnapshotDisposition;
+  classifyFailure: (
+    error: unknown,
+  ) => ChatConfirmedStopSnapshotFailureDisposition;
+  waitForRetry: (signal: AbortSignal) => Promise<void>;
+}>;
+
+export const reconcileConfirmedChatStopSnapshot = async <Snapshot>(
+  params: ReconcileConfirmedChatStopSnapshotParams<Snapshot>,
+): Promise<ChatConfirmedStopSnapshotResolution<Snapshot>> => {
+  while (!params.signal.aborted && params.isOwnerCurrent()) {
+    let snapshot: Snapshot | null;
+    try {
+      snapshot = await params.loadSnapshot(params.signal);
+    } catch (error) {
+      if (params.signal.aborted || !params.isOwnerCurrent()) {
+        return {
+          kind: "superseded",
+          snapshot: null,
+        };
+      }
+      if (params.classifyFailure(error) === "fail") {
+        throw error;
+      }
+      await params.waitForRetry(params.signal);
+      continue;
+    }
+
+    if (params.signal.aborted || !params.isOwnerCurrent()) {
+      return {
+        kind: "superseded",
+        snapshot: null,
+      };
+    }
+    if (snapshot === null) {
+      await params.waitForRetry(params.signal);
+      continue;
+    }
+    const disposition = params.resolveSnapshot(snapshot);
+    if (disposition === "settled") {
+      return {
+        kind: "settled",
+        snapshot,
+      };
+    }
+    if (disposition === "superseded") {
+      return {
+        kind: "superseded",
+        snapshot,
+      };
+    }
+    await params.waitForRetry(params.signal);
+  }
+
+  return {
+    kind: "superseded",
+    snapshot: null,
+  };
+};
+
+export const resolveConfirmedChatStopSnapshotDisposition = (
+  turnId: string | null,
+  snapshot: Pick<ChatSessionSnapshot, "activeTurnId" | "runState">,
+): ChatConfirmedStopSnapshotDisposition => {
+  if (
+    snapshot.runState !== "idle"
+    && snapshot.runState !== "running"
+    && snapshot.runState !== "interrupted"
+  ) {
+    throw new Error(
+      `Chat snapshot included an invalid runState while settling Stop: turnId=${turnId ?? "none"}, runState=${String(snapshot.runState)}`,
+    );
+  }
+  if (snapshot.runState === "running") {
+    if (snapshot.activeTurnId === null) {
+      throw new Error(
+        `Running chat snapshot did not include an activeTurnId while settling Stop: turnId=${turnId ?? "none"}`,
+      );
+    }
+    return turnId !== null && snapshot.activeTurnId !== turnId
+      ? "superseded"
+      : "retry";
+  }
+  if (snapshot.activeTurnId !== null) {
+    throw new Error(
+      `Terminal chat snapshot retained an activeTurnId while settling Stop: turnId=${turnId ?? "none"}, activeTurnId=${snapshot.activeTurnId}`,
+    );
+  }
+
+  return "settled";
+};
+
+export const isDefinitiveChatRequestRejection = (
+  result: StreamChatResponseResult,
+): boolean =>
+  result.failureStage === "request"
+  && result.requestAcceptance === "rejected";
+
+export type ChatSendReconciliationDisposition =
+  | "preserve_success"
+  | "acceptance_unknown";
+
+export const resolveChatSendReconciliationDisposition = (
+  turnId: string,
+  snapshot: Pick<ChatSessionSnapshot, "messages">,
+): ChatSendReconciliationDisposition =>
+  snapshot.messages.some((message) => message.messageId === turnId)
+    ? "preserve_success"
+    : "acceptance_unknown";
+
+export type ChatExactTurnOwnership = Readonly<{
+  pendingTurn: ChatSendReconciliationOwner | null;
+  activeTurn: ChatSendReconciliationOwner | null;
+}>;
+
+export const resolveChatExactTurnOwnership = (
+  snapshot: ChatSessionSnapshot,
+  pendingTurn: ChatSendReconciliationOwner | null,
+  activeTurn: ChatSendReconciliationOwner | null,
+  cancellation: ChatSendReconciliationOwner | null,
+): ChatExactTurnOwnership => {
+  let nextPendingTurn = pendingTurn;
+  let nextActiveTurn = activeTurn;
+  const pendingTurnWasAccepted = pendingTurn !== null
+    && pendingTurn.sessionId === snapshot.sessionId
+    && resolveChatSendReconciliationDisposition(
+      pendingTurn.turnId,
+      snapshot,
+    ) === "preserve_success";
+
+  if (pendingTurnWasAccepted && pendingTurn !== null) {
+    if (
+      (
+        snapshot.runState === "running"
+        && snapshot.activeTurnId === pendingTurn.turnId
+      )
+      || cancellation?.ownerId === pendingTurn.ownerId
+    ) {
+      nextActiveTurn = pendingTurn;
+    }
+    nextPendingTurn = null;
+  }
+
+  if (snapshot.runState === "running") {
+    if (snapshot.activeTurnId === null) {
+      throw new Error(
+        `Running chat snapshot did not include an activeTurnId: sessionId=${snapshot.sessionId}`,
+      );
+    }
+    if (
+      nextActiveTurn?.sessionId !== snapshot.sessionId
+      || nextActiveTurn.turnId !== snapshot.activeTurnId
+    ) {
+      nextActiveTurn = {
+        ownerId: Symbol(snapshot.activeTurnId),
+        sessionId: snapshot.sessionId,
+        turnId: snapshot.activeTurnId,
+      };
+    }
+  } else if (
+    nextActiveTurn?.sessionId === snapshot.sessionId
+    && cancellation?.ownerId !== nextActiveTurn.ownerId
+  ) {
+    nextActiveTurn = null;
+  }
+
+  return {
+    pendingTurn: nextPendingTurn,
+    activeTurn: nextActiveTurn,
+  };
+};
+
+export const buildFailedChatSendHistory = (
+  authoritativeMessages: ReadonlyArray<StoredMessage>,
+  submittedContent: ReadonlyArray<ContentPart>,
+  errorMessage: string,
+  timestamp: number,
+): ReadonlyArray<StoredMessage> => [
+  ...authoritativeMessages,
+  {
+    role: "user",
+    content: submittedContent,
+    timestamp,
+    isError: false,
+    isStopped: false,
+  },
+  {
+    role: "assistant",
+    content: [{ type: "text", text: errorMessage }],
+    timestamp,
+    isError: true,
+    isStopped: false,
+  },
+];
+
+export const buildPendingChatSendHistory = (
+  authoritativeMessages: ReadonlyArray<StoredMessage>,
+  submittedContent: ReadonlyArray<ContentPart>,
+  timestamp: number,
+): ReadonlyArray<StoredMessage> => [
+  ...authoritativeMessages,
+  {
+    role: "user",
+    content: submittedContent,
+    timestamp,
+    isError: false,
+    isStopped: false,
+  },
+  {
+    role: "assistant",
+    content: [],
+    timestamp,
+    isError: false,
+    isStopped: false,
+  },
+];
+
+export const buildStoppedChatSendHistory = (
+  authoritativeMessages: ReadonlyArray<StoredMessage>,
+  submittedContent: ReadonlyArray<ContentPart>,
+  timestamp: number,
+): ReadonlyArray<StoredMessage> => [
+  ...authoritativeMessages,
+  {
+    role: "user",
+    content: submittedContent,
+    timestamp,
+    isError: false,
+    isStopped: false,
+  },
+  {
+    role: "assistant",
+    content: [],
+    timestamp,
+    isError: false,
+    isStopped: true,
+  },
+];
+
+export type PendingChatTurnTranscript = Readonly<{
+  authoritativeMessages: ReadonlyArray<StoredMessage>;
+  submittedContent: ReadonlyArray<ContentPart>;
+  turnId: string;
+}>;
+
+export const resolveConfirmedChatTurnStopHistory = (
+  snapshot: Pick<
+    ChatSessionSnapshot,
+    "activeTurnId" | "messages" | "runState"
+  >,
+  pendingTurn: PendingChatTurnTranscript,
+  timestamp: number,
+): ReadonlyArray<StoredMessage> | null => {
+  if (
+    snapshot.runState === "running"
+    || snapshot.activeTurnId !== null
+    || resolveChatSendReconciliationDisposition(
+      pendingTurn.turnId,
+      snapshot,
+    ) === "preserve_success"
+  ) {
+    return null;
+  }
+
+  return buildStoppedChatSendHistory(
+    snapshot.messages,
+    pendingTurn.submittedContent,
+    timestamp,
+  );
+};
 
 const IMAGE_MEDIA_TYPES = new Set<string>(OPENAI_IMAGE_MIME_TYPES);
 const HEIC_SIGNATURE_PREFIX_BASE64_CHARACTERS = 16;
 
 const MAX_BODY_BYTES = 90 * 1024 * 1024;
 const STREAM_TIMEOUT_MS = 6 * 60 * 1000;
+
+const resolveRejectedChatRequestAcceptance = (
+  response: Response,
+): Exclude<ChatRequestAcceptance, "accepted"> => {
+  if (response.status >= 500) {
+    return "unknown";
+  }
+
+  return "rejected";
+};
 
 const decodeBase64Prefix = (base64Data: string): Uint8Array => {
   const binary = atob(base64Data.slice(0, HEIC_SIGNATURE_PREFIX_BASE64_CHARACTERS));
@@ -174,6 +1099,7 @@ export const prepareChatSendRequest = (
 
   const requestBody = JSON.stringify({
     sessionId: "session-size-check",
+    turnId: "00000000-0000-4000-8000-000000000000",
     model: CHAT_MODEL_ID,
     content: contentParts,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -198,9 +1124,11 @@ export const prepareChatSendRequest = (
 export const buildChatSendRequestBody = (
   content: ReadonlyArray<ContentPart>,
   sessionId: string,
+  turnId: string,
 ): string =>
   JSON.stringify({
     sessionId,
+    turnId,
     model: CHAT_MODEL_ID,
     content,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -431,6 +1359,66 @@ export class ChatSessionSnapshotRequestError extends Error {
   }
 }
 
+export type ChatSessionSnapshotTransportErrorKind =
+  | "network"
+  | "preflight_rejected";
+
+export class ChatSessionSnapshotTransportError extends Error {
+  public readonly kind: ChatSessionSnapshotTransportErrorKind;
+
+  public constructor(
+    message: string,
+    kind: ChatSessionSnapshotTransportErrorKind,
+  ) {
+    super(message);
+    this.name = "ChatSessionSnapshotTransportError";
+    this.kind = kind;
+  }
+}
+
+export const classifyConfirmedChatStopSnapshotFailure = (
+  error: unknown,
+): ChatConfirmedStopSnapshotFailureDisposition => {
+  if (error instanceof ChatSessionSnapshotTransportError) {
+    return error.kind === "network" ? "retry" : "fail";
+  }
+  if (error instanceof ChatSessionSnapshotRequestError) {
+    return error.status >= 500
+      || error.kind === "active_response_conflict"
+      ? "retry"
+      : "fail";
+  }
+
+  return "fail";
+};
+
+export const resolveDefinitiveChatSendSnapshotFailureHistory = (
+  error: unknown,
+  pendingTurn: ChatSendReconciliationOwner & PendingChatTurnTranscript,
+  currentPendingTurn: ChatSendReconciliationOwner | null,
+  currentSessionId: string | null,
+  errorMessage: string,
+  timestamp: number,
+): ReadonlyArray<StoredMessage> | null => {
+  if (
+    classifyConfirmedChatStopSnapshotFailure(error) !== "fail"
+    || !isChatSendReconciliationOwnerCurrent(
+      pendingTurn,
+      currentPendingTurn,
+      currentSessionId,
+    )
+  ) {
+    return null;
+  }
+
+  return buildFailedChatSendHistory(
+    pendingTurn.authoritativeMessages,
+    pendingTurn.submittedContent,
+    errorMessage,
+    timestamp,
+  );
+};
+
 export const isUnavailableChatSessionSnapshotError = (
   error: unknown,
 ): error is ChatSessionSnapshotRequestError =>
@@ -464,13 +1452,43 @@ export const fetchChatSessionSnapshot = async (
   const url = sessionId === undefined
     ? "/api/chat"
     : `/api/chat?sessionId=${encodeURIComponent(sessionId)}`;
-  const response = await fetchWithCsrf(url, {
+  const request = startChatRequest(url, {
     method: "GET",
     signal,
   });
+  if (request.kind === "preflight_rejected") {
+    throw new ChatSessionSnapshotTransportError(
+      `Chat snapshot request was rejected before sending: sessionId=${sessionId ?? "current"}, error=${request.error.message}`,
+      "preflight_rejected",
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await request.response;
+  } catch (error) {
+    const requestError = toError(error);
+    throw new ChatSessionSnapshotTransportError(
+      `Chat snapshot request failed before receiving a response: sessionId=${sessionId ?? "current"}, error=${requestError.message}`,
+      "network",
+    );
+  }
 
   if (!response.ok) {
-    const rawError = await response.text();
+    let rawError: string;
+    try {
+      rawError = await response.text();
+    } catch (error) {
+      const statusText = response.statusText.trim() === ""
+        ? "Snapshot request failed"
+        : response.statusText;
+      const readFailure = toError(error);
+      throw new ChatSessionSnapshotRequestError(
+        response.status,
+        `Error ${String(response.status)}: ${statusText}; response body could not be read: ${readFailure.message}`,
+        classifyChatSessionSnapshotRequestError(response.status, ""),
+      );
+    }
     throw new ChatSessionSnapshotRequestError(
       response.status,
       `Error ${response.status}: ${sanitizeChatRouteErrorText(response.status, rawError, t)}`,
@@ -478,24 +1496,144 @@ export const fetchChatSessionSnapshot = async (
     );
   }
 
-  return response.json() as Promise<ChatSessionSnapshot>;
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    const readFailure = toError(error);
+    if (error instanceof SyntaxError) {
+      throw new ChatSessionSnapshotSchemaError(
+        `Chat snapshot response contained malformed JSON: sessionId=${sessionId ?? "current"}, error=${readFailure.message}`,
+      );
+    }
+    throw new ChatSessionSnapshotTransportError(
+      `Chat snapshot response body could not be read: sessionId=${sessionId ?? "current"}, error=${readFailure.message}`,
+      "network",
+    );
+  }
+  assertValidChatSessionSnapshot(payload);
+  if (sessionId !== undefined && payload.sessionId !== sessionId) {
+    throw new ChatSessionSnapshotSchemaError(
+      `Chat snapshot response session did not match the requested session: requestedSessionId=${sessionId}, returnedSessionId=${payload.sessionId}`,
+    );
+  }
+  return payload;
 };
 
-export const postStopChatSession = async (
+const isStopChatSessionResponse = (
+  payload: unknown,
   sessionId: string,
+  turnId: string | null,
+): payload is StopChatSessionResponse => {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return false;
+  }
+
+  const candidate = payload as Readonly<Record<string, unknown>>;
+  if (
+    candidate.ok !== true
+    || candidate.sessionId !== sessionId
+    || typeof candidate.stopped !== "boolean"
+    || typeof candidate.stillRunning !== "boolean"
+  ) {
+    return false;
+  }
+
+  return turnId === null
+    || (
+      candidate.turnId === turnId
+      && candidate.cancellationConfirmed === true
+    );
+};
+
+export function postStopChatSession(
+  sessionId: string,
+  turnId: string,
+  signal: AbortSignal | undefined,
   t: ChatTranslation,
-): Promise<void> => {
-  const response = await fetchWithCsrf("/api/chat/stop", {
+): Promise<ExactTurnStopChatSessionResponse>;
+export function postStopChatSession(
+  sessionId: string,
+  turnId: null,
+  signal: AbortSignal | undefined,
+  t: ChatTranslation,
+): Promise<SessionLevelStopChatSessionResponse>;
+export function postStopChatSession(
+  sessionId: string,
+  turnId: string | null,
+  signal: AbortSignal | undefined,
+  t: ChatTranslation,
+): Promise<StopChatSessionResponse>;
+export async function postStopChatSession(
+  sessionId: string,
+  turnId: string | null,
+  signal: AbortSignal | undefined,
+  t: ChatTranslation,
+): Promise<StopChatSessionResponse> {
+  const request = startChatRequest("/api/chat/stop", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ sessionId }),
+    body: JSON.stringify({
+      sessionId,
+      ...(turnId === null ? {} : { turnId }),
+    }),
+    signal,
   });
+  if (request.kind === "preflight_rejected") {
+    throw new ChatTurnCancellationRequestError(
+      `Chat stop request was rejected before sending: sessionId=${sessionId}, turnId=${turnId ?? "none"}, error=${request.error.message}`,
+      null,
+      "rejected",
+    );
+  }
+  const response = await request.response;
 
   if (!response.ok) {
-    const rawError = await response.text();
-    throw new Error(`Error ${response.status}: ${sanitizeChatRouteErrorText(response.status, rawError, t)}`);
+    const kind: ChatTurnCancellationRequestErrorKind =
+      response.status >= 500 ? "acceptance_unknown" : "rejected";
+    let rawError: string;
+    try {
+      rawError = await response.text();
+    } catch (error) {
+      const statusText = response.statusText.trim() === ""
+        ? (kind === "rejected" ? "Request rejected" : "Server error")
+        : response.statusText;
+      const readFailure = error instanceof Error
+        ? error.message
+        : String(error);
+      throw new ChatTurnCancellationRequestError(
+        `Error ${String(response.status)}: ${statusText}; response body could not be read: ${readFailure}`,
+        response.status,
+        kind,
+      );
+    }
+    throw new ChatTurnCancellationRequestError(
+      `Error ${response.status}: ${sanitizeChatRouteErrorText(response.status, rawError, t)}`,
+      response.status,
+      kind,
+    );
   }
-};
+
+  let payload: unknown;
+  try {
+    payload = await response.json() as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ChatTurnCancellationRequestError(
+      `Chat stop confirmation could not be read: sessionId=${sessionId}, turnId=${turnId ?? "none"}, status=${String(response.status)}, error=${message}`,
+      response.status,
+      "acceptance_unknown",
+    );
+  }
+  if (!isStopChatSessionResponse(payload, sessionId, turnId)) {
+    throw new ChatTurnCancellationRequestError(
+      `Chat stop returned an invalid confirmation: sessionId=${sessionId}, turnId=${turnId ?? "none"}`,
+      response.status,
+      "acceptance_unknown",
+    );
+  }
+  return payload;
+}
 
 export const createChatSession = async (
   t: ChatTranslation,
@@ -530,6 +1668,7 @@ export const ensureWritableChatSession = async (
 
 export const deleteChatConversation = async (
   sessionId: string | null,
+  signal: AbortSignal,
   t: ChatTranslation,
 ): Promise<ChatClearConversationResponse> => {
   const clearUrl = sessionId === null
@@ -537,6 +1676,7 @@ export const deleteChatConversation = async (
     : `/api/chat?sessionId=${encodeURIComponent(sessionId)}`;
   const response = await fetchWithCsrf(clearUrl, {
     method: "DELETE",
+    signal,
   });
 
   if (!response.ok) {
@@ -606,16 +1746,30 @@ export const streamChatResponse = async (
   let streamFailure: Error | null = null;
   let failureStage: StreamChatFailureStage = null;
   let receivedContent = false;
+  let requestAcceptance: ChatRequestAcceptance = "unknown";
+
+  const request = startChatRequest("/api/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: params.requestBody,
+    signal: params.signal,
+  });
+  if (request.kind === "preflight_rejected") {
+    return {
+      responseSessionId: null,
+      streamFailure: request.error,
+      failureStage: "request",
+      receivedContent: false,
+      wasAborted: params.signal.aborted,
+      requestAcceptance: "rejected",
+    };
+  }
 
   try {
-    const response = await fetchWithCsrf("/api/chat", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: params.requestBody,
-      signal: params.signal,
-    });
+    const response = await request.response;
 
     if (!response.ok) {
+      requestAcceptance = resolveRejectedChatRequestAcceptance(response);
       const rawError = await response.text();
       return {
         responseSessionId: null,
@@ -623,9 +1777,11 @@ export const streamChatResponse = async (
         failureStage: "request",
         receivedContent: false,
         wasAborted: false,
+        requestAcceptance,
       };
     }
 
+    requestAcceptance = "accepted";
     const reader = response.body?.getReader();
     if (reader === undefined) {
       return {
@@ -634,6 +1790,7 @@ export const streamChatResponse = async (
         failureStage: "request",
         receivedContent: false,
         wasAborted: false,
+        requestAcceptance,
       };
     }
 
@@ -691,7 +1848,7 @@ export const streamChatResponse = async (
   } catch (error) {
     if (!params.signal.aborted) {
       streamFailure = error instanceof Error ? error : new Error(String(error));
-      failureStage = "stream";
+      failureStage = requestAcceptance === "accepted" ? "stream" : "request";
     }
   }
 
@@ -701,5 +1858,6 @@ export const streamChatResponse = async (
     failureStage,
     receivedContent,
     wasAborted: params.signal.aborted,
+    requestAcceptance,
   };
 };

--- a/apps/web/src/ui/chat/session/controller/useChatSessionController.ts
+++ b/apps/web/src/ui/chat/session/controller/useChatSessionController.ts
@@ -14,6 +14,7 @@ import {
   useChatHistory,
   type StoredMessage,
 } from "@/ui/hooks/useChatHistory";
+import type { ContentPart } from "@/server/chat/types";
 import type { PendingAttachment } from "../../shell/panel/FileAttachment";
 import {
   createChatBootstrapLocalState,
@@ -31,18 +32,55 @@ import {
   type ChatRunState,
 } from "../../stream/streamRecovery";
 import {
+  assertCanonicalChatTurnId,
   beginChatSnapshotRequest,
   buildChatSendRequestBody,
+  buildFailedChatSendHistory,
+  buildPendingChatSendHistory,
+  buildStoppedChatSendHistory,
+  classifyConfirmedChatStopSnapshotFailure,
+  completeChatTurnCancellation,
   createChatSession,
+  createSingleFlightChatClearOperationRunner,
+  createSingleFlightChatSendReconciliationRunner,
+  createSingleFlightChatTurnCancellationRunner,
   createChatSnapshotRequestCoordinator,
   createSingleFlightChatSnapshotPoller,
   deleteChatConversation,
   fetchChatSessionSnapshot,
+  isDefinitiveChatRequestRejection,
+  isChatClearOperationOwnerCurrent,
+  isChatPreSessionSendOwnerCurrent,
+  isChatSnapshotPollingOwnerCurrent,
+  isChatSendReconciliationOwnerCurrent,
+  isChatStopOperationOwnerCurrent,
   isChatStopSettlementOwned,
+  isChatTurnOwnerForSession,
+  isChatTurnCancellationSettlementOwned,
   postStopChatSession,
   prepareChatSendRequest,
+  reconcileConfirmedChatStopSnapshot,
+  resolveChatExactTurnOwnership,
+  resolveChatPreSessionSendAdoption,
+  resolveChatSendReconciliationDisposition,
+  resolveDefinitiveChatSendSnapshotFailureHistory,
+  resolveConfirmedChatStopSnapshotDisposition,
+  resolveConfirmedChatTurnStopHistory,
   resolveChatSnapshotRequest,
+  restorePendingChatTurnAfterCancellationRejection,
+  shouldRestoreChatRunAfterSnapshotFailure,
+  shouldRestoreChatTurnAfterCancellationRejection,
   streamChatResponse,
+  type ChatSendReconciliationOwner,
+  type ChatSendReconciliationRunner,
+  type ChatClearOperationOwner,
+  type ChatClearOperationRunner,
+  type ChatConfirmedStopSnapshotResolution,
+  type ChatPreSessionSendOwner,
+  type ChatStopOperationOwner,
+  type ChatTurnCancellationResolution,
+  type ChatTurnCancellationRunner,
+  type ExactTurnStopChatSessionResponse,
 } from "./chatSessionControllerRuntime";
 import {
   createInitialChatSessionControllerState,
@@ -90,6 +128,8 @@ export type ChatSessionController = Readonly<{
 type NormalizedChatSessionSnapshot = Readonly<{
   sessionId: string;
   runState: ChatRunState;
+  authoritativeRunState: ChatRunState;
+  activeTurnId: string | null;
   updatedAt: number;
   mainContentInvalidationVersion: number;
   messages: ChatSessionSnapshot["messages"];
@@ -105,15 +145,94 @@ type ChatSnapshotLoadResult =
     snapshot: NormalizedChatSessionSnapshot | null;
   }>;
 
-const shouldAlwaysAdoptChatSnapshot = (): boolean => true;
+type PendingChatTurn = ChatSendReconciliationOwner & Readonly<{
+  requestBody: string;
+  submittedContent: ReadonlyArray<ContentPart>;
+  authoritativeMessages: ReadonlyArray<StoredMessage>;
+  retryAbortController: AbortController;
+}>;
 
-const assertValidChatSessionSnapshot = (
-  snapshot: ChatSessionSnapshot,
-): void => {
-  if (typeof snapshot.sessionId !== "string" || snapshot.sessionId.trim() === "") {
-    throw new Error("Chat session snapshot did not include a sessionId");
+type PendingChatTurnCancellation = ChatSendReconciliationOwner;
+
+type ConfirmedChatTurnCancellation =
+  ChatSendReconciliationOwner & Readonly<{
+    response: ExactTurnStopChatSessionResponse;
+  }>;
+
+type PreSessionChatTurn = ChatPreSessionSendOwner & Readonly<{
+  authoritativeMessages: ReadonlyArray<StoredMessage>;
+  retryAbortController: AbortController;
+  submittedContent: ReadonlyArray<ContentPart>;
+}>;
+
+type ChatStopSnapshotReconciliationOwner = Readonly<{
+  ownerId: symbol;
+  sessionId: string;
+  abortController: AbortController;
+}>;
+
+type IsChatOperationOwnerCurrent = () => boolean;
+
+const toExactChatTurnOwner = (
+  preSessionChatTurn: PreSessionChatTurn | null,
+): ChatSendReconciliationOwner | null => {
+  if (
+    preSessionChatTurn === null
+    || preSessionChatTurn.initialSessionId === null
+  ) {
+    return null;
   }
+
+  return {
+    ownerId: preSessionChatTurn.ownerId,
+    sessionId: preSessionChatTurn.initialSessionId,
+    turnId: preSessionChatTurn.turnId,
+  };
 };
+
+const isPendingChatTurnForSession = (
+  pendingChatTurn: PendingChatTurn | null,
+  sessionId: string | null,
+): boolean =>
+  pendingChatTurn !== null
+  && pendingChatTurn.sessionId === sessionId;
+
+const isPendingChatTurnOwnerCurrent = (
+  pendingChatTurn: PendingChatTurn,
+  currentPendingChatTurn: PendingChatTurn | null,
+  currentSessionId: string | null,
+): boolean =>
+  !pendingChatTurn.retryAbortController.signal.aborted
+  && isChatSendReconciliationOwnerCurrent(
+    pendingChatTurn,
+    currentPendingChatTurn,
+    currentSessionId,
+  );
+
+const waitForChatReconciliationRetry = (
+  signal: AbortSignal,
+): Promise<void> => {
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve) => {
+    const finish = (): void => {
+      window.clearTimeout(intervalId);
+      signal.removeEventListener("abort", finish);
+      resolve();
+    };
+    const intervalId = window.setTimeout(
+      finish,
+      ACTIVE_RUN_SNAPSHOT_POLL_INTERVAL_MS,
+    );
+    signal.addEventListener("abort", finish, { once: true });
+  });
+};
+
+const shouldAlwaysAdoptChatSnapshot = (
+  _snapshot: ChatSessionSnapshot,
+): boolean => true;
 
 export const useChatSessionController = (
   params: UseChatSessionControllerParams,
@@ -142,6 +261,17 @@ export const useChatSessionController = (
   const stateRef = useRef(state);
   const abortRef = useRef<AbortController | null>(null);
   const pendingSessionIdRef = useRef<Promise<string> | null>(null);
+  const preSessionChatTurnRef = useRef<PreSessionChatTurn | null>(null);
+  const pendingChatTurnRef = useRef<PendingChatTurn | null>(null);
+  const activeChatTurnRef = useRef<ChatSendReconciliationOwner | null>(null);
+  const pendingChatTurnCancellationRef =
+    useRef<PendingChatTurnCancellation | null>(null);
+  const confirmedChatTurnCancellationRef =
+    useRef<ConfirmedChatTurnCancellation | null>(null);
+  const clearOperationRef = useRef<ChatClearOperationOwner | null>(null);
+  const stopOperationRef = useRef<ChatStopOperationOwner | null>(null);
+  const stopSnapshotReconciliationRef =
+    useRef<ChatStopSnapshotReconciliationOwner | null>(null);
   const invalidationSourceIdRef = useRef<string | null>(null);
   const snapshotRequestCoordinatorRef = useRef(
     createChatSnapshotRequestCoordinator(),
@@ -211,7 +341,7 @@ export const useChatSessionController = (
     sessionId: string | undefined,
     signal: AbortSignal | undefined,
     replaceHistory: boolean,
-    shouldAdoptSnapshot: () => boolean,
+    shouldAdoptSnapshot: (snapshot: ChatSessionSnapshot) => boolean,
   ): Promise<ChatSnapshotLoadResult> => {
     const snapshotPromise = fetchChatSessionSnapshot(sessionId, signal, t);
     const snapshotRequest = beginChatSnapshotRequest(
@@ -237,12 +367,12 @@ export const useChatSessionController = (
     }
 
     const payload = resolution.snapshot;
-    assertValidChatSessionSnapshot(payload);
     if (resolution.kind === "superseded") {
       return {
         kind: "superseded",
         snapshot: {
           ...payload,
+          authoritativeRunState: payload.runState,
           runState: selectEffectiveSnapshotRunState(
             stateRef.current,
             payload.sessionId,
@@ -251,11 +381,62 @@ export const useChatSessionController = (
         },
       };
     }
-    if (!shouldAdoptSnapshot()) {
+    if (!shouldAdoptSnapshot(payload)) {
       return {
         kind: "superseded",
         snapshot: null,
       };
+    }
+    const pendingChatTurn = pendingChatTurnRef.current;
+    if (
+      pendingChatTurn !== null
+      && pendingChatTurn.sessionId === payload.sessionId
+      && resolveChatSendReconciliationDisposition(
+        pendingChatTurn.turnId,
+        payload,
+      ) === "acceptance_unknown"
+    ) {
+      return {
+        kind: "superseded",
+        snapshot: {
+          ...payload,
+          authoritativeRunState: payload.runState,
+          runState: selectEffectiveSnapshotRunState(
+            stateRef.current,
+            payload.sessionId,
+            payload.runState,
+          ),
+        },
+      };
+    }
+    const exactTurnOwnership = resolveChatExactTurnOwnership(
+      payload,
+      pendingChatTurnRef.current,
+      activeChatTurnRef.current,
+      pendingChatTurnCancellationRef.current,
+    );
+    if (exactTurnOwnership.pendingTurn === null) {
+      pendingChatTurnRef.current = null;
+    }
+    activeChatTurnRef.current = exactTurnOwnership.activeTurn;
+    const currentExactTurn = pendingChatTurnRef.current
+      ?? activeChatTurnRef.current;
+    if (
+      pendingChatTurnCancellationRef.current !== null
+      && currentExactTurn?.ownerId
+        !== pendingChatTurnCancellationRef.current.ownerId
+    ) {
+      pendingChatTurnCancellationRef.current = null;
+    }
+    const confirmedCancellation = confirmedChatTurnCancellationRef.current;
+    if (
+      confirmedCancellation?.sessionId === payload.sessionId
+      && (
+        payload.runState !== "running"
+        || payload.activeTurnId !== confirmedCancellation.turnId
+      )
+    ) {
+      confirmedChatTurnCancellationRef.current = null;
     }
 
     const currentState = stateRef.current;
@@ -292,10 +473,870 @@ export const useChatSessionController = (
       kind: "applied",
       snapshot: {
         ...payload,
+        authoritativeRunState: payload.runState,
         runState: effectiveRunState,
       },
     };
   }, [dispatchAction, refreshMainContent, replaceMessages, t, workspaceId]);
+
+  const reconcileConfirmedStopSnapshotForOwner = useCallback(async (
+    sessionId: string,
+    turnId: string | null,
+    operationSignal: AbortSignal,
+    isOperationOwnerCurrent: IsChatOperationOwnerCurrent,
+  ): Promise<
+    ChatConfirmedStopSnapshotResolution<NormalizedChatSessionSnapshot>
+  > => {
+    stopSnapshotReconciliationRef.current?.abortController.abort();
+    const reconciliationOwner: ChatStopSnapshotReconciliationOwner = {
+      ownerId: Symbol(sessionId),
+      sessionId,
+      abortController: new AbortController(),
+    };
+    stopSnapshotReconciliationRef.current = reconciliationOwner;
+    const abortReconciliation = (): void => {
+      reconciliationOwner.abortController.abort();
+    };
+    if (operationSignal.aborted) {
+      abortReconciliation();
+    } else {
+      operationSignal.addEventListener(
+        "abort",
+        abortReconciliation,
+        { once: true },
+      );
+    }
+    const isReconciliationOwnerCurrent = (): boolean =>
+      !operationSignal.aborted
+      && !reconciliationOwner.abortController.signal.aborted
+      && stopSnapshotReconciliationRef.current?.ownerId
+        === reconciliationOwner.ownerId
+      && stateRef.current.currentSessionId === sessionId
+      && isOperationOwnerCurrent();
+    const shouldAdoptSnapshot = (
+      _snapshot: ChatSessionSnapshot,
+    ): boolean =>
+      isReconciliationOwnerCurrent();
+
+    try {
+      return await reconcileConfirmedChatStopSnapshot({
+        signal: reconciliationOwner.abortController.signal,
+        isOwnerCurrent: isReconciliationOwnerCurrent,
+        loadSnapshot: async (
+          signal,
+        ): Promise<NormalizedChatSessionSnapshot | null> => {
+          const snapshotResult = await loadChatSnapshot(
+            sessionId,
+            signal,
+            true,
+            shouldAdoptSnapshot,
+          );
+          return snapshotResult.snapshot;
+        },
+        resolveSnapshot: (snapshot) =>
+          resolveConfirmedChatStopSnapshotDisposition(
+            turnId,
+            {
+              runState: snapshot.authoritativeRunState,
+              activeTurnId: snapshot.activeTurnId,
+            },
+          ),
+        classifyFailure: classifyConfirmedChatStopSnapshotFailure,
+        waitForRetry: waitForChatReconciliationRetry,
+      });
+    } finally {
+      operationSignal.removeEventListener("abort", abortReconciliation);
+      if (
+        stopSnapshotReconciliationRef.current?.ownerId
+        === reconciliationOwner.ownerId
+      ) {
+        stopSnapshotReconciliationRef.current = null;
+      }
+    }
+  }, [loadChatSnapshot]);
+
+  const performPendingChatTurnCycle = useCallback(async (
+    pendingChatTurn: PendingChatTurn,
+    attemptAbortController: AbortController,
+  ): Promise<void> => {
+    const abortAttempt = (): void => {
+      attemptAbortController.abort();
+    };
+    if (pendingChatTurn.retryAbortController.signal.aborted) {
+      return;
+    }
+    pendingChatTurn.retryAbortController.signal.addEventListener(
+      "abort",
+      abortAttempt,
+      { once: true },
+    );
+
+    const isOwnerCurrent = (): boolean =>
+      isPendingChatTurnOwnerCurrent(
+        pendingChatTurn,
+        pendingChatTurnRef.current,
+        stateRef.current.currentSessionId,
+      );
+
+    try {
+      if (!isOwnerCurrent()) {
+        return;
+      }
+
+      replaceMessages(buildPendingChatSendHistory(
+        pendingChatTurn.authoritativeMessages,
+        pendingChatTurn.submittedContent,
+        Date.now(),
+      ));
+      abortRef.current = attemptAbortController;
+      const streamResult = await streamChatResponse({
+        requestBody: pendingChatTurn.requestBody,
+        signal: attemptAbortController.signal,
+        abortStream: (): void => {
+          attemptAbortController.abort();
+        },
+        t,
+        handlers: {
+          appendAssistantChunk: (text, streamPosition): void => {
+            if (isOwnerCurrent()) {
+              appendAssistantChunk(text, streamPosition);
+            }
+          },
+          upsertReasoningSummary: (reasoningSummary): void => {
+            if (isOwnerCurrent()) {
+              upsertReasoningSummary(reasoningSummary);
+            }
+          },
+          upsertToolCall: (toolCall): void => {
+            if (isOwnerCurrent()) {
+              upsertToolCall(toolCall);
+            }
+          },
+          markAssistantError: (errorMessage): void => {
+            if (isOwnerCurrent()) {
+              markAssistantError(errorMessage);
+            }
+          },
+          applyMainContentInvalidationVersion: (nextVersion): void => {
+            if (isOwnerCurrent()) {
+              applyMainContentInvalidationVersion(nextVersion, "live");
+            }
+          },
+        },
+        onSessionIdReceived: (sessionId): void => {
+          if (isOwnerCurrent() && sessionId === pendingChatTurn.sessionId) {
+            dispatchAction({
+              type: "server_session_accepted",
+              sessionId,
+            });
+          }
+        },
+        onLiveStreamConnected: (): void => {
+          if (!isOwnerCurrent()) {
+            return;
+          }
+          dispatchAction({ type: "live_stream_connected" });
+        },
+      });
+
+      if (!isOwnerCurrent()) {
+        return;
+      }
+      if (streamResult.receivedContent) {
+        finalizeAssistant();
+      }
+      dispatchAction({ type: "live_stream_disconnected" });
+
+      if (
+        isDefinitiveChatRequestRejection(streamResult)
+        && !streamResult.wasAborted
+      ) {
+        const requestFailureMessage = streamResult.streamFailure === null
+          ? t("chat.errorNoResponse")
+          : streamResult.streamFailure.message;
+        pendingChatTurnRef.current = null;
+        replaceMessages(buildFailedChatSendHistory(
+          pendingChatTurn.authoritativeMessages,
+          pendingChatTurn.submittedContent,
+          requestFailureMessage,
+          Date.now(),
+        ));
+        dispatchAction({ type: "run_finished" });
+        return;
+      }
+
+      if (streamResult.wasAborted) {
+        return;
+      }
+
+      try {
+        const snapshotResult = await loadChatSnapshot(
+          pendingChatTurn.sessionId,
+          attemptAbortController.signal,
+          true,
+          (): boolean => isOwnerCurrent(),
+        );
+        if (!isOwnerCurrent()) {
+          return;
+        }
+        if (snapshotResult.snapshot === null) {
+          if (streamResult.streamFailure !== null) {
+            markAssistantError(t("chat.errorFailed", {
+              message: streamResult.streamFailure.message,
+            }));
+          }
+          return;
+        }
+        const reconciliationDisposition = resolveChatSendReconciliationDisposition(
+          pendingChatTurn.turnId,
+          snapshotResult.snapshot,
+        );
+        if (reconciliationDisposition === "acceptance_unknown") {
+          if (streamResult.streamFailure !== null) {
+            markAssistantError(t("chat.errorFailed", {
+              message: streamResult.streamFailure.message,
+            }));
+          }
+          return;
+        }
+        if (shouldSuppressStreamFailure(snapshotResult.snapshot)) {
+          return;
+        }
+      } catch (error) {
+        if (!isOwnerCurrent()) {
+          return;
+        }
+        const snapshotFailureMessage = error instanceof Error
+          ? error.message
+          : String(error);
+        const failedHistory =
+          resolveDefinitiveChatSendSnapshotFailureHistory(
+            error,
+            pendingChatTurn,
+            pendingChatTurnRef.current,
+            stateRef.current.currentSessionId,
+            t("chat.errorFailed", { message: snapshotFailureMessage }),
+            Date.now(),
+          );
+        if (failedHistory !== null) {
+          pendingChatTurnRef.current = null;
+          replaceMessages(failedHistory);
+          dispatchAction({ type: "run_finished" });
+          return;
+        }
+        const retryableFailureMessage = streamResult.streamFailure?.message
+          ?? snapshotFailureMessage;
+        markAssistantError(t("chat.errorFailed", {
+          message: retryableFailureMessage,
+        }));
+        return;
+      }
+
+      if (
+        streamResult.streamFailure !== null
+        && isOwnerCurrent()
+      ) {
+        markAssistantError(t("chat.errorFailed", {
+          message: streamResult.streamFailure.message,
+        }));
+      }
+    } finally {
+      pendingChatTurn.retryAbortController.signal.removeEventListener(
+        "abort",
+        abortAttempt,
+      );
+      if (
+        abortRef.current === attemptAbortController
+        && !pendingChatTurn.retryAbortController.signal.aborted
+      ) {
+        abortRef.current = null;
+      }
+    }
+  }, [
+    appendAssistantChunk,
+    applyMainContentInvalidationVersion,
+    dispatchAction,
+    finalizeAssistant,
+    loadChatSnapshot,
+    markAssistantError,
+    replaceMessages,
+    t,
+    upsertReasoningSummary,
+    upsertToolCall,
+  ]);
+
+  const performPendingChatTurnCycleRef = useRef(performPendingChatTurnCycle);
+  performPendingChatTurnCycleRef.current = performPendingChatTurnCycle;
+  const pendingChatTurnRunnerRef = useRef<
+    ChatSendReconciliationRunner<PendingChatTurn> | null
+  >(null);
+  if (pendingChatTurnRunnerRef.current === null) {
+    pendingChatTurnRunnerRef.current =
+      createSingleFlightChatSendReconciliationRunner(
+        (pendingChatTurn, abortController): Promise<void> =>
+          performPendingChatTurnCycleRef.current(
+            pendingChatTurn,
+            abortController,
+          ),
+      );
+  }
+  const pendingChatTurnRunner = pendingChatTurnRunnerRef.current;
+
+  const performPendingChatTurnCancellation = useCallback(async (
+    cancellation: PendingChatTurnCancellation,
+    attemptAbortController: AbortController,
+  ): Promise<ChatTurnCancellationResolution> =>
+    completeChatTurnCancellation({
+      signal: attemptAbortController.signal,
+      isOwnerCurrent: (): boolean =>
+        isChatTurnCancellationSettlementOwned(
+          cancellation,
+          pendingChatTurnCancellationRef.current,
+          pendingChatTurnRef.current
+            ?? toExactChatTurnOwner(preSessionChatTurnRef.current)
+            ?? activeChatTurnRef.current,
+          stateRef.current.currentSessionId,
+        ),
+      requestCancellation: (signal) =>
+        postStopChatSession(
+          cancellation.sessionId,
+          cancellation.turnId,
+          signal,
+          t,
+        ),
+      waitForRetry: waitForChatReconciliationRetry,
+      clearCancellationAttempt: (): void => {
+        if (
+          pendingChatTurnCancellationRef.current?.ownerId
+          === cancellation.ownerId
+        ) {
+          pendingChatTurnCancellationRef.current = null;
+        }
+      },
+      clearExactTurnOwnership: (): void => {
+        if (pendingChatTurnRef.current?.ownerId === cancellation.ownerId) {
+          pendingChatTurnRef.current = null;
+        }
+        if (activeChatTurnRef.current?.ownerId === cancellation.ownerId) {
+          activeChatTurnRef.current = null;
+        }
+        if (preSessionChatTurnRef.current?.ownerId === cancellation.ownerId) {
+          preSessionChatTurnRef.current = null;
+        }
+      },
+    }), [t]);
+  const performPendingChatTurnCancellationRef =
+    useRef(performPendingChatTurnCancellation);
+  performPendingChatTurnCancellationRef.current =
+    performPendingChatTurnCancellation;
+  const pendingChatTurnCancellationRunnerRef = useRef<
+    ChatTurnCancellationRunner<PendingChatTurnCancellation> | null
+  >(null);
+  if (pendingChatTurnCancellationRunnerRef.current === null) {
+    pendingChatTurnCancellationRunnerRef.current =
+      createSingleFlightChatTurnCancellationRunner(
+        (cancellation, abortController) =>
+          performPendingChatTurnCancellationRef.current(
+            cancellation,
+            abortController,
+          ),
+      );
+  }
+  const pendingChatTurnCancellationRunner =
+    pendingChatTurnCancellationRunnerRef.current;
+
+  const cancelExactChatTurn = useCallback(async (
+    exactChatTurn: ChatSendReconciliationOwner,
+  ): Promise<ChatTurnCancellationResolution> => {
+    const confirmedCancellation =
+      confirmedChatTurnCancellationRef.current;
+    if (
+      confirmedCancellation?.sessionId === exactChatTurn.sessionId
+      && confirmedCancellation.turnId === exactChatTurn.turnId
+    ) {
+      return {
+        kind: "confirmed",
+        response: confirmedCancellation.response,
+      };
+    }
+
+    const pendingChatTurn = pendingChatTurnRef.current;
+    if (pendingChatTurn?.ownerId === exactChatTurn.ownerId) {
+      pendingChatTurn.retryAbortController.abort();
+      pendingChatTurnRunner.cancel(pendingChatTurn);
+    }
+
+    const existingCancellation = pendingChatTurnCancellationRef.current;
+    const cancellation = existingCancellation?.ownerId === exactChatTurn.ownerId
+      ? existingCancellation
+      : {
+        ownerId: exactChatTurn.ownerId,
+        sessionId: exactChatTurn.sessionId,
+        turnId: exactChatTurn.turnId,
+      };
+    pendingChatTurnCancellationRef.current = cancellation;
+
+    const resolution =
+      await pendingChatTurnCancellationRunner.run(cancellation);
+    if (
+      resolution.kind === "confirmed"
+      && stateRef.current.currentSessionId === exactChatTurn.sessionId
+    ) {
+      const currentExactTurn = pendingChatTurnRef.current
+        ?? toExactChatTurnOwner(preSessionChatTurnRef.current)
+        ?? activeChatTurnRef.current;
+      if (
+        currentExactTurn?.sessionId === exactChatTurn.sessionId
+        && currentExactTurn.turnId !== exactChatTurn.turnId
+      ) {
+        return { kind: "superseded" };
+      }
+      confirmedChatTurnCancellationRef.current = {
+        ...exactChatTurn,
+        response: resolution.response,
+      };
+    }
+    return resolution;
+  }, [pendingChatTurnCancellationRunner, pendingChatTurnRunner]);
+
+  const restoreChatTurnAfterCancellationRejection = useCallback((
+    error: unknown,
+    rejectedTurn: ChatSendReconciliationOwner,
+  ): void => {
+    const currentPendingTurn = pendingChatTurnRef.current;
+    const currentPreSessionTurn = preSessionChatTurnRef.current;
+    const currentPreSessionExactTurn = toExactChatTurnOwner(
+      currentPreSessionTurn,
+    );
+    const currentTurn = currentPendingTurn
+      ?? currentPreSessionExactTurn
+      ?? activeChatTurnRef.current;
+    const currentSessionId = stateRef.current.currentSessionId;
+    if (!shouldRestoreChatTurnAfterCancellationRejection(
+      error,
+      rejectedTurn,
+      currentTurn,
+      currentSessionId,
+    )) {
+      return;
+    }
+
+    const restoredPendingTurn =
+      restorePendingChatTurnAfterCancellationRejection(
+        error,
+        rejectedTurn,
+        currentPendingTurn,
+        currentSessionId,
+      );
+    if (restoredPendingTurn !== null) {
+      pendingChatTurnRef.current = restoredPendingTurn;
+    } else if (
+      currentPreSessionTurn !== null
+      && currentPreSessionExactTurn?.ownerId === rejectedTurn.ownerId
+      && currentPreSessionTurn.initialSessionId !== null
+    ) {
+      const resumablePendingTurn: PendingChatTurn = {
+        ownerId: currentPreSessionTurn.ownerId,
+        sessionId: currentPreSessionTurn.initialSessionId,
+        turnId: currentPreSessionTurn.turnId,
+        requestBody: buildChatSendRequestBody(
+          currentPreSessionTurn.submittedContent,
+          currentPreSessionTurn.initialSessionId,
+          currentPreSessionTurn.turnId,
+        ),
+        submittedContent: currentPreSessionTurn.submittedContent,
+        authoritativeMessages: currentPreSessionTurn.authoritativeMessages,
+        retryAbortController: currentPreSessionTurn.retryAbortController,
+      };
+      const restoredPreSessionTurn =
+        restorePendingChatTurnAfterCancellationRejection(
+          error,
+          rejectedTurn,
+          resumablePendingTurn,
+          currentSessionId,
+        );
+      if (restoredPreSessionTurn !== null) {
+        preSessionChatTurnRef.current = null;
+        pendingChatTurnRef.current = restoredPreSessionTurn;
+      }
+    }
+
+    dispatchAction({ type: "run_started" });
+  }, [dispatchAction]);
+
+  const releaseSupersededExactTurnStop = useCallback((
+    exactChatTurn: ChatSendReconciliationOwner,
+  ): void => {
+    dispatchAction({
+      type: "stop_completed",
+      sessionId: exactChatTurn.sessionId,
+    });
+    const activeChatTurn = activeChatTurnRef.current;
+    if (
+      activeChatTurn?.sessionId === exactChatTurn.sessionId
+      && activeChatTurn.ownerId !== exactChatTurn.ownerId
+    ) {
+      dispatchAction({ type: "run_started" });
+    }
+  }, [dispatchAction]);
+
+  const performClearOperation = useCallback(async (
+    owner: ChatClearOperationOwner,
+    attemptAbortController: AbortController,
+  ): Promise<void> => {
+    const isOwnerCurrent = (): boolean =>
+      !attemptAbortController.signal.aborted
+      && isChatClearOperationOwnerCurrent(
+        owner,
+        clearOperationRef.current,
+        stateRef.current.currentSessionId,
+      );
+
+    if (!isOwnerCurrent()) {
+      return;
+    }
+    if (owner.targetSessionId !== null) {
+      dispatchAction({
+        type: "stop_requested",
+        sessionId: owner.targetSessionId,
+      });
+    }
+
+    const preSessionChatTurn = preSessionChatTurnRef.current;
+    if (
+      preSessionChatTurn !== null
+      && preSessionChatTurn.initialSessionId === null
+    ) {
+      preSessionChatTurn.retryAbortController.abort();
+      preSessionChatTurnRef.current = null;
+      abortRef.current?.abort();
+      abortRef.current = null;
+      if (!isOwnerCurrent()) {
+        return;
+      }
+      dispatchAction({ type: "live_stream_disconnected" });
+      dispatchAction({ type: "run_finished" });
+      clearHistory();
+      return;
+    }
+
+    const pendingChatTurn = pendingChatTurnRef.current;
+    const preSessionExactChatTurn = toExactChatTurnOwner(
+      preSessionChatTurnRef.current,
+    );
+    const exactChatTurn =
+      preSessionExactChatTurn?.sessionId === owner.targetSessionId
+        ? preSessionExactChatTurn
+        : pendingChatTurn?.sessionId === owner.targetSessionId
+          ? pendingChatTurn
+          : activeChatTurnRef.current?.sessionId === owner.targetSessionId
+            ? activeChatTurnRef.current
+            : confirmedChatTurnCancellationRef.current?.sessionId
+                === owner.targetSessionId
+              ? confirmedChatTurnCancellationRef.current
+              : null;
+
+    if (exactChatTurn !== null) {
+      let cancellationResolution: ChatTurnCancellationResolution;
+      try {
+        if (preSessionExactChatTurn?.ownerId === exactChatTurn.ownerId) {
+          preSessionChatTurnRef.current?.retryAbortController.abort();
+        }
+        cancellationResolution = await cancelExactChatTurn(
+          exactChatTurn,
+        );
+      } catch (error) {
+        if (!isOwnerCurrent()) {
+          return;
+        }
+        restoreChatTurnAfterCancellationRejection(error, exactChatTurn);
+        const message = error instanceof Error ? error.message : String(error);
+        markAssistantError(t("chat.errorFailed", { message }));
+        if (owner.targetSessionId !== null) {
+          dispatchAction({
+            type: "stop_failed",
+            sessionId: owner.targetSessionId,
+          });
+        }
+        return;
+      }
+      if (!isOwnerCurrent()) {
+        return;
+      }
+      if (cancellationResolution.kind === "superseded") {
+        releaseSupersededExactTurnStop(exactChatTurn);
+        return;
+      }
+      if (cancellationResolution.response.stillRunning) {
+        let snapshotResolution: ChatConfirmedStopSnapshotResolution<
+          NormalizedChatSessionSnapshot
+        >;
+        try {
+          snapshotResolution =
+            await reconcileConfirmedStopSnapshotForOwner(
+              exactChatTurn.sessionId,
+              exactChatTurn.turnId,
+              attemptAbortController.signal,
+              isOwnerCurrent,
+            );
+        } catch (error) {
+          if (!isOwnerCurrent()) {
+            return;
+          }
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+          markAssistantError(t("chat.errorFailed", { message }));
+          dispatchAction({
+            type: "stop_failed",
+            sessionId: exactChatTurn.sessionId,
+          });
+          if (shouldRestoreChatRunAfterSnapshotFailure(
+            exactChatTurn,
+            activeChatTurnRef.current,
+            stateRef.current.currentSessionId,
+          )) {
+            dispatchAction({ type: "run_started" });
+          }
+          return;
+        }
+        if (!isOwnerCurrent()) {
+          return;
+        }
+        if (snapshotResolution.kind === "superseded") {
+          if (snapshotResolution.snapshot !== null) {
+            releaseSupersededExactTurnStop(exactChatTurn);
+          }
+          return;
+        }
+      } else if (
+        confirmedChatTurnCancellationRef.current?.sessionId
+          === exactChatTurn.sessionId
+        && confirmedChatTurnCancellationRef.current?.turnId
+          === exactChatTurn.turnId
+      ) {
+        confirmedChatTurnCancellationRef.current = null;
+      }
+    } else if (
+      owner.targetSessionId !== null
+      && selectIsAssistantRunActive(stateRef.current)
+    ) {
+      try {
+        await postStopChatSession(
+          owner.targetSessionId,
+          null,
+          attemptAbortController.signal,
+          t,
+        );
+      } catch {
+        if (!isOwnerCurrent()) {
+          return;
+        }
+        // Preserve the existing best-effort session stop before reset.
+      }
+    }
+
+    if (!isOwnerCurrent()) {
+      return;
+    }
+    abortRef.current?.abort();
+    abortRef.current = null;
+    dispatchAction({ type: "live_stream_disconnected" });
+
+    try {
+      const payload = await deleteChatConversation(
+        owner.targetSessionId,
+        attemptAbortController.signal,
+        t,
+      );
+      if (!isOwnerCurrent()) {
+        return;
+      }
+
+      clearHistory();
+      if (
+        confirmedChatTurnCancellationRef.current?.sessionId
+        === owner.targetSessionId
+      ) {
+        confirmedChatTurnCancellationRef.current = null;
+      }
+      if (owner.targetSessionId !== null) {
+        dispatchAction({
+          type: "stop_completed",
+          sessionId: owner.targetSessionId,
+        });
+        dispatchAction({
+          type: "stopped_session_cleared",
+          sessionId: owner.targetSessionId,
+        });
+      }
+      dispatchAction({
+        type: "conversation_cleared",
+        sessionId: payload.sessionId,
+      });
+    } catch (error) {
+      if (!isOwnerCurrent()) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      markAssistantError(t("chat.errorFailed", { message }));
+      if (owner.targetSessionId !== null) {
+        dispatchAction({
+          type: "stop_failed",
+          sessionId: owner.targetSessionId,
+        });
+      }
+    }
+  }, [
+    cancelExactChatTurn,
+    clearHistory,
+    dispatchAction,
+    markAssistantError,
+    reconcileConfirmedStopSnapshotForOwner,
+    releaseSupersededExactTurnStop,
+    restoreChatTurnAfterCancellationRejection,
+    t,
+  ]);
+  const performClearOperationRef = useRef(performClearOperation);
+  performClearOperationRef.current = performClearOperation;
+  const clearOperationRunnerRef = useRef<ChatClearOperationRunner | null>(null);
+  if (clearOperationRunnerRef.current === null) {
+    clearOperationRunnerRef.current =
+      createSingleFlightChatClearOperationRunner(
+        async (owner, abortController): Promise<void> => {
+          try {
+            await performClearOperationRef.current(owner, abortController);
+          } finally {
+            if (clearOperationRef.current?.ownerId === owner.ownerId) {
+              clearOperationRef.current = null;
+            }
+          }
+        },
+      );
+  }
+  const clearOperationRunner = clearOperationRunnerRef.current;
+
+  useEffect(() => (): void => {
+    stopOperationRef.current?.abortController.abort();
+    stopOperationRef.current = null;
+    stopSnapshotReconciliationRef.current?.abortController.abort();
+    stopSnapshotReconciliationRef.current = null;
+    confirmedChatTurnCancellationRef.current = null;
+    clearOperationRef.current = null;
+    clearOperationRunner.cancelActive();
+    preSessionChatTurnRef.current?.retryAbortController.abort();
+    pendingChatTurnRef.current?.retryAbortController.abort();
+    pendingChatTurnRunner.cancelActive();
+    pendingChatTurnCancellationRunner.cancelActive();
+  }, [
+    clearOperationRunner,
+    pendingChatTurnCancellationRunner,
+    pendingChatTurnRunner,
+  ]);
+
+  useEffect(() => {
+    const stopOperation = stopOperationRef.current;
+    if (
+      stopOperation !== null
+      && stopOperation.sessionId !== state.currentSessionId
+    ) {
+      stopOperation.abortController.abort();
+      stopOperationRef.current = null;
+    }
+    const stopSnapshotReconciliation =
+      stopSnapshotReconciliationRef.current;
+    if (
+      stopSnapshotReconciliation !== null
+      && stopSnapshotReconciliation.sessionId !== state.currentSessionId
+    ) {
+      stopSnapshotReconciliation.abortController.abort();
+      stopSnapshotReconciliationRef.current = null;
+    }
+    if (
+      confirmedChatTurnCancellationRef.current !== null
+      && confirmedChatTurnCancellationRef.current.sessionId
+        !== state.currentSessionId
+    ) {
+      confirmedChatTurnCancellationRef.current = null;
+    }
+
+    const clearOperation = clearOperationRef.current;
+    if (
+      clearOperation !== null
+      && clearOperation.targetSessionId !== state.currentSessionId
+    ) {
+      clearOperationRunner.cancel(clearOperation);
+      clearOperationRef.current = null;
+      if (clearOperation.targetSessionId !== null) {
+        dispatchAction({
+          type: "stop_completed",
+          sessionId: clearOperation.targetSessionId,
+        });
+      }
+    }
+
+    const preSessionChatTurn = preSessionChatTurnRef.current;
+    if (
+      preSessionChatTurn !== null
+      && preSessionChatTurn.initialSessionId !== state.currentSessionId
+    ) {
+      preSessionChatTurn.retryAbortController.abort();
+      const preSessionCancellation = pendingChatTurnCancellationRef.current;
+      if (preSessionCancellation?.ownerId === preSessionChatTurn.ownerId) {
+        pendingChatTurnCancellationRunner.cancel(preSessionCancellation);
+        pendingChatTurnCancellationRef.current = null;
+      }
+      preSessionChatTurnRef.current = null;
+    }
+
+    const pendingChatTurn = pendingChatTurnRef.current;
+    if (
+      pendingChatTurn !== null
+      && pendingChatTurn.sessionId !== state.currentSessionId
+    ) {
+      pendingChatTurn.retryAbortController.abort();
+      pendingChatTurnRunner.cancel(pendingChatTurn);
+      const pendingCancellation = pendingChatTurnCancellationRef.current;
+      if (pendingCancellation?.ownerId === pendingChatTurn.ownerId) {
+        pendingChatTurnCancellationRunner.cancel(pendingCancellation);
+        pendingChatTurnCancellationRef.current = null;
+      }
+      pendingChatTurnRef.current = null;
+    }
+
+    const activeChatTurn = activeChatTurnRef.current;
+    if (
+      activeChatTurn !== null
+      && activeChatTurn.sessionId !== state.currentSessionId
+    ) {
+      const activeCancellation = pendingChatTurnCancellationRef.current;
+      if (activeCancellation?.ownerId === activeChatTurn.ownerId) {
+        pendingChatTurnCancellationRunner.cancel(activeCancellation);
+        pendingChatTurnCancellationRef.current = null;
+      }
+      activeChatTurnRef.current = null;
+    }
+
+    if (
+      (
+        pendingChatTurn !== null
+        && pendingChatTurn.sessionId !== state.currentSessionId
+      )
+      || (
+        activeChatTurn !== null
+        && activeChatTurn.sessionId !== state.currentSessionId
+      )
+    ) {
+      abortRef.current?.abort();
+      abortRef.current = null;
+    }
+  }, [
+    clearOperationRunner,
+    dispatchAction,
+    pendingChatTurnCancellationRunner,
+    pendingChatTurnRunner,
+    state.currentSessionId,
+  ]);
 
   useEffect(() => {
     if (!state.isHistoryLoaded) {
@@ -453,22 +1494,52 @@ export const useChatSessionController = (
       return;
     }
 
+    const requestedSessionId = state.currentSessionId;
+    const pollAbortController = new AbortController();
+    const isPollingOwnerCurrent = (): boolean =>
+      isChatSnapshotPollingOwnerCurrent(
+        requestedSessionId,
+        stateRef.current.currentSessionId,
+        pollAbortController.signal,
+      )
+      && clearOperationRef.current === null;
     const pollSnapshot = createSingleFlightChatSnapshotPoller(
       async (): Promise<void> => {
         try {
+          const pendingChatTurn = pendingChatTurnRef.current;
+          if (
+            pendingChatTurn !== null
+            && pendingChatTurn.sessionId === requestedSessionId
+            && !pendingChatTurn.retryAbortController.signal.aborted
+          ) {
+            await pendingChatTurnRunner.run(pendingChatTurn);
+            return;
+          }
+
           await loadChatSnapshot(
-            state.currentSessionId ?? undefined,
-            undefined,
+            requestedSessionId,
+            pollAbortController.signal,
             true,
-            shouldAlwaysAdoptChatSnapshot,
+            (snapshot): boolean =>
+              snapshot.sessionId === requestedSessionId
+              && isPollingOwnerCurrent(),
           );
         } catch (error) {
+          if (!isPollingOwnerCurrent()) {
+            return;
+          }
           if (stateRef.current.isLiveStreamConnected) {
             return;
           }
 
           const message = error instanceof Error ? error.message : String(error);
           markAssistantError(t("chat.errorFailed", { message }));
+          if (isPendingChatTurnForSession(
+            pendingChatTurnRef.current,
+            stateRef.current.currentSessionId,
+          )) {
+            return;
+          }
           dispatchAction({ type: "run_interrupted" });
         }
       },
@@ -477,11 +1548,15 @@ export const useChatSessionController = (
       void pollSnapshot();
     }, ACTIVE_RUN_SNAPSHOT_POLL_INTERVAL_MS);
 
-    return () => clearInterval(intervalId);
+    return () => {
+      clearInterval(intervalId);
+      pollAbortController.abort();
+    };
   }, [
     dispatchAction,
     loadChatSnapshot,
     markAssistantError,
+    pendingChatTurnRunner,
     state.currentSessionId,
     state.isHistoryLoaded,
     state.runState,
@@ -499,15 +1574,6 @@ export const useChatSessionController = (
     }
 
     const pendingSessionId = createChatSession(t)
-      .then((writableSessionId) => {
-        if (stateRef.current.currentSessionId !== writableSessionId) {
-          dispatchAction({
-            type: "server_session_created",
-            sessionId: writableSessionId,
-          });
-        }
-        return writableSessionId;
-      })
       .finally(() => {
         pendingSessionIdRef.current = null;
       });
@@ -516,13 +1582,31 @@ export const useChatSessionController = (
     const writableSessionId = await pendingSessionId;
 
     return writableSessionId;
-  }, [dispatchAction, t]);
+  }, [t]);
 
   const sendMessage = useCallback(async (
     sendParams: SendChatMessageParams,
   ): Promise<void> => {
     const currentState = stateRef.current;
-    if (selectIsAssistantRunActive(currentState) || currentState.isLiveStreamConnected || selectIsSelectedSessionStopping(currentState)) {
+    if (
+      selectIsAssistantRunActive(currentState)
+      || currentState.isLiveStreamConnected
+      || selectIsSelectedSessionStopping(currentState)
+      || clearOperationRef.current !== null
+      || pendingChatTurnCancellationRef.current !== null
+      || isChatTurnOwnerForSession(
+        activeChatTurnRef.current,
+        currentState.currentSessionId,
+      )
+      || isChatTurnOwnerForSession(
+        confirmedChatTurnCancellationRef.current,
+        currentState.currentSessionId,
+      )
+      || isPendingChatTurnForSession(
+        pendingChatTurnRef.current,
+        currentState.currentSessionId,
+      )
+    ) {
       return;
     }
 
@@ -530,6 +1614,7 @@ export const useChatSessionController = (
       return;
     }
 
+    const authoritativeMessagesBeforeSend = messages;
     const preparedRequest = prepareChatSendRequest(
       sendParams.text,
       sendParams.attachments,
@@ -544,210 +1629,354 @@ export const useChatSessionController = (
       return;
     }
 
+    if (preparedRequest.kind === "too_large") {
+      appendUserMessage(preparedRequest.contentParts);
+      dispatchAction({ type: "run_started" });
+      startAssistantMessage();
+      markAssistantError(preparedRequest.errorMessage);
+      dispatchAction({ type: "run_finished" });
+      return;
+    }
+
+    const turnId = crypto.randomUUID();
+    assertCanonicalChatTurnId(turnId);
+    const preSessionChatTurn: PreSessionChatTurn = {
+      ownerId: Symbol(turnId),
+      initialSessionId: currentState.currentSessionId,
+      turnId,
+      authoritativeMessages: authoritativeMessagesBeforeSend,
+      retryAbortController: new AbortController(),
+      submittedContent: preparedRequest.contentParts,
+    };
+    preSessionChatTurnRef.current = preSessionChatTurn;
+
     appendUserMessage(preparedRequest.contentParts);
     dispatchAction({ type: "run_started" });
     startAssistantMessage();
-
-    const abortController = new AbortController();
-    abortRef.current = abortController;
-
-    if (preparedRequest.kind === "too_large") {
-      markAssistantError(preparedRequest.errorMessage);
-      dispatchAction({ type: "run_finished" });
-      abortRef.current = null;
-      return;
-    }
 
     let writableSessionId: string;
     try {
       writableSessionId = await ensureWritableSessionId();
     } catch (error) {
+      if (!isChatPreSessionSendOwnerCurrent(
+        preSessionChatTurn,
+        preSessionChatTurnRef.current,
+        stateRef.current.currentSessionId,
+      ) || preSessionChatTurn.retryAbortController.signal.aborted) {
+        return;
+      }
+      preSessionChatTurnRef.current = null;
       const message = error instanceof Error ? error.message : String(error);
       markAssistantError(t("chat.errorFailed", { message }));
       dispatchAction({ type: "run_finished" });
-      abortRef.current = null;
       return;
     }
 
-    const streamResult = await streamChatResponse({
-      requestBody: buildChatSendRequestBody(preparedRequest.contentParts, writableSessionId),
-      signal: abortController.signal,
-      abortStream: (): void => {
-        abortController.abort();
-      },
-      t,
-      handlers: {
-        appendAssistantChunk,
-        upsertReasoningSummary,
-        upsertToolCall,
-        markAssistantError,
-        applyMainContentInvalidationVersion: (nextVersion): void => {
-          applyMainContentInvalidationVersion(nextVersion, "live");
-        },
-      },
-      onSessionIdReceived: (sessionId): void => {
-        dispatchAction({
-          type: "server_session_accepted",
-          sessionId,
-        });
-      },
-      onLiveStreamConnected: (): void => {
-        dispatchAction({ type: "live_stream_connected" });
-      },
-    });
-
-    if (streamResult.receivedContent) {
-      finalizeAssistant();
-    }
-
-    dispatchAction({ type: "live_stream_disconnected" });
-    abortRef.current = null;
-
-    if (streamResult.failureStage === "request" && !streamResult.wasAborted) {
-      const requestFailureMessage = streamResult.streamFailure === null
-        ? t("chat.errorNoResponse")
-        : streamResult.streamFailure.message;
-      markAssistantError(requestFailureMessage);
-      dispatchAction({ type: "run_finished" });
+    const adoptedTurnOwner = resolveChatPreSessionSendAdoption(
+      preSessionChatTurn,
+      preSessionChatTurnRef.current,
+      stateRef.current.currentSessionId,
+      writableSessionId,
+      preSessionChatTurn.retryAbortController.signal,
+    );
+    if (adoptedTurnOwner === null) {
       return;
     }
 
-    const sessionIdToReload = streamResult.responseSessionId ?? stateRef.current.currentSessionId ?? undefined;
-    if (!streamResult.wasAborted && sessionIdToReload !== undefined) {
-      try {
-        const snapshotResult = await loadChatSnapshot(
-          sessionIdToReload,
-          undefined,
-          true,
-          shouldAlwaysAdoptChatSnapshot,
-        );
-        if (snapshotResult.snapshot === null) {
-          return;
-        }
-        if (shouldSuppressStreamFailure(snapshotResult.snapshot)) {
-          return;
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (streamResult.streamFailure === null) {
-          markAssistantError(t("chat.errorFailed", { message }));
-          dispatchAction({ type: "run_interrupted" });
-        }
-      }
+    const pendingChatTurn: PendingChatTurn = {
+      ...adoptedTurnOwner,
+      requestBody: buildChatSendRequestBody(
+        preparedRequest.contentParts,
+        writableSessionId,
+        turnId,
+      ),
+      submittedContent: preparedRequest.contentParts,
+      authoritativeMessages: authoritativeMessagesBeforeSend,
+      retryAbortController: preSessionChatTurn.retryAbortController,
+    };
+    preSessionChatTurnRef.current = null;
+    pendingChatTurnRef.current = pendingChatTurn;
+    pendingChatTurnCancellationRef.current = null;
+    if (stateRef.current.currentSessionId !== writableSessionId) {
+      dispatchAction({
+        type: "server_session_created",
+        sessionId: writableSessionId,
+      });
     }
-
-    if (streamResult.streamFailure !== null && !streamResult.wasAborted) {
-      markAssistantError(t("chat.errorFailed", { message: streamResult.streamFailure.message }));
-      dispatchAction({ type: "run_interrupted" });
-    }
+    await pendingChatTurnRunner.run(pendingChatTurn);
   }, [
-    appendAssistantChunk,
     appendUserMessage,
-    applyMainContentInvalidationVersion,
     dispatchAction,
     ensureWritableSessionId,
-    finalizeAssistant,
-    loadChatSnapshot,
     markAssistantError,
+    messages,
+    pendingChatTurnRunner,
     startAssistantMessage,
     t,
-    upsertReasoningSummary,
-    upsertToolCall,
   ]);
 
   const stopMessage = useCallback(async (): Promise<void> => {
     const currentState = stateRef.current;
-    if (currentState.currentSessionId === null || !selectIsAssistantRunActive(currentState) || selectIsSelectedSessionStopping(currentState)) {
+    if (!selectIsAssistantRunActive(currentState) || selectIsSelectedSessionStopping(currentState)) {
+      return;
+    }
+    const preSessionChatTurn = preSessionChatTurnRef.current;
+    if (currentState.currentSessionId === null) {
+      if (preSessionChatTurn === null) {
+        return;
+      }
+      preSessionChatTurn.retryAbortController.abort();
+      preSessionChatTurnRef.current = null;
+      abortRef.current?.abort();
+      abortRef.current = null;
+      replaceMessages(buildStoppedChatSendHistory(
+        preSessionChatTurn.authoritativeMessages,
+        preSessionChatTurn.submittedContent,
+        Date.now(),
+      ));
+      dispatchAction({ type: "live_stream_disconnected" });
+      dispatchAction({ type: "run_finished" });
       return;
     }
     const stoppedSessionId = currentState.currentSessionId;
+    stopOperationRef.current?.abortController.abort();
+    const stopOwner: ChatStopOperationOwner = {
+      ownerId: Symbol(stoppedSessionId),
+      sessionId: stoppedSessionId,
+      abortController: new AbortController(),
+    };
+    stopOperationRef.current = stopOwner;
+    const isStopOwnerCurrent = (): boolean =>
+      isChatStopOperationOwnerCurrent(
+        stopOwner,
+        stopOperationRef.current,
+        stateRef.current.currentSessionId,
+      );
     const stopStreamController = abortRef.current;
+    const preSessionExactChatTurn = toExactChatTurnOwner(
+      preSessionChatTurnRef.current,
+    );
+    const pendingChatTurn = pendingChatTurnRef.current;
+    const exactChatTurn = preSessionExactChatTurn?.sessionId === stoppedSessionId
+      ? preSessionExactChatTurn
+      : pendingChatTurn?.sessionId === stoppedSessionId
+        ? pendingChatTurn
+        : activeChatTurnRef.current?.sessionId === stoppedSessionId
+          ? activeChatTurnRef.current
+          : confirmedChatTurnCancellationRef.current?.sessionId
+              === stoppedSessionId
+            ? confirmedChatTurnCancellationRef.current
+            : null;
+    const retainedStoppedChatTurn =
+      preSessionExactChatTurn?.ownerId === exactChatTurn?.ownerId
+        && preSessionChatTurn !== null
+        ? preSessionChatTurn
+        : pendingChatTurn?.ownerId === exactChatTurn?.ownerId
+          ? pendingChatTurn
+          : null;
+    if (preSessionExactChatTurn?.ownerId === exactChatTurn?.ownerId) {
+      preSessionChatTurnRef.current?.retryAbortController.abort();
+    }
+    if (
+      pendingChatTurn !== null
+      && pendingChatTurn.sessionId === stoppedSessionId
+    ) {
+      pendingChatTurn.retryAbortController.abort();
+      pendingChatTurnRunner.cancel(pendingChatTurn);
+    }
 
     dispatchAction({
       type: "stop_requested",
       sessionId: stoppedSessionId,
     });
 
+    let exactCancellationResolution: ChatTurnCancellationResolution | null =
+      null;
+    let sessionStopConfirmed = false;
+    let stopSnapshotSettled = false;
+    let stopWasSupersededBySnapshot = false;
     try {
-      await postStopChatSession(stoppedSessionId, t);
-    } catch {
-      // The stop request is best-effort, but we still abort the local stream below.
+      if (
+        exactChatTurn !== null
+      ) {
+        exactCancellationResolution = await cancelExactChatTurn(exactChatTurn);
+      } else {
+        await postStopChatSession(
+          stoppedSessionId,
+          null,
+          stopOwner.abortController.signal,
+          t,
+        );
+        sessionStopConfirmed = true;
+      }
+    } catch (error) {
+      if (isStopOwnerCurrent()) {
+        if (exactChatTurn !== null) {
+          restoreChatTurnAfterCancellationRejection(error, exactChatTurn);
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        markAssistantError(t("chat.errorFailed", { message }));
+        dispatchAction({
+          type: "stop_failed",
+          sessionId: stoppedSessionId,
+        });
+      }
     } finally {
+      if (!isStopOwnerCurrent()) {
+        return;
+      }
       stopStreamController?.abort();
-      if (isChatStopSettlementOwned(
+      const isStopStreamSettlementOwned = isChatStopSettlementOwned(
         stoppedSessionId,
         stateRef.current.currentSessionId,
         stopStreamController,
         abortRef.current,
-      )) {
+      );
+      if (isStopStreamSettlementOwned) {
         abortRef.current = null;
         dispatchAction({ type: "live_stream_disconnected" });
-        const shouldAdoptStopSnapshot = (): boolean =>
-          isChatStopSettlementOwned(
+      }
+
+      if (exactCancellationResolution?.kind === "superseded") {
+        if (clearOperationRef.current === null && exactChatTurn !== null) {
+          releaseSupersededExactTurnStop(exactChatTurn);
+        }
+      } else {
+        const stopConfirmed =
+          exactCancellationResolution?.kind === "confirmed"
+          || sessionStopConfirmed;
+        const isStopSettlementOwnerCurrent = (): boolean =>
+          isStopOwnerCurrent()
+          && !stopOwner.abortController.signal.aborted
+          && clearOperationRef.current === null
+          && isChatStopSettlementOwned(
             stoppedSessionId,
             stateRef.current.currentSessionId,
             null,
             abortRef.current,
           );
 
-        try {
-          await loadChatSnapshot(
-            stoppedSessionId,
-            undefined,
-            true,
-            shouldAdoptStopSnapshot,
-          );
-        } catch (error) {
-          if (shouldAdoptStopSnapshot()) {
-            const message = error instanceof Error ? error.message : String(error);
-            markAssistantError(t("chat.errorFailed", { message }));
-            dispatchAction({ type: "run_interrupted" });
+        if (stopConfirmed && isStopStreamSettlementOwned) {
+          try {
+            const snapshotResolution =
+              await reconcileConfirmedStopSnapshotForOwner(
+                stoppedSessionId,
+                exactChatTurn?.turnId ?? null,
+                stopOwner.abortController.signal,
+                isStopSettlementOwnerCurrent,
+              );
+
+            if (
+              snapshotResolution.kind === "settled"
+              && isStopSettlementOwnerCurrent()
+            ) {
+              if (
+                retainedStoppedChatTurn !== null
+              ) {
+                const stoppedHistory = resolveConfirmedChatTurnStopHistory(
+                  snapshotResolution.snapshot,
+                  retainedStoppedChatTurn,
+                  Date.now(),
+                );
+                if (stoppedHistory !== null) {
+                  replaceMessages(stoppedHistory);
+                }
+              }
+              stopSnapshotSettled = true;
+            } else if (
+              snapshotResolution.kind === "superseded"
+              && snapshotResolution.snapshot !== null
+              && exactChatTurn !== null
+              && isStopSettlementOwnerCurrent()
+            ) {
+              releaseSupersededExactTurnStop(exactChatTurn);
+              stopWasSupersededBySnapshot = true;
+            }
+          } catch (error) {
+            if (isStopSettlementOwnerCurrent()) {
+              const message = error instanceof Error
+                ? error.message
+                : String(error);
+              markAssistantError(t("chat.errorFailed", { message }));
+              dispatchAction({
+                type: "stop_failed",
+                sessionId: stoppedSessionId,
+              });
+              if (
+                exactChatTurn !== null
+                && shouldRestoreChatRunAfterSnapshotFailure(
+                  exactChatTurn,
+                  activeChatTurnRef.current,
+                  stateRef.current.currentSessionId,
+                )
+              ) {
+                dispatchAction({ type: "run_started" });
+              }
+            }
           }
         }
+        if (
+          isStopOwnerCurrent()
+          && !stopWasSupersededBySnapshot
+          && stopConfirmed
+          && stopSnapshotSettled
+        ) {
+          dispatchAction({
+            type: "stop_completed",
+            sessionId: stoppedSessionId,
+          });
+        }
       }
-      dispatchAction({ type: "stop_completed", sessionId: stoppedSessionId });
+      if (stopOperationRef.current?.ownerId === stopOwner.ownerId) {
+        stopOperationRef.current = null;
+      }
     }
-  }, [dispatchAction, loadChatSnapshot, markAssistantError, t]);
+  }, [
+    dispatchAction,
+    markAssistantError,
+    cancelExactChatTurn,
+    pendingChatTurnRunner,
+    reconcileConfirmedStopSnapshotForOwner,
+    releaseSupersededExactTurnStop,
+    replaceMessages,
+    restoreChatTurnAfterCancellationRejection,
+    t,
+  ]);
 
-  const clearConversation = useCallback(async (): Promise<void> => {
-    const currentState = stateRef.current;
-    if (currentState.currentSessionId !== null && selectIsAssistantRunActive(currentState)) {
-      try {
-        await postStopChatSession(currentState.currentSessionId, t);
-      } catch {
-        // Continue clearing the UI even if stop fails.
+  const clearConversation = useCallback((): Promise<void> => {
+    stopOperationRef.current?.abortController.abort();
+    stopOperationRef.current = null;
+    stopSnapshotReconciliationRef.current?.abortController.abort();
+    stopSnapshotReconciliationRef.current = null;
+    const targetSessionId = stateRef.current.currentSessionId;
+    const existingOperation = clearOperationRef.current;
+    if (
+      existingOperation !== null
+      && existingOperation.targetSessionId === targetSessionId
+    ) {
+      return clearOperationRunner.run(existingOperation);
+    }
+
+    if (existingOperation !== null) {
+      clearOperationRunner.cancel(existingOperation);
+      if (existingOperation.targetSessionId !== null) {
+        dispatchAction({
+          type: "stop_completed",
+          sessionId: existingOperation.targetSessionId,
+        });
       }
     }
 
-    if (abortRef.current !== null) {
-      abortRef.current.abort();
-      abortRef.current = null;
-    }
-
-    dispatchAction({ type: "live_stream_disconnected" });
-    if (currentState.currentSessionId !== null) {
-      dispatchAction({
-        type: "stop_completed",
-        sessionId: currentState.currentSessionId,
-      });
-      dispatchAction({
-        type: "stopped_session_cleared",
-        sessionId: currentState.currentSessionId,
-      });
-    }
-
-    try {
-      const payload = await deleteChatConversation(currentState.currentSessionId, t);
-      dispatchAction({
-        type: "conversation_cleared",
-        sessionId: payload.sessionId,
-      });
-      clearHistory();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      markAssistantError(t("chat.errorFailed", { message }));
-    }
-  }, [clearHistory, dispatchAction, markAssistantError, t]);
+    const owner: ChatClearOperationOwner = {
+      ownerId: Symbol(targetSessionId ?? "local-clear"),
+      targetSessionId,
+    };
+    clearOperationRef.current = owner;
+    return clearOperationRunner.run(owner);
+  }, [
+    clearOperationRunner,
+    dispatchAction,
+  ]);
 
   const acceptServerSessionId = useCallback((sessionId: string): void => {
     dispatchAction({


### PR DESCRIPTION
## Summary
- activate canonical client turn identity and acceptance-unknown retry/reconciliation
- add exact-turn Stop and typed Clear ownership with lifecycle fencing
- validate authoritative snapshot identity and persisted message contracts

## Validation
- direct TypeScript passed
- controller runtime: 63/63
- focused server + controller matrix: 194/194 (124 server + 70 controller/runtime/state)
- untracked-inclusive diff check passed
- lint passed
- production build passed: 40/40 pages
- fresh empty-history review: no P0-P4 findings; green commit gate