### PR TITLE
Add inert chat transport and selection primitives

### DIFF
--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.test.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.test.ts
@@ -17,6 +17,7 @@ import {
   ChatTurnCancellationRequestError,
   classifyConfirmedChatStopSnapshotFailure,
   completeChatTurnCancellation,
+  createChatSendTransport,
   createChatSnapshotRequestCoordinator,
   createSingleFlightChatClearOperationRunner,
   createSingleFlightChatSendReconciliationRunner,
@@ -26,6 +27,7 @@ import {
   fetchChatSessionSnapshot,
   isChatClearOperationOwnerCurrent,
   isChatPreSessionSendOwnerCurrent,
+  isChatSelectionGuardCurrent,
   isCanonicalChatUuid,
   isChatSnapshotPollingOwnerCurrent,
   isChatSnapshotRequestCurrent,
@@ -47,10 +49,14 @@ import {
   resolveDefinitiveChatSendSnapshotFailureHistory,
   resolveConfirmedChatStopSnapshotDisposition,
   resolveConfirmedChatTurnStopHistory,
+  resolveSelectedChatSessionGuard,
   resolveChatSnapshotFailureDisposition,
   resolveChatSnapshotRequest,
   restorePendingChatTurnAfterCancellationRejection,
   selectSupersedingChatSnapshotRequestResult,
+  shouldAbortChatStreamForControllerCleanup,
+  shouldAbortChatStreamForSelectionChange,
+  shouldAbortChatStreamForSelectionEpoch,
   shouldRestoreChatRunAfterSnapshotFailure,
   shouldRestoreChatTurnAfterCancellationRejection,
   streamChatResponse,
@@ -124,6 +130,138 @@ test("buildChatSendRequestBody serializes explicit session ids", (): void => {
   assert.equal(parsedRequestBody.sessionId, "session-4");
   assert.equal(parsedRequestBody.turnId, TURN_ID);
   assert.deepEqual(parsedRequestBody.content, [{ type: "text", text: "Hello" }]);
+});
+
+test("fresh drafts send through the lazy creation route without session or turn ids", (): void => {
+  const transport = createChatSendTransport(
+    { kind: "draft", draftId: "draft-1" },
+    [{ type: "text", text: "Hello" }],
+    TURN_ID,
+  );
+  const payload = JSON.parse(transport.requestBody) as Readonly<Record<string, unknown>>;
+
+  assert.equal(transport.url, "/api/chat/new");
+  assert.equal("sessionId" in payload, false);
+  assert.equal("turnId" in payload, false);
+});
+
+test("existing sessions retain exact-turn identity on the session route", (): void => {
+  const transport = createChatSendTransport(
+    { kind: "session", sessionId: "session-1" },
+    [{ type: "text", text: "Continue" }],
+    TURN_ID,
+  );
+  const payload = JSON.parse(transport.requestBody) as Readonly<Record<string, unknown>>;
+
+  assert.equal(transport.url, "/api/chat");
+  assert.equal(payload.sessionId, "session-1");
+  assert.equal(payload.turnId, TURN_ID);
+});
+
+test("selection guards require both the target id and monotonic epoch", (): void => {
+  const guard = {
+    target: { kind: "session", sessionId: "session-a" },
+    selectionEpoch: 3,
+  } as const;
+
+  assert.equal(
+    isChatSelectionGuardCurrent(
+      guard,
+      { kind: "session", sessionId: "session-a" },
+      3,
+    ),
+    true,
+  );
+  assert.equal(
+    isChatSelectionGuardCurrent(
+      guard,
+      { kind: "session", sessionId: "session-b" },
+      3,
+    ),
+    false,
+  );
+  assert.equal(
+    isChatSelectionGuardCurrent(
+      guard,
+      { kind: "session", sessionId: "session-a" },
+      4,
+    ),
+    false,
+  );
+});
+
+test("a delayed failed Stop refreshes the latest A selection after A to B to A", (): void => {
+  const initiatingGuard = {
+    target: { kind: "session", sessionId: "session-a" },
+    selectionEpoch: 1,
+  } as const;
+  let controllerState = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "selection_changed", sessionId: "session-a" },
+  );
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "run_started",
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "stop_requested",
+    sessionId: "session-a",
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "selection_changed",
+    sessionId: "session-b",
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "selection_changed",
+    sessionId: "session-a",
+  });
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "snapshot_applied",
+    sessionId: "session-a",
+    runState: "running",
+    updatedAt: 10,
+    mainContentInvalidationVersion: 0,
+  });
+  assert.equal(controllerState.runState, "idle");
+
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "stop_failed",
+    sessionId: "session-a",
+  });
+  const latestTarget = {
+    kind: "session",
+    sessionId: "session-a",
+  } as const;
+  const latestGuard = resolveSelectedChatSessionGuard(
+    "session-a",
+    latestTarget,
+    3,
+  );
+
+  assert.equal(
+    isChatSelectionGuardCurrent(initiatingGuard, latestTarget, 3),
+    false,
+  );
+  assert.notEqual(latestGuard, null);
+  if (latestGuard === null) {
+    assert.fail("Expected the latest A selection to produce a refresh guard");
+  }
+  assert.equal(
+    isChatSelectionGuardCurrent(latestGuard, latestTarget, 3),
+    true,
+  );
+  controllerState = reduceChatSessionControllerState(controllerState, {
+    type: "snapshot_applied",
+    sessionId: "session-a",
+    runState: "running",
+    updatedAt: 20,
+    mainContentInvalidationVersion: 0,
+  });
+
+  assert.equal(controllerState.runState, "running");
+  assert.equal(controllerState.lastSnapshotUpdatedAt, 20);
+  assert.equal(controllerState.stoppedSessionIds.has("session-a"), false);
+  assert.equal(controllerState.stoppingSessionIds.has("session-a"), false);
+  assert.equal(selectComposerAction(controllerState), "stop");
 });
 
 test("client, active-turn, and persisted-message identities match canonical Zod UUID semantics", (): void => {
@@ -2813,7 +2951,7 @@ test("a pre-Stop running poll cannot overwrite the idle Stop snapshot", async ()
 
   assert.equal(controllerState.runState, "idle");
   assert.equal(controllerState.lastSnapshotUpdatedAt, 20);
-  assert.equal(controllerState.isHistoryLoaded, false);
+  assert.equal(controllerState.isHistoryLoaded, true);
   assert.equal(selectIsAssistantRunActive(controllerState), false);
   assert.equal(selectComposerAction(controllerState), "send");
   assert.equal(appliedMessage, "stopped transcript");
@@ -2901,6 +3039,141 @@ test("a superseded ambiguous reconciliation cannot roll back its accepted owner"
   assert.equal(disposition, "preserve_success");
   assert.deepEqual(appliedMessages, acceptedMessages);
   assert.equal(controllerState.runState, "running");
+});
+
+test("same-epoch draft adoption keeps session SSE and delayed chunks attached", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  const encoder = new TextEncoder();
+  const receivedChunks: Array<string> = [];
+  const streamSelectionEpoch = 7;
+  let pullCount = 0;
+  const adoption = Promise.withResolvers<void>();
+  const firstChunkHandled = Promise.withResolvers<void>();
+  const laterChunkGate = Promise.withResolvers<void>();
+  const responseBody = new ReadableStream<Uint8Array>({
+    pull: async (controller): Promise<void> => {
+      pullCount += 1;
+      if (pullCount === 1) {
+        controller.enqueue(encoder.encode([
+          "data: {\"type\":\"session\",\"sessionId\":\"session-adopted\"}",
+          "data: {\"type\":\"delta\",\"text\":\"first\",\"itemId\":\"assistant-1\",\"responseIndex\":0,\"outputIndex\":0,\"contentIndex\":0,\"sequenceNumber\":0}",
+          "",
+        ].join("\n\n")));
+        return;
+      }
+
+      await laterChunkGate.promise;
+      controller.enqueue(encoder.encode([
+        "data: {\"type\":\"delta\",\"text\":\"later\",\"itemId\":\"assistant-1\",\"responseIndex\":0,\"outputIndex\":0,\"contentIndex\":0,\"sequenceNumber\":1}",
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n")));
+      controller.close();
+    },
+  });
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (): Promise<Response> =>
+      new Response(responseBody, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "X-Chat-Session-Id": "session-adopted",
+        },
+      }),
+  });
+
+  const abortController = new AbortController();
+  try {
+    const resultPromise = streamChatResponse({
+      url: "/api/chat/new",
+      requestBody: "{}",
+      signal: abortController.signal,
+      abortStream: (): void => abortController.abort(),
+      t: (key: string): string => key,
+      handlers: {
+        appendAssistantChunk: (text): void => {
+          receivedChunks.push(text);
+          if (text === "first") {
+            firstChunkHandled.resolve();
+          }
+        },
+        upsertReasoningSummary: (): void => {},
+        upsertToolCall: (): void => {},
+        markAssistantError: (): void => {},
+        applyMainContentInvalidationVersion: (): void => {},
+      },
+      onSessionIdReceived: (sessionId: string): void => {
+        assert.equal(sessionId, "session-adopted");
+        if (shouldAbortChatStreamForSelectionEpoch(
+          streamSelectionEpoch,
+          streamSelectionEpoch,
+        )) {
+          abortController.abort();
+        }
+        adoption.resolve();
+      },
+      onLiveStreamConnected: (): void => {},
+    });
+
+    await adoption.promise;
+    assert.equal(abortController.signal.aborted, false);
+    await firstChunkHandled.promise;
+    assert.deepEqual(receivedChunks, ["first"]);
+    laterChunkGate.resolve();
+    const result = await resultPromise;
+
+    assert.deepEqual(receivedChunks, ["first", "later"]);
+    assert.equal(result.responseSessionId, "session-adopted");
+    assert.equal(result.receivedContent, true);
+    assert.equal(result.wasAborted, false);
+    assert.equal(result.requestAcceptance, "accepted");
+    assert.equal(
+      shouldAbortChatStreamForSelectionEpoch(
+        streamSelectionEpoch,
+        streamSelectionEpoch + 1,
+      ),
+      true,
+    );
+  } finally {
+    laterChunkGate.resolve();
+    abortController.abort();
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
+test("an unadopted draft create survives selection and controller cleanup", (): void => {
+  assert.equal(
+    shouldAbortChatStreamForSelectionChange(2, 3, "draft-pending"),
+    false,
+  );
+  assert.equal(
+    shouldAbortChatStreamForControllerCleanup("draft-pending"),
+    false,
+  );
+  assert.equal(
+    shouldAbortChatStreamForSelectionChange(2, 3, null),
+    true,
+  );
+  assert.equal(
+    shouldAbortChatStreamForControllerCleanup(null),
+    true,
+  );
 });
 
 test("a deferred Stop cannot abort, disconnect, or adopt into a newer session stream", async (): Promise<void> => {
@@ -3094,6 +3367,72 @@ test("outer Stop ownership fences every continuation after unmount, session swit
   }
 });
 
+test("fresh-session transport distinguishes rejection from ambiguous failures", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  const createParams = (): Parameters<typeof streamChatResponse>[0] => ({
+    url: "/api/chat/new",
+    requestBody: "{}",
+    signal: new AbortController().signal,
+    abortStream: (): void => {},
+    t: (key: string): string => key,
+    handlers: {
+      appendAssistantChunk: (): void => {},
+      upsertReasoningSummary: (): void => {},
+      upsertToolCall: (): void => {},
+      markAssistantError: (): void => {},
+      applyMainContentInvalidationVersion: (): void => {},
+    },
+    onSessionIdReceived: (): void => {},
+    onLiveStreamConnected: (): void => {},
+  });
+
+  try {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (): Promise<Response> =>
+        new Response("Fresh chat rejected", { status: 400 }),
+    });
+    const rejectedResult = await streamChatResponse(createParams());
+    assert.equal(rejectedResult.requestAcceptance, "rejected");
+    assert.equal(rejectedResult.failureStage, "request");
+
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (): Promise<Response> =>
+        new Response("Upstream response unavailable", { status: 503 }),
+    });
+    const ambiguousServerResult = await streamChatResponse(createParams());
+    assert.equal(ambiguousServerResult.requestAcceptance, "unknown");
+    assert.equal(ambiguousServerResult.failureStage, "request");
+
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (): Promise<Response> => {
+        throw new TypeError("network unavailable");
+      },
+    });
+    const ambiguousNetworkResult = await streamChatResponse(createParams());
+    assert.equal(ambiguousNetworkResult.requestAcceptance, "unknown");
+    assert.equal(ambiguousNetworkResult.failureStage, "request");
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
+});
+
 test("existing-session transport reconciles ambiguous failures and fast-fails explicit rejection", async (): Promise<void> => {
   const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
   const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
@@ -3102,6 +3441,7 @@ test("existing-session transport reconciles ambiguous failures and fast-fails ex
     value: { cookie: "__Host-csrf=test-token" },
   });
   const createParams = (): Parameters<typeof streamChatResponse>[0] => ({
+    url: "/api/chat",
     requestBody: "{}",
     signal: new AbortController().signal,
     abortStream: (): void => {},

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
@@ -13,6 +13,10 @@ import type { ContentPart } from "@/server/chat/types";
 import type { PendingAttachment } from "../../shell/panel/FileAttachment";
 import type { ChatSessionSnapshot } from "../bootstrap/chatSessionSnapshot";
 import {
+  areChatTargetsEqual,
+  type ChatTarget,
+} from "../../workspace/chatWorkspaceState";
+import {
   applyChatStreamEvent,
   drainChatStreamChunk,
   type ChatStreamTransportHandlers,
@@ -53,12 +57,15 @@ export type StopChatSessionResponse =
   | SessionLevelStopChatSessionResponse
   | ExactTurnStopChatSessionResponse;
 
-type ChatSendRequestBody = Readonly<{
-  sessionId: string;
-  turnId: string;
+type ChatMessageRequestBody = Readonly<{
   model: string;
   content: ReadonlyArray<ContentPart>;
   timezone: string;
+}>;
+
+type ExistingChatSendRequestBody = ChatMessageRequestBody & Readonly<{
+  sessionId: string;
+  turnId: string;
 }>;
 
 export type PreparedChatSendRequest =
@@ -78,6 +85,7 @@ export type PreparedChatSendRequest =
   }>;
 
 export type StreamChatResponseParams = Readonly<{
+  url?: "/api/chat" | "/api/chat/new";
   requestBody: string;
   signal: AbortSignal;
   abortStream: () => void;
@@ -128,6 +136,16 @@ export type ChatPreSessionSendOwner = Readonly<{
   ownerId: symbol;
   initialSessionId: string | null;
   turnId: string;
+}>;
+
+export type ChatSendTransport = Readonly<{
+  url: "/api/chat" | "/api/chat/new";
+  requestBody: string;
+}>;
+
+export type ChatSelectionGuard = Readonly<{
+  target: ChatTarget;
+  selectionEpoch: number;
 }>;
 
 type ChatRequestStartResult =
@@ -1103,7 +1121,7 @@ export const prepareChatSendRequest = (
     model: CHAT_MODEL_ID,
     content: contentParts,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-  } satisfies ChatSendRequestBody);
+  } satisfies ExistingChatSendRequestBody);
 
   if (requestBody.length > MAX_BODY_BYTES) {
     const sizeMb = (requestBody.length / (1024 * 1024)).toFixed(1);
@@ -1132,7 +1150,35 @@ export const buildChatSendRequestBody = (
     model: CHAT_MODEL_ID,
     content,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-  } satisfies ChatSendRequestBody);
+  } satisfies ExistingChatSendRequestBody);
+
+export const buildFreshChatSendRequestBody = (
+  content: ReadonlyArray<ContentPart>,
+): string =>
+  JSON.stringify({
+    model: CHAT_MODEL_ID,
+    content,
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  } satisfies ChatMessageRequestBody);
+
+export const createChatSendTransport = (
+  target: ChatTarget,
+  content: ReadonlyArray<ContentPart>,
+  turnId: string,
+): ChatSendTransport =>
+  target.kind === "draft"
+    ? {
+      url: "/api/chat/new",
+      requestBody: buildFreshChatSendRequestBody(content),
+    }
+    : {
+      url: "/api/chat",
+      requestBody: buildChatSendRequestBody(
+        content,
+        target.sessionId,
+        turnId,
+      ),
+    };
 
 export type ChatSessionSnapshotRequestErrorKind =
   | "not_found"
