### PR TITLE
feat(chat): prepare workspace history controller

### DIFF
--- a/apps/web/src/i18n/ar.json
+++ b/apps/web/src/i18n/ar.json
@@ -255,6 +255,8 @@
   "chat.historyRunningStatus": "قيد التشغيل",
   "chat.historyRecent": "الأخيرة",
   "chat.historyEmpty": "لا توجد دردشات بعد.",
+  "chat.historyLoadMore": "عرض المزيد",
+  "chat.sessionUnavailable": "هذه الدردشة غير متاحة. تم اختيار دردشة آمنة.",
   "chat.send": "إرسال",
   "chat.stop": "إيقاف",
   "chat.attach": "إرفاق",

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -255,6 +255,8 @@
   "chat.historyRunningStatus": "Running",
   "chat.historyRecent": "Recent",
   "chat.historyEmpty": "No chats yet.",
+  "chat.historyLoadMore": "Load more",
+  "chat.sessionUnavailable": "This chat is unavailable. A safe chat was selected.",
   "chat.send": "Send",
   "chat.stop": "Stop",
   "chat.attach": "Attach",

--- a/apps/web/src/i18n/es.json
+++ b/apps/web/src/i18n/es.json
@@ -255,6 +255,8 @@
   "chat.historyRunningStatus": "En curso",
   "chat.historyRecent": "Recientes",
   "chat.historyEmpty": "Aún no hay chats.",
+  "chat.historyLoadMore": "Cargar más",
+  "chat.sessionUnavailable": "Este chat no está disponible. Se seleccionó un chat seguro.",
   "chat.send": "Enviar",
   "chat.stop": "Detener",
   "chat.attach": "Adjuntar",

--- a/apps/web/src/i18n/fa.json
+++ b/apps/web/src/i18n/fa.json
@@ -255,6 +255,8 @@
   "chat.historyRunningStatus": "در حال اجرا",
   "chat.historyRecent": "اخیر",
   "chat.historyEmpty": "هنوز گفت‌وگویی وجود ندارد.",
+  "chat.historyLoadMore": "نمایش بیشتر",
+  "chat.sessionUnavailable": "این گفت‌وگو در دسترس نیست. یک گفت‌وگوی امن انتخاب شد.",
   "chat.send": "ارسال",
   "chat.stop": "توقف",
   "chat.attach": "پیوست",

--- a/apps/web/src/i18n/he.json
+++ b/apps/web/src/i18n/he.json
@@ -255,6 +255,8 @@
   "chat.historyRunningStatus": "פעיל",
   "chat.historyRecent": "אחרונים",
   "chat.historyEmpty": "אין עדיין צ׳אטים.",
+  "chat.historyLoadMore": "טעינת עוד",
+  "chat.sessionUnavailable": "הצ׳אט הזה אינו זמין. נבחר צ׳אט בטוח.",
   "chat.send": "שלח",
   "chat.stop": "עצור",
   "chat.attach": "צרף",

--- a/apps/web/src/i18n/ru.json
+++ b/apps/web/src/i18n/ru.json
@@ -255,6 +255,8 @@
   "chat.historyRunningStatus": "Выполняется",
   "chat.historyRecent": "Недавние",
   "chat.historyEmpty": "Чатов пока нет.",
+  "chat.historyLoadMore": "Загрузить ещё",
+  "chat.sessionUnavailable": "Этот чат недоступен. Выбран безопасный чат.",
   "chat.send": "Отправить",
   "chat.stop": "Остановить",
   "chat.attach": "Прикрепить",

--- a/apps/web/src/i18n/uk.json
+++ b/apps/web/src/i18n/uk.json
@@ -255,6 +255,8 @@
   "chat.historyRunningStatus": "Виконується",
   "chat.historyRecent": "Нещодавні",
   "chat.historyEmpty": "Чатів поки немає.",
+  "chat.historyLoadMore": "Завантажити ще",
+  "chat.sessionUnavailable": "Цей чат недоступний. Вибрано безпечний чат.",
   "chat.send": "Надіслати",
   "chat.stop": "Зупинити",
   "chat.attach": "Прикріпити",

--- a/apps/web/src/i18n/zh.json
+++ b/apps/web/src/i18n/zh.json
@@ -255,6 +255,8 @@
   "chat.historyRunningStatus": "运行中",
   "chat.historyRecent": "最近",
   "chat.historyEmpty": "暂无对话。",
+  "chat.historyLoadMore": "加载更多",
+  "chat.sessionUnavailable": "此对话不可用。已选择安全的对话。",
   "chat.send": "发送",
   "chat.stop": "停止",
   "chat.attach": "添加附件",

--- a/apps/web/src/ui/chat/shell/history/ChatHistoryDialog.module.css
+++ b/apps/web/src/ui/chat/shell/history/ChatHistoryDialog.module.css
@@ -20,6 +20,7 @@
 
 .historyButton:focus-visible,
 .dialogAction:focus-visible,
+.loadMoreButton:focus-visible,
 .sessionButton:focus-visible {
   outline: 2px solid var(--text);
   outline-offset: 1px;
@@ -234,7 +235,8 @@
   color: inherit;
 }
 