@@ -1687,6 +1733,48 @@ export const deleteChatConversation = async (
   return response.json() as Promise<ChatClearConversationResponse>;
 };
 
+export const isChatSelectionGuardCurrent = (
+  guard: ChatSelectionGuard,
+  target: ChatTarget,
+  selectionEpoch: number,
+): boolean =>
+  guard.selectionEpoch === selectionEpoch
+  && areChatTargetsEqual(guard.target, target);
+
+export const resolveSelectedChatSessionGuard = (
+  sessionId: string,
+  target: ChatTarget,
+  selectionEpoch: number,
+): ChatSelectionGuard | null =>
+  target.kind === "session" && target.sessionId === sessionId
+    ? {
+      target,
+      selectionEpoch,
+    }
+    : null;
+
+export const shouldAbortChatStreamForSelectionEpoch = (
+  streamSelectionEpoch: number,
+  nextSelectionEpoch: number,
+): boolean =>
+  streamSelectionEpoch !== nextSelectionEpoch;
+
+export const shouldAbortChatStreamForSelectionChange = (
+  streamSelectionEpoch: number,
+  nextSelectionEpoch: number,
+  unadoptedDraftId: string | null,
+): boolean =>
+  unadoptedDraftId === null
+  && shouldAbortChatStreamForSelectionEpoch(
+    streamSelectionEpoch,
+    nextSelectionEpoch,
+  );
+
+export const shouldAbortChatStreamForControllerCleanup = (
+  unadoptedDraftId: string | null,
+): boolean =>
+  unadoptedDraftId === null;
+
 export const isChatStreamControllerOwnedByStop = (
   stopStreamController: AbortController | null,
   activeStreamController: AbortController | null,
@@ -1748,7 +1836,7 @@ export const streamChatResponse = async (
   let receivedContent = false;
   let requestAcceptance: ChatRequestAcceptance = "unknown";
 
-  const request = startChatRequest("/api/chat", {
+  const request = startChatRequest(params.url ?? "/api/chat", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: params.requestBody,
@@ -1782,23 +1870,23 @@ export const streamChatResponse = async (
     }
 
     requestAcceptance = "accepted";
+    responseSessionId = response.headers.get("X-Chat-Session-Id");
+    if (responseSessionId !== null && responseSessionId.length > 0) {
+      params.onSessionIdReceived(responseSessionId);
+    } else {
+      responseSessionId = null;
+    }
+
     const reader = response.body?.getReader();
     if (reader === undefined) {
       return {
-        responseSessionId: null,
+        responseSessionId,
         streamFailure: new Error(params.t("chat.errorNoResponse")),
         failureStage: "request",
         receivedContent: false,
         wasAborted: false,
         requestAcceptance,
       };
-    }
-
-    responseSessionId = response.headers.get("X-Chat-Session-Id");
-    if (responseSessionId !== null && responseSessionId.length > 0) {
-      params.onSessionIdReceived(responseSessionId);
-    } else {
-      responseSessionId = null;
     }
 
     params.onLiveStreamConnected();

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerState.test.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerState.test.ts
@@ -33,10 +33,48 @@ test("initial historical snapshot does not refresh without an invalidation basel
   assert.equal(shouldRefreshMainContentForVersion(state, "snapshot", 1), false);
 });
 
+test("selection changes detach local state without recording a stop", (): void => {
+  const runningState = reduceChatSessionControllerState(
+    reduceChatSessionControllerState(
+      createInitialChatSessionControllerState(),
+      { type: "selection_changed", sessionId: "session-a" },
+    ),
+    { type: "run_started" },
+  );
+  const selectedB = reduceChatSessionControllerState(
+    runningState,
+    { type: "selection_changed", sessionId: "session-b" },
+  );
+
+  assert.equal(selectedB.currentSessionId, "session-b");
+  assert.equal(selectedB.runState, "idle");
+  assert.equal(selectedB.isLiveStreamConnected, false);
+  assert.deepEqual([...selectedB.stoppedSessionIds], []);
+});
+
+test("returning to a running session restores persisted run state", (): void => {
+  const selectedA = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "selection_changed", sessionId: "session-a" },
+  );
+  const restoredA = reduceChatSessionControllerState(selectedA, {
+    type: "snapshot_applied",
+    sessionId: "session-a",
+    runState: "running",
+    updatedAt: 10,
+    mainContentInvalidationVersion: 0,
+  });
+
+  assert.equal(restoredA.currentSessionId, "session-a");
+  assert.equal(restoredA.runState, "running");
+  assert.equal(restoredA.bootstrapStatus, "ready");
+  assert.equal(restoredA.isHistoryLoaded, true);
+});
+
 test("stop suppression is scoped to the explicitly stopped session", (): void => {
   const selectedA = reduceChatSessionControllerState(
     createInitialChatSessionControllerState(),
-    { type: "server_session_created", sessionId: "session-a" },
+    { type: "selection_changed", sessionId: "session-a" },
   );
   const stoppingA = reduceChatSessionControllerState(selectedA, {
     type: "stop_requested",
@@ -50,14 +88,14 @@ test("stop suppression is scoped to the explicitly stopped session", (): void =>
 test("a delayed failed Stop for A does not mutate B stop state", (): void => {
   const selectedA = reduceChatSessionControllerState(
     createInitialChatSessionControllerState(),
-    { type: "server_session_created", sessionId: "session-a" },
+    { type: "selection_changed", sessionId: "session-a" },
   );
   const stoppingA = reduceChatSessionControllerState(selectedA, {
     type: "stop_requested",
     sessionId: "session-a",
   });
   const selectedB = reduceChatSessionControllerState(stoppingA, {
-    type: "server_session_created",
+    type: "selection_changed",
     sessionId: "session-b",
   });
   const stoppingB = reduceChatSessionControllerState(selectedB, {
@@ -77,10 +115,47 @@ test("a delayed failed Stop for A does not mutate B stop state", (): void => {
   assert.equal(selectIsSelectedSessionStopping(failedA), true);
 });
 
+test("workspace reload conflicts keep history blocked", (): void => {
+  const selectedState = reduceChatSessionControllerState(
+    createInitialChatSessionControllerState(),
+    { type: "selection_changed", sessionId: "session-a" },
+  );
+  const blockedState = reduceChatSessionControllerState(selectedState, {
+    type: "bootstrap_blocked",
+  });
+
+  assert.equal(blockedState.currentSessionId, "session-a");
+  assert.equal(blockedState.bootstrapStatus, "blocked");
+  assert.equal(blockedState.isHistoryLoaded, false);
+});
+
+test("matching cross-tab session changes block sending until the snapshot refreshes", (): void => {
+  const selectedA = reduceChatSessionControllerState(
+    reduceChatSessionControllerState(
+      createInitialChatSessionControllerState(),
+      { type: "selection_changed", sessionId: "session-a" },
+    ),
+    { type: "bootstrap_succeeded" },
+  );
+  const ignoredB = reduceChatSessionControllerState(selectedA, {
+    type: "external_session_change_observed",
+    sessionId: "session-b",
+  });
+  const refreshingA = reduceChatSessionControllerState(selectedA, {
+    type: "external_session_change_observed",
+    sessionId: "session-a",
+  });
+
+  assert.equal(ignoredB, selectedA);
+  assert.equal(refreshingA.currentSessionId, "session-a");
+  assert.equal(refreshingA.isHistoryLoaded, false);
+  assert.equal(refreshingA.bootstrapStatus, "loading");
+});
+
 test("idle snapshot retains a pending Stop marker until explicit completion", (): void => {
   const selectedA = reduceChatSessionControllerState(
     createInitialChatSessionControllerState(),
-    { type: "server_session_created", sessionId: "session-a" },
+    { type: "selection_changed", sessionId: "session-a" },
   );
   const stoppingA = reduceChatSessionControllerState(selectedA, {
     type: "stop_requested",
@@ -115,7 +190,7 @@ test("idle snapshot retains a pending Stop marker until explicit completion", ()
 test("completed Stop clears suppression for later cross-tab runs", (): void => {
   const selectedA = reduceChatSessionControllerState(
     createInitialChatSessionControllerState(),
-    { type: "server_session_created", sessionId: "session-a" },
+    { type: "selection_changed", sessionId: "session-a" },
   );
   const stoppingA = reduceChatSessionControllerState(selectedA, {
     type: "stop_requested",

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerState.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerState.ts
@@ -12,9 +12,11 @@ import {
 } from "../../stream/streamRecovery";
 
 export type ChatMainContentInvalidationSource = "live" | "snapshot";
+export type ChatBootstrapStatus = "loading" | "ready" | "failed" | "blocked";
 
 export type ChatSessionControllerState = Readonly<{
   isHistoryLoaded: boolean;
+  bootstrapStatus: ChatBootstrapStatus;
   currentSessionId: string | null;
   runState: ChatRunState;
   isLiveStreamConnected: boolean;
@@ -26,8 +28,14 @@ export type ChatSessionControllerState = Readonly<{
 
 export type ChatSessionControllerAction =
   | Readonly<{ type: "workspace_reset" }>
+  | Readonly<{ type: "selection_changed"; sessionId: string | null }>
   | Readonly<{ type: "bootstrap_succeeded" }>
   | Readonly<{ type: "bootstrap_failed" }>
+  | Readonly<{ type: "bootstrap_blocked" }>
+  | Readonly<{
+    type: "external_session_change_observed";
+    sessionId: string;
+  }>
   | Readonly<{
     type: "snapshot_applied";
     sessionId: string;
@@ -72,6 +80,7 @@ const removeSessionId = (
 
 export const createInitialChatSessionControllerState = (): ChatSessionControllerState => ({
   isHistoryLoaded: false,
+  bootstrapStatus: "loading",
   currentSessionId: null,
   runState: "idle",
   isLiveStreamConnected: false,
@@ -88,11 +97,39 @@ export const reduceChatSessionControllerState = (
   switch (action.type) {
     case "workspace_reset":
       return createInitialChatSessionControllerState();
+    case "selection_changed":
+      return {
+        ...createInitialChatSessionControllerState(),
+        currentSessionId: action.sessionId,
+        stoppedSessionIds: state.stoppedSessionIds,
+        stoppingSessionIds: state.stoppingSessionIds,
+      };
     case "bootstrap_succeeded":
+      return {
+        ...state,
+        isHistoryLoaded: true,
+        bootstrapStatus: "ready",
+      };
     case "bootstrap_failed":
       return {
         ...state,
         isHistoryLoaded: true,
+        bootstrapStatus: "failed",
+      };
+    case "bootstrap_blocked":
+      return {
+        ...state,
+        isHistoryLoaded: false,
+        bootstrapStatus: "blocked",
+      };
+    case "external_session_change_observed":
+      if (state.currentSessionId !== action.sessionId) {
+        return state;
+      }
+      return {
+        ...state,
+        isHistoryLoaded: false,
+        bootstrapStatus: "loading",
       };
     case "snapshot_applied": {
       const stoppedSessionIds = action.runState === "idle"
@@ -100,6 +137,8 @@ export const reduceChatSessionControllerState = (
         : state.stoppedSessionIds;
       return {
         ...state,
+        isHistoryLoaded: true,
+        bootstrapStatus: "ready",
         currentSessionId: action.sessionId,
         runState: getEffectiveSnapshotRunState(
           action.runState,

--- a/apps/web/src/ui/chat/session/controller/useChatSessionController.ts
+++ b/apps/web/src/ui/chat/session/controller/useChatSessionController.ts
@@ -590,6 +590,7 @@ export const useChatSessionController = (
       ));
       abortRef.current = attemptAbortController;
       const streamResult = await streamChatResponse({
+        url: "/api/chat",
         requestBody: pendingChatTurn.requestBody,
         signal: attemptAbortController.signal,
         abortStream: (): void => {

--- a/apps/web/src/ui/chat/stream/chatStreamTransport.ts
+++ b/apps/web/src/ui/chat/stream/chatStreamTransport.ts
@@ -86,6 +86,13 @@ export const applyChatStreamEvent = (
   event: ChatStreamEvent,
   handlers: ChatStreamTransportHandlers,
 ): ChatStreamTransportResult => {
+  if (event.type === "session") {
+    return {
+      receivedContent: false,
+      reachedTerminalState: false,
+    };
+  }
+
   if (event.type === "delta") {
     handlers.appendAssistantChunk(event.text, buildToolContentStreamPosition(event));
     return {


### PR DESCRIPTION
## Summary
- add inert lazy draft/session transport selection with exact-turn preservation for existing sessions
- add selection, bootstrap, session-adoption, and stream-ownership primitives
- handle additive session SSE events without activating the mounted lazy flow

## Validation
- focused controller tests: 81/81
- full relevant matrix: 205/205
- direct TypeScript check under Node 24.18.0
- npm run lint
- npm run build: 40/40 pages
- fresh review: no P0-P4 findings