-.emptyState {
+.emptyState,
+.loadingState {
   margin: 0;
   padding-block: 20px;
   padding-inline: 12px;
@@ -242,6 +244,50 @@
   color: var(--text);
   font-size: 12px;
   text-align: start;
+}
+
+.loadingState {
+  color: var(--muted);
+}
+
+.errorState {
+  margin: 0;
+  padding-block: 12px;
+  padding-inline: 12px;
+  border-block-end: 1px solid var(--panel-border);
+  background: var(--panel);
+  color: #c0392b;
+  font-size: 12px;
+  text-align: start;
+  white-space: pre-wrap;
+}
+
+.loadMoreRow {
+  display: flex;
+  justify-content: center;
+  padding-block: 10px;
+  padding-inline: 12px;
+  border-block-start: 1px solid var(--panel-border);
+}
+
+.loadMoreButton {
+  min-block-size: 28px;
+  padding-block: 4px;
+  padding-inline: 12px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.loadMoreButton:hover:not([aria-disabled="true"]) {
+  border-color: var(--text);
+}
+
+.loadMoreButton[aria-disabled="true"] {
+  color: var(--muted);
+  cursor: wait;
 }
 
 @keyframes runningPulse {

--- a/apps/web/src/ui/chat/shell/history/ChatHistoryDialog.tsx
+++ b/apps/web/src/ui/chat/shell/history/ChatHistoryDialog.tsx
@@ -15,6 +15,10 @@ import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
 
+import {
+  resolveChatHistoryPaginationFocus,
+  resolveChatHistoryStatusVisibility,
+} from "../../workspace/useChatWorkspaceController";
 import { ChatHistoryButton } from "./ChatHistoryButton";
 import styles from "./ChatHistoryDialog.module.css";
 
@@ -32,9 +36,14 @@ type Props = Readonly<{
   sessions: ReadonlyArray<ChatHistorySession>;
   selectedSessionId: string | null;
   runningCount: number;
+  isLoading: boolean;
+  hasLoadedFirstPage: boolean;
+  hasMore: boolean;
+  errorMessage: string | null;
   onOpenChange: (open: boolean) => void;
   onSelectSession: (sessionId: string) => void;
   onCreateDraft: () => void;
+  onLoadMore: () => void;
 }>;
 
 type SessionListProps = Readonly<{
@@ -123,9 +132,14 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
     sessions,
     selectedSessionId,
     runningCount,
+    isLoading,
+    hasLoadedFirstPage,
+    hasMore,
+    errorMessage,
     onOpenChange,
     onSelectSession,
     onCreateDraft,
+    onLoadMore,
   } = props;
   const { i18n, t } = useTranslation();
   const reactId = useId();
@@ -136,10 +150,18 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const historyButtonRef = useRef<HTMLButtonElement | null>(null);
   const createDraftButtonRef = useRef<HTMLButtonElement | null>(null);
+  const loadMoreButtonRef = useRef<HTMLButtonElement | null>(null);
   const previousOpenRef = useRef<boolean>(false);
   const focusedSessionIdRef = useRef<string | null>(null);
+  const loadMoreOwnsFocusRef = useRef<boolean>(false);
   const runningSessions = sessions.filter((session) => session.status === "running");
   const recentSessions = sessions.filter((session) => session.status !== "running");
+  const statusVisibility = resolveChatHistoryStatusVisibility(
+    sessions.length,
+    isLoading,
+    hasLoadedFirstPage,
+    errorMessage,
+  );
   const activityFormatter = useMemo(
     (): Intl.DateTimeFormat => new Intl.DateTimeFormat(
       i18n.resolvedLanguage ?? i18n.language,
@@ -156,17 +178,45 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
   useLayoutEffect(() => {
     if (!open) {
       focusedSessionIdRef.current = null;
+      loadMoreOwnsFocusRef.current = false;
+      return;
+    }
+
+    const dialog = dialogRef.current;
+    if (dialog === null) {
+      throw new Error("Cannot restore chat history focus: dialog is not mounted");
+    }
+    const paginationFocusTarget = resolveChatHistoryPaginationFocus(
+      loadMoreOwnsFocusRef.current,
+      hasMore,
+    );
+    if (paginationFocusTarget === "create_draft") {
+      const createDraftButton = createDraftButtonRef.current;
+      if (createDraftButton === null) {
+        throw new Error(
+          "Cannot restore chat history focus after Load more was removed: New chat button is not mounted",
+        );
+      }
+      loadMoreOwnsFocusRef.current = false;
+      createDraftButton.focus();
+      return;
+    }
+    if (document.activeElement !== null && dialog.contains(document.activeElement)) {
+      return;
+    }
+    if (paginationFocusTarget === "load_more") {
+      const loadMoreButton = loadMoreButtonRef.current;
+      if (loadMoreButton === null) {
+        throw new Error(
+          "Cannot restore chat history focus: Load more button is not mounted",
+        );
+      }
+      loadMoreButton.focus();
       return;
     }
 
     const focusedSessionId = focusedSessionIdRef.current;
     if (focusedSessionId === null) return;
-
-    const dialog = dialogRef.current;
-    if (dialog === null) {
-      throw new Error("Cannot restore chat history row focus: dialog is not mounted");
-    }
-    if (document.activeElement !== null && dialog.contains(document.activeElement)) return;
 
     const focusedSessionStillExists = sessions.some(
       (session) => session.sessionId === focusedSessionId,
@@ -194,7 +244,7 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
       );
     }
     sessionButton.focus();
-  }, [open, sessions]);
+  }, [hasMore, isLoading, open, sessions]);
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -248,6 +298,8 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
       throw new TypeError("Cannot track chat history focus: focused target is not an element");
     }
     focusedSessionIdRef.current = target.dataset.chatHistorySessionId ?? null;
+    loadMoreOwnsFocusRef.current =
+      target.dataset.chatHistoryFocusOwner === "load-more";
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDialogElement>): void => {
@@ -296,6 +348,7 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
         className={styles.dialog}
         data-testid="chat-history-dialog"
         aria-labelledby={titleId}
+        aria-busy={isLoading}
         tabIndex={-1}
         onCancel={handleCancel}
         onFocusCapture={handleFocusCapture}
@@ -337,6 +390,25 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
           </div>
         </header>
         <div className={styles.dialogBody}>
+          {errorMessage !== null && (
+            <p
+              className={styles.errorState}
+              data-testid="chat-history-error"
+              role="alert"
+            >
+              {errorMessage}
+            </p>
+          )}
+          {statusVisibility.showLoading && (
+            <p
+              className={styles.loadingState}
+              data-testid="chat-history-loading"
+              role="status"
+              aria-live="polite"
+            >
+              {t("common.loading")}
+            </p>
+          )}
           {runningSessions.length > 0 && (
             <SessionList
               headingId={runningHeadingId}
@@ -361,10 +433,27 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
               onSelectSession={handleSelectSession}
             />
           )}
-          {sessions.length === 0 && (
+          {statusVisibility.showEmpty && (
             <p className={styles.emptyState} data-testid="chat-history-empty">
               {t("chat.historyEmpty")}
             </p>
+          )}
+          {hasMore && (
+            <div className={styles.loadMoreRow}>
+              <button
+                ref={loadMoreButtonRef}
+                type="button"
+                className={styles.loadMoreButton}
+                data-testid="chat-history-load-more"
+                data-chat-history-focus-owner="load-more"
+                aria-disabled={isLoading}
+                onClick={() => {
+                  if (!isLoading) onLoadMore();
+                }}
+              >
+                {isLoading ? t("common.loading") : t("chat.historyLoadMore")}
+              </button>
+            </div>
           )}
         </div>
       </dialog>

--- a/apps/web/src/ui/chat/shell/layout/ChatLayoutProvider.tsx
+++ b/apps/web/src/ui/chat/shell/layout/ChatLayoutProvider.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type Dispatch,
@@ -13,6 +14,22 @@ import {
   type SetStateAction,
 } from "react";
 
+import {
+  getChatTargetKey,
+  type ChatTarget,
+} from "../../workspace/chatWorkspaceState";
+import {
+  useChatWorkspaceController,
+  type ChatWorkspaceController,
+} from "../../workspace/useChatWorkspaceController";
+import {
+  deleteTargetChatComposerMemory,
+  isChatDraftUntouched,
+  readTargetChatComposerMemory,
+  rekeyTargetChatComposerMemory,
+  updateTargetChatComposerMemory,
+  type ChatComposerMemoryState,
+} from "../panel/chatPanelRuntime";
 import {
   getChatDraftStorageKey,
   readAndMigrateChatDraft,
@@ -25,18 +42,133 @@ type ChatLayoutContextValue = Readonly<{
   setIsOpen: (open: boolean) => void;
   chatWidth: number;
   setChatWidth: (width: number) => void;
+  chatWorkspace: ChatWorkspaceController;
+  isSelectedWorkspaceDraftUntouched: boolean;
+  chatTargetKey: string;
   chatDraftText: string;
   setChatDraftText: Dispatch<SetStateAction<string>>;
+  setChatDraftTextForTarget: (
+    target: ChatTarget,
+    update: SetStateAction<string>,
+  ) => void;
+  chatComposerMemory: ChatComposerMemoryState;
+  setChatComposerMemoryForTarget: (
+    target: ChatTarget,
+    update: SetStateAction<ChatComposerMemoryState>,
+  ) => void;
+  adoptChatTargetState: (
+    sourceTarget: ChatTarget,
+    destinationTarget: ChatTarget,
+  ) => void;
+  disposeChatTargetState: (target: ChatTarget) => void;
 }>;
 
 const ChatLayoutContext = createContext<ChatLayoutContextValue | null>(null);
 
 const COOKIE_MAX_AGE = "max-age=31536000";
 
-const COMPATIBILITY_DRAFT_TARGET = {
+const COMPATIBILITY_CHAT_COMPOSER_TARGET = {
   kind: "draft",
   draftId: "pre-workspace-controller",
 } as const;
+
+export const getMountedChatComposerTarget = (): ChatTarget =>
+  COMPATIBILITY_CHAT_COMPOSER_TARGET;
+
+export const readMountedChatDraftText = (
+  draftTextByTarget: ReadonlyMap<string, string>,
+  draftScope: ChatDraftScope,
+): string => {
+  const storageKey = getChatDraftStorageKey(
+    draftScope,
+    getMountedChatComposerTarget(),
+  );
+  return draftTextByTarget.get(storageKey) ?? "";
+};
+
+export const restoreChatDraftTextForTarget = (
+  storage: Storage,
+  draftTextByTarget: ReadonlyMap<string, string>,
+  draftScope: ChatDraftScope,
+  target: ChatTarget,
+): ReadonlyMap<string, string> => {
+  const storageKey = getChatDraftStorageKey(draftScope, target);
+  if (draftTextByTarget.has(storageKey)) {
+    return draftTextByTarget;
+  }
+
+  const nextDraftTextByTarget = new Map(draftTextByTarget);
+  nextDraftTextByTarget.set(
+    storageKey,
+    readAndMigrateChatDraft(
+      storage,
+      draftScope,
+      target,
+    ),
+  );
+  return nextDraftTextByTarget;
+};
+
+export const restoreMountedChatDraftText = (
+  storage: Storage,
+  draftTextByTarget: ReadonlyMap<string, string>,
+  draftScope: ChatDraftScope,
+): ReadonlyMap<string, string> =>
+  restoreChatDraftTextForTarget(
+    storage,
+    draftTextByTarget,
+    draftScope,
+    getMountedChatComposerTarget(),
+  );
+
+export const resolveSelectedChatDraftUntouched = (
+  isWorkspaceReady: boolean,
+  selectedTarget: ChatTarget,
+  draftTextByTarget: ReadonlyMap<string, string>,
+  composerMemoryByTarget: ReadonlyMap<string, ChatComposerMemoryState>,
+  draftScope: ChatDraftScope,
+): boolean => {
+  if (!isWorkspaceReady || selectedTarget.kind !== "draft") {
+    return false;
+  }
+  const storageKey = getChatDraftStorageKey(draftScope, selectedTarget);
+  const selectedDraftText = draftTextByTarget.get(storageKey);
+  if (selectedDraftText === undefined) {
+    return false;
+  }
+  const selectedComposerMemory = readTargetChatComposerMemory(
+    composerMemoryByTarget,
+    getChatTargetKey(selectedTarget),
+  );
+
+  return isChatDraftUntouched({
+    text: selectedDraftText,
+    pendingAttachmentCount:
+      selectedComposerMemory.pendingAttachments.length,
+    attachmentErrorCount: selectedComposerMemory.attachmentErrors.length,
+    isAttachmentProcessing: selectedComposerMemory.isAttachmentProcessing,
+    hasPendingSubmission: selectedComposerMemory.pendingSubmission !== null,
+    messageCount: 0,
+  });
+};
+
+export const updateChatDraftTextForTarget = (
+  storage: Storage,
+  draftTextByTarget: ReadonlyMap<string, string>,
+  draftScope: ChatDraftScope,
+  target: ChatTarget,
+  update: SetStateAction<string>,
+): ReadonlyMap<string, string> => {
+  const storageKey = getChatDraftStorageKey(draftScope, target);
+  const currentText = draftTextByTarget.get(storageKey)
+    ?? readAndMigrateChatDraft(storage, draftScope, target);
+  const nextText = typeof update === "function" ? update(currentText) : update;
+  writeChatDraft(storage, draftScope, target, nextText);
+
+  const nextDraftTextByTarget = new Map(draftTextByTarget);
+  nextDraftTextByTarget.set(storageKey, nextText);
+  return nextDraftTextByTarget;
+};
 
 const writeCookie = (name: string, value: string): void => {
   document.cookie = `${name}=${value}; path=/; ${COOKIE_MAX_AGE}`;
@@ -49,11 +181,6 @@ type Props = Readonly<{
   draftScope: ChatDraftScope;
 }>;
 
-type ChatDraftState = Readonly<{
-  storageKey: string;
-  text: string;
-}>;
-
 export const ChatLayoutProvider = (props: Props): ReactElement => {
   const {
     children,
@@ -63,29 +190,70 @@ export const ChatLayoutProvider = (props: Props): ReactElement => {
   } = props;
   const [isOpen, setIsOpenState] = useState<boolean>(initialChatOpen);
   const [chatWidth, setChatWidthState] = useState<number>(initialChatWidth);
-  const draftStorageKey = getChatDraftStorageKey(
-    draftScope,
-    COMPATIBILITY_DRAFT_TARGET,
+  const draftWorkspaceId = draftScope.mode === "workspace"
+    ? draftScope.workspaceId
+    : null;
+  const stableDraftScope = useMemo<ChatDraftScope>(
+    (): ChatDraftScope => draftScope.mode === "demo"
+      ? {
+          mode: "demo",
+          userId: draftScope.userId,
+        }
+      : {
+          mode: "workspace",
+          userId: draftScope.userId,
+          workspaceId: draftScope.workspaceId,
+        },
+    [draftScope.mode, draftScope.userId, draftWorkspaceId],
   );
-  const initialChatDraftState: ChatDraftState = {
-    storageKey: draftStorageKey,
-    text: "",
-  };
-  const [chatDraftState, setChatDraftState] = useState<ChatDraftState>(initialChatDraftState);
-  const chatDraftStateRef = useRef<ChatDraftState>(initialChatDraftState);
+  const chatWorkspace = useChatWorkspaceController({ scope: stableDraftScope });
+  const mountedChatComposerTarget = getMountedChatComposerTarget();
+  const chatTargetKey = getChatTargetKey(mountedChatComposerTarget);
+  const [draftTextByTarget, setDraftTextByTarget] = useState<
+    ReadonlyMap<string, string>
+  >(new Map<string, string>());
+  const draftTextByTargetRef = useRef(draftTextByTarget);
+  const [composerMemoryByTarget, setComposerMemoryByTarget] = useState<
+    ReadonlyMap<string, ChatComposerMemoryState>
+  >(new Map<string, ChatComposerMemoryState>());
+  const composerMemoryByTargetRef = useRef(composerMemoryByTarget);
 
   useEffect(() => {
-    const nextState: ChatDraftState = {
-      storageKey: draftStorageKey,
-      text: readAndMigrateChatDraft(
-        window.sessionStorage,
-        draftScope,
-        COMPATIBILITY_DRAFT_TARGET,
-      ),
-    };
-    chatDraftStateRef.current = nextState;
-    setChatDraftState(nextState);
-  }, [draftScope, draftStorageKey]);
+    const restoredDraftTextByTarget = restoreMountedChatDraftText(
+      window.sessionStorage,
+      new Map<string, string>(),
+      stableDraftScope,
+    );
+    draftTextByTargetRef.current = restoredDraftTextByTarget;
+    setDraftTextByTarget(restoredDraftTextByTarget);
+    const emptyComposerMemoryByTarget =
+      new Map<string, ChatComposerMemoryState>();
+    composerMemoryByTargetRef.current = emptyComposerMemoryByTarget;
+    setComposerMemoryByTarget(emptyComposerMemoryByTarget);
+  }, [stableDraftScope]);
+
+  const selectedWorkspaceTarget = chatWorkspace.state.target;
+  useEffect(() => {
+    if (!chatWorkspace.isReady || selectedWorkspaceTarget.kind !== "draft") {
+      return;
+    }
+    const currentDraftTextByTarget = draftTextByTargetRef.current;
+    const nextDraftTextByTarget = restoreChatDraftTextForTarget(
+      window.sessionStorage,
+      currentDraftTextByTarget,
+      stableDraftScope,
+      selectedWorkspaceTarget,
+    );
+    if (nextDraftTextByTarget === currentDraftTextByTarget) {
+      return;
+    }
+    draftTextByTargetRef.current = nextDraftTextByTarget;
+    setDraftTextByTarget(nextDraftTextByTarget);
+  }, [
+    chatWorkspace.isReady,
+    selectedWorkspaceTarget,
+    stableDraftScope,
+  ]);
 
   const setIsOpen = (open: boolean): void => {
     setIsOpenState(open);
@@ -97,33 +265,128 @@ export const ChatLayoutProvider = (props: Props): ReactElement => {
     writeCookie("chat-width", String(Math.round(width)));
   };
 
-  const setChatDraftText = useCallback((update: SetStateAction<string>): void => {
-    const currentText = chatDraftStateRef.current.storageKey === draftStorageKey
-      ? chatDraftStateRef.current.text
-      : readAndMigrateChatDraft(
-        window.sessionStorage,
-        draftScope,
-        COMPATIBILITY_DRAFT_TARGET,
-      );
-    const nextText = typeof update === "function" ? update(currentText) : update;
-    const nextState: ChatDraftState = {
-      storageKey: draftStorageKey,
-      text: nextText,
-    };
+  const setChatDraftTextForTarget = useCallback((
+    targetToUpdate: ChatTarget,
+    update: SetStateAction<string>,
+  ): void => {
+    const nextDraftTextByTarget = updateChatDraftTextForTarget(
+      window.sessionStorage,
+      draftTextByTargetRef.current,
+      stableDraftScope,
+      targetToUpdate,
+      update,
+    );
+    draftTextByTargetRef.current = nextDraftTextByTarget;
+    setDraftTextByTarget(nextDraftTextByTarget);
+  }, [stableDraftScope]);
 
+  const setChatDraftText = useCallback((
+    update: SetStateAction<string>,
+  ): void => {
+    setChatDraftTextForTarget(mountedChatComposerTarget, update);
+  }, [mountedChatComposerTarget, setChatDraftTextForTarget]);
+
+  const setChatComposerMemoryForTarget = useCallback((
+    targetToUpdate: ChatTarget,
+    update: SetStateAction<ChatComposerMemoryState>,
+  ): void => {
+    const targetKey = getChatTargetKey(targetToUpdate);
+    const nextMemoryByTarget = updateTargetChatComposerMemory(
+      composerMemoryByTargetRef.current,
+      targetKey,
+      update,
+    );
+    composerMemoryByTargetRef.current = nextMemoryByTarget;
+    setComposerMemoryByTarget(nextMemoryByTarget);
+  }, []);
+
+  const adoptChatTargetState = useCallback((
+    sourceTarget: ChatTarget,
+    destinationTarget: ChatTarget,
+  ): void => {
+    const sourceStorageKey = getChatDraftStorageKey(
+      stableDraftScope,
+      sourceTarget,
+    );
+    const destinationStorageKey = getChatDraftStorageKey(
+      stableDraftScope,
+      destinationTarget,
+    );
+    const sourceText = draftTextByTargetRef.current.get(sourceStorageKey)
+      ?? readAndMigrateChatDraft(
+        window.sessionStorage,
+        stableDraftScope,
+        sourceTarget,
+      );
     writeChatDraft(
       window.sessionStorage,
-      draftScope,
-      COMPATIBILITY_DRAFT_TARGET,
-      nextText,
+      stableDraftScope,
+      destinationTarget,
+      sourceText,
     );
-    chatDraftStateRef.current = nextState;
-    setChatDraftState(nextState);
-  }, [draftScope, draftStorageKey]);
+    writeChatDraft(
+      window.sessionStorage,
+      stableDraftScope,
+      sourceTarget,
+      "",
+    );
 
-  const chatDraftText = chatDraftState.storageKey === draftStorageKey
-    ? chatDraftState.text
-    : "";
+    const nextDraftTextByTarget = new Map(draftTextByTargetRef.current);
+    nextDraftTextByTarget.delete(sourceStorageKey);
+    nextDraftTextByTarget.set(destinationStorageKey, sourceText);
+    draftTextByTargetRef.current = nextDraftTextByTarget;
+    setDraftTextByTarget(nextDraftTextByTarget);
+
+    const nextComposerMemoryByTarget = rekeyTargetChatComposerMemory(
+      composerMemoryByTargetRef.current,
+      getChatTargetKey(sourceTarget),
+      getChatTargetKey(destinationTarget),
+    );
+    composerMemoryByTargetRef.current = nextComposerMemoryByTarget;
+    setComposerMemoryByTarget(nextComposerMemoryByTarget);
+  }, [stableDraftScope]);
+
+  const disposeChatTargetState = useCallback((
+    targetToDispose: ChatTarget,
+  ): void => {
+    const storageKey = getChatDraftStorageKey(
+      stableDraftScope,
+      targetToDispose,
+    );
+    writeChatDraft(
+      window.sessionStorage,
+      stableDraftScope,
+      targetToDispose,
+      "",
+    );
+    const nextDraftTextByTarget = new Map(draftTextByTargetRef.current);
+    nextDraftTextByTarget.delete(storageKey);
+    draftTextByTargetRef.current = nextDraftTextByTarget;
+    setDraftTextByTarget(nextDraftTextByTarget);
+
+    const nextComposerMemoryByTarget = deleteTargetChatComposerMemory(
+      composerMemoryByTargetRef.current,
+      getChatTargetKey(targetToDispose),
+    );
+    composerMemoryByTargetRef.current = nextComposerMemoryByTarget;
+    setComposerMemoryByTarget(nextComposerMemoryByTarget);
+  }, [stableDraftScope]);
+
+  const chatDraftText = readMountedChatDraftText(
+    draftTextByTarget,
+    stableDraftScope,
+  );
+  const chatComposerMemory = readTargetChatComposerMemory(
+    composerMemoryByTarget,
+    chatTargetKey,
+  );
+  const isSelectedWorkspaceDraftUntouched = resolveSelectedChatDraftUntouched(
+    chatWorkspace.isReady,
+    selectedWorkspaceTarget,
+    draftTextByTarget,
+    composerMemoryByTarget,
+    stableDraftScope,
+  );
 
   return (
     <ChatLayoutContext.Provider value={{
@@ -131,8 +394,16 @@ export const ChatLayoutProvider = (props: Props): ReactElement => {
       setIsOpen,
       chatWidth,
       setChatWidth,
+      chatWorkspace,
+      isSelectedWorkspaceDraftUntouched,
+      chatTargetKey,
       chatDraftText,
       setChatDraftText,
+      setChatDraftTextForTarget,
+      chatComposerMemory,
+      setChatComposerMemoryForTarget,
+      adoptChatTargetState,
+      disposeChatTargetState,
     }}>
       {children}
     </ChatLayoutContext.Provider>

--- a/apps/web/src/ui/chat/workspace/chatWorkspaceState.test.ts
+++ b/apps/web/src/ui/chat/workspace/chatWorkspaceState.test.ts
@@ -7,11 +7,46 @@ import {
   failChatSessionCatalogLoad,
   findChatSessionInvalidationIncrements,
   getRunningChatSessionCount,
+  getChatTargetKey,
   replaceChatSessionCatalog,
+  resolveFailedSessionRecoveryTarget,
+  resolveNewChatDraftTarget,
   selectChatWorkspaceTarget,
   startChatSessionCatalogLoad,
 } from "./chatWorkspaceState";
 import type { ChatSessionSummary } from "./chatSessionSummaryTransport";
+import {
+  getMountedChatComposerTarget,
+  readMountedChatDraftText,
+  resolveSelectedChatDraftUntouched,
+  restoreChatDraftTextForTarget,
+  restoreMountedChatDraftText,
+  updateChatDraftTextForTarget,
+} from "../shell/layout/ChatLayoutProvider";
+import {
+  getChatDraftStorageKey,
+  writeChatDraft,
+} from "../shell/layout/chatDraftStorage";
+import { isChatDraftUntouched } from "../shell/panel/chatPanelRuntime";
+import {
+  clearChatSelection,
+  getChatSelectionStorageKey,
+  writeChatSelection,
+} from "./chatSelectionStorage";
+import {
+  resolveChatBootstrapRecovery,
+  resolveChatBootstrapSelection,
+  resolveChatControllerNavigationObservation,
+  resolveChatControllerNavigationWrite,
+  resolveChatHistoryErrorMessage,
+  resolveChatHistoryPaginationFocus,
+  resolveChatHistoryStatusVisibility,
+  resolveInvalidChatUrlRecovery,
+  resolveChatPopStateNavigation,
+  resolvePostReadyAutomaticCatalogSelection,
+  resolveChatUrlSynchronization,
+  shouldReuseSelectedChatDraft,
+} from "./useChatWorkspaceController";
 
 const createSummary = (
   sessionId: string,
@@ -24,6 +59,25 @@ const createSummary = (
   status,
   mainContentInvalidationVersion,
 });
+
+const createStorage = (): Storage => {
+  const values = new Map<string, string>();
+
+  return {
+    get length(): number {
+      return values.size;
+    },
+    clear: (): void => values.clear(),
+    getItem: (key: string): string | null => values.get(key) ?? null,
+    key: (index: number): string | null => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string): void => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string): void => {
+      values.set(key, value);
+    },
+  };
+};
 
 test("chat workspace state keeps an explicit target and selection reason", (): void => {
   const draftState = createChatWorkspaceState(
@@ -85,6 +139,45 @@ test("catalog page state preserves ordering, pagination, and known summaries on 
   });
 });
 
+test("failed next-page loads retain the cursor and retry appends without duplicates", (): void => {
+  const firstPageState = replaceChatSessionCatalog(
+    createChatWorkspaceState(
+      { kind: "draft", draftId: "draft-1" },
+      "automatic",
+    ),
+    {
+      sessions: [
+        createSummary("session-1", "idle", 0),
+        createSummary("session-2", "running", 1),
+      ],
+      nextCursor: "cursor-1",
+    },
+  );
+  const failedState = failChatSessionCatalogLoad(
+    startChatSessionCatalogLoad(firstPageState),
+    "Chat session catalog request failed: status=503",
+  );
+  const retriedState = appendChatSessionCatalogPage(failedState, {
+    sessions: [
+      createSummary("session-2", "idle", 2),
+      createSummary("session-3", "interrupted", 0),
+    ],
+    nextCursor: null,
+  });
+
+  assert.deepEqual(
+    failedState.summaries.map((summary) => summary.sessionId),
+    ["session-1", "session-2"],
+  );
+  assert.equal(failedState.pagination.nextCursor, "cursor-1");
+  assert.deepEqual(
+    retriedState.summaries.map((summary) => summary.sessionId),
+    ["session-1", "session-2", "session-3"],
+  );
+  assert.equal(retriedState.summaries[1]?.status, "idle");
+  assert.equal(retriedState.catalogRequest.errorMessage, null);
+});
+
 test("running count is derived across all catalog summaries", (): void => {
   assert.equal(
     getRunningChatSessionCount([
@@ -142,4 +235,1337 @@ test("first catalog observation establishes invalidation baselines without incre
   );
 
   assert.deepEqual(increments, []);
+});
+
+test("repeated New reuses one untouched local draft", (): void => {
+  const currentDraft = { kind: "draft", draftId: "draft-1" } as const;
+
+  assert.deepEqual(
+    resolveNewChatDraftTarget(
+      currentDraft,
+      "draft-1",
+      true,
+      "draft-unused",
+    ),
+    currentDraft,
+  );
+});
+
+test("New revisits an existing tab draft from a selected session", (): void => {
+  assert.deepEqual(
+    resolveNewChatDraftTarget(
+      { kind: "session", sessionId: "session-1" },
+      "draft-1",
+      false,
+      "draft-unused",
+    ),
+    { kind: "draft", draftId: "draft-1" },
+  );
+});
+
+test("failed URL session recovery excludes the failed row and selects a safe catalog target", (): void => {
+  assert.deepEqual(
+    resolveFailedSessionRecoveryTarget(
+      [
+        createSummary("session-failed", "running", 0),
+        createSummary("session-safe", "running", 0),
+      ],
+      new Set(["session-failed"]),
+      Date.parse("2026-07-26T13:00:00.000Z"),
+      "draft-safe",
+    ),
+    { kind: "session", sessionId: "session-safe" },
+  );
+});
+
+test("failed URL session recovery falls back to a local draft when no safe session remains", (): void => {
+  assert.deepEqual(
+    resolveFailedSessionRecoveryTarget(
+      [createSummary("session-failed", "running", 0)],
+      new Set(["session-failed"]),
+      Date.parse("2026-07-26T13:00:00.000Z"),
+      "draft-safe",
+    ),
+    { kind: "draft", draftId: "draft-safe" },
+  );
+});
+
+test("failed session recovery never alternates between multiple stale rows", (): void => {
+  const staleSummaries = [
+    createSummary("session-a", "running", 0),
+    createSummary("session-b", "running", 0),
+  ];
+  const afterFirstFailure = resolveFailedSessionRecoveryTarget(
+    staleSummaries,
+    new Set(["session-a"]),
+    Date.parse("2026-07-26T13:00:00.000Z"),
+    "draft-safe",
+  );
+  const afterSecondFailure = resolveFailedSessionRecoveryTarget(
+    staleSummaries,
+    new Set(["session-a", "session-b"]),
+    Date.parse("2026-07-26T13:00:00.000Z"),
+    "draft-safe",
+  );
+
+  assert.deepEqual(afterFirstFailure, {
+    kind: "session",
+    sessionId: "session-b",
+  });
+  assert.deepEqual(afterSecondFailure, {
+    kind: "draft",
+    draftId: "draft-safe",
+  });
+});
+
+test("workspace selection does not retarget the mounted compatibility composer", (): void => {
+  const draftScope = {
+    mode: "workspace",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  } as const;
+  const selectedState = selectChatWorkspaceTarget(
+    createChatWorkspaceState(
+      { kind: "draft", draftId: "draft-workspace" },
+      "automatic",
+    ),
+    { kind: "session", sessionId: "session-selected" },
+    "explicit",
+  );
+  const mountedComposerTarget = getMountedChatComposerTarget();
+  const draftTextByTarget = new Map<string, string>([
+    [
+      getChatDraftStorageKey(draftScope, mountedComposerTarget),
+      "Mounted controller draft",
+    ],
+    [
+      getChatDraftStorageKey(draftScope, selectedState.target),
+      "Selected workspace target draft",
+    ],
+  ]);
+
+  assert.deepEqual(selectedState.target, {
+    kind: "session",
+    sessionId: "session-selected",
+  });
+  assert.deepEqual(mountedComposerTarget, {
+    kind: "draft",
+    draftId: "pre-workspace-controller",
+  });
+  assert.notEqual(
+    getChatTargetKey(selectedState.target),
+    getChatTargetKey(mountedComposerTarget),
+  );
+  assert.equal(
+    readMountedChatDraftText(draftTextByTarget, draftScope),
+    "Mounted controller draft",
+  );
+});
+
+test("mounted compatibility draft restores before catalog readiness and keeps the first edit", (): void => {
+  const storage = createStorage();
+  const draftScope = {
+    mode: "workspace",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  } as const;
+  const mountedComposerTarget = getMountedChatComposerTarget();
+  writeChatDraft(
+    storage,
+    draftScope,
+    mountedComposerTarget,
+    "Saved compatibility draft",
+  );
+
+  const restoredDraftTextByTarget = restoreMountedChatDraftText(
+    storage,
+    new Map<string, string>(),
+    draftScope,
+  );
+  assert.equal(
+    readMountedChatDraftText(restoredDraftTextByTarget, draftScope),
+    "Saved compatibility draft",
+  );
+
+  const editedDraftTextByTarget = updateChatDraftTextForTarget(
+    storage,
+    restoredDraftTextByTarget,
+    draftScope,
+    mountedComposerTarget,
+    "Saved compatibility draft plus first edit",
+  );
+  assert.equal(
+    readMountedChatDraftText(editedDraftTextByTarget, draftScope),
+    "Saved compatibility draft plus first edit",
+  );
+  assert.equal(
+    storage.getItem(getChatDraftStorageKey(draftScope, mountedComposerTarget)),
+    "Saved compatibility draft plus first edit",
+  );
+});
+
+test("selected workspace draft reuse uses only restored target-aware state", (): void => {
+  const storage = createStorage();
+  const draftScope = {
+    mode: "workspace",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  } as const;
+  const selectedDraft = {
+    kind: "draft",
+    draftId: "draft-selected",
+  } as const;
+  const compatibilityTranscriptMessageCount = 2;
+  const restoredEmptyDrafts = restoreChatDraftTextForTarget(
+    storage,
+    new Map<string, string>(),
+    draftScope,
+    selectedDraft,
+  );
+
+  assert.equal(compatibilityTranscriptMessageCount > 0, true);
+  assert.equal(
+    resolveSelectedChatDraftUntouched(
+      true,
+      selectedDraft,
+      restoredEmptyDrafts,
+      new Map(),
+      draftScope,
+    ),
+    true,
+  );
+
+  writeChatDraft(storage, draftScope, selectedDraft, "Persisted draft text");
+  const restoredTextDrafts = restoreChatDraftTextForTarget(
+    storage,
+    new Map<string, string>(),
+    draftScope,
+    selectedDraft,
+  );
+  assert.equal(
+    resolveSelectedChatDraftUntouched(
+      true,
+      selectedDraft,
+      restoredTextDrafts,
+      new Map(),
+      draftScope,
+    ),
+    false,
+  );
+  assert.equal(
+    resolveSelectedChatDraftUntouched(
+      true,
+      selectedDraft,
+      new Map(),
+      new Map(),
+      draftScope,
+    ),
+    false,
+  );
+  assert.equal(
+    resolveSelectedChatDraftUntouched(
+      false,
+      selectedDraft,
+      restoredEmptyDrafts,
+      new Map(),
+      draftScope,
+    ),
+    false,
+  );
+  assert.equal(
+    resolveSelectedChatDraftUntouched(
+      true,
+      { kind: "session", sessionId: "session-selected" },
+      restoredEmptyDrafts,
+      new Map(),
+      draftScope,
+    ),
+    false,
+  );
+
+  const pendingComposerMemory = new Map([
+    [
+      getChatTargetKey(selectedDraft),
+      {
+        pendingAttachments: [],
+        attachmentErrors: [],
+        isAttachmentProcessing: false,
+        pendingSubmission: {
+          text: "Pending submission",
+          attachments: [],
+        },
+        composerContentOwner: "pending_submission" as const,
+      },
+    ],
+  ]);
+  assert.equal(
+    resolveSelectedChatDraftUntouched(
+      true,
+      selectedDraft,
+      restoredEmptyDrafts,
+      pendingComposerMemory,
+      draftScope,
+    ),
+    false,
+  );
+});
+
+test("deferred bootstrap preserves the exact draft selected by New", (): void => {
+  const initializingTarget = { kind: "draft", draftId: "initializing" } as const;
+  const selectedDraft = resolveNewChatDraftTarget(
+    initializingTarget,
+    null,
+    shouldReuseSelectedChatDraft(false, initializingTarget, true),
+    "draft-selected-during-bootstrap",
+  );
+
+  assert.deepEqual(selectedDraft, {
+    kind: "draft",
+    draftId: "draft-selected-during-bootstrap",
+  });
+  assert.deepEqual(
+    resolveChatBootstrapSelection({
+      bootstrapSelectionEpoch: 0,
+      currentSelectionEpoch: 1,
+      currentTarget: selectedDraft,
+      currentSelectionReason: "explicit",
+      urlTarget: { kind: "session", sessionId: "session-stale-url" },
+      storedTarget: { kind: "session", sessionId: "session-stale-storage" },
+      automaticTarget: { kind: "session", sessionId: "session-stale-automatic" },
+    }),
+    {
+      target: selectedDraft,
+      selectionReason: "explicit",
+      selectionChangedDuringBootstrap: true,
+    },
+  );
+});
+
+test("bootstrap selection keeps URL then stored then automatic precedence", (): void => {
+  const commonInput = {
+    bootstrapSelectionEpoch: 0,
+    currentSelectionEpoch: 0,
+    currentTarget: { kind: "draft", draftId: "draft-initializing" },
+    currentSelectionReason: "automatic",
+    automaticTarget: { kind: "draft", draftId: "draft-automatic" },
+  } as const;
+
+  assert.deepEqual(
+    resolveChatBootstrapSelection({
+      ...commonInput,
+      urlTarget: { kind: "session", sessionId: "session-url" },
+      storedTarget: { kind: "session", sessionId: "session-stored" },
+    }),
+    {
+      target: { kind: "session", sessionId: "session-url" },
+      selectionReason: "explicit",
+      selectionChangedDuringBootstrap: false,
+    },
+  );
+  assert.deepEqual(
+    resolveChatBootstrapSelection({
+      ...commonInput,
+      urlTarget: null,
+      storedTarget: { kind: "session", sessionId: "session-stored" },
+    }).target,
+    { kind: "session", sessionId: "session-stored" },
+  );
+  assert.deepEqual(
+    resolveChatBootstrapSelection({
+      ...commonInput,
+      urlTarget: null,
+      storedTarget: null,
+    }).target,
+    { kind: "draft", draftId: "draft-automatic" },
+  );
+});
+
+test("bootstrap recovery follows the highest-precedence source", (): void => {
+  const automaticDraft = {
+    target: { kind: "draft", draftId: "draft-automatic" },
+    selectionReason: "automatic",
+    selectionChangedDuringBootstrap: false,
+  } as const;
+  const automaticSession = {
+    target: { kind: "session", sessionId: "session-automatic" },
+    selectionReason: "automatic",
+    selectionChangedDuringBootstrap: false,
+  } as const;
+  const validUrlSelection = {
+    target: { kind: "session", sessionId: "session-url" },
+    selectionReason: "explicit",
+    selectionChangedDuringBootstrap: false,
+  } as const;
+  const newerSelection = {
+    target: { kind: "draft", draftId: "draft-newer" },
+    selectionReason: "explicit",
+    selectionChangedDuringBootstrap: true,
+  } as const;
+  const cases = [
+    {
+      name: "valid URL suppresses an invalid stored selection",
+      input: {
+        selection: validUrlSelection,
+        hasUrlSessionParameter: true,
+        urlSelectionFailed: false,
+        storedTarget: null,
+        storedSelectionFailed: true,
+        activeDraftFailed: false,
+      },
+      expected: {
+        showRecoveryNotice: false,
+        shouldReplaceUrl: false,
+      },
+    },
+    {
+      name: "valid URL suppresses an invalid active draft",
+      input: {
+        selection: validUrlSelection,
+        hasUrlSessionParameter: true,
+        urlSelectionFailed: false,
+        storedTarget: null,
+        storedSelectionFailed: false,
+        activeDraftFailed: true,
+      },
+      expected: {
+        showRecoveryNotice: false,
+        shouldReplaceUrl: false,
+      },
+    },
+    {
+      name: "invalid URL fallback reports recovery and replaces the URL",
+      input: {
+        selection: automaticDraft,
+        hasUrlSessionParameter: true,
+        urlSelectionFailed: true,
+        storedTarget: null,
+        storedSelectionFailed: false,
+        activeDraftFailed: false,
+      },
+      expected: {
+        showRecoveryNotice: true,
+        shouldReplaceUrl: true,
+      },
+    },
+    {
+      name: "invalid winning stored selection reports recovery without replacing the URL",
+      input: {
+        selection: automaticSession,
+        hasUrlSessionParameter: false,
+        urlSelectionFailed: false,
+        storedTarget: null,
+        storedSelectionFailed: true,
+        activeDraftFailed: false,
+      },
+      expected: {
+        showRecoveryNotice: true,
+        shouldReplaceUrl: false,
+      },
+    },
+    {
+      name: "invalid winning active draft reports recovery",
+      input: {
+        selection: automaticDraft,
+        hasUrlSessionParameter: false,
+        urlSelectionFailed: false,
+        storedTarget: null,
+        storedSelectionFailed: false,
+        activeDraftFailed: true,
+      },
+      expected: {
+        showRecoveryNotice: true,
+        shouldReplaceUrl: false,
+      },
+    },
+    {
+      name: "invalid unused active draft stays silent",
+      input: {
+        selection: automaticSession,
+        hasUrlSessionParameter: false,
+        urlSelectionFailed: false,
+        storedTarget: null,
+        storedSelectionFailed: false,
+        activeDraftFailed: true,
+      },
+      expected: {
+        showRecoveryNotice: false,
+        shouldReplaceUrl: false,
+      },
+    },
+    {
+      name: "newer selection suppresses stale bootstrap recovery",
+      input: {
+        selection: newerSelection,
+        hasUrlSessionParameter: true,
+        urlSelectionFailed: true,
+        storedTarget: null,
+        storedSelectionFailed: true,
+        activeDraftFailed: true,
+      },
+      expected: {
+        showRecoveryNotice: false,
+        shouldReplaceUrl: false,
+      },
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    assert.deepEqual(
+      resolveChatBootstrapRecovery(testCase.input),
+      testCase.expected,
+      testCase.name,
+    );
+  }
+});
+
+test("post-ready first-page refresh reconciles only the request's current automatic selection", (): void => {
+  const automaticDraft = {
+    kind: "draft",
+    draftId: "draft-automatic",
+  } as const;
+  const recentSession = createSummary("session-recent", "idle", 0);
+  const runningSession = createSummary("session-running", "running", 0);
+  const cases = [
+    {
+      name: "successful refresh after an initial failure selects a recent session",
+      input: {
+        requestStartedReady: true,
+        requestSelectionEpoch: 1,
+        requestSelectionReason: "automatic",
+        currentSelectionEpoch: 1,
+        currentSelectionReason: "automatic",
+        currentTarget: automaticDraft,
+        summaries: [recentSession],
+        unavailableSessionIds: new Set<string>(),
+        currentTimeMs: Date.parse("2026-07-26T13:00:00.000Z"),
+        draftId: automaticDraft.draftId,
+      },
+      expected: { kind: "session", sessionId: "session-recent" },
+    },
+    {
+      name: "a running session remains eligible regardless of age",
+      input: {
+        requestStartedReady: true,
+        requestSelectionEpoch: 2,
+        requestSelectionReason: "automatic",
+        currentSelectionEpoch: 2,
+        currentSelectionReason: "automatic",
+        currentTarget: automaticDraft,
+        summaries: [runningSession],
+        unavailableSessionIds: new Set<string>(),
+        currentTimeMs: Date.parse("2026-07-27T13:00:00.000Z"),
+        draftId: automaticDraft.draftId,
+      },
+      expected: { kind: "session", sessionId: "session-running" },
+    },
+    {
+      name: "New during the request fences the automatic response",
+      input: {
+        requestStartedReady: true,
+        requestSelectionEpoch: 3,
+        requestSelectionReason: "automatic",
+        currentSelectionEpoch: 4,
+        currentSelectionReason: "explicit",
+        currentTarget: { kind: "draft", draftId: "draft-new" },
+        summaries: [recentSession],
+        unavailableSessionIds: new Set<string>(),
+        currentTimeMs: Date.parse("2026-07-26T13:00:00.000Z"),
+        draftId: "draft-new",
+      },
+      expected: null,
+    },
+    {
+      name: "an explicit session during the request fences the automatic response",
+      input: {
+        requestStartedReady: true,
+        requestSelectionEpoch: 5,
+        requestSelectionReason: "automatic",
+        currentSelectionEpoch: 6,
+        currentSelectionReason: "explicit",
+        currentTarget: { kind: "session", sessionId: "session-explicit" },
+        summaries: [recentSession],
+        unavailableSessionIds: new Set<string>(),
+        currentTimeMs: Date.parse("2026-07-26T13:00:00.000Z"),
+        draftId: automaticDraft.draftId,
+      },
+      expected: null,
+    },
+    {
+      name: "an automatic idle session crossing six hours returns to its draft",
+      input: {
+        requestStartedReady: true,
+        requestSelectionEpoch: 7,
+        requestSelectionReason: "automatic",
+        currentSelectionEpoch: 7,
+        currentSelectionReason: "automatic",
+        currentTarget: { kind: "session", sessionId: "session-recent" },
+        summaries: [recentSession],
+        unavailableSessionIds: new Set<string>(),
+        currentTimeMs: Date.parse("2026-07-26T18:00:00.001Z"),
+        draftId: automaticDraft.draftId,
+      },
+      expected: automaticDraft,
+    },
+    {
+      name: "the initial bootstrap response cannot bypass source precedence",
+      input: {
+        requestStartedReady: false,
+        requestSelectionEpoch: 0,
+        requestSelectionReason: "automatic",
+        currentSelectionEpoch: 0,
+        currentSelectionReason: "automatic",
+        currentTarget: { kind: "draft", draftId: "initializing" },
+        summaries: [recentSession],
+        unavailableSessionIds: new Set<string>(),
+        currentTimeMs: Date.parse("2026-07-26T13:00:00.000Z"),
+        draftId: automaticDraft.draftId,
+      },
+      expected: null,
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    assert.deepEqual(
+      resolvePostReadyAutomaticCatalogSelection(testCase.input),
+      testCase.expected,
+      testCase.name,
+    );
+  }
+});
+
+test("post-recovery refresh excludes unavailable sessions until recovery makes them eligible", (): void => {
+  const failedSession = createSummary("session-failed", "running", 0);
+  const availableSession = createSummary("session-available", "idle", 0);
+  const commonInput = {
+    requestStartedReady: true,
+    requestSelectionEpoch: 4,
+    requestSelectionReason: "automatic",
+    currentSelectionEpoch: 4,
+    currentSelectionReason: "automatic",
+    currentTarget: { kind: "draft", draftId: "draft-safe" },
+    currentTimeMs: Date.parse("2026-07-26T13:00:00.000Z"),
+    draftId: "draft-safe",
+  } as const;
+
+  assert.deepEqual(
+    resolvePostReadyAutomaticCatalogSelection({
+      ...commonInput,
+      summaries: [failedSession, availableSession],
+      unavailableSessionIds: new Set(["session-failed"]),
+    }),
+    { kind: "session", sessionId: "session-available" },
+  );
+  assert.equal(
+    resolvePostReadyAutomaticCatalogSelection({
+      ...commonInput,
+      summaries: [failedSession],
+      unavailableSessionIds: new Set(["session-failed"]),
+    }),
+    null,
+  );
+  assert.deepEqual(
+    resolvePostReadyAutomaticCatalogSelection({
+      ...commonInput,
+      summaries: [failedSession, availableSession],
+      unavailableSessionIds: new Set<string>(),
+    }),
+    { kind: "session", sessionId: "session-failed" },
+  );
+});
+
+test("New reuses an untouched automatic draft as an explicit selection and fences a deferred refresh", (): void => {
+  const requestSelectionEpoch = 8;
+  const automaticState = createChatWorkspaceState(
+    { kind: "draft", draftId: "draft-reused" },
+    "automatic",
+  );
+  const reusedTarget = resolveNewChatDraftTarget(
+    automaticState.target,
+    "draft-reused",
+    shouldReuseSelectedChatDraft(
+      true,
+      automaticState.target,
+      true,
+    ),
+    "draft-unused",
+  );
+  const explicitState = selectChatWorkspaceTarget(
+    automaticState,
+    reusedTarget,
+    "explicit",
+  );
+  const explicitSelectionEpoch = requestSelectionEpoch + 1;
+
+  assert.deepEqual(reusedTarget, {
+    kind: "draft",
+    draftId: "draft-reused",
+  });
+  assert.deepEqual(explicitState.target, reusedTarget);
+  assert.equal(explicitState.selectionReason, "explicit");
+  assert.equal(explicitSelectionEpoch, 9);
+  assert.equal(
+    resolvePostReadyAutomaticCatalogSelection({
+      requestStartedReady: true,
+      requestSelectionEpoch,
+      requestSelectionReason: "automatic",
+      currentSelectionEpoch: explicitSelectionEpoch,
+      currentSelectionReason: explicitState.selectionReason,
+      currentTarget: explicitState.target,
+      summaries: [createSummary("session-running", "running", 0)],
+      unavailableSessionIds: new Set<string>(),
+      currentTimeMs: Date.parse("2026-07-26T13:00:00.000Z"),
+      draftId: reusedTarget.draftId,
+    }),
+    null,
+  );
+});
+
+test("malformed runtime URL recovery preserves valid stored targets and clears only malformed storage", (): void => {
+  const scope = {
+    mode: "workspace",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  } as const;
+  const summaries = [createSummary("session-automatic", "running", 0)];
+  const currentTimeMs = Date.parse("2026-07-26T13:00:00.000Z");
+
+  for (const storedTarget of [
+    { kind: "session", sessionId: "session-stored" },
+    { kind: "draft", draftId: "draft-stored" },
+  ] as const) {
+    const storage = createStorage();
+    writeChatSelection(storage, scope, storedTarget);
+    assert.deepEqual(
+      resolveInvalidChatUrlRecovery(
+        storage,
+        scope,
+        summaries,
+        currentTimeMs,
+        "draft-automatic",
+      ),
+      {
+        target: storedTarget,
+        selectionReason: "explicit",
+        shouldClearStoredSelection: false,
+      },
+    );
+    assert.notEqual(
+      storage.getItem(getChatSelectionStorageKey(scope)),
+      null,
+    );
+  }
+
+  const malformedStorage = createStorage();
+  malformedStorage.setItem(getChatSelectionStorageKey(scope), "{");
+  const malformedDecision = resolveInvalidChatUrlRecovery(
+    malformedStorage,
+    scope,
+    summaries,
+    currentTimeMs,
+    "draft-automatic",
+  );
+  if (malformedDecision.shouldClearStoredSelection) {
+    clearChatSelection(malformedStorage, scope);
+  }
+  assert.deepEqual(malformedDecision, {
+    target: { kind: "session", sessionId: "session-automatic" },
+    selectionReason: "automatic",
+    shouldClearStoredSelection: true,
+  });
+  assert.equal(
+    malformedStorage.getItem(getChatSelectionStorageKey(scope)),
+    null,
+  );
+
+  const emptyStorage = createStorage();
+  assert.deepEqual(
+    resolveInvalidChatUrlRecovery(
+      emptyStorage,
+      scope,
+      summaries,
+      currentTimeMs,
+      "draft-automatic",
+    ),
+    {
+      target: { kind: "session", sessionId: "session-automatic" },
+      selectionReason: "automatic",
+      shouldClearStoredSelection: false,
+    },
+  );
+});
+
+test("New reuses only a completely untouched mounted draft", (): void => {
+  const untouchedInput = {
+    text: "",
+    pendingAttachmentCount: 0,
+    attachmentErrorCount: 0,
+    isAttachmentProcessing: false,
+    hasPendingSubmission: false,
+    messageCount: 0,
+  } as const;
+  const currentDraft = { kind: "draft", draftId: "draft-current" } as const;
+
+  assert.equal(isChatDraftUntouched(untouchedInput), true);
+  assert.equal(
+    shouldReuseSelectedChatDraft(true, currentDraft, true),
+    true,
+  );
+  assert.deepEqual(
+    resolveNewChatDraftTarget(
+      currentDraft,
+      currentDraft.draftId,
+      isChatDraftUntouched(untouchedInput),
+      "draft-unused",
+    ),
+    currentDraft,
+  );
+  for (const touchedInput of [
+    { ...untouchedInput, text: "draft" },
+    { ...untouchedInput, pendingAttachmentCount: 1 },
+    { ...untouchedInput, attachmentErrorCount: 1 },
+    { ...untouchedInput, isAttachmentProcessing: true },
+    { ...untouchedInput, hasPendingSubmission: true },
+    { ...untouchedInput, messageCount: 1 },
+  ]) {
+    assert.equal(isChatDraftUntouched(touchedInput), false);
+  }
+});
+
+test("same-path external URL queries select sessions while controller writes do not feed back", (): void => {
+  const input = {
+    previousPathname: "/chat",
+    pathname: "/chat",
+    urlTarget: { kind: "session", sessionId: "session-b" },
+    currentTarget: { kind: "session", sessionId: "session-a" },
+    currentSelectionReason: "explicit",
+    activeDraftTarget: { kind: "draft", draftId: "draft-active" },
+  } as const;
+
+  assert.deepEqual(
+    resolveChatUrlSynchronization({
+      ...input,
+      controllerNavigationMatches: false,
+    }),
+    {
+      kind: "select",
+      target: { kind: "session", sessionId: "session-b" },
+    },
+  );
+  assert.deepEqual(
+    resolveChatUrlSynchronization({
+      ...input,
+      controllerNavigationMatches: true,
+    }),
+    { kind: "none" },
+  );
+});
+
+test("same-target URL navigation promotes automatic selection and fences a stale refresh", (): void => {
+  const automaticTarget = {
+    kind: "session",
+    sessionId: "session-current",
+  } as const;
+  const urlDecision = resolveChatUrlSynchronization({
+    previousPathname: "/chat",
+    pathname: "/chat",
+    controllerNavigationMatches: false,
+    urlTarget: automaticTarget,
+    currentTarget: automaticTarget,
+    currentSelectionReason: "automatic",
+    activeDraftTarget: { kind: "draft", draftId: "draft-active" },
+  });
+
+  assert.deepEqual(urlDecision, {
+    kind: "select",
+    target: automaticTarget,
+  });
+  const requestSelectionEpoch = 2;
+  const explicitSelectionEpoch = requestSelectionEpoch + 1;
+  const explicitState = selectChatWorkspaceTarget(
+    createChatWorkspaceState(automaticTarget, "automatic"),
+    automaticTarget,
+    "explicit",
+  );
+  assert.equal(explicitState.selectionReason, "explicit");
+  assert.equal(
+    resolvePostReadyAutomaticCatalogSelection({
+      requestStartedReady: true,
+      requestSelectionEpoch,
+      requestSelectionReason: "automatic",
+      currentSelectionEpoch: explicitSelectionEpoch,
+      currentSelectionReason: explicitState.selectionReason,
+      currentTarget: explicitState.target,
+      summaries: [createSummary("session-new", "running", 0)],
+      unavailableSessionIds: new Set<string>(),
+      currentTimeMs: Date.parse("2026-07-26T13:00:00.000Z"),
+      draftId: "draft-active",
+    }),
+    null,
+  );
+  assert.deepEqual(
+    resolveChatUrlSynchronization({
+      previousPathname: "/chat",
+      pathname: "/chat",
+      controllerNavigationMatches: false,
+      urlTarget: automaticTarget,
+      currentTarget: explicitState.target,
+      currentSelectionReason: explicitState.selectionReason,
+      activeDraftTarget: { kind: "draft", draftId: "draft-active" },
+    }),
+    { kind: "none" },
+  );
+});
+
+test("same-visible URL supersession uses replace and retires canceled ownership", (): void => {
+  const pendingPush = {
+    generation: 6,
+    url: "/chat?session=session-b",
+    outstandingOrigins: [],
+  } as const;
+  const writeDecision = resolveChatControllerNavigationWrite(
+    "/chat",
+    "/chat",
+    "push",
+    pendingPush.generation,
+    pendingPush,
+  );
+
+  assert.equal(writeDecision.kind, "navigate");
+  if (writeDecision.kind !== "navigate") {
+    throw new Error("Conflicting navigation must be superseded");
+  }
+  assert.equal(writeDecision.navigationMode, "replace");
+  assert.equal(writeDecision.generation, 7);
+  assert.equal(writeDecision.controllerNavigation, null);
+  assert.deepEqual(
+    resolveChatControllerNavigationObservation(
+      writeDecision.controllerNavigation,
+      7,
+      "/chat",
+    ),
+    { kind: "external" },
+  );
+  assert.deepEqual(
+    resolveChatControllerNavigationObservation(
+      writeDecision.controllerNavigation,
+      7,
+      "/chat?session=session-b",
+    ),
+    { kind: "external" },
+  );
+  assert.deepEqual(
+    resolveChatControllerNavigationWrite(
+      "/chat",
+      "/chat",
+      "replace",
+      7,
+      null,
+    ),
+    {
+      kind: "none",
+      controllerNavigation: null,
+    },
+  );
+});
+
+test("an older URL observed before the newest target settles is restored and retired", (): void => {
+  const navigationToB = resolveChatControllerNavigationWrite(
+    "/chat",
+    "/chat?session=session-b",
+    "push",
+    20,
+    null,
+  );
+  assert.equal(navigationToB.kind, "navigate");
+  if (navigationToB.kind !== "navigate") {
+    throw new Error("B navigation must be created");
+  }
+  if (navigationToB.controllerNavigation === null) {
+    throw new Error("B navigation must remain pending");
+  }
+  const navigationToC = resolveChatControllerNavigationWrite(
+    "/chat",
+    "/chat?session=session-c",
+    "push",
+    navigationToB.generation,
+    navigationToB.controllerNavigation,
+  );
+  assert.equal(navigationToC.kind, "navigate");
+  if (navigationToC.kind !== "navigate") {
+    throw new Error("C navigation must supersede B");
+  }
+  if (navigationToC.controllerNavigation === null) {
+    throw new Error("C navigation must remain pending");
+  }
+  assert.deepEqual(
+    navigationToC.controllerNavigation.outstandingOrigins,
+    [{
+      generation: navigationToB.generation,
+      url: "/chat?session=session-b",
+    }],
+  );
+
+  const staleB = resolveChatControllerNavigationObservation(
+    navigationToC.controllerNavigation,
+    navigationToC.generation,
+    "/chat?session=session-b",
+  );
+  assert.equal(staleB.kind, "restore");
+  if (staleB.kind !== "restore") {
+    throw new Error("Stale B must restore the pending C URL");
+  }
+  assert.equal(staleB.url, "/chat?session=session-c");
+  assert.deepEqual(staleB.controllerNavigation.outstandingOrigins, []);
+  assert.deepEqual(
+    resolveChatControllerNavigationObservation(
+      staleB.controllerNavigation,
+      staleB.controllerNavigation.generation,
+      "/chat?session=session-c",
+    ),
+    { kind: "settle" },
+  );
+});
+
+test("newest target settlement clears canceled origins and later old URLs are external", (): void => {
+  const navigationToB = resolveChatControllerNavigationWrite(
+    "/chat",
+    "/chat?session=session-b",
+    "push",
+    30,
+    null,
+  );
+  assert.equal(navigationToB.kind, "navigate");
+  if (navigationToB.kind !== "navigate") {
+    throw new Error("B navigation must be created");
+  }
+  if (navigationToB.controllerNavigation === null) {
+    throw new Error("B navigation must remain pending");
+  }
+  const navigationToC = resolveChatControllerNavigationWrite(
+    "/chat",
+    "/chat?session=session-c",
+    "push",
+    navigationToB.generation,
+    navigationToB.controllerNavigation,
+  );
+  assert.equal(navigationToC.kind, "navigate");
+  if (navigationToC.kind !== "navigate") {
+    throw new Error("C navigation must supersede B");
+  }
+  if (navigationToC.controllerNavigation === null) {
+    throw new Error("C navigation must remain pending");
+  }
+  assert.deepEqual(
+    resolveChatControllerNavigationObservation(
+      navigationToC.controllerNavigation,
+      navigationToC.generation,
+      "/chat?session=session-c",
+    ),
+    { kind: "settle" },
+  );
+  assert.deepEqual(
+    resolveChatControllerNavigationObservation(
+      null,
+      navigationToC.generation,
+      "/chat?session=session-b",
+    ),
+    { kind: "external" },
+  );
+  assert.deepEqual(
+    resolveChatUrlSynchronization({
+      previousPathname: "/chat",
+      pathname: "/chat",
+      controllerNavigationMatches: false,
+      urlTarget: { kind: "session", sessionId: "session-b" },
+      currentTarget: { kind: "session", sessionId: "session-c" },
+      currentSelectionReason: "explicit",
+      activeDraftTarget: { kind: "draft", draftId: "draft-a" },
+    }),
+    {
+      kind: "select",
+      target: { kind: "session", sessionId: "session-b" },
+    },
+  );
+});
+
+test("repeated B target retires C before settlement or cancels it when B settles", (): void => {
+  const firstB = resolveChatControllerNavigationWrite(
+    "/chat",
+    "/chat?session=session-b",
+    "push",
+    40,
+    null,
+  );
+  assert.equal(firstB.kind, "navigate");
+  if (firstB.kind !== "navigate") {
+    throw new Error("First B navigation must be created");
+  }
+  if (firstB.controllerNavigation === null) {
+    throw new Error("First B navigation must remain pending");
+  }
+  const navigationToC = resolveChatControllerNavigationWrite(
+    "/chat",
+    "/chat?session=session-c",
+    "push",
+    firstB.generation,
+    firstB.controllerNavigation,
+  );
+  assert.equal(navigationToC.kind, "navigate");
+  if (navigationToC.kind !== "navigate") {
+    throw new Error("C navigation must supersede the first B");
+  }
+  if (navigationToC.controllerNavigation === null) {
+    throw new Error("C navigation must remain pending");
+  }
+  const newestB = resolveChatControllerNavigationWrite(
+    "/chat",
+    "/chat?session=session-b",
+    "push",
+    navigationToC.generation,
+    navigationToC.controllerNavigation,
+  );
+  assert.equal(newestB.kind, "navigate");
+  if (newestB.kind !== "navigate") {
+    throw new Error("Newest B navigation must supersede C");
+  }
+  if (newestB.controllerNavigation === null) {
+    throw new Error("Newest B navigation must remain pending");
+  }
+  assert.deepEqual(
+    newestB.controllerNavigation.outstandingOrigins,
+    [{
+      generation: navigationToC.generation,
+      url: "/chat?session=session-c",
+    }],
+  );
+
+  const staleCBeforeB = resolveChatControllerNavigationObservation(
+    newestB.controllerNavigation,
+    newestB.generation,
+    "/chat?session=session-c",
+  );
+  assert.equal(staleCBeforeB.kind, "restore");
+  if (staleCBeforeB.kind !== "restore") {
+    throw new Error("C completion must restore newest B");
+  }
+  assert.deepEqual(staleCBeforeB.controllerNavigation.outstandingOrigins, []);
+  assert.deepEqual(
+    resolveChatControllerNavigationObservation(
+      staleCBeforeB.controllerNavigation,
+      staleCBeforeB.controllerNavigation.generation,
+      "/chat?session=session-b",
+    ),
+    { kind: "settle" },
+  );
+  assert.deepEqual(
+    resolveChatControllerNavigationObservation(
+      null,
+      newestB.generation,
+      "/chat?session=session-c",
+    ),
+    { kind: "external" },
+  );
+  assert.deepEqual(
+    resolveChatControllerNavigationObservation(
+      newestB.controllerNavigation,
+      newestB.generation,
+      "/chat?session=session-b",
+    ),
+    { kind: "settle" },
+  );
+});
+
+test("popstate retires canceled controller origins and accepts their URL exactly once", (): void => {
+  const pendingPush = {
+    generation: 10,
+    url: "/chat?session=session-b",
+    outstandingOrigins: [],
+  } as const;
+  const supersedingWrite = resolveChatControllerNavigationWrite(
+    "/chat",
+    "/chat",
+    "replace",
+    pendingPush.generation,
+    pendingPush,
+  );
+  assert.equal(supersedingWrite.kind, "navigate");
+  if (supersedingWrite.kind !== "navigate") {
+    throw new Error("Same-URL selection must supersede the pending push");
+  }
+  assert.equal(supersedingWrite.generation, 11);
+  assert.equal(supersedingWrite.controllerNavigation, null);
+
+  const retirement = resolveChatPopStateNavigation(
+    "/chat",
+    supersedingWrite.generation,
+  );
+  assert.deepEqual(retirement, {
+    generation: 12,
+    controllerNavigation: null,
+    targetNavigationMode: "none",
+  });
+  assert.deepEqual(
+    resolveChatControllerNavigationObservation(
+      retirement.controllerNavigation,
+      retirement.generation,
+      "/chat?session=session-b",
+    ),
+    { kind: "external" },
+  );
+
+  const poppedTarget = {
+    kind: "session",
+    sessionId: "session-b",
+  } as const;
+  const poppedState = selectChatWorkspaceTarget(
+    createChatWorkspaceState(
+      { kind: "draft", draftId: "draft-a" },
+      "explicit",
+    ),
+    poppedTarget,
+    "explicit",
+  );
+  assert.deepEqual(poppedState.target, poppedTarget);
+  assert.deepEqual(
+    resolveChatUrlSynchronization({
+      previousPathname: "/chat",
+      pathname: "/chat",
+      controllerNavigationMatches: false,
+      urlTarget: poppedTarget,
+      currentTarget: poppedState.target,
+      currentSelectionReason: poppedState.selectionReason,
+      activeDraftTarget: { kind: "draft", draftId: "draft-a" },
+    }),
+    { kind: "none" },
+  );
+});
+
+test("non-chat popstate retires pending chat ownership without replacement navigation", (): void => {
+  const pendingChatNavigation = {
+    generation: 50,
+    url: "/chat?session=session-b",
+    outstandingOrigins: [{
+      generation: 49,
+      url: "/chat?session=session-a",
+    }],
+  } as const;
+  const popStateNavigation = resolveChatPopStateNavigation(
+    "/balances",
+    pendingChatNavigation.generation,
+  );
+
+  assert.deepEqual(popStateNavigation, {
+    generation: 51,
+    controllerNavigation: null,
+    targetNavigationMode: null,
+  });
+  assert.deepEqual(
+    resolveChatControllerNavigationObservation(
+      popStateNavigation.controllerNavigation,
+      popStateNavigation.generation,
+      pendingChatNavigation.url,
+    ),
+    { kind: "external" },
+  );
+  assert.deepEqual(
+    resolveChatUrlSynchronization({
+      previousPathname: "/chat",
+      pathname: "/balances",
+      controllerNavigationMatches: false,
+      urlTarget: { kind: "session", sessionId: "session-b" },
+      currentTarget: { kind: "session", sessionId: "session-a" },
+      currentSelectionReason: "explicit",
+      activeDraftTarget: { kind: "draft", draftId: "draft-a" },
+    }),
+    { kind: "none" },
+  );
+});
+
+test("same-path URL removal selects the active draft and chat entry restores an explicit session URL", (): void => {
+  const commonInput = {
+    pathname: "/chat",
+    controllerNavigationMatches: false,
+    urlTarget: null,
+    currentTarget: { kind: "session", sessionId: "session-a" },
+    currentSelectionReason: "explicit",
+    activeDraftTarget: { kind: "draft", draftId: "draft-active" },
+  } as const;
+
+  assert.deepEqual(
+    resolveChatUrlSynchronization({
+      ...commonInput,
+      previousPathname: "/chat",
+    }),
+    {
+      kind: "select",
+      target: { kind: "draft", draftId: "draft-active" },
+    },
+  );
+  assert.deepEqual(
+    resolveChatUrlSynchronization({
+      ...commonInput,
+      previousPathname: "/balances",
+    }),
+    {
+      kind: "navigate",
+      target: { kind: "session", sessionId: "session-a" },
+    },
+  );
+});
+
+test("recovery notices remain visible until catalog success or failure settles them", (): void => {
+  assert.equal(
+    resolveChatHistoryErrorMessage(
+      null,
+      "This chat is unavailable. A safe chat was selected.",
+    ),
+    "This chat is unavailable. A safe chat was selected.",
+  );
+  assert.equal(
+    resolveChatHistoryErrorMessage(
+      "Chat session catalog request failed: status=503",
+      "This chat is unavailable. A safe chat was selected.",
+    ),
+    "Chat session catalog request failed: status=503",
+  );
+  assert.equal(resolveChatHistoryErrorMessage(null, null), null);
+});
+
+test("history shows loading instead of empty until the first page settles", (): void => {
+  assert.deepEqual(
+    resolveChatHistoryStatusVisibility(0, true, false, null),
+    {
+      showEmpty: false,
+      showLoading: true,
+    },
+  );
+  assert.deepEqual(
+    resolveChatHistoryStatusVisibility(0, false, true, null),
+    {
+      showEmpty: true,
+      showLoading: false,
+    },
+  );
+  assert.deepEqual(
+    resolveChatHistoryStatusVisibility(0, false, false, null),
+    {
+      showEmpty: false,
+      showLoading: false,
+    },
+  );
+});
+
+test("history pagination focus stays with Load more or moves to New on the final page", (): void => {
+  assert.equal(
+    resolveChatHistoryPaginationFocus(true, true),
+    "load_more",
+  );
+  assert.equal(
+    resolveChatHistoryPaginationFocus(true, false),
+    "create_draft",
+  );
+  assert.equal(
+    resolveChatHistoryPaginationFocus(false, false),
+    "none",
+  );
 });

--- a/apps/web/src/ui/chat/workspace/useChatWorkspaceController.ts
+++ b/apps/web/src/ui/chat/workspace/useChatWorkspaceController.ts
@@ -1,0 +1,1440 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type SetStateAction,
+} from "react";
+import {
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
+import { useTranslation } from "react-i18next";
+
+import {
+  getMainContentInvalidationSourceId,
+  publishMainContentInvalidation,
+} from "../session/invalidation/mainContentInvalidationChannel";
+import {
+  buildChatTargetUrl,
+  clearChatSelection,
+  getChatSelectionStorageKey,
+  parseStoredChatTarget,
+  readChatActiveDraftId,
+  readChatSelection,
+  readChatSessionTargetFromSearchParams,
+  writeChatActiveDraftId,
+  writeChatSelection,
+  type ChatSelectionScope,
+} from "./chatSelectionStorage";
+import {
+  fetchChatSessionSummaryPage,
+  type ChatSessionSummary,
+  type ChatSessionSummaryPage,
+} from "./chatSessionSummaryTransport";
+import {
+  areChatTargetsEqual,
+  appendChatSessionCatalogPage,
+  createChatWorkspaceState,
+  failChatSessionCatalogLoad,
+  findChatSessionInvalidationIncrements,
+  getRunningChatSessionCount,
+  observeChatSessionInvalidationVersion,
+  replaceChatSessionCatalog,
+  resolveAutomaticChatTarget,
+  resolveFailedSessionRecoveryTarget,
+  resolveNewChatDraftTarget,
+  selectChatWorkspaceTarget,
+  startChatSessionCatalogLoad,
+  type ChatSelectionReason,
+  type ChatTarget,
+  type ChatWorkspaceState,
+} from "./chatWorkspaceState";
+
+const CHAT_SESSION_CATALOG_LIMIT = 100;
+
+type NavigationMode = "none" | "push" | "replace";
+
+export type ChatWorkspaceInvalidationSource = "live" | "snapshot";
+
+export type ChatDraftSessionAdoption =
+  | Readonly<{
+    kind: "selected";
+    target: Extract<ChatTarget, { kind: "session" }>;
+    selectionEpoch: number;
+  }>
+  | Readonly<{
+    kind: "background";
+    target: Extract<ChatTarget, { kind: "session" }>;
+  }>;
+
+type UseChatWorkspaceControllerParams = Readonly<{
+  scope: ChatSelectionScope;
+}>;
+
+export type ChatWorkspaceController = Readonly<{
+  state: ChatWorkspaceState;
+  selectionEpoch: number;
+  isReady: boolean;
+  historyOpen: boolean;
+  historyErrorMessage: string | null;
+  runningCount: number;
+  setHistoryOpen: (open: boolean) => void;
+  selectSession: (sessionId: string) => void;
+  createDraft: (isSelectedDraftUntouched: boolean) => void;
+  adoptDraftSession: (
+    draftId: string,
+    sessionId: string,
+  ) => ChatDraftSessionAdoption;
+  isSelectionCurrent: (
+    target: ChatTarget,
+    selectionEpoch: number,
+  ) => boolean;
+  refreshCatalog: () => Promise<void>;
+  loadNextCatalogPage: () => Promise<void>;
+  observeSessionInvalidation: (
+    sessionId: string,
+    version: number,
+    source: ChatWorkspaceInvalidationSource,
+  ) => void;
+  recoverInvalidSessionSelection: (
+    sessionId: string,
+    errorMessage: string,
+  ) => boolean;
+}>;
+
+const createDraftId = (): string => {
+  if (typeof crypto === "undefined" || typeof crypto.randomUUID !== "function") {
+    throw new Error("Browser crypto.randomUUID is unavailable for local chat drafts");
+  }
+
+  return `draft-${crypto.randomUUID()}`;
+};
+
+type ChatBootstrapSelectionInput = Readonly<{
+  bootstrapSelectionEpoch: number;
+  currentSelectionEpoch: number;
+  currentTarget: ChatTarget;
+  currentSelectionReason: ChatSelectionReason;
+  urlTarget: ChatTarget | null;
+  storedTarget: ChatTarget | null;
+  automaticTarget: ChatTarget;
+}>;
+
+export type ChatBootstrapSelection = Readonly<{
+  target: ChatTarget;
+  selectionReason: ChatSelectionReason;
+  selectionChangedDuringBootstrap: boolean;
+}>;
+
+export const resolveChatBootstrapSelection = (
+  input: ChatBootstrapSelectionInput,
+): ChatBootstrapSelection => {
+  if (input.currentSelectionEpoch !== input.bootstrapSelectionEpoch) {
+    return {
+      target: input.currentTarget,
+      selectionReason: input.currentSelectionReason,
+      selectionChangedDuringBootstrap: true,
+    };
+  }
+
+  const target = input.urlTarget
+    ?? input.storedTarget
+    ?? input.automaticTarget;
+  return {
+    target,
+    selectionReason:
+      input.urlTarget !== null || input.storedTarget !== null
+        ? "explicit"
+        : "automatic",
+    selectionChangedDuringBootstrap: false,
+  };
+};
+
+type ChatBootstrapRecoveryInput = Readonly<{
+  selection: ChatBootstrapSelection;
+  hasUrlSessionParameter: boolean;
+  urlSelectionFailed: boolean;
+  storedTarget: ChatTarget | null;
+  storedSelectionFailed: boolean;
+  activeDraftFailed: boolean;
+}>;
+
+export type ChatBootstrapRecoveryDecision = Readonly<{
+  showRecoveryNotice: boolean;
+  shouldReplaceUrl: boolean;
+}>;
+
+export const resolveChatBootstrapRecovery = (
+  input: ChatBootstrapRecoveryInput,
+): ChatBootstrapRecoveryDecision => {
+  if (input.selection.selectionChangedDuringBootstrap) {
+    return {
+      showRecoveryNotice: false,
+      shouldReplaceUrl: false,
+    };
+  }
+  if (input.hasUrlSessionParameter) {
+    return input.urlSelectionFailed
+      ? {
+          showRecoveryNotice: true,
+          shouldReplaceUrl: true,
+        }
+      : {
+          showRecoveryNotice: false,
+          shouldReplaceUrl: false,
+        };
+  }
+  if (input.storedSelectionFailed) {
+    return {
+      showRecoveryNotice: true,
+      shouldReplaceUrl: false,
+    };
+  }
+  if (input.storedTarget !== null) {
+    return {
+      showRecoveryNotice: false,
+      shouldReplaceUrl: false,
+    };
+  }
+
+  return {
+    showRecoveryNotice:
+      input.activeDraftFailed && input.selection.target.kind === "draft",
+    shouldReplaceUrl: false,
+  };
+};
+
+type ChatUrlSynchronizationInput = Readonly<{
+  previousPathname: string;
+  pathname: string;
+  controllerNavigationMatches: boolean;
+  urlTarget: ChatTarget | null;
+  currentTarget: ChatTarget;
+  currentSelectionReason: ChatSelectionReason;
+  activeDraftTarget: Extract<ChatTarget, { kind: "draft" }>;
+}>;
+
+export type ChatUrlSynchronizationDecision =
+  | Readonly<{ kind: "none" }>
+  | Readonly<{ kind: "navigate"; target: ChatTarget }>
+  | Readonly<{ kind: "select"; target: ChatTarget }>;
+
+export const resolveChatUrlSynchronization = (
+  input: ChatUrlSynchronizationInput,
+): ChatUrlSynchronizationDecision => {
+  if (
+    input.pathname !== "/chat"
+    || input.controllerNavigationMatches
+  ) {
+    return { kind: "none" };
+  }
+  if (input.urlTarget !== null) {
+    return (
+      areChatTargetsEqual(input.currentTarget, input.urlTarget)
+      && input.currentSelectionReason === "explicit"
+    )
+      ? { kind: "none" }
+      : { kind: "select", target: input.urlTarget };
+  }
+  if (input.previousPathname === "/chat") {
+    return (
+      input.currentTarget.kind === "draft"
+      && input.currentSelectionReason === "explicit"
+      && areChatTargetsEqual(
+        input.currentTarget,
+        input.activeDraftTarget,
+      )
+    )
+      ? { kind: "none" }
+      : { kind: "select", target: input.activeDraftTarget };
+  }
+  if (
+    input.currentTarget.kind === "session"
+    && input.currentSelectionReason === "explicit"
+  ) {
+    return { kind: "navigate", target: input.currentTarget };
+  }
+
+  return { kind: "none" };
+};
+
+export const resolveChatHistoryErrorMessage = (
+  catalogErrorMessage: string | null,
+  recoveryNotice: string | null,
+): string | null =>
+  catalogErrorMessage ?? recoveryNotice;
+
+export type ChatHistoryStatusVisibility = Readonly<{
+  showEmpty: boolean;
+  showLoading: boolean;
+}>;
+
+export const resolveChatHistoryStatusVisibility = (
+  sessionCount: number,
+  isLoading: boolean,
+  hasLoadedFirstPage: boolean,
+  errorMessage: string | null,
+): ChatHistoryStatusVisibility => {
+  if (!Number.isSafeInteger(sessionCount) || sessionCount < 0) {
+    throw new Error(
+      "Chat history session count must be a non-negative safe integer",
+    );
+  }
+
+  return {
+    showLoading: isLoading && sessionCount === 0,
+    showEmpty:
+      hasLoadedFirstPage
+      && !isLoading
+      && sessionCount === 0
+      && errorMessage === null,
+  };
+};
+
+export type ChatHistoryPaginationFocusTarget =
+  | "none"
+  | "load_more"
+  | "create_draft";
+
+export const resolveChatHistoryPaginationFocus = (
+  loadMoreOwnsFocus: boolean,
+  hasMore: boolean,
+): ChatHistoryPaginationFocusTarget => {
+  if (!loadMoreOwnsFocus) {
+    return "none";
+  }
+  return hasMore ? "load_more" : "create_draft";
+};
+
+export const shouldReuseSelectedChatDraft = (
+  isReady: boolean,
+  currentTarget: ChatTarget,
+  isSelectedDraftUntouched: boolean,
+): boolean =>
+  isReady
+  && currentTarget.kind === "draft"
+  && isSelectedDraftUntouched;
+
+type PostReadyAutomaticCatalogSelectionInput = Readonly<{
+  requestStartedReady: boolean;
+  requestSelectionEpoch: number;
+  requestSelectionReason: ChatSelectionReason;
+  currentSelectionEpoch: number;
+  currentSelectionReason: ChatSelectionReason;
+  currentTarget: ChatTarget;
+  summaries: ReadonlyArray<ChatSessionSummary>;
+  unavailableSessionIds: ReadonlySet<string>;
+  currentTimeMs: number;
+  draftId: string;
+}>;
+
+export const resolvePostReadyAutomaticCatalogSelection = (
+  input: PostReadyAutomaticCatalogSelectionInput,
+): ChatTarget | null => {
+  if (
+    !input.requestStartedReady
+    || input.requestSelectionReason !== "automatic"
+    || input.currentSelectionEpoch !== input.requestSelectionEpoch
+    || input.currentSelectionReason !== "automatic"
+  ) {
+    return null;
+  }
+
+  const target = resolveAutomaticChatTarget(
+    input.summaries.filter(
+      (summary): boolean =>
+        !input.unavailableSessionIds.has(summary.sessionId),
+    ),
+    input.currentTimeMs,
+    input.draftId,
+  );
+  return areChatTargetsEqual(input.currentTarget, target) ? null : target;
+};
+
+export type InvalidChatUrlRecoveryDecision = Readonly<{
+  target: ChatTarget;
+  selectionReason: ChatSelectionReason;
+  shouldClearStoredSelection: boolean;
+}>;
+
+export const resolveInvalidChatUrlRecovery = (
+  storage: Storage,
+  scope: ChatSelectionScope,
+  summaries: ReadonlyArray<ChatSessionSummary>,
+  currentTimeMs: number,
+  draftId: string,
+): InvalidChatUrlRecoveryDecision => {
+  const storedValue = storage.getItem(getChatSelectionStorageKey(scope));
+  if (storedValue === null) {
+    return {
+      target: resolveAutomaticChatTarget(
+        summaries,
+        currentTimeMs,
+        draftId,
+      ),
+      selectionReason: "automatic",
+      shouldClearStoredSelection: false,
+    };
+  }
+
+  let storedTarget: ChatTarget | null;
+  try {
+    storedTarget = parseStoredChatTarget(storedValue);
+  } catch {
+    return {
+      target: resolveAutomaticChatTarget(
+        summaries,
+        currentTimeMs,
+        draftId,
+      ),
+      selectionReason: "automatic",
+      shouldClearStoredSelection: true,
+    };
+  }
+  return storedTarget === null
+    ? {
+      target: resolveAutomaticChatTarget(
+        summaries,
+        currentTimeMs,
+        draftId,
+      ),
+      selectionReason: "automatic",
+      shouldClearStoredSelection: false,
+    }
+    : {
+      target: storedTarget,
+      selectionReason: "explicit",
+      shouldClearStoredSelection: false,
+    };
+};
+
+export type ChatControllerNavigationOrigin = Readonly<{
+  generation: number;
+  url: string;
+}>;
+
+export type ChatControllerNavigation = Readonly<{
+  generation: number;
+  url: string;
+  outstandingOrigins: ReadonlyArray<ChatControllerNavigationOrigin>;
+}>;
+
+export type ChatControllerNavigationWriteDecision =
+  | Readonly<{
+    kind: "none";
+    controllerNavigation: ChatControllerNavigation | null;
+  }>
+  | Readonly<{
+    kind: "navigate";
+    navigationMode: Exclude<NavigationMode, "none">;
+    generation: number;
+    controllerNavigation: ChatControllerNavigation | null;
+  }>;
+
+export const resolveChatControllerNavigationWrite = (
+  currentUrl: string,
+  targetUrl: string,
+  requestedNavigationMode: Exclude<NavigationMode, "none">,
+  currentGeneration: number,
+  controllerNavigation: ChatControllerNavigation | null,
+): ChatControllerNavigationWriteDecision => {
+  const activeControllerNavigation =
+    controllerNavigation?.generation === currentGeneration
+      ? controllerNavigation
+      : null;
+  if (
+    activeControllerNavigation?.url === targetUrl
+    || (
+      activeControllerNavigation === null
+      && currentUrl === targetUrl
+    )
+  ) {
+    return {
+      kind: "none",
+      controllerNavigation: activeControllerNavigation,
+    };
+  }
+
+  const nextGeneration = currentGeneration + 1;
+  if (currentUrl === targetUrl) {
+    return {
+      kind: "navigate",
+      navigationMode: "replace",
+      generation: nextGeneration,
+      controllerNavigation: null,
+    };
+  }
+
+  const outstandingOrigins = activeControllerNavigation === null
+    ? []
+    : [
+      ...activeControllerNavigation.outstandingOrigins,
+      {
+        generation: activeControllerNavigation.generation,
+        url: activeControllerNavigation.url,
+      },
+    ].filter(
+      (origin): boolean => origin.url !== targetUrl,
+    );
+  return {
+    kind: "navigate",
+    navigationMode: requestedNavigationMode,
+    generation: nextGeneration,
+    controllerNavigation: {
+      generation: nextGeneration,
+      url: targetUrl,
+      outstandingOrigins,
+    },
+  };
+};
+
+export type ChatControllerNavigationObservation =
+  | Readonly<{ kind: "external" }>
+  | Readonly<{
+    kind: "settle";
+  }>
+  | Readonly<{
+    kind: "restore";
+    url: string;
+    controllerNavigation: ChatControllerNavigation;
+  }>;
+
+export const resolveChatControllerNavigationObservation = (
+  controllerNavigation: ChatControllerNavigation | null,
+  currentGeneration: number,
+  currentUrl: string,
+): ChatControllerNavigationObservation => {
+  if (
+    controllerNavigation === null
+    || controllerNavigation.generation !== currentGeneration
+  ) {
+    return { kind: "external" };
+  }
+  if (controllerNavigation.url === currentUrl) {
+    return { kind: "settle" };
+  }
+  const completedOrigin = controllerNavigation.outstandingOrigins.find(
+    (origin): boolean => origin.url === currentUrl,
+  );
+  if (completedOrigin !== undefined) {
+    return {
+      kind: "restore",
+      url: controllerNavigation.url,
+      controllerNavigation: {
+        ...controllerNavigation,
+        outstandingOrigins:
+          controllerNavigation.outstandingOrigins.filter(
+            (origin): boolean =>
+              origin.generation !== completedOrigin.generation,
+          ),
+      },
+    };
+  }
+  return { kind: "external" };
+};
+
+export type ChatControllerNavigationRetirement = Readonly<{
+  generation: number;
+  controllerNavigation: null;
+}>;
+
+export const retireChatControllerNavigation = (
+  currentGeneration: number,
+): ChatControllerNavigationRetirement => ({
+  generation: currentGeneration + 1,
+  controllerNavigation: null,
+});
+
+export type ChatPopStateNavigation = ChatControllerNavigationRetirement &
+  Readonly<{
+    targetNavigationMode: "none" | null;
+  }>;
+
+export const resolveChatPopStateNavigation = (
+  pathname: string,
+  currentGeneration: number,
+): ChatPopStateNavigation => ({
+  ...retireChatControllerNavigation(currentGeneration),
+  targetNavigationMode: pathname === "/chat" ? "none" : null,
+});
+
+export const useChatWorkspaceController = (
+  params: UseChatWorkspaceControllerParams,
+): ChatWorkspaceController => {
+  const { scope } = params;
+  const { t } = useTranslation();
+  const workspaceId = scope.mode === "workspace" ? scope.workspaceId : "";
+  const stableScope = useMemo<ChatSelectionScope>(
+    () => scope.mode === "demo"
+      ? { mode: "demo", userId: scope.userId }
+      : {
+        mode: "workspace",
+        userId: scope.userId,
+        workspaceId,
+      },
+    [scope.mode, scope.userId, workspaceId],
+  );
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
+  const translationRef = useRef(t);
+  translationRef.current = t;
+  const scopeKey = getChatSelectionStorageKey(stableScope);
+  const initialTarget = { kind: "draft", draftId: "initializing" } as const;
+  const [state, setState] = useState<ChatWorkspaceState>(
+    createChatWorkspaceState(initialTarget, "automatic"),
+  );
+  const [selectionEpoch, setSelectionEpoch] = useState<number>(0);
+  const [isReady, setIsReady] = useState<boolean>(false);
+  const [historyOpen, setHistoryOpenState] = useState<boolean>(false);
+  const [recoveryNotice, setRecoveryNotice] = useState<string | null>(null);
+  const stateRef = useRef<ChatWorkspaceState>(state);
+  const selectionEpochRef = useRef<number>(selectionEpoch);
+  const isReadyRef = useRef<boolean>(isReady);
+  const activeDraftIdRef = useRef<string | null>(null);
+  const unavailableSessionIdsRef = useRef<Set<string>>(new Set<string>());
+  const hasRefreshedUnavailableSessionsRef = useRef<boolean>(false);
+  const catalogRequestIdRef = useRef<number>(0);
+  const catalogAbortRef = useRef<AbortController | null>(null);
+  const navigationGenerationRef = useRef<number>(0);
+  const controllerNavigationRef =
+    useRef<ChatControllerNavigation | null>(null);
+  const invalidationSourceIdRef = useRef<string | null>(null);
+  const lastInvalidationEmittedAtRef = useRef<number>(0);
+  const observedUrlRef = useRef<string | null>(null);
+
+  const commitState = useCallback((
+    update: SetStateAction<ChatWorkspaceState>,
+  ): ChatWorkspaceState => {
+    const nextState = typeof update === "function"
+      ? update(stateRef.current)
+      : update;
+    stateRef.current = nextState;
+    setState(nextState);
+    return nextState;
+  }, []);
+
+  const commitSelectionEpoch = useCallback((nextEpoch: number): void => {
+    selectionEpochRef.current = nextEpoch;
+    setSelectionEpoch(nextEpoch);
+  }, []);
+
+  const commitReady = useCallback((nextReady: boolean): void => {
+    isReadyRef.current = nextReady;
+    setIsReady(nextReady);
+  }, []);
+
+  const commitRecoveryNotice = useCallback((
+    nextRecoveryNotice: string | null,
+  ): void => {
+    setRecoveryNotice(nextRecoveryNotice);
+  }, []);
+
+  const commitActiveDraftId = useCallback((
+    draftId: string | null,
+  ): void => {
+    activeDraftIdRef.current = draftId;
+    writeChatActiveDraftId(window.sessionStorage, stableScope, draftId);
+  }, [stableScope]);
+
+  const navigateToTarget = useCallback((
+    target: ChatTarget,
+    navigationMode: NavigationMode,
+  ): void => {
+    if (navigationMode === "none" || window.location.pathname !== "/chat") {
+      return;
+    }
+
+    const url = buildChatTargetUrl(target);
+    const currentUrl = `${window.location.pathname}${window.location.search}`;
+    const decision = resolveChatControllerNavigationWrite(
+      currentUrl,
+      url,
+      navigationMode,
+      navigationGenerationRef.current,
+      controllerNavigationRef.current,
+    );
+    controllerNavigationRef.current = decision.controllerNavigation;
+    if (decision.kind === "none") {
+      return;
+    }
+
+    navigationGenerationRef.current = decision.generation;
+    if (decision.navigationMode === "push") {
+      router.push(url, { scroll: false });
+      return;
+    }
+
+    router.replace(url, { scroll: false });
+  }, [router]);
+
+  const persistSelectedTarget = useCallback((
+    target: ChatTarget,
+    selectionReason: ChatSelectionReason,
+  ): void => {
+    if (selectionReason !== "explicit") {
+      return;
+    }
+
+    writeChatSelection(window.sessionStorage, stableScope, target);
+  }, [stableScope]);
+
+  const selectTarget = useCallback((
+    target: ChatTarget,
+    selectionReason: ChatSelectionReason,
+    navigationMode: NavigationMode,
+  ): void => {
+    const currentState = stateRef.current;
+    if (
+      areChatTargetsEqual(currentState.target, target)
+      && currentState.selectionReason === selectionReason
+    ) {
+      if (navigationMode === "replace") {
+        navigateToTarget(target, navigationMode);
+      }
+      return;
+    }
+
+    const nextEpoch = selectionEpochRef.current + 1;
+    commitSelectionEpoch(nextEpoch);
+    commitState(selectChatWorkspaceTarget(
+      currentState,
+      target,
+      selectionReason,
+    ));
+    persistSelectedTarget(target, selectionReason);
+    navigateToTarget(target, navigationMode);
+  }, [
+    commitSelectionEpoch,
+    commitState,
+    navigateToTarget,
+    persistSelectedTarget,
+  ]);
+
+  const publishInvalidation = useCallback((
+    version: number,
+  ): void => {
+    if (invalidationSourceIdRef.current === null) {
+      invalidationSourceIdRef.current = getMainContentInvalidationSourceId();
+    }
+    const emittedAt = Math.max(
+      Date.now(),
+      lastInvalidationEmittedAtRef.current + 1,
+    );
+    lastInvalidationEmittedAtRef.current = emittedAt;
+
+    publishMainContentInvalidation({
+      workspaceId,
+      version,
+      sourceId: invalidationSourceIdRef.current,
+      emittedAt,
+    });
+    if (window.location.pathname !== "/chat") {
+      router.refresh();
+    }
+  }, [router, workspaceId]);
+
+  const publishCatalogPageInvalidations = useCallback((
+    currentState: ChatWorkspaceState,
+    nextState: ChatWorkspaceState,
+    page: ChatSessionSummaryPage,
+  ): void => {
+    const increments = findChatSessionInvalidationIncrements(
+      currentState.mainContentInvalidationVersions,
+      page.sessions,
+    );
+    commitState(nextState);
+    for (const increment of increments) {
+      publishInvalidation(increment.nextVersion);
+    }
+  }, [commitState, publishInvalidation]);
+
+  const applyFirstCatalogPage = useCallback((
+    page: ChatSessionSummaryPage,
+  ): void => {
+    const currentState = stateRef.current;
+    publishCatalogPageInvalidations(
+      currentState,
+      replaceChatSessionCatalog(currentState, page),
+      page,
+    );
+    commitRecoveryNotice(null);
+    if (unavailableSessionIdsRef.current.size > 0) {
+      const catalogSessionIds = new Set(
+        page.sessions.map((summary): string => summary.sessionId),
+      );
+      const remainingUnavailableSessionIds = new Set(
+        [...unavailableSessionIdsRef.current].filter(
+          (sessionId: string): boolean => catalogSessionIds.has(sessionId),
+        ),
+      );
+      unavailableSessionIdsRef.current = remainingUnavailableSessionIds;
+      if (remainingUnavailableSessionIds.size === 0) {
+        hasRefreshedUnavailableSessionsRef.current = false;
+      }
+    }
+  }, [commitRecoveryNotice, publishCatalogPageInvalidations]);
+
+  const applyNextCatalogPage = useCallback((
+    page: ChatSessionSummaryPage,
+  ): void => {
+    const currentState = stateRef.current;
+    publishCatalogPageInvalidations(
+      currentState,
+      appendChatSessionCatalogPage(currentState, page),
+      page,
+    );
+    commitRecoveryNotice(null);
+  }, [commitRecoveryNotice, publishCatalogPageInvalidations]);
+
+  const loadCatalogPage = useCallback(async (): Promise<ChatSessionSummaryPage | null> => {
+    const requestStartedReady = isReadyRef.current;
+    const requestSelectionEpoch = selectionEpochRef.current;
+    const requestSelectionReason = stateRef.current.selectionReason;
+    const reconcilePostReadyAutomaticSelection = (
+      page: ChatSessionSummaryPage,
+    ): void => {
+      const draftId = activeDraftIdRef.current ?? createDraftId();
+      const target = resolvePostReadyAutomaticCatalogSelection({
+        requestStartedReady,
+        requestSelectionEpoch,
+        requestSelectionReason,
+        currentSelectionEpoch: selectionEpochRef.current,
+        currentSelectionReason: stateRef.current.selectionReason,
+        currentTarget: stateRef.current.target,
+        summaries: page.sessions,
+        unavailableSessionIds: unavailableSessionIdsRef.current,
+        currentTimeMs: Date.now(),
+        draftId,
+      });
+      if (target === null) {
+        return;
+      }
+      if (
+        activeDraftIdRef.current === null
+        || target.kind === "draft"
+      ) {
+        commitActiveDraftId(draftId);
+      }
+      selectTarget(target, "automatic", "replace");
+    };
+
+    if (stableScope.mode === "demo") {
+      const page: ChatSessionSummaryPage = {
+        sessions: [],
+        nextCursor: null,
+      };
+      applyFirstCatalogPage(page);
+      reconcilePostReadyAutomaticSelection(page);
+      return page;
+    }
+
+    const requestId = catalogRequestIdRef.current + 1;
+    catalogRequestIdRef.current = requestId;
+    catalogAbortRef.current?.abort();
+    const abortController = new AbortController();
+    catalogAbortRef.current = abortController;
+    commitState(startChatSessionCatalogLoad(stateRef.current));
+
+    try {
+      const page = await fetchChatSessionSummaryPage(
+        CHAT_SESSION_CATALOG_LIMIT,
+        null,
+        abortController.signal,
+      );
+      if (
+        abortController.signal.aborted
+        || requestId !== catalogRequestIdRef.current
+      ) {
+        return null;
+      }
+
+      applyFirstCatalogPage(page);
+      reconcilePostReadyAutomaticSelection(page);
+      return page;
+    } catch (error) {
+      if (
+        abortController.signal.aborted
+        || requestId !== catalogRequestIdRef.current
+      ) {
+        return null;
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      commitRecoveryNotice(null);
+      commitState(failChatSessionCatalogLoad(stateRef.current, message));
+      return null;
+    } finally {
+      if (catalogAbortRef.current === abortController) {
+        catalogAbortRef.current = null;
+      }
+    }
+  }, [
+    applyFirstCatalogPage,
+    commitActiveDraftId,
+    commitRecoveryNotice,
+    commitState,
+    selectTarget,
+    stableScope.mode,
+  ]);
+
+  const refreshCatalog = useCallback(async (): Promise<void> => {
+    await loadCatalogPage();
+  }, [loadCatalogPage]);
+
+  const loadNextCatalogPage = useCallback(async (): Promise<void> => {
+    if (stableScope.mode === "demo" || catalogAbortRef.current !== null) {
+      return;
+    }
+
+    const nextCursor = stateRef.current.pagination.nextCursor;
+    if (nextCursor === null) {
+      return;
+    }
+
+    const requestId = catalogRequestIdRef.current + 1;
+    catalogRequestIdRef.current = requestId;
+    const abortController = new AbortController();
+    catalogAbortRef.current = abortController;
+    commitState(startChatSessionCatalogLoad(stateRef.current));
+
+    try {
+      const page = await fetchChatSessionSummaryPage(
+        CHAT_SESSION_CATALOG_LIMIT,
+        nextCursor,
+        abortController.signal,
+      );
+      if (
+        abortController.signal.aborted
+        || requestId !== catalogRequestIdRef.current
+      ) {
+        return;
+      }
+
+      applyNextCatalogPage(page);
+    } catch (error) {
+      if (
+        abortController.signal.aborted
+        || requestId !== catalogRequestIdRef.current
+      ) {
+        return;
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      commitRecoveryNotice(null);
+      commitState(failChatSessionCatalogLoad(stateRef.current, message));
+    } finally {
+      if (catalogAbortRef.current === abortController) {
+        catalogAbortRef.current = null;
+      }
+    }
+  }, [
+    applyNextCatalogPage,
+    commitRecoveryNotice,
+    commitState,
+    stableScope.mode,
+  ]);
+
+  const recoverToSafeTarget = useCallback((
+    errorMessage: string,
+    excludedSessionIds: ReadonlySet<string> | null,
+  ): void => {
+    const draftId = activeDraftIdRef.current ?? createDraftId();
+    if (activeDraftIdRef.current === null) {
+      commitActiveDraftId(draftId);
+    }
+    const safeTarget = excludedSessionIds === null
+      ? resolveAutomaticChatTarget(
+        stateRef.current.summaries,
+        Date.now(),
+        draftId,
+      )
+      : resolveFailedSessionRecoveryTarget(
+        stateRef.current.summaries,
+        excludedSessionIds,
+        Date.now(),
+        draftId,
+      );
+    if (safeTarget.kind === "draft") {
+      commitActiveDraftId(safeTarget.draftId);
+    }
+
+    clearChatSelection(window.sessionStorage, stableScope);
+    commitRecoveryNotice(errorMessage);
+    selectTarget(safeTarget, "automatic", "replace");
+  }, [
+    commitActiveDraftId,
+    commitRecoveryNotice,
+    selectTarget,
+    stableScope,
+  ]);
+
+  const recoverInvalidUrlSelection = useCallback((
+    errorMessage: string,
+  ): void => {
+    const draftId = activeDraftIdRef.current ?? createDraftId();
+    const decision = resolveInvalidChatUrlRecovery(
+      window.sessionStorage,
+      stableScope,
+      stateRef.current.summaries,
+      Date.now(),
+      draftId,
+    );
+    if (decision.shouldClearStoredSelection) {
+      clearChatSelection(window.sessionStorage, stableScope);
+    }
+    if (
+      activeDraftIdRef.current === null
+      || decision.target.kind === "draft"
+    ) {
+      commitActiveDraftId(
+        decision.target.kind === "draft"
+          ? decision.target.draftId
+          : draftId,
+      );
+    }
+
+    commitRecoveryNotice(errorMessage);
+    selectTarget(
+      decision.target,
+      decision.selectionReason,
+      "replace",
+    );
+  }, [
+    commitActiveDraftId,
+    commitRecoveryNotice,
+    selectTarget,
+    stableScope,
+  ]);
+
+  useEffect(() => {
+    let isCurrentScope = true;
+    catalogAbortRef.current?.abort();
+    catalogRequestIdRef.current += 1;
+    activeDraftIdRef.current = null;
+    unavailableSessionIdsRef.current = new Set<string>();
+    hasRefreshedUnavailableSessionsRef.current = false;
+    controllerNavigationRef.current = null;
+    commitReady(false);
+    commitRecoveryNotice(null);
+    commitSelectionEpoch(0);
+    commitState(createChatWorkspaceState(initialTarget, "automatic"));
+
+    void (async (): Promise<void> => {
+      let storedTarget: ChatTarget | null = null;
+      let storedActiveDraftId: string | null = null;
+      let storedSelectionFailed = false;
+      let activeDraftFailed = false;
+      const bootstrapSelectionEpoch = selectionEpochRef.current;
+
+      try {
+        storedTarget = readChatSelection(window.sessionStorage, stableScope);
+      } catch {
+        storedSelectionFailed = true;
+        clearChatSelection(window.sessionStorage, stableScope);
+      }
+
+      try {
+        storedActiveDraftId = readChatActiveDraftId(
+          window.sessionStorage,
+          stableScope,
+        );
+      } catch {
+        activeDraftFailed = true;
+        writeChatActiveDraftId(window.sessionStorage, stableScope, null);
+      }
+      const draftId = storedActiveDraftId ?? createDraftId();
+      commitActiveDraftId(draftId);
+
+      const page = await loadCatalogPage();
+      if (!isCurrentScope) {
+        return;
+      }
+
+      const currentPathname = window.location.pathname;
+      const currentSearchParams = new URLSearchParams(window.location.search);
+      const hasUrlSessionParameter = currentPathname === "/chat"
+        && currentSearchParams.has("session");
+      let urlTarget: ChatTarget | null = null;
+      let urlSelectionFailed = false;
+      try {
+        urlTarget = currentPathname === "/chat"
+          ? readChatSessionTargetFromSearchParams(currentSearchParams)
+          : null;
+      } catch {
+        urlSelectionFailed = true;
+      }
+      const bootstrapSelection = resolveChatBootstrapSelection({
+        bootstrapSelectionEpoch,
+        currentSelectionEpoch: selectionEpochRef.current,
+        currentTarget: stateRef.current.target,
+        currentSelectionReason: stateRef.current.selectionReason,
+        urlTarget,
+        storedTarget,
+        automaticTarget: resolveAutomaticChatTarget(
+          page?.sessions ?? [],
+          Date.now(),
+          draftId,
+        ),
+      });
+      const bootstrapRecovery = resolveChatBootstrapRecovery({
+        selection: bootstrapSelection,
+        hasUrlSessionParameter,
+        urlSelectionFailed,
+        storedTarget,
+        storedSelectionFailed,
+        activeDraftFailed,
+      });
+      const { target, selectionReason: reason } = bootstrapSelection;
+      if (target.kind === "draft") {
+        commitActiveDraftId(target.draftId);
+      }
+      selectTarget(
+        target,
+        reason,
+        bootstrapSelection.selectionChangedDuringBootstrap
+          ? "none"
+          : bootstrapRecovery.shouldReplaceUrl
+          ? "replace"
+          : urlTarget === null && reason === "explicit" ? "replace" : "none",
+      );
+      if (bootstrapRecovery.showRecoveryNotice) {
+        commitRecoveryNotice(
+          translationRef.current("chat.sessionUnavailable"),
+        );
+      }
+      commitReady(true);
+    })();
+
+    return () => {
+      isCurrentScope = false;
+      catalogAbortRef.current?.abort();
+      catalogAbortRef.current = null;
+    };
+  }, [
+    commitReady,
+    commitActiveDraftId,
+    commitRecoveryNotice,
+    commitSelectionEpoch,
+    commitState,
+    loadCatalogPage,
+    scopeKey,
+    stableScope,
+    selectTarget,
+  ]);
+
+  const runningCount = getRunningChatSessionCount(state.summaries);
+
+  useEffect(() => {
+    const handlePopState = (): void => {
+      const popStateNavigation = resolveChatPopStateNavigation(
+        window.location.pathname,
+        navigationGenerationRef.current,
+      );
+      navigationGenerationRef.current = popStateNavigation.generation;
+      controllerNavigationRef.current =
+        popStateNavigation.controllerNavigation;
+      if (popStateNavigation.targetNavigationMode === null) {
+        return;
+      }
+
+      try {
+        const urlTarget = readChatSessionTargetFromSearchParams(
+          new URLSearchParams(window.location.search),
+        );
+        if (urlTarget !== null) {
+          selectTarget(
+            urlTarget,
+            "explicit",
+            popStateNavigation.targetNavigationMode,
+          );
+          return;
+        }
+
+        const draftId = activeDraftIdRef.current ?? createDraftId();
+        commitActiveDraftId(draftId);
+        selectTarget(
+          { kind: "draft", draftId },
+          "explicit",
+          popStateNavigation.targetNavigationMode,
+        );
+      } catch {
+        recoverInvalidUrlSelection(
+          translationRef.current("chat.sessionUnavailable"),
+        );
+      }
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [commitActiveDraftId, recoverInvalidUrlSelection, selectTarget]);
+
+  useEffect(() => {
+    const currentUrl = searchParamsString === ""
+      ? pathname
+      : `${pathname}?${searchParamsString}`;
+    const previousUrl = observedUrlRef.current;
+    observedUrlRef.current = currentUrl;
+    const controllerNavigation = controllerNavigationRef.current;
+    const controllerNavigationObservation =
+      resolveChatControllerNavigationObservation(
+        controllerNavigation,
+        navigationGenerationRef.current,
+        currentUrl,
+      );
+    if (controllerNavigationObservation.kind === "settle") {
+      controllerNavigationRef.current = null;
+      return;
+    }
+    if (controllerNavigationObservation.kind === "restore") {
+      controllerNavigationRef.current =
+        controllerNavigationObservation.controllerNavigation;
+      router.replace(
+        controllerNavigationObservation.url,
+        { scroll: false },
+      );
+      return;
+    }
+    if (
+      pathname !== "/chat"
+      || previousUrl === null
+      || previousUrl === currentUrl
+    ) {
+      if (pathname !== "/chat") {
+        controllerNavigationRef.current = null;
+      }
+      return;
+    }
+
+    try {
+      const urlTarget = readChatSessionTargetFromSearchParams(
+        new URLSearchParams(searchParamsString),
+      );
+      const draftId = activeDraftIdRef.current ?? createDraftId();
+      const activeDraftTarget = { kind: "draft", draftId } as const;
+      const queryStart = previousUrl.indexOf("?");
+      const previousPathname = queryStart === -1
+        ? previousUrl
+        : previousUrl.slice(0, queryStart);
+      const currentState = stateRef.current;
+      const decision = resolveChatUrlSynchronization({
+        previousPathname,
+        pathname,
+        controllerNavigationMatches:
+          controllerNavigationObservation.kind !== "external",
+        urlTarget,
+        currentTarget: currentState.target,
+        currentSelectionReason: currentState.selectionReason,
+        activeDraftTarget,
+      });
+      if (decision.kind === "navigate") {
+        navigateToTarget(decision.target, "replace");
+        return;
+      }
+      if (decision.kind === "select") {
+        if (decision.target.kind === "draft") {
+          commitActiveDraftId(decision.target.draftId);
+        }
+        selectTarget(decision.target, "explicit", "replace");
+        return;
+      }
+      navigateToTarget(currentState.target, "replace");
+    } catch {
+      recoverInvalidUrlSelection(
+        translationRef.current("chat.sessionUnavailable"),
+      );
+    }
+  }, [
+    commitActiveDraftId,
+    navigateToTarget,
+    pathname,
+    recoverInvalidUrlSelection,
+    router,
+    searchParamsString,
+    selectTarget,
+  ]);
+
+  const setHistoryOpen = useCallback((open: boolean): void => {
+    setHistoryOpenState(open);
+    if (open && isReadyRef.current) {
+      void loadCatalogPage();
+    }
+  }, [loadCatalogPage]);
+
+  const selectSession = useCallback((sessionId: string): void => {
+    if (unavailableSessionIdsRef.current.has(sessionId)) {
+      const nextUnavailableSessionIds = new Set(
+        unavailableSessionIdsRef.current,
+      );
+      nextUnavailableSessionIds.delete(sessionId);
+      unavailableSessionIdsRef.current = nextUnavailableSessionIds;
+      if (nextUnavailableSessionIds.size === 0) {
+        hasRefreshedUnavailableSessionsRef.current = false;
+      }
+    }
+    selectTarget(
+      { kind: "session", sessionId },
+      "explicit",
+      "push",
+    );
+  }, [selectTarget]);
+
+  const createDraft = useCallback((
+    isSelectedDraftUntouched: boolean,
+  ): void => {
+    const currentTarget = stateRef.current.target;
+    const shouldReuseCurrentDraft = shouldReuseSelectedChatDraft(
+      isReadyRef.current,
+      currentTarget,
+      isSelectedDraftUntouched,
+    );
+    if (shouldReuseCurrentDraft) {
+      selectTarget(currentTarget, "explicit", "replace");
+      return;
+    }
+    if (
+      currentTarget.kind === "draft"
+      && activeDraftIdRef.current === currentTarget.draftId
+    ) {
+      commitActiveDraftId(null);
+    }
+    const draftTarget = resolveNewChatDraftTarget(
+      currentTarget,
+      activeDraftIdRef.current,
+      shouldReuseCurrentDraft,
+      createDraftId(),
+    );
+    if (draftTarget.kind !== "draft") {
+      throw new Error("New chat draft resolution returned a server session");
+    }
+    commitActiveDraftId(draftTarget.draftId);
+    selectTarget(
+      draftTarget,
+      "explicit",
+      "push",
+    );
+  }, [commitActiveDraftId, selectTarget]);
+
+  const isSelectionCurrent = useCallback((
+    target: ChatTarget,
+    expectedSelectionEpoch: number,
+  ): boolean =>
+    selectionEpochRef.current === expectedSelectionEpoch
+    && areChatTargetsEqual(stateRef.current.target, target), []);
+
+  const adoptDraftSession = useCallback((
+    draftId: string,
+    sessionId: string,
+  ): ChatDraftSessionAdoption => {
+    const draftTarget = { kind: "draft", draftId } as const;
+    const sessionTarget = { kind: "session", sessionId } as const;
+    const isSelected = areChatTargetsEqual(
+      stateRef.current.target,
+      draftTarget,
+    );
+    if (isSelected) {
+      commitState(selectChatWorkspaceTarget(
+        stateRef.current,
+        sessionTarget,
+        "explicit",
+      ));
+    }
+    if (activeDraftIdRef.current === draftId) {
+      commitActiveDraftId(null);
+    }
+    if (isSelected) {
+      persistSelectedTarget(sessionTarget, "explicit");
+      navigateToTarget(sessionTarget, "replace");
+    }
+    void loadCatalogPage();
+    return isSelected
+      ? {
+        kind: "selected",
+        target: sessionTarget,
+        selectionEpoch: selectionEpochRef.current,
+      }
+      : {
+        kind: "background",
+        target: sessionTarget,
+      };
+  }, [
+    commitState,
+    commitActiveDraftId,
+    loadCatalogPage,
+    navigateToTarget,
+    persistSelectedTarget,
+  ]);
+
+  const observeSessionInvalidation = useCallback((
+    sessionId: string,
+    version: number,
+    source: ChatWorkspaceInvalidationSource,
+  ): void => {
+    const currentState = stateRef.current;
+    const previousVersion = currentState.mainContentInvalidationVersions.get(sessionId);
+    const shouldPublish = version > (previousVersion ?? -1)
+      && (previousVersion !== undefined || source === "live");
+    commitState(observeChatSessionInvalidationVersion(
+      currentState,
+      sessionId,
+      version,
+    ));
+    if (shouldPublish) {
+      publishInvalidation(version);
+    }
+  }, [commitState, publishInvalidation]);
+
+  const recoverInvalidSessionSelection = useCallback((
+    sessionId: string,
+    errorMessage: string,
+  ): boolean => {
+    const currentTarget = stateRef.current.target;
+    if (
+      currentTarget.kind !== "session"
+      || currentTarget.sessionId !== sessionId
+    ) {
+      return false;
+    }
+
+    const unavailableSessionIds = new Set(
+      unavailableSessionIdsRef.current,
+    );
+    unavailableSessionIds.add(sessionId);
+    unavailableSessionIdsRef.current = unavailableSessionIds;
+    recoverToSafeTarget(errorMessage, unavailableSessionIds);
+    if (!hasRefreshedUnavailableSessionsRef.current) {
+      hasRefreshedUnavailableSessionsRef.current = true;
+      void loadCatalogPage();
+    }
+    return true;
+  }, [loadCatalogPage, recoverToSafeTarget]);
+
+  const historyErrorMessage = resolveChatHistoryErrorMessage(
+    state.catalogRequest.errorMessage,
+    recoveryNotice,
+  );
+
+  return {
+    state,
+    selectionEpoch,
+    isReady,
+    historyOpen,
+    historyErrorMessage,
+    runningCount,
+    setHistoryOpen,
+    selectSession,
+    createDraft,
+    adoptDraftSession,
+    isSelectionCurrent,
+    refreshCatalog,
+    loadNextCatalogPage,
+    observeSessionInvalidation,
+    recoverInvalidSessionSelection,
+  };
+};


### PR DESCRIPTION
## Summary
- prepare the per-target chat workspace controller and provider state without activating history selection in the mounted panel
- add catalog bootstrap, URL recovery, cursor pagination, and accessible inert history states
- preserve the mounted compatibility transcript, composer, and New/Clear behavior for the later activation items

## Validation
- direct TypeScript check
- workspace/provider policies: 56/56
- draft/composer compatibility: 23/23
- client controller/Clear/invalidation: 94/94
- npm run lint
- npm run build (40/40 pages)
- locale parity and untracked-inclusive diff check