### PR TITLE
Activate multi-chat composer

### DIFF
--- a/apps/web/e2e-local/chat-draft.local-demo.spec.ts
+++ b/apps/web/e2e-local/chat-draft.local-demo.spec.ts
@@ -2,9 +2,240 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
 
 type NavigationHref = "/chat" | "/transactions";
 const localNavigationTimeoutMs = 20_000;
+const RUNNING_SNAPSHOT_TURN_ID =
+  "00000000-0000-4000-8000-000000000001";
+const SECOND_RUNNING_SNAPSHOT_TURN_ID =
+  "00000000-0000-4000-8000-000000000002";
+const NEWER_RUNNING_SNAPSHOT_TURN_ID =
+  "00000000-0000-4000-8000-000000000003";
+const PERSISTED_SNAPSHOT_MESSAGE_ID =
+  "00000000-0000-4000-8000-000000000004";
+
+type DictationTestWindow = Window & Readonly<{
+  __resolveChatMicrophonePermission?: () => void;
+  __chatMicrophonePermissionRequestCount?: number;
+  __chatMicrophoneTrackStopCount?: number;
+}>;
+
+type LayoutCleanupTestWindow = Window & Readonly<{
+  __releaseChatCreateAtLayoutCommit?: () => Promise<void>;
+  __chatCreateReleasedAtLayoutCommit?: boolean;
+  __chatAbortAfterCreateReleaseCount?: number;
+  __chatPreviousScopeRenderedAfterCommit?: boolean;
+  __chatPreviousCatalogRenderedAfterCommit?: boolean;
+}>;
+
+type StorageMutationTestWindow = Window & Readonly<{
+  __chatStorageMutationFailed?: boolean;
+  __chatStorageMutationAttemptCount?: number;
+  __restoreChatStorageMutation?: () => void;
+}>;
+
+type StopContinuationTestWindow = Window & Readonly<{
+  __chatStopResponseTerminalCount?: number;
+}>;
+
+type Deferred = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+}>;
+
+const createDeferred = (): Deferred => {
+  let resolvePromise: (() => void) | null = null;
+  const promise = new Promise<void>((resolve): void => {
+    resolvePromise = resolve;
+  });
+  if (resolvePromise === null) {
+    throw new Error("Failed to create deferred browser-test operation");
+  }
+
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+};
+
+const failNextSessionStorageMutation = async (
+  page: Page,
+  method: "setItem" | "removeItem",
+  storageKey: string,
+): Promise<void> => {
+  await page.evaluate(
+    ({ mutationMethod, keyToFail }): void => {
+      const testWindow = window as StorageMutationTestWindow;
+      const storagePrototype = Storage.prototype;
+      const originalSetItem = storagePrototype.setItem;
+      const originalRemoveItem = storagePrototype.removeItem;
+      const originalMethod = mutationMethod === "setItem"
+        ? originalSetItem
+        : originalRemoveItem;
+      let hasFailed = false;
+      let matchingAttemptCount = 0;
+      const replacement = function (
+        this: Storage,
+        key: string,
+        value?: string,
+      ): void {
+        if (
+          this === window.sessionStorage
+          && key === keyToFail
+        ) {
+          matchingAttemptCount += 1;
+          Object.defineProperty(
+            testWindow,
+            "__chatStorageMutationAttemptCount",
+            {
+              configurable: true,
+              value: matchingAttemptCount,
+            },
+          );
+        }
+        if (
+          this === window.sessionStorage
+          && key === keyToFail
+          && !hasFailed
+        ) {
+          hasFailed = true;
+          Object.defineProperty(testWindow, "__chatStorageMutationFailed", {
+            configurable: true,
+            value: true,
+          });
+          throw new DOMException(
+            `Synthetic chat storage failure for ${key}`,
+            "QuotaExceededError",
+          );
+        }
+        if (mutationMethod === "setItem") {
+          if (value === undefined) {
+            throw new Error("Storage setItem replacement requires a value");
+          }
+          originalSetItem.call(this, key, value);
+          return;
+        }
+        originalRemoveItem.call(this, key);
+      };
+      Object.defineProperty(storagePrototype, mutationMethod, {
+        configurable: true,
+        value: replacement,
+        writable: true,
+      });
+      Object.defineProperty(testWindow, "__restoreChatStorageMutation", {
+        configurable: true,
+        value: (): void => {
+          Object.defineProperty(storagePrototype, mutationMethod, {
+            configurable: true,
+            value: originalMethod,
+            writable: true,
+          });
+        },
+      });
+    },
+    {
+      mutationMethod: method,
+      keyToFail: storageKey,
+    },
+  );
+};
+
+const restoreSessionStorageMutation = async (page: Page): Promise<void> => {
+  await page.evaluate((): void => {
+    const restore =
+      (window as StorageMutationTestWindow).__restoreChatStorageMutation;
+    if (restore === undefined) {
+      throw new Error("Storage mutation restore callback is missing");
+    }
+    restore();
+  });
+};
 
 const getNavigationLink = (page: Page, href: NavigationHref): Locator =>
   page.getByRole("navigation").locator(`a[href="${href}"]`);
+
+const mockWorkspaceClientDependencies = async (page: Page): Promise<void> => {
+  await page.route("**/api/categories", async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ categories: [] }),
+    });
+  });
+  await page.route(
+    "**/api/workspace-settings",
+    async (route): Promise<void> => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ filteredCategories: null }),
+      });
+    },
+  );
+};
+
+type DelayedChatBootstrap = Readonly<{
+  catalogRequestReceived: Promise<void>;
+  releaseCatalog: () => void;
+  snapshotSessionIds: Array<string>;
+}>;
+
+const mockDelayedChatBootstrap = async (
+  page: Page,
+  sessionIds: ReadonlyArray<string>,
+): Promise<DelayedChatBootstrap> => {
+  const catalogRequestReceived = createDeferred();
+  const releaseCatalog = createDeferred();
+  const snapshotSessionIds: Array<string> = [];
+  const lastMessageAt = new Date().toISOString();
+
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    catalogRequestReceived.resolve();
+    await releaseCatalog.promise;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: sessionIds.map((sessionId) => ({
+          sessionId,
+          title: sessionId,
+          lastMessageAt,
+          status: "idle",
+          mainContentInvalidationVersion: 0,
+        })),
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId === null) {
+        throw new Error("Chat snapshot request is missing sessionId");
+      }
+      snapshotSessionIds.push(sessionId);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+
+  return {
+    catalogRequestReceived: catalogRequestReceived.promise,
+    releaseCatalog: releaseCatalog.resolve,
+    snapshotSessionIds,
+  };
+};
 
 test("keeps an unsent chat draft within one tab", async ({ page, baseURL, context }) => {
   if (baseURL === undefined) {
@@ -12,6 +243,13 @@ test("keeps an unsent chat draft within one tab", async ({ page, baseURL, contex
   }
 
   const origin = new URL(baseURL);
+  const catalogRequests: Array<string> = [];
+  page.on("request", (request): void => {
+    const url = new URL(request.url());
+    if (url.pathname === "/api/chat/sessions") {
+      catalogRequests.push(request.url());
+    }
+  });
   await context.addCookies([
     { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
     { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
@@ -53,4 +291,4306 @@ test("keeps an unsent chat draft within one tab", async ({ page, baseURL, contex
   await page.getByTestId("chat-composer-input").fill("");
   await page.reload({ waitUntil: "domcontentloaded" });
   await expect(page.getByTestId("chat-composer-input")).toHaveValue("");
+  expect(catalogRequests).toEqual([]);
+});
+
+test("reopens the same unsent draft after reloading a selected session", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const sessionId = "session-selected";
+  const activeDraftStorageKey =
+    "expense-tracker-chat-active-draft:v1:workspace:local:local";
+  const lastMessageAt = new Date().toISOString();
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [{
+          sessionId,
+          title: "Selected session",
+          lastMessageAt,
+          status: "idle",
+          mainContentInvalidationVersion: 0,
+        }],
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const requestedSessionId = new URL(
+        route.request().url(),
+      ).searchParams.get("sessionId");
+      if (requestedSessionId !== sessionId) {
+        throw new Error(
+          `Unexpected chat snapshot sessionId: ${String(requestedSessionId)}`,
+        );
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+
+  await page.getByTestId("chat-new").click();
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("draft retained while a session is selected");
+  const draftIdBeforeReload = await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    activeDraftStorageKey,
+  );
+  expect(draftIdBeforeReload).toMatch(/^draft-/u);
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${sessionId}`).click();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && url.searchParams.get("session") === sessionId,
+  );
+  await expect(composer).toHaveValue("");
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && url.searchParams.get("session") === sessionId,
+  );
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+
+  await page.getByTestId("chat-new").click();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && !url.searchParams.has("session"),
+  );
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue(
+    "draft retained while a session is selected",
+  );
+  expect(await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    activeDraftStorageKey,
+  )).toBe(draftIdBeforeReload);
+});
+
+test("reevaluates an automatic draft on reload but restores an explicit draft", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  await page.addInitScript((): void => {
+    class ImmediateMediaRecorder extends EventTarget {
+      public static isTypeSupported(_mimeType: string): boolean {
+        return true;
+      }
+
+      public state: RecordingState = "inactive";
+      public readonly mimeType: string;
+
+      public constructor(_stream: MediaStream, options?: MediaRecorderOptions) {
+        super();
+        this.mimeType = options?.mimeType ?? "audio/webm";
+      }
+
+      public start(): void {
+        this.state = "recording";
+      }
+
+      public stop(): void {
+        if (this.state === "inactive") {
+          return;
+        }
+        this.state = "inactive";
+        this.dispatchEvent(new BlobEvent("dataavailable", {
+          data: new Blob(["automatic selection audio"], {
+            type: this.mimeType,
+          }),
+        }));
+        this.dispatchEvent(new Event("stop"));
+      }
+    }
+
+    const mediaStream = {
+      getTracks: (): ReadonlyArray<Readonly<{ stop: () => void }>> => [{
+        stop: (): void => undefined,
+      }],
+    };
+    Object.defineProperty(window, "MediaRecorder", {
+      configurable: true,
+      value: ImmediateMediaRecorder,
+    });
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: async (): Promise<typeof mediaStream> => mediaStream,
+      },
+    });
+  });
+
+  const sessionId = "session-policy";
+  const selectionStorageKey =
+    "expense-tracker-chat-selection:v1:workspace:local:local";
+  let catalogStatus: "idle" | "running" = "idle";
+  let snapshotRequestCount = 0;
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [{
+          sessionId,
+          title: "Policy session",
+          lastMessageAt: catalogStatus === "running"
+            ? new Date().toISOString()
+            : new Date(Date.now() - (7 * 60 * 60 * 1000)).toISOString(),
+          status: catalogStatus,
+          mainContentInvalidationVersion: 0,
+        }],
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      snapshotRequestCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "running",
+          activeTurnId: RUNNING_SNAPSHOT_TURN_ID,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [{
+            messageId: PERSISTED_SNAPSHOT_MESSAGE_ID,
+            role: "assistant",
+            content: [{
+              type: "text",
+              text: "Automatic session transcript",
+            }],
+            timestamp: Date.now(),
+            isError: false,
+            isStopped: false,
+          }],
+        }),
+      });
+    },
+  );
+  await page.route("**/api/chat/transcriptions", async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ text: "automatic dictation" }),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await expect(page.getByTestId("chat-submit")).toHaveText("Send");
+  expect(await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    selectionStorageKey,
+  )).toBeNull();
+
+  catalogStatus = "running";
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect.poll(() => snapshotRequestCount).toBe(1);
+  await expect(page.getByTestId("chat-submit")).toHaveText("Stop");
+
+  const assertAutomaticPromotionPreservesLifecycle = async (
+    marker: string,
+    snapshotCount: number,
+    url: string,
+  ): Promise<void> => {
+    await expect.poll(async (): Promise<string | null> =>
+      page.evaluate(
+        (storageKey: string): string | null =>
+          window.sessionStorage.getItem(storageKey),
+        selectionStorageKey,
+      )).toContain("\"selectionReason\":\"explicit\"");
+    await expect(page).toHaveURL(url);
+    await expect(page.getByTestId("chat-submit")).toHaveText("Stop");
+    expect(snapshotRequestCount).toBe(snapshotCount);
+    expect(await composer.evaluate((element): string | undefined =>
+      (element as HTMLTextAreaElement & {
+        __automaticPromotionMarker?: string;
+      }).__automaticPromotionMarker)).toBe(marker);
+    expect(await page.getByTestId("chat-panel").evaluate(
+      (element): string | undefined => element.dataset.promotionMarker,
+    )).toBe(marker);
+  };
+  const markAutomaticLifecycle = async (marker: string): Promise<{
+    snapshotCount: number;
+    url: string;
+  }> => {
+    await composer.evaluate((element, nextMarker): void => {
+      const textarea = element as HTMLTextAreaElement & {
+        __automaticPromotionMarker?: string;
+      };
+      textarea.__automaticPromotionMarker = nextMarker;
+    }, marker);
+    await page.getByTestId("chat-panel").evaluate(
+      (element, nextMarker): void => {
+        element.dataset.promotionMarker = nextMarker;
+      },
+      marker,
+    );
+    return {
+      snapshotCount: snapshotRequestCount,
+      url: page.url(),
+    };
+  };
+  const reloadAutomaticSession = async (): Promise<void> => {
+    await page.evaluate((storageKey: string): void => {
+      window.sessionStorage.removeItem(storageKey);
+    }, selectionStorageKey);
+    const previousSnapshotCount = snapshotRequestCount;
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect.poll(() => snapshotRequestCount).toBe(
+      previousSnapshotCount + 1,
+    );
+    await expect(page.getByTestId("chat-submit")).toHaveText("Stop");
+  };
+
+  const editLifecycle = await markAutomaticLifecycle("edit");
+  await composer.fill("automatic session edit");
+  await assertAutomaticPromotionPreservesLifecycle(
+    "edit",
+    editLifecycle.snapshotCount,
+    editLifecycle.url,
+  );
+  await composer.fill("");
+
+  await reloadAutomaticSession();
+  const attachmentLifecycle = await markAutomaticLifecycle("attachment");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "automatic-session.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("automatic session attachment"),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "automatic-session.txt",
+  );
+  await assertAutomaticPromotionPreservesLifecycle(
+    "attachment",
+    attachmentLifecycle.snapshotCount,
+    attachmentLifecycle.url,
+  );
+
+  await reloadAutomaticSession();
+  const dictationLifecycle = await markAutomaticLifecycle("dictation");
+  await page.getByTestId("chat-dictation").click();
+  await expect(page.getByTestId("chat-dictation")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await assertAutomaticPromotionPreservesLifecycle(
+    "dictation",
+    dictationLifecycle.snapshotCount,
+    dictationLifecycle.url,
+  );
+  await page.getByTestId("chat-dictation").click();
+  await expect(composer).toHaveValue("automatic dictation");
+
+  await page.getByTestId("chat-new").click();
+  await composer.fill("discard this automatic draft");
+  await page.getByTestId("chat-new").click();
+  await composer.fill("restore this explicit draft");
+  expect(await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    selectionStorageKey,
+  )).toContain("\"selectionReason\":\"explicit\"");
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(composer).toHaveValue("restore this explicit draft");
+  await expect(page.getByTestId("chat-submit")).toHaveText("Send");
+  expect(snapshotRequestCount).toBe(3);
+});
+
+test("keeps an edited automatic draft selected while History refreshes", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const sessionId = "session-arriving-during-history-refresh";
+  const selectionStorageKey =
+    "expense-tracker-chat-selection:v1:workspace:local:local";
+  let catalogRequestCount = 0;
+  let snapshotRequestCount = 0;
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    catalogRequestCount += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: catalogRequestCount === 1
+          ? []
+          : [{
+            sessionId,
+            title: "Newly active session",
+            lastMessageAt: new Date().toISOString(),
+            status: "running",
+            mainContentInvalidationVersion: 0,
+          }],
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      snapshotRequestCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "running",
+          activeTurnId: RUNNING_SNAPSHOT_TURN_ID,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("keep this edited automatic draft");
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (storageKey: string): string | null =>
+        window.sessionStorage.getItem(storageKey),
+      selectionStorageKey,
+    )).toContain("\"selectionReason\":\"explicit\"");
+
+  await page.getByTestId("chat-history-open").click();
+  await expect(
+    page.getByTestId(`chat-history-session-${sessionId}`),
+  ).toBeVisible();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat" && url.searchParams.get("session") === null,
+  );
+  await expect(composer).toHaveValue("keep this edited automatic draft");
+  expect(snapshotRequestCount).toBe(0);
+});
+
+test("keeps History selection unchanged when explicit persistence fails", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const sessionA = "session-history-storage-a";
+  const sessionB = "session-history-storage-b";
+  const selectionStorageKey =
+    "expense-tracker-chat-selection:v1:workspace:local:local";
+  const lastMessageAt = new Date().toISOString();
+  const pageErrors: Array<string> = [];
+  page.on("pageerror", (error): void => {
+    pageErrors.push(error.message);
+  });
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [sessionA, sessionB].map((sessionId) => ({
+          sessionId,
+          title: sessionId,
+          lastMessageAt,
+          status: "idle",
+          mainContentInvalidationVersion: 0,
+        })),
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== sessionA && sessionId !== sessionB) {
+        throw new Error(
+          `Unexpected History storage test session: ${String(sessionId)}`,
+        );
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto(`/chat?session=${sessionA}`, {
+    waitUntil: "domcontentloaded",
+  });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  const previousSelection = await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    selectionStorageKey,
+  );
+  expect(previousSelection).toContain(sessionA);
+
+  await page.getByTestId("chat-history-open").click();
+  await expect(
+    page.getByTestId(`chat-history-session-${sessionB}`),
+  ).toBeVisible();
+  await failNextSessionStorageMutation(
+    page,
+    "setItem",
+    selectionStorageKey,
+  );
+  await page.getByTestId(`chat-history-session-${sessionB}`).evaluate(
+    (button: HTMLElement): void => button.click(),
+  );
+  await expect.poll(async (): Promise<boolean> =>
+    page.evaluate((): boolean =>
+      (window as StorageMutationTestWindow).__chatStorageMutationFailed
+        === true),
+  ).toBe(true);
+  await expect.poll((): number => pageErrors.length).toBe(1);
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionA,
+  );
+  await expect(composer).toBeEditable();
+  expect(await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    selectionStorageKey,
+  )).toBe(previousSelection);
+
+  await restoreSessionStorageMutation(page);
+  await page.getByTestId(`chat-history-session-${sessionB}`).click();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionB,
+  );
+  await expect(composer).toBeEditable();
+  expect(pageErrors).toHaveLength(1);
+});
+
+test("does not promote a recovered automatic target from stale dictation", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  await page.addInitScript((): void => {
+    const mediaStream = {
+      getTracks: (): ReadonlyArray<Readonly<{ stop: () => void }>> => [{
+        stop: (): void => undefined,
+      }],
+    };
+    let resolvePermission: ((stream: typeof mediaStream) => void) | null = null;
+    const permission = new Promise<typeof mediaStream>((resolve): void => {
+      resolvePermission = resolve;
+    });
+    if (resolvePermission === null) {
+      throw new Error("Failed to create deferred microphone permission");
+    }
+    Object.defineProperty(
+      window,
+      "__resolveChatMicrophonePermission",
+      {
+        configurable: true,
+        value: (): void => resolvePermission?.(mediaStream),
+      },
+    );
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: async (): Promise<typeof mediaStream> => permission,
+      },
+    });
+  });
+
+  const sessionA = "session-dictation-recovery-a";
+  const sessionB = "session-dictation-recovery-b";
+  const snapshotCounts = new Map<string, number>();
+  const selectionStorageKey =
+    "expense-tracker-chat-selection:v1:workspace:local:local";
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [sessionA, sessionB].map((sessionId) => ({
+          sessionId,
+          title: sessionId,
+          lastMessageAt: new Date().toISOString(),
+          status: "running",
+          mainContentInvalidationVersion: 0,
+        })),
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== sessionA && sessionId !== sessionB) {
+        throw new Error(
+          `Unexpected dictation recovery sessionId: ${String(sessionId)}`,
+        );
+      }
+      const requestCount = (snapshotCounts.get(sessionId) ?? 0) + 1;
+      snapshotCounts.set(sessionId, requestCount);
+      if (sessionId === sessionA && requestCount > 1) {
+        await route.fulfill({
+          status: 404,
+          contentType: "text/plain",
+          body: "Selected dictation session is unavailable",
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: sessionId === sessionA ? "running" : "idle",
+          activeTurnId: sessionId === sessionA
+            ? RUNNING_SNAPSHOT_TURN_ID
+            : null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await expect.poll((): number => snapshotCounts.get(sessionA) ?? 0).toBe(1);
+  await expect(page.getByTestId("chat-submit")).toHaveText("Stop");
+  await page.getByTestId("chat-dictation").click();
+  await expect(page.getByTestId("chat-dictation")).toBeDisabled();
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (storageKey: string): string | null =>
+        window.sessionStorage.getItem(storageKey),
+      selectionStorageKey,
+    )).toContain(sessionA);
+
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionB,
+    { timeout: 15_000 },
+  );
+  await expect.poll((): number => snapshotCounts.get(sessionB) ?? 0)
+    .toBeGreaterThanOrEqual(1);
+  expect(await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    selectionStorageKey,
+  )).toBeNull();
+
+  await page.evaluate((): void => {
+    const resolvePermission =
+      (window as DictationTestWindow).__resolveChatMicrophonePermission;
+    if (resolvePermission === undefined) {
+      throw new Error("Deferred microphone permission resolver is missing");
+    }
+    resolvePermission();
+  });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  expect(await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    selectionStorageKey,
+  )).toBeNull();
+});
+
+test("cancels pending dictation after a batched session round trip", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  await page.addInitScript((): void => {
+    let permissionRequestCount = 0;
+    let trackStopCount = 0;
+    const mediaStream = {
+      getTracks: (): ReadonlyArray<Readonly<{ stop: () => void }>> => [{
+        stop: (): void => {
+          trackStopCount += 1;
+        },
+      }],
+    };
+    let resolvePermission: ((stream: typeof mediaStream) => void) | null = null;
+    const permission = new Promise<typeof mediaStream>((resolve): void => {
+      resolvePermission = resolve;
+    });
+    if (resolvePermission === null) {
+      throw new Error("Failed to create deferred microphone permission");
+    }
+    Object.defineProperties(window, {
+      __resolveChatMicrophonePermission: {
+        configurable: true,
+        value: (): void => resolvePermission?.(mediaStream),
+      },
+      __chatMicrophonePermissionRequestCount: {
+        configurable: true,
+        get: (): number => permissionRequestCount,
+      },
+      __chatMicrophoneTrackStopCount: {
+        configurable: true,
+        get: (): number => trackStopCount,
+      },
+    });
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: async (): Promise<typeof mediaStream> => {
+          permissionRequestCount += 1;
+          return permission;
+        },
+      },
+    });
+  });
+
+  const sessionA = "session-dictation-round-trip-a";
+  const sessionB = "session-dictation-round-trip-b";
+  const snapshotCounts = new Map<string, number>();
+  let transcriptionRequestCount = 0;
+  const pageErrors: Array<string> = [];
+  const dialogMessages: Array<string> = [];
+  page.on("pageerror", (error): void => {
+    pageErrors.push(error.message);
+  });
+  page.on("dialog", (dialog): void => {
+    dialogMessages.push(dialog.message());
+    void dialog.dismiss();
+  });
+
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [sessionA, sessionB].map((sessionId) => ({
+          sessionId,
+          title: sessionId,
+          lastMessageAt: new Date().toISOString(),
+          status: "idle",
+          mainContentInvalidationVersion: 0,
+        })),
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== sessionA && sessionId !== sessionB) {
+        throw new Error(
+          `Unexpected dictation round-trip sessionId: ${String(sessionId)}`,
+        );
+      }
+      snapshotCounts.set(
+        sessionId,
+        (snapshotCounts.get(sessionId) ?? 0) + 1,
+      );
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await page.route(
+    "**/api/chat/transcriptions",
+    async (route): Promise<void> => {
+      transcriptionRequestCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ text: "unexpected stale transcript" }),
+      });
+    },
+  );
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto(`/chat?session=${sessionA}`, {
+    waitUntil: "domcontentloaded",
+  });
+  const composer = page.getByTestId("chat-composer-input");
+  const dictationButton = page.getByTestId("chat-dictation");
+  await expect(composer).toBeEditable();
+  await composer.fill("text owned by session A");
+  await dictationButton.click();
+  await expect(dictationButton).toBeDisabled();
+  await expect.poll(async (): Promise<number | undefined> =>
+    page.evaluate((): number | undefined =>
+      (window as DictationTestWindow)
+        .__chatMicrophonePermissionRequestCount)).toBe(1);
+
+  await page.evaluate(({ firstSessionId, secondSessionId }): void => {
+    window.history.pushState(
+      window.history.state,
+      "",
+      `/chat?session=${encodeURIComponent(secondSessionId)}`,
+    );
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    window.history.pushState(
+      window.history.state,
+      "",
+      `/chat?session=${encodeURIComponent(firstSessionId)}`,
+    );
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, {
+    firstSessionId: sessionA,
+    secondSessionId: sessionB,
+  });
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionA,
+  );
+  await expect.poll((): number => snapshotCounts.get(sessionA) ?? 0)
+    .toBeGreaterThanOrEqual(2);
+
+  await page.evaluate((): void => {
+    const resolvePermission =
+      (window as DictationTestWindow).__resolveChatMicrophonePermission;
+    if (resolvePermission === undefined) {
+      throw new Error("Deferred microphone permission resolver is missing");
+    }
+    resolvePermission();
+  });
+  await expect.poll(async (): Promise<number | undefined> =>
+    page.evaluate((): number | undefined =>
+      (window as DictationTestWindow).__chatMicrophoneTrackStopCount)).toBe(1);
+
+  await expect(composer).toBeEditable();
+  await expect(composer).toHaveValue("text owned by session A");
+  await expect(dictationButton).toBeEnabled();
+  await expect(dictationButton).toHaveAttribute("aria-pressed", "false");
+  await expect(page.getByTestId("chat-file-input")).toBeEnabled();
+  await expect(page.getByTestId("chat-submit")).toBeEnabled();
+  await expect(page.getByTestId("chat-attachment-error")).toHaveCount(0);
+  expect(transcriptionRequestCount).toBe(0);
+  expect(dialogMessages).toEqual([]);
+  expect(pageErrors).toEqual([]);
+});
+
+test("focuses the new composer from the header and History dialog", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+  const composer = page.getByTestId("chat-composer-input");
+  await composer.fill("replace from the header");
+  await page.getByTestId("chat-new").click();
+  await expect(composer).toHaveValue("");
+  await expect(composer).toBeFocused();
+
+  await composer.fill("replace from History");
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId("chat-history-new").click();
+  await expect(page.getByTestId("chat-history-dialog")).not.toBeVisible();
+  await expect(composer).toHaveValue("");
+  await expect(composer).toBeFocused();
+});
+
+test("retains New focus until slow workspace bootstrap enables the composer", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const bootstrap = await mockDelayedChatBootstrap(page, []);
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await bootstrap.catalogRequestReceived;
+
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeDisabled();
+  await page.getByTestId("chat-new").click();
+  await expect(composer).not.toBeFocused();
+
+  bootstrap.releaseCatalog();
+  await expect(composer).toBeEditable();
+  await expect(composer).toBeFocused();
+});
+
+test("restores a failed first submission without overwriting follow-up edits", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const sessionId = "session-switch-target";
+  const firstRequestReceived = createDeferred();
+  const releaseFirstFailure = createDeferred();
+  const secondRequestReceived = createDeferred();
+  const releaseSecondFailure = createDeferred();
+  let newChatRequestCount = 0;
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [{
+          sessionId,
+          title: "Switch target",
+          lastMessageAt: new Date(
+            Date.now() - (7 * 60 * 60 * 1000),
+          ).toISOString(),
+          status: "idle",
+          mainContentInvalidationVersion: 0,
+        }],
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    newChatRequestCount += 1;
+    if (newChatRequestCount === 1) {
+      firstRequestReceived.resolve();
+      await releaseFirstFailure.promise;
+    } else if (newChatRequestCount === 2) {
+      secondRequestReceived.resolve();
+      await releaseSecondFailure.promise;
+    }
+    await route.fulfill({
+      status: 400,
+      contentType: "text/plain",
+      body: "Fresh chat request failed",
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("original failed prompt");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "original.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("original attachment bytes"),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "original.txt",
+  );
+  await page.getByTestId("chat-submit").click();
+  await firstRequestReceived.promise;
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${sessionId}`).click();
+  await expect(composer).toHaveValue("");
+  releaseFirstFailure.resolve();
+  await page.getByTestId("chat-new").click();
+  await expect(composer).toHaveValue("original failed prompt");
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "original.txt",
+  );
+
+  await page.getByTestId("chat-submit").click();
+  await secondRequestReceived.promise;
+  await composer.fill("follow-up edit");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "follow-up.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("follow-up attachment bytes"),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "follow-up.txt",
+  );
+  releaseSecondFailure.resolve();
+
+  await expect(composer).toHaveValue("follow-up edit");
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "follow-up.txt",
+  );
+  await expect(page.getByTestId("chat-prepared-attachment")).not.toContainText(
+    "original.txt",
+  );
+});
+
+test("does not retry an ambiguous first-send failure", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  let createRequestCount = 0;
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestCount += 1;
+    await route.fulfill({
+      status: 503,
+      contentType: "text/plain",
+      body: "Upstream response unavailable",
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  const submit = page.getByTestId("chat-submit");
+  await composer.fill("do not create this twice");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "uncertain.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("uncertain bytes"),
+  });
+  await submit.click();
+
+  await expect(composer).toHaveValue("do not create this twice");
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "uncertain.txt",
+  );
+  await expect(submit).toBeDisabled();
+  await submit.evaluate((button: HTMLElement): void => button.click());
+  expect(createRequestCount).toBe(1);
+  const unresolvedDraftStorageKeys = await page.evaluate(
+    (expectedText: string): ReadonlyArray<string> =>
+      Object.keys(window.sessionStorage).filter(
+        (storageKey: string): boolean =>
+          storageKey.startsWith("expense-tracker-chat-draft:v2:")
+          && window.sessionStorage.getItem(storageKey) === expectedText,
+      ),
+    "do not create this twice",
+  );
+  expect(unresolvedDraftStorageKeys).toHaveLength(1);
+
+  await page.getByTestId("chat-new").click();
+  await expect(composer).toHaveValue("");
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+  await expect.poll(async (): Promise<ReadonlyArray<string>> =>
+    page.evaluate(
+      (expectedText: string): ReadonlyArray<string> =>
+        Object.keys(window.sessionStorage).filter(
+          (storageKey: string): boolean =>
+            storageKey.startsWith("expense-tracker-chat-draft:v2:")
+            && window.sessionStorage.getItem(storageKey) === expectedText,
+        ),
+      "do not create this twice",
+    )).toEqual([]);
+  expect(createRequestCount).toBe(1);
+});
+
+for (const settlementCase of [
+  {
+    kind: "rejected",
+    status: 400,
+    errorText: "Rejected chat submission settlement failed",
+  },
+  {
+    kind: "unresolved",
+    status: 503,
+    errorText: "Unresolved chat submission settlement failed",
+  },
+] as const) {
+  test(`recovers ${settlementCase.kind} settlement after draft storage failure`, async ({
+    page,
+    baseURL,
+    context,
+  }) => {
+    if (baseURL === undefined) {
+      throw new Error("Local Demo Playwright baseURL is required");
+    }
+
+    const firstRequestReceived = createDeferred();
+    const releaseFirstResponse = createDeferred();
+    const pageErrors: Array<string> = [];
+    let createRequestCount = 0;
+    page.on("pageerror", (error): void => {
+      pageErrors.push(error.message);
+    });
+    await mockWorkspaceClientDependencies(page);
+    await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [], nextCursor: null }),
+      });
+    });
+    await page.route(
+      /\/api\/chat\?sessionId=/u,
+      async (route): Promise<void> => {
+        const sessionId = new URL(route.request().url()).searchParams.get(
+          "sessionId",
+        );
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            sessionId,
+            runState: "idle",
+            activeTurnId: null,
+            updatedAt: Date.now(),
+            mainContentInvalidationVersion: 0,
+            messages: [],
+          }),
+        });
+      },
+    );
+    await page.route("**/api/chat/new", async (route): Promise<void> => {
+      createRequestCount += 1;
+      if (createRequestCount === 1) {
+        firstRequestReceived.resolve();
+        await releaseFirstResponse.promise;
+        await route.fulfill({
+          status: settlementCase.status,
+          contentType: "text/plain",
+          body: `${settlementCase.kind} first submission`,
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "X-Chat-Session-Id": "session-settlement-retry",
+        },
+        body: [
+          "data: {\"type\":\"session\",\"sessionId\":\"session-settlement-retry\"}",
+          "data: {\"type\":\"done\"}",
+          "",
+        ].join("\n\n"),
+      });
+    });
+
+    const origin = new URL(baseURL);
+    await context.addCookies([
+      { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+      { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    ]);
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+    const composer = page.getByTestId("chat-composer-input");
+    const submit = page.getByTestId("chat-submit");
+    const submittedText = `${settlementCase.kind} settlement retry prompt`;
+    await composer.fill(submittedText);
+    await page.getByTestId("chat-file-input").setInputFiles({
+      name: `${settlementCase.kind}-settlement.txt`,
+      mimeType: "text/plain",
+      buffer: Buffer.from(`${settlementCase.kind} settlement attachment`),
+    });
+    const draftStorageKey = await page.evaluate(
+      (expectedText: string): string => {
+        const storageKey = Object.keys(window.sessionStorage).find(
+          (key: string): boolean =>
+            key.startsWith("expense-tracker-chat-draft:v2:demo:local:")
+            && window.sessionStorage.getItem(key) === expectedText,
+        );
+        if (storageKey === undefined) {
+          throw new Error("Settlement retry draft storage key was not found");
+        }
+        return storageKey;
+      },
+      submittedText,
+    );
+
+    await submit.click();
+    await firstRequestReceived.promise;
+    await failNextSessionStorageMutation(
+      page,
+      "setItem",
+      draftStorageKey,
+    );
+    releaseFirstResponse.resolve();
+
+    await expect.poll(async (): Promise<number | undefined> =>
+      page.evaluate((): number | undefined =>
+        (window as StorageMutationTestWindow)
+          .__chatStorageMutationAttemptCount)).toBe(2);
+    await expect.poll((): number => pageErrors.length).toBe(1);
+    expect(pageErrors[0]).toContain(settlementCase.errorText);
+    await expect(composer).toHaveValue(submittedText);
+    await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+      `${settlementCase.kind}-settlement.txt`,
+    );
+    await expect(submit).toHaveText("Send");
+    expect(createRequestCount).toBe(1);
+
+    await restoreSessionStorageMutation(page);
+    if (settlementCase.kind === "rejected") {
+      await expect(submit).toBeEnabled();
+      await submit.click();
+      await expect.poll((): number => createRequestCount).toBe(2);
+      await expect(page).toHaveURL(
+        (url) => url.searchParams.get("session")
+          === "session-settlement-retry",
+      );
+    } else {
+      await expect(submit).toBeDisabled();
+      await page.getByTestId("chat-new").click();
+      await expect(composer).toHaveValue("");
+      await expect(
+        page.getByTestId("chat-prepared-attachment"),
+      ).toHaveCount(0);
+      expect(createRequestCount).toBe(1);
+    }
+    expect(pageErrors).toHaveLength(1);
+  });
+}
+
+test("releases exact submission ownership when input storage staging fails", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const pageErrors: Array<string> = [];
+  let createRequestCount = 0;
+  page.on("pageerror", (error): void => {
+    pageErrors.push(error.message);
+  });
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestCount += 1;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": "session-after-staging-retry",
+      },
+      body: [
+        "data: {\"type\":\"session\",\"sessionId\":\"session-after-staging-retry\"}",
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  const submit = page.getByTestId("chat-submit");
+  const submittedText = "retry after local submission staging failure";
+  await composer.fill(submittedText);
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "staging-retry.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("staging retry attachment"),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "staging-retry.txt",
+  );
+  const draftStorageKey = await page.evaluate(
+    (expectedText: string): string => {
+      const storageKey = Object.keys(window.sessionStorage).find(
+        (key: string): boolean =>
+          key.startsWith("expense-tracker-chat-draft:v2:demo:local:")
+          && window.sessionStorage.getItem(key) === expectedText,
+      );
+      if (storageKey === undefined) {
+        throw new Error("Submission staging draft storage key was not found");
+      }
+      return storageKey;
+    },
+    submittedText,
+  );
+  await failNextSessionStorageMutation(
+    page,
+    "removeItem",
+    draftStorageKey,
+  );
+
+  await submit.evaluate((button: HTMLElement): void => button.click());
+  await expect.poll(async (): Promise<boolean> =>
+    page.evaluate((): boolean =>
+      (window as StorageMutationTestWindow).__chatStorageMutationFailed
+        === true),
+  ).toBe(true);
+  await expect.poll((): number => pageErrors.length).toBe(1);
+  expect(pageErrors[0]).toContain("Chat submission staging failed");
+  expect(createRequestCount).toBe(0);
+  await expect(composer).toHaveValue(submittedText);
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "staging-retry.txt",
+  );
+  await expect(submit).toBeEnabled();
+
+  await restoreSessionStorageMutation(page);
+  await submit.evaluate((button: HTMLElement): void => button.click());
+  await expect.poll((): number => createRequestCount).toBe(1);
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session")
+      === "session-after-staging-retry",
+  );
+  expect(pageErrors).toHaveLength(1);
+});
+
+test("keeps an abandoned draft reachable when New disposal storage fails", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const pageErrors: Array<string> = [];
+  page.on("pageerror", (error): void => {
+    pageErrors.push(error.message);
+  });
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions: [], nextCursor: null }),
+    });
+  });
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+  const composer = page.getByTestId("chat-composer-input");
+  const retainedText = "abandoned draft survives failed New disposal";
+  await expect(composer).toBeEditable();
+  await composer.fill(retainedText);
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "new-disposal-retry.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("New disposal retry attachment bytes"),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "new-disposal-retry.txt",
+  );
+  const storageBeforeNew = await page.evaluate(
+    (expectedText: string): Readonly<{
+      activeDraft: string | null;
+      selection: string | null;
+      draftStorageKey: string;
+    }> => {
+      const draftStorageKey = Object.keys(window.sessionStorage).find(
+        (storageKey: string): boolean =>
+          storageKey.startsWith("expense-tracker-chat-draft:v2:demo:local:")
+          && window.sessionStorage.getItem(storageKey) === expectedText,
+      );
+      if (draftStorageKey === undefined) {
+        throw new Error("New disposal source draft storage key was not found");
+      }
+      return {
+        activeDraft: window.sessionStorage.getItem(
+          "expense-tracker-chat-active-draft:v1:demo:local",
+        ),
+        selection: window.sessionStorage.getItem(
+          "expense-tracker-chat-selection:v1:demo:local",
+        ),
+        draftStorageKey,
+      };
+    },
+    retainedText,
+  );
+
+  await failNextSessionStorageMutation(
+    page,
+    "removeItem",
+    storageBeforeNew.draftStorageKey,
+  );
+  await page.getByTestId("chat-new").evaluate(
+    (button: HTMLElement): void => button.click(),
+  );
+  await expect.poll(async (): Promise<boolean> =>
+    page.evaluate((): boolean =>
+      (window as StorageMutationTestWindow).__chatStorageMutationFailed
+        === true),
+  ).toBe(true);
+  await expect.poll((): number => pageErrors.length).toBe(1);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat" && !url.searchParams.has("session"),
+  );
+  await expect(composer).toHaveValue(retainedText);
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "new-disposal-retry.txt",
+  );
+  expect(await page.evaluate(
+    (params): Readonly<{
+      activeDraft: string | null;
+      selection: string | null;
+      draftText: string | null;
+    }> => ({
+      activeDraft: window.sessionStorage.getItem(
+        "expense-tracker-chat-active-draft:v1:demo:local",
+      ),
+      selection: window.sessionStorage.getItem(
+        "expense-tracker-chat-selection:v1:demo:local",
+      ),
+      draftText: window.sessionStorage.getItem(params.draftStorageKey),
+    }),
+    storageBeforeNew,
+  )).toEqual({
+    activeDraft: storageBeforeNew.activeDraft,
+    selection: storageBeforeNew.selection,
+    draftText: retainedText,
+  });
+
+  await restoreSessionStorageMutation(page);
+  await page.getByTestId("chat-new").click();
+  await expect(composer).toHaveValue("");
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (storageKey: string): string | null =>
+        window.sessionStorage.getItem(storageKey),
+      storageBeforeNew.draftStorageKey,
+    )).toBeNull();
+  expect(await page.evaluate(
+    (): string | null => window.sessionStorage.getItem(
+      "expense-tracker-chat-active-draft:v1:demo:local",
+    ),
+  )).not.toBe(storageBeforeNew.activeDraft);
+  expect(pageErrors).toHaveLength(1);
+});
+
+const pendingNewStorageFailureCases = [
+  {
+    name: "active draft",
+    storageKey: "expense-tracker-chat-active-draft:v1:demo:local",
+  },
+  {
+    name: "selection",
+    storageKey: "expense-tracker-chat-selection:v1:demo:local",
+  },
+] as const;
+
+for (const storageFailureCase of pendingNewStorageFailureCases) {
+  test(`keeps a live pending draft attached when New ${storageFailureCase.name} storage fails`, async ({
+    page,
+    baseURL,
+    context,
+  }) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const createRequestReceived = createDeferred();
+  const releaseCreateFailure = createDeferred();
+  const pageErrors: Array<string> = [];
+  page.on("pageerror", (error): void => {
+    pageErrors.push(error.message);
+  });
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestReceived.resolve();
+    await releaseCreateFailure.promise;
+    await route.fulfill({
+      status: 400,
+      contentType: "text/plain",
+      body: "Pending create rejected after New storage failure",
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  const submit = page.getByTestId("chat-submit");
+  const submittedText = "pending draft survives failed New";
+  await composer.fill(submittedText);
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "pending-new-failure.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("pending New failure attachment"),
+  });
+  await submit.click();
+  await createRequestReceived.promise;
+
+  const activeDraftStorageKey =
+    "expense-tracker-chat-active-draft:v1:demo:local";
+  const selectionStorageKey =
+    "expense-tracker-chat-selection:v1:demo:local";
+  const storageBeforeNew = await page.evaluate(
+    ({ activeKey, selectionKey }): Readonly<{
+      activeDraft: string | null;
+      selection: string | null;
+    }> => ({
+      activeDraft: window.sessionStorage.getItem(activeKey),
+      selection: window.sessionStorage.getItem(selectionKey),
+    }),
+    {
+      activeKey: activeDraftStorageKey,
+      selectionKey: selectionStorageKey,
+    },
+  );
+  await failNextSessionStorageMutation(
+    page,
+    "setItem",
+    storageFailureCase.storageKey,
+  );
+  await page.getByTestId("chat-new").evaluate(
+    (button: HTMLElement): void => button.click(),
+  );
+  await expect.poll(async (): Promise<boolean> =>
+    page.evaluate((): boolean =>
+      (window as StorageMutationTestWindow).__chatStorageMutationFailed
+        === true),
+  ).toBe(true);
+  await expect.poll((): number => pageErrors.length).toBe(1);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && !url.searchParams.has("session"),
+  );
+  await expect.poll(async (): Promise<Readonly<{
+    activeDraft: string | null;
+    selection: string | null;
+  }>> => page.evaluate(
+    ({ activeKey, selectionKey }): Readonly<{
+      activeDraft: string | null;
+      selection: string | null;
+    }> => ({
+      activeDraft: window.sessionStorage.getItem(activeKey),
+      selection: window.sessionStorage.getItem(selectionKey),
+    }),
+    {
+      activeKey: activeDraftStorageKey,
+      selectionKey: selectionStorageKey,
+    },
+  )).toEqual(storageBeforeNew);
+  await expect(submit).toBeDisabled();
+
+  await restoreSessionStorageMutation(page);
+  releaseCreateFailure.resolve();
+  await expect(composer).toHaveValue(submittedText);
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "pending-new-failure.txt",
+  );
+  await expect(submit).toBeEnabled();
+  expect(pageErrors).toHaveLength(1);
+  });
+}
+
+const detachedTerminalCases = [
+  {
+    kind: "rejected",
+    status: 400,
+    responseBody: "Detached fresh chat request rejected",
+  },
+  {
+    kind: "unresolved",
+    status: 503,
+    responseBody: "Detached fresh chat request unresolved",
+  },
+] as const;
+
+for (const terminalCase of detachedTerminalCases) {
+  test(`disposes a detached draft after ${terminalCase.kind} create settlement`, async ({
+    page,
+    baseURL,
+    context,
+  }) => {
+    if (baseURL === undefined) {
+      throw new Error("Local Demo Playwright baseURL is required");
+    }
+
+    const createRequestReceived = createDeferred();
+    const releaseCreateResponse = createDeferred();
+    const retainedText = `retained ${terminalCase.kind} detached text`;
+    let createRequestCount = 0;
+
+    await page.route("**/api/chat/new", async (route): Promise<void> => {
+      createRequestCount += 1;
+      createRequestReceived.resolve();
+      await releaseCreateResponse.promise;
+      await route.fulfill({
+        status: terminalCase.status,
+        contentType: "text/plain",
+        body: terminalCase.responseBody,
+      });
+    });
+
+    const origin = new URL(baseURL);
+    await context.addCookies([
+      { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+      { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    ]);
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+    const composer = page.getByTestId("chat-composer-input");
+    await expect(composer).toBeEditable();
+    await composer.fill(`submitted ${terminalCase.kind} detached prompt`);
+    await page.getByTestId("chat-file-input").setInputFiles({
+      name: `submitted-${terminalCase.kind}.txt`,
+      mimeType: "text/plain",
+      buffer: Buffer.from(`submitted ${terminalCase.kind} attachment`),
+    });
+    await page.getByTestId("chat-submit").click();
+    await createRequestReceived.promise;
+
+    await composer.fill(retainedText);
+    await page.getByTestId("chat-file-input").setInputFiles({
+      name: `retained-${terminalCase.kind}.txt`,
+      mimeType: "text/plain",
+      buffer: Buffer.from(`retained ${terminalCase.kind} attachment`),
+    });
+    await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+      `retained-${terminalCase.kind}.txt`,
+    );
+    await expect.poll(
+      async (): Promise<string | null> =>
+        page.evaluate(
+          (expectedText: string): string | null =>
+            Object.keys(window.sessionStorage).find(
+              (storageKey: string): boolean =>
+                storageKey.startsWith("expense-tracker-chat-draft:v2:")
+                && window.sessionStorage.getItem(storageKey) === expectedText,
+            ) ?? null,
+          retainedText,
+        ),
+    ).not.toBeNull();
+    const detachedDraftStorageKey = await page.evaluate(
+      (expectedText: string): string | null =>
+        Object.keys(window.sessionStorage).find(
+          (storageKey: string): boolean =>
+            storageKey.startsWith("expense-tracker-chat-draft:v2:")
+            && window.sessionStorage.getItem(storageKey) === expectedText,
+        ) ?? null,
+      retainedText,
+    );
+    if (typeof detachedDraftStorageKey !== "string") {
+      throw new Error(
+        `Detached ${terminalCase.kind} draft storage key was not found`,
+      );
+    }
+
+    await page.getByTestId("chat-new").click();
+    await expect(composer).toHaveValue("");
+    await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+    await expect.poll(async (): Promise<string | null> =>
+      page.evaluate(
+        (storageKey: string): string | null =>
+          window.sessionStorage.getItem(storageKey),
+        detachedDraftStorageKey,
+      )).toBe(retainedText);
+
+    releaseCreateResponse.resolve();
+    await expect.poll(async (): Promise<string | null> =>
+      page.evaluate(
+        (storageKey: string): string | null =>
+          window.sessionStorage.getItem(storageKey),
+        detachedDraftStorageKey,
+      )).toBeNull();
+    await expect(composer).toHaveValue("");
+    await expect(composer).toBeEditable();
+    await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+    expect(createRequestCount).toBe(1);
+  });
+}
+
+test("retains detached terminal state after storage failure and disposes it on New retry", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const createRequestReceived = createDeferred();
+  const releaseCreateResponse = createDeferred();
+  const pageErrors: Array<string> = [];
+  let createRequestCount = 0;
+  page.on("pageerror", (error): void => {
+    pageErrors.push(error.message);
+  });
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestCount += 1;
+    createRequestReceived.resolve();
+    await releaseCreateResponse.promise;
+    await route.fulfill({
+      status: 400,
+      contentType: "text/plain",
+      body: "Detached disposal storage failure",
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+  const composer = page.getByTestId("chat-composer-input");
+  const retainedText = "detached terminal disposal retry";
+  await composer.fill("submitted before detached disposal failure");
+  await page.getByTestId("chat-submit").click();
+  await createRequestReceived.promise;
+  await composer.fill(retainedText);
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "detached-disposal-retry.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("detached disposal retry attachment"),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "detached-disposal-retry.txt",
+  );
+  const detachedDraftStorageKey = await page.evaluate(
+    (expectedText: string): string => {
+      const storageKey = Object.keys(window.sessionStorage).find(
+        (key: string): boolean =>
+          key.startsWith("expense-tracker-chat-draft:v2:demo:local:")
+          && window.sessionStorage.getItem(key) === expectedText,
+      );
+      if (storageKey === undefined) {
+        throw new Error("Detached disposal retry draft storage key was not found");
+      }
+      return storageKey;
+    },
+    retainedText,
+  );
+
+  await page.getByTestId("chat-new").click();
+  await expect(composer).toHaveValue("");
+  await failNextSessionStorageMutation(
+    page,
+    "removeItem",
+    detachedDraftStorageKey,
+  );
+  releaseCreateResponse.resolve();
+  await expect.poll(async (): Promise<boolean> =>
+    page.evaluate((): boolean =>
+      (window as StorageMutationTestWindow).__chatStorageMutationFailed
+        === true),
+  ).toBe(true);
+  await expect.poll((): number => pageErrors.length).toBe(1);
+  expect(pageErrors[0]).toContain("Synthetic chat storage failure");
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (storageKey: string): string | null =>
+        window.sessionStorage.getItem(storageKey),
+      detachedDraftStorageKey,
+    )).toBe(retainedText);
+  await expect(composer).toHaveValue("");
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+
+  await restoreSessionStorageMutation(page);
+  await page.getByTestId("chat-new").click();
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (storageKey: string): string | null =>
+        window.sessionStorage.getItem(storageKey),
+      detachedDraftStorageKey,
+    )).toBeNull();
+  await expect(composer).toHaveValue("");
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+  expect(createRequestCount).toBe(1);
+  expect(pageErrors).toHaveLength(1);
+});
+
+test("adopts a delayed first send in the background after selecting another chat", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const selectedSessionId = "session-selected-during-create";
+  const createdSessionId = "session-created-in-background";
+  const createRequestReceived = createDeferred();
+  const releaseCreateResponse = createDeferred();
+  const activeDraftStorageKey =
+    "expense-tracker-chat-active-draft:v1:workspace:local:local";
+  let createRequestCount = 0;
+  let createdSessionAccepted = false;
+  const oldLastMessageAt = new Date(
+    Date.now() - (7 * 60 * 60 * 1000),
+  ).toISOString();
+
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    const sessions = [{
+      sessionId: selectedSessionId,
+      title: "Selected while creating",
+      lastMessageAt: oldLastMessageAt,
+      status: "idle",
+      mainContentInvalidationVersion: 0,
+    }];
+    if (createdSessionAccepted) {
+      sessions.unshift({
+        sessionId: createdSessionId,
+        title: "Created in background",
+        lastMessageAt: new Date().toISOString(),
+        status: "running",
+        mainContentInvalidationVersion: 0,
+      });
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions, nextCursor: null }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== selectedSessionId && sessionId !== createdSessionId) {
+        throw new Error(`Unexpected chat snapshot sessionId: ${String(sessionId)}`);
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: sessionId === createdSessionId ? "running" : "idle",
+          activeTurnId: sessionId === createdSessionId
+            ? RUNNING_SNAPSHOT_TURN_ID
+            : null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestCount += 1;
+    createRequestReceived.resolve();
+    await releaseCreateResponse.promise;
+    createdSessionAccepted = true;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": createdSessionId,
+      },
+      body: [
+        `data: {"type":"session","sessionId":"${createdSessionId}"}`,
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("send before navigating");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "background.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("background attachment"),
+  });
+  await page.getByTestId("chat-submit").click();
+  await createRequestReceived.promise;
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${selectedSessionId}`).click();
+  releaseCreateResponse.resolve();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === selectedSessionId,
+  );
+
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (storageKey: string): string | null =>
+        window.sessionStorage.getItem(storageKey),
+      activeDraftStorageKey,
+    )).toBeNull();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === selectedSessionId,
+  );
+  await page.getByTestId("chat-history-open").click();
+  await expect(
+    page.getByTestId(`chat-history-session-${createdSessionId}`),
+  ).toBeVisible();
+  await page.getByTestId(`chat-history-session-${createdSessionId}`).click();
+  await expect(page.getByTestId("chat-submit")).toHaveText("Stop");
+  expect(createRequestCount).toBe(1);
+});
+
+test("settles the exact pending submission after a delayed A to B to A create", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const selectedSessionId = "session-selected-between-draft-visits";
+  const createdSessionId = "session-created-after-draft-revisit";
+  const createRequestReceived = createDeferred();
+  const releaseCreateResponse = createDeferred();
+  const oldLastMessageAt = new Date(
+    Date.now() - (7 * 60 * 60 * 1000),
+  ).toISOString();
+  let createdSessionAccepted = false;
+  let createRequestCount = 0;
+
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    const sessions = [{
+      sessionId: selectedSessionId,
+      title: "Selected between draft visits",
+      lastMessageAt: oldLastMessageAt,
+      status: "idle",
+      mainContentInvalidationVersion: 0,
+    }];
+    if (createdSessionAccepted) {
+      sessions.unshift({
+        sessionId: createdSessionId,
+        title: "Created after draft revisit",
+        lastMessageAt: new Date().toISOString(),
+        status: "running",
+        mainContentInvalidationVersion: 0,
+      });
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions, nextCursor: null }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== selectedSessionId) {
+        throw new Error(`Unexpected chat snapshot sessionId: ${String(sessionId)}`);
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestCount += 1;
+    createRequestReceived.resolve();
+    await releaseCreateResponse.promise;
+    createdSessionAccepted = true;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": createdSessionId,
+      },
+      body: [
+        `data: {"type":"session","sessionId":"${createdSessionId}"}`,
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+  const composer = page.getByTestId("chat-composer-input");
+  const submit = page.getByTestId("chat-submit");
+  await expect(composer).toBeEditable();
+  await composer.fill("first submission");
+  await submit.click();
+  await createRequestReceived.promise;
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${selectedSessionId}`).click();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === selectedSessionId,
+  );
+  await page.getByTestId("chat-new").click();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat" && url.searchParams.get("session") === null,
+  );
+
+  await composer.fill("follow-up after returning");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "follow-up.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("follow-up attachment bytes"),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "follow-up.txt",
+  );
+  await expect(submit).toBeDisabled();
+
+  releaseCreateResponse.resolve();
+  await expect(submit).toBeEnabled();
+  await expect(composer).toHaveValue("follow-up after returning");
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "follow-up.txt",
+  );
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat" && url.searchParams.get("session") === null,
+  );
+  await page.getByTestId("chat-history-open").click();
+  await expect(
+    page.getByTestId(`chat-history-session-${createdSessionId}`),
+  ).toBeVisible();
+  expect(createRequestCount).toBe(1);
+});
+
+test("adopts a delayed first send after the sidebar remounts before the response", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const createdSessionId = "session-created-after-unmount";
+  const createRequestReceived = createDeferred();
+  const releaseCreateResponse = createDeferred();
+  const selectionStorageKey =
+    "expense-tracker-chat-selection:v1:demo:local";
+  let createRequestCount = 0;
+  let createdSnapshotRequestCount = 0;
+
+  await mockWorkspaceClientDependencies(page);
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestCount += 1;
+    createRequestReceived.resolve();
+    await releaseCreateResponse.promise;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": createdSessionId,
+      },
+      body: [
+        `data: {"type":"session","sessionId":"${createdSessionId}"}`,
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== createdSessionId) {
+        throw new Error(`Unexpected chat snapshot sessionId: ${String(sessionId)}`);
+      }
+      createdSnapshotRequestCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId: createdSessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [{
+            messageId: PERSISTED_SNAPSHOT_MESSAGE_ID,
+            role: "assistant",
+            content: [{
+              type: "text",
+              text: "Authoritative adopted session after remount",
+            }],
+            timestamp: Date.now(),
+            isError: false,
+            isStopped: false,
+          }],
+        }),
+      });
+    },
+  );
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "chat-open", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/transactions", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("create while sidebar closes");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "receipt.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("receipt bytes"),
+  });
+  await page.getByTestId("chat-submit").click();
+  await createRequestReceived.promise;
+
+  await page.getByTestId("chat-sidebar-close").click();
+  await expect(page.getByTestId("chat-panel")).toHaveCount(0);
+  await page.getByTestId("chat-sidebar-open").click();
+  await expect(page.getByTestId("chat-panel")).toBeVisible();
+  expect(createRequestCount).toBe(1);
+  releaseCreateResponse.resolve();
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (storageKey: string): string | null =>
+        window.sessionStorage.getItem(storageKey),
+      selectionStorageKey,
+    )).toContain(createdSessionId);
+
+  await expect.poll(() => createdSnapshotRequestCount).toBeGreaterThanOrEqual(1);
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue("");
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+  await page.getByTestId("chat-new").click();
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue("");
+  expect(createRequestCount).toBe(1);
+});
+
+test("protects a live delayed create across sidebar remount and New", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const createdSessionId = "session-created-after-remount-new";
+  const createdSessionDraftStorageKey =
+    `expense-tracker-chat-draft:v2:demo:local:${
+      encodeURIComponent(`session:${createdSessionId}`)
+    }`;
+  const createRequestReceived = createDeferred();
+  const releaseCreateResponse = createDeferred();
+  let createRequestCount = 0;
+  let createdSessionAccepted = false;
+
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: createdSessionAccepted
+          ? [{
+              sessionId: createdSessionId,
+              title: "Created after remount and New",
+              lastMessageAt: new Date().toISOString(),
+              status: "idle",
+              mainContentInvalidationVersion: 0,
+            }]
+          : [],
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== createdSessionId) {
+        throw new Error(`Unexpected chat snapshot sessionId: ${String(sessionId)}`);
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestCount += 1;
+    createRequestReceived.resolve();
+    await releaseCreateResponse.promise;
+    createdSessionAccepted = true;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": createdSessionId,
+      },
+      body: [
+        `data: {"type":"session","sessionId":"${createdSessionId}"}`,
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "chat-open", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/transactions", { waitUntil: "domcontentloaded" });
+
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("create before remount and New");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "submitted.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("submitted attachment bytes"),
+  });
+  await page.getByTestId("chat-submit").click();
+  await createRequestReceived.promise;
+
+  await page.getByTestId("chat-sidebar-close").click();
+  await expect(page.getByTestId("chat-panel")).toHaveCount(0);
+  await page.getByTestId("chat-sidebar-open").click();
+  await expect(page.getByTestId("chat-panel")).toBeVisible();
+
+  await composer.fill("retained follow-up after remount");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "retained.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("retained attachment bytes"),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "retained.txt",
+  );
+  await page.getByTestId("chat-new").click();
+  await expect(composer).toHaveValue("");
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+  expect(createRequestCount).toBe(1);
+
+  releaseCreateResponse.resolve();
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (storageKey: string): string | null =>
+        window.sessionStorage.getItem(storageKey),
+      createdSessionDraftStorageKey,
+    )).toBe("retained follow-up after remount");
+  await getNavigationLink(page, "/chat").click();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && url.searchParams.get("session") === null,
+    { timeout: localNavigationTimeoutMs },
+  );
+  await expect(composer).toHaveValue("");
+  await page.evaluate((sessionId: string): void => {
+    window.history.pushState(
+      {},
+      "",
+      `/chat?session=${encodeURIComponent(sessionId)}`,
+    );
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, createdSessionId);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && url.searchParams.get("session") === createdSessionId,
+  );
+  await expect(composer).toHaveValue("retained follow-up after remount");
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "retained.txt",
+  );
+  await expect(page.getByTestId("chat-submit")).toBeEnabled();
+  expect(createRequestCount).toBe(1);
+});
+
+test("fences a delayed create after the provider scope changes", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const staleSessionId = "session-from-stale-workspace-scope";
+  const createRequestReceived = createDeferred();
+  const releaseCreateResponse = createDeferred();
+  let unexpectedSnapshotCount = 0;
+
+  await page.exposeFunction(
+    "__releaseChatCreateAtLayoutCommit",
+    (): void => releaseCreateResponse.resolve(),
+  );
+  await page.addInitScript((): void => {
+    const originalAbort = AbortController.prototype.abort;
+    AbortController.prototype.abort = function abort(
+      reason?: unknown,
+    ): void {
+      const testWindow = window as LayoutCleanupTestWindow;
+      if (testWindow.__chatCreateReleasedAtLayoutCommit === true) {
+        Object.defineProperty(
+          testWindow,
+          "__chatAbortAfterCreateReleaseCount",
+          {
+            configurable: true,
+            value: (testWindow.__chatAbortAfterCreateReleaseCount ?? 0) + 1,
+          },
+        );
+      }
+      originalAbort.call(this, reason);
+    };
+    const observeDemoCommit = (): void => {
+      let didRelease = false;
+      const releaseWhenDemoIsCommitted = (): void => {
+        const demoButton = document.querySelector(
+          '[data-testid="mode-demo"][aria-pressed="true"]',
+        );
+        if (didRelease || demoButton === null) {
+          return;
+        }
+        const testWindow = window as LayoutCleanupTestWindow;
+        const composer = document.querySelector(
+          '[data-testid="chat-composer-input"]',
+        );
+        const chatPanel = document.querySelector('[data-testid="chat-panel"]');
+        const renderedPreviousScope =
+          composer instanceof HTMLTextAreaElement
+          && composer.value === "pending in the original workspace scope"
+          || chatPanel?.textContent?.includes(
+            "pending in the original workspace scope",
+          ) === true;
+        Object.defineProperty(
+          testWindow,
+          "__chatPreviousScopeRenderedAfterCommit",
+          {
+            configurable: true,
+            value: renderedPreviousScope,
+          },
+        );
+        const releaseCreate = testWindow.__releaseChatCreateAtLayoutCommit;
+        if (releaseCreate === undefined) {
+          throw new Error(
+            "Layout cleanup create-response resolver is missing",
+          );
+        }
+        didRelease = true;
+        Object.defineProperty(
+          testWindow,
+          "__chatCreateReleasedAtLayoutCommit",
+          {
+            configurable: true,
+            value: true,
+          },
+        );
+        void releaseCreate();
+      };
+      const observer = new MutationObserver(releaseWhenDemoIsCommitted);
+      observer.observe(document.documentElement, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+        attributeFilter: ["aria-pressed"],
+      });
+      releaseWhenDemoIsCommitted();
+    };
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", observeDemoCommit, {
+        once: true,
+      });
+    } else {
+      observeDemoCommit();
+    }
+  });
+
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [],
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      unexpectedSnapshotCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId: staleSessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestReceived.resolve();
+    await releaseCreateResponse.promise;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": staleSessionId,
+      },
+      body: [
+        `data: {"type":"session","sessionId":"${staleSessionId}"}`,
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "chat-open", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("pending in the original workspace scope");
+  await page.getByTestId("chat-submit").click();
+  await createRequestReceived.promise;
+
+  await page.evaluate((): void => {
+    document.cookie = "demo=true; path=/; max-age=31536000";
+    const channel = new BroadcastChannel(
+      "expense-tracker-main-content-invalidation",
+    );
+    channel.postMessage({
+      type: "main_content_invalidation",
+      workspaceId: "local",
+      version: 1,
+      sourceId: "scope-change-test",
+      emittedAt: Date.now(),
+    });
+    channel.close();
+  });
+  await expect(page.getByTestId("mode-demo")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(page.getByTestId("chat-panel")).toBeVisible();
+  await expect(composer).toBeEditable();
+  await expect(composer).toHaveValue("");
+  await composer.fill("new demo scope remains selected");
+  await page.evaluate((): void => {
+    window.localStorage.removeItem(
+      "expense-tracker-main-content-invalidation",
+    );
+  });
+
+  await expect.poll(async (): Promise<boolean> =>
+    page.evaluate((): boolean =>
+      (window as LayoutCleanupTestWindow)
+        .__chatCreateReleasedAtLayoutCommit === true)).toBe(true);
+  await expect.poll(async (): Promise<boolean | undefined> =>
+    page.evaluate((): boolean | undefined =>
+      (window as LayoutCleanupTestWindow)
+        .__chatPreviousScopeRenderedAfterCommit)).toBe(false);
+  await expect.poll(async (): Promise<number> =>
+    page.evaluate((): number =>
+      (window as LayoutCleanupTestWindow)
+        .__chatAbortAfterCreateReleaseCount ?? 0)).toBeGreaterThan(0);
+
+  await expect(composer).toHaveValue("new demo scope remains selected");
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+  await page.getByTestId("chat-history-open").click();
+  await expect(
+    page.getByTestId(`chat-history-session-${staleSessionId}`),
+  ).toHaveCount(0);
+  await expect(page.getByTestId("chat-history-empty")).toBeVisible();
+  await page.getByTestId("chat-history-close").click();
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (): string | null => window.localStorage.getItem(
+        "expense-tracker-main-content-invalidation",
+      ),
+    )).toBeNull();
+  const demoSelection = await page.evaluate(
+    (): string | null => window.sessionStorage.getItem(
+      "expense-tracker-chat-selection:v1:demo:local",
+    ),
+  );
+  expect(demoSelection).not.toContain(staleSessionId);
+  expect(unexpectedSnapshotCount).toBe(0);
+
+  await getNavigationLink(page, "/transactions").click();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/transactions",
+    { timeout: localNavigationTimeoutMs },
+  );
+  await expect(page.getByTestId("chat-panel")).toBeVisible();
+  await page.getByTestId("chat-sidebar-close").click();
+  await expect(page.getByTestId("chat-panel")).toHaveCount(0);
+  await page.getByTestId("chat-sidebar-open").click();
+  await expect(composer).toHaveValue("new demo scope remains selected");
+});
+
+test("fences delayed controller catalog work after the provider scope changes", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const workspaceSessionId = "session-old-scope-controller";
+  const reconciliationSnapshotReceived = createDeferred();
+  const releaseReconciliationSnapshot = createDeferred();
+  const reconciliationRequestTerminated = createDeferred();
+  const lastMessageAt = new Date().toISOString();
+  let catalogRequestCount = 0;
+  let snapshotRequestCount = 0;
+  let snapshotRequestTerminalCount = 0;
+  const markReleasedReconciliationRequestTerminated = (
+    requestUrl: string,
+    requestMethod: string,
+  ): void => {
+    if (
+      requestMethod === "GET"
+      && requestUrl.includes(
+        `/api/chat?sessionId=${workspaceSessionId}`,
+      )
+    ) {
+      snapshotRequestTerminalCount += 1;
+      if (snapshotRequestTerminalCount === 2) {
+        reconciliationRequestTerminated.resolve();
+      }
+    }
+  };
+  page.on("requestfinished", (request): void => {
+    markReleasedReconciliationRequestTerminated(
+      request.url(),
+      request.method(),
+    );
+  });
+  page.on("requestfailed", (request): void => {
+    markReleasedReconciliationRequestTerminated(
+      request.url(),
+      request.method(),
+    );
+  });
+
+  await page.addInitScript((sessionId: string): void => {
+    const observeDemoCommit = (): void => {
+      const observer = new MutationObserver((): void => {
+        const demoButton = document.querySelector(
+          '[data-testid="mode-demo"][aria-pressed="true"]',
+        );
+        if (demoButton === null) {
+          return;
+        }
+        const previousValue = (window as LayoutCleanupTestWindow)
+          .__chatPreviousCatalogRenderedAfterCommit === true;
+        const renderedPreviousCatalog = document.querySelector(
+          `[data-testid="chat-history-session-${sessionId}"]`,
+        ) !== null;
+        Object.defineProperty(
+          window,
+          "__chatPreviousCatalogRenderedAfterCommit",
+          {
+            configurable: true,
+            value: previousValue || renderedPreviousCatalog,
+          },
+        );
+      });
+      observer.observe(document.documentElement, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+        attributeFilter: ["aria-pressed"],
+      });
+    };
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", observeDemoCommit, {
+        once: true,
+      });
+    } else {
+      observeDemoCommit();
+    }
+  }, workspaceSessionId);
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    catalogRequestCount += 1;
+    const isDemoRequest = route.request().headers()["cookie"]
+      ?.split(";")
+      .some((value): boolean => value.trim() === "demo=true") === true;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: isDemoRequest
+          ? []
+          : [{
+              sessionId: workspaceSessionId,
+              title: workspaceSessionId,
+              lastMessageAt,
+              status: "idle",
+              mainContentInvalidationVersion: 0,
+            }],
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const requestUrl = new URL(route.request().url());
+      const sessionId = requestUrl.searchParams.get("sessionId");
+      if (sessionId !== workspaceSessionId) {
+        throw new Error(
+          `Unexpected old-scope chat session: ${String(sessionId)}`,
+        );
+      }
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 200,
+          headers: {
+            "Content-Type": "text/event-stream",
+          },
+          body: [
+            "data: {\"type\":\"done\"}",
+            "",
+          ].join("\n\n"),
+        });
+        return;
+      }
+
+      snapshotRequestCount += 1;
+      if (snapshotRequestCount === 2) {
+        reconciliationSnapshotReceived.resolve();
+        await releaseReconciliationSnapshot.promise;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "chat-open", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto(`/chat?session=${workspaceSessionId}`, {
+    waitUntil: "domcontentloaded",
+  });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("send before changing provider scope");
+  await page.getByTestId("chat-submit").click();
+  await reconciliationSnapshotReceived.promise;
+  expect(catalogRequestCount).toBe(1);
+  await page.getByTestId("chat-history-open").click();
+  await expect(
+    page.getByTestId(`chat-history-session-${workspaceSessionId}`),
+  ).toBeVisible();
+
+  await page.evaluate((): void => {
+    document.cookie = "demo=true; path=/; max-age=31536000";
+    const channel = new BroadcastChannel(
+      "expense-tracker-main-content-invalidation",
+    );
+    channel.postMessage({
+      type: "main_content_invalidation",
+      workspaceId: "local",
+      version: 2,
+      sourceId: "controller-scope-change-test",
+      emittedAt: Date.now(),
+    });
+    channel.close();
+  });
+  await expect(page.getByTestId("mode-demo")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect.poll(async (): Promise<boolean | undefined> =>
+    page.evaluate((): boolean | undefined =>
+      (window as LayoutCleanupTestWindow)
+        .__chatPreviousCatalogRenderedAfterCommit)).toBe(false);
+  await expect(composer).toBeEditable();
+  await composer.fill("demo scope remains authoritative");
+
+  await reconciliationRequestTerminated.promise;
+  releaseReconciliationSnapshot.resolve();
+  expect(catalogRequestCount).toBe(2);
+  await expect(composer).toHaveValue("demo scope remains authoritative");
+  await page.getByTestId("chat-history-open").click();
+  await expect(
+    page.getByTestId(`chat-history-session-${workspaceSessionId}`),
+  ).toHaveCount(0);
+  await expect(page.getByTestId("chat-history-empty")).toBeVisible();
+});
+
+test("keeps the newest session popstate during a slow catalog bootstrap", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const sessionA = "session-bootstrap-a";
+  const sessionB = "session-bootstrap-b";
+  const bootstrap = await mockDelayedChatBootstrap(
+    page,
+    [sessionA, sessionB],
+  );
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+
+  await page.goto(`/chat?session=${sessionA}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await bootstrap.catalogRequestReceived;
+  await page.evaluate((nextSessionId: string): void => {
+    window.history.pushState(
+      window.history.state,
+      "",
+      `/chat?session=${encodeURIComponent(nextSessionId)}`,
+    );
+    window.history.back();
+  }, sessionB);
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionA,
+  );
+  await page.evaluate((): void => window.history.forward());
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionB,
+  );
+
+  bootstrap.releaseCatalog();
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await expect.poll(
+    (): Array<string> => [...bootstrap.snapshotSessionIds],
+  ).toEqual([sessionB]);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && url.searchParams.get("session") === sessionB,
+  );
+});
+
+test("keeps a newer draft popstate over an older bootstrap session", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const sessionId = "session-bootstrap-draft";
+  const selectionStorageKey =
+    "expense-tracker-chat-selection:v1:workspace:local:local";
+  const bootstrap = await mockDelayedChatBootstrap(page, [sessionId]);
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+
+  await page.goto(`/chat?session=${sessionId}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await bootstrap.catalogRequestReceived;
+  await page.evaluate((): void => {
+    window.history.pushState(window.history.state, "", "/chat");
+    window.history.back();
+  });
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionId,
+  );
+  await page.evaluate((): void => window.history.forward());
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat" && !url.searchParams.has("session"),
+  );
+
+  bootstrap.releaseCatalog();
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await expect.poll(
+    (): Array<string> => [...bootstrap.snapshotSessionIds],
+  ).toEqual([]);
+  const storedTarget = await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    selectionStorageKey,
+  );
+  expect(storedTarget).toMatch(/"kind":"draft"/u);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat" && !url.searchParams.has("session"),
+  );
+});
+
+test("loads additional history pages without overlap and preserves rows on retry", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const nextCursor = "cursor-1";
+  const nextPageRequestReceived = createDeferred();
+  const releaseNextPageFailure = createDeferred();
+  let nextPageRequestCount = 0;
+  const lastMessageAt = new Date(
+    Date.now() - (7 * 60 * 60 * 1000),
+  ).toISOString();
+  const createSummary = (
+    sessionId: string,
+    title: string,
+  ): Readonly<{
+    sessionId: string;
+    title: string;
+    lastMessageAt: string;
+    status: "idle";
+    mainContentInvalidationVersion: number;
+  }> => ({
+    sessionId,
+    title,
+    lastMessageAt,
+    status: "idle",
+    mainContentInvalidationVersion: 0,
+  });
+
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    const cursor = new URL(route.request().url()).searchParams.get("cursor");
+    if (cursor === null) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessions: [
+            createSummary("session-page-1", "First page"),
+            createSummary("session-deduped", "Original title"),
+          ],
+          nextCursor,
+        }),
+      });
+      return;
+    }
+    if (cursor !== nextCursor) {
+      throw new Error(`Unexpected chat catalog cursor: ${cursor}`);
+    }
+
+    nextPageRequestCount += 1;
+    if (nextPageRequestCount === 1) {
+      nextPageRequestReceived.resolve();
+      await releaseNextPageFailure.promise;
+      await route.fulfill({
+        status: 503,
+        contentType: "text/plain",
+        body: "Catalog page unavailable",
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [
+          createSummary("session-deduped", "Updated title"),
+          createSummary("session-page-2", "Second page"),
+        ],
+        nextCursor: null,
+      }),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await page.getByTestId("chat-history-open").click();
+  const loadMore = page.getByTestId("chat-history-load-more");
+  await expect(loadMore).toBeEnabled();
+  await loadMore.click();
+  await nextPageRequestReceived.promise;
+  await expect(loadMore).toBeDisabled();
+  await loadMore.evaluate((button: HTMLElement): void => button.click());
+  expect(nextPageRequestCount).toBe(1);
+
+  releaseNextPageFailure.resolve();
+  await expect(page.getByTestId("chat-history-error")).toBeVisible();
+  await expect(page.getByTestId("chat-history-session-session-page-1")).toBeVisible();
+  await expect(page.getByTestId("chat-history-session-session-deduped")).toBeVisible();
+  await expect(loadMore).toBeEnabled();
+
+  await loadMore.click();
+  await expect(page.getByTestId("chat-history-session-session-page-2")).toBeVisible();
+  await expect(
+    page.getByTestId("chat-history-session-session-deduped"),
+  ).toHaveCount(1);
+  await expect(
+    page.getByTestId("chat-history-session-session-deduped"),
+  ).toContainText("Updated title");
+  await expect(loadMore).toHaveCount(0);
+  expect(nextPageRequestCount).toBe(2);
+});
+
+test("repairs an unavailable sidebar history selection outside fullscreen chat", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const safeSessionId = "session-safe";
+  const missingSessionId = "session-missing";
+  const secondMissingSessionId = "session-missing-second";
+  const selectionStorageKey =
+    "expense-tracker-chat-selection:v1:workspace:local:local";
+  const lastMessageAt = new Date().toISOString();
+  let safeSnapshotRequestCount = 0;
+  let missingSnapshotRequestCount = 0;
+  let secondMissingSnapshotRequestCount = 0;
+  let hasObservedMissingSnapshot = false;
+
+  await page.addInitScript((params: Readonly<{
+    storageKey: string;
+    sessionId: string;
+  }>): void => {
+    const initializationMarker = `${params.storageKey}:initialized`;
+    if (window.sessionStorage.getItem(initializationMarker) !== null) {
+      return;
+    }
+    window.sessionStorage.setItem(initializationMarker, "true");
+    window.sessionStorage.setItem(params.storageKey, JSON.stringify({
+      kind: "session",
+      sessionId: params.sessionId,
+    }));
+  }, {
+    storageKey: selectionStorageKey,
+    sessionId: safeSessionId,
+  });
+
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    const sessions = hasObservedMissingSnapshot
+      ? [
+        {
+          sessionId: safeSessionId,
+          title: "Safe session",
+          lastMessageAt,
+          status: "idle",
+          mainContentInvalidationVersion: 0,
+        },
+      ]
+      : [
+        {
+          sessionId: secondMissingSessionId,
+          title: "Second unavailable session",
+          lastMessageAt,
+          status: "running",
+          mainContentInvalidationVersion: 0,
+        },
+        {
+          sessionId: missingSessionId,
+          title: "Unavailable session",
+          lastMessageAt,
+          status: "running",
+          mainContentInvalidationVersion: 0,
+        },
+        {
+          sessionId: safeSessionId,
+          title: "Safe session",
+          lastMessageAt,
+          status: "idle",
+          mainContentInvalidationVersion: 0,
+        },
+      ];
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions,
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId === missingSessionId) {
+        missingSnapshotRequestCount += 1;
+        hasObservedMissingSnapshot = true;
+        await route.fulfill({
+          status: 404,
+          contentType: "text/plain",
+          body: `Chat session not found: ${missingSessionId}`,
+        });
+        return;
+      }
+      if (sessionId === secondMissingSessionId) {
+        secondMissingSnapshotRequestCount += 1;
+        await route.fulfill({
+          status: 404,
+          contentType: "text/plain",
+          body: `Chat session not found: ${secondMissingSessionId}`,
+        });
+        return;
+      }
+      if (sessionId !== safeSessionId) {
+        throw new Error(`Unexpected chat snapshot sessionId: ${String(sessionId)}`);
+      }
+
+      safeSnapshotRequestCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId: safeSessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await page.route(
+    "**/api/account-suggestions",
+    async (route): Promise<void> => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "[]",
+      });
+    },
+  );
+  await page.route("**/api/categories", async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ categories: [] }),
+    });
+  });
+  await page.route(
+    "**/api/workspace-settings",
+    async (route): Promise<void> => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ filteredCategories: null }),
+      });
+    },
+  );
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "chat-open", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await expect.poll(() => safeSnapshotRequestCount).toBe(1);
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${missingSessionId}`).click();
+
+  await expect.poll(() => missingSnapshotRequestCount).toBe(1);
+  await expect.poll(() => secondMissingSnapshotRequestCount).toBe(1);
+  await expect.poll(() => safeSnapshotRequestCount).toBeGreaterThanOrEqual(2);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/" && url.search === "",
+  );
+  expect(await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    selectionStorageKey,
+  )).toBeNull();
+
+  await page.getByTestId("chat-history-open").click();
+  await expect(
+    page.getByTestId(`chat-history-session-${safeSessionId}`),
+  ).toHaveAttribute("aria-current", "true");
+  await page.getByTestId("chat-history-close").click();
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await expect.poll(() => safeSnapshotRequestCount).toBeGreaterThanOrEqual(3);
+  expect(missingSnapshotRequestCount).toBe(1);
+  expect(secondMissingSnapshotRequestCount).toBe(1);
+  expect(await page.evaluate(
+    (storageKey: string): string | null =>
+      window.sessionStorage.getItem(storageKey),
+    selectionStorageKey,
+  )).toBeNull();
+});
+
+test("switches between running sessions without aborting bootstrap or leaking Stop state", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const sessionA = "session-running-a";
+  const sessionB = "session-running-b";
+  const bSnapshotRequestReceived = createDeferred();
+  const releaseFirstBSnapshot = createDeferred();
+  const stopRequestReceived = createDeferred();
+  const releaseStopResponse = createDeferred();
+  const snapshotRequestCounts = new Map<string, number>();
+  const stoppedSessionIds: Array<string> = [];
+  const lastMessageAt = new Date().toISOString();
+  let chatSendRequestCount = 0;
+
+  await page.addInitScript((): void => {
+    const originalFetch = window.fetch.bind(window);
+    const markStopContinuationTerminal = (): void => {
+      const channel = new MessageChannel();
+      channel.port1.onmessage = (): void => {
+        const testWindow = window as StopContinuationTestWindow;
+        const currentCount =
+          testWindow.__chatStopResponseTerminalCount ?? 0;
+        Object.defineProperty(
+          testWindow,
+          "__chatStopResponseTerminalCount",
+          {
+            configurable: true,
+            value: currentCount + 1,
+          },
+        );
+        channel.port1.close();
+        channel.port2.close();
+      };
+      channel.port2.postMessage(null);
+    };
+    window.fetch = async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const requestUrl = input instanceof Request
+        ? input.url
+        : String(input);
+      if (new URL(requestUrl, window.location.href).pathname !== "/api/chat/stop") {
+        return originalFetch(input, init);
+      }
+      let response: Response;
+      try {
+        response = await originalFetch(input, init);
+      } catch (error) {
+        markStopContinuationTerminal();
+        throw error;
+      }
+      const originalText = response.text.bind(response);
+      Object.defineProperty(response, "text", {
+        configurable: true,
+        value: async (): Promise<string> => {
+          const text = await originalText();
+          markStopContinuationTerminal();
+          return text;
+        },
+      });
+      return response;
+    };
+  });
+  await mockWorkspaceClientDependencies(page);
+  page.on("request", (request): void => {
+    const url = new URL(request.url());
+    if (request.method() === "POST" && url.pathname === "/api/chat") {
+      chatSendRequestCount += 1;
+    }
+  });
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [sessionA, sessionB].map((sessionId) => ({
+          sessionId,
+          title: sessionId,
+          lastMessageAt,
+          status: "running",
+          mainContentInvalidationVersion: 0,
+        })),
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== sessionA && sessionId !== sessionB) {
+        throw new Error(`Unexpected chat snapshot sessionId: ${String(sessionId)}`);
+      }
+
+      const requestCount = (snapshotRequestCounts.get(sessionId) ?? 0) + 1;
+      snapshotRequestCounts.set(sessionId, requestCount);
+      if (sessionId === sessionB && requestCount === 1) {
+        bSnapshotRequestReceived.resolve();
+        await releaseFirstBSnapshot.promise;
+      }
+      const runState = "running";
+      const activeTurnId = sessionId === sessionB
+          ? SECOND_RUNNING_SNAPSHOT_TURN_ID
+          : requestCount === 1
+            ? RUNNING_SNAPSHOT_TURN_ID
+            : NEWER_RUNNING_SNAPSHOT_TURN_ID;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState,
+          activeTurnId,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await page.route("**/api/chat/stop", async (route): Promise<void> => {
+    const body = route.request().postDataJSON() as Readonly<{
+      sessionId: string;
+    }>;
+    stoppedSessionIds.push(body.sessionId);
+    stopRequestReceived.resolve();
+    await releaseStopResponse.promise;
+    await route.fulfill({
+      status: 503,
+      contentType: "text/plain",
+      body: "Stop request failed",
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await expect.poll(() => snapshotRequestCounts.get(sessionA) ?? 0).toBe(1);
+  await expect(page.getByTestId("chat-submit")).toBeEnabled();
+  await expect(page.getByTestId("chat-submit")).toHaveText("Stop");
+
+  await page.getByTestId("chat-submit").click();
+  await stopRequestReceived.promise;
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${sessionB}`).click();
+  await bSnapshotRequestReceived.promise;
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionB,
+  );
+  releaseFirstBSnapshot.resolve();
+  await expect(page.getByTestId("chat-submit")).toBeEnabled();
+  await expect(page.getByTestId("chat-submit")).toHaveText("Stop");
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${sessionA}`).click();
+  await expect.poll(() => snapshotRequestCounts.get(sessionA) ?? 0).toBe(2);
+  const submitButton = page.getByTestId("chat-submit");
+  await expect(submitButton).toBeEnabled();
+  await expect(submitButton).toHaveText("Stop");
+  expect(chatSendRequestCount).toBe(0);
+
+  releaseStopResponse.resolve();
+  await expect.poll(async (): Promise<number | undefined> =>
+    page.evaluate((): number | undefined =>
+      (window as StopContinuationTestWindow)
+        .__chatStopResponseTerminalCount)).toBe(1);
+  expect(snapshotRequestCounts.get(sessionA)).toBe(2);
+  await expect(page.getByTestId("chat-submit")).toBeEnabled();
+  await expect(page.getByTestId("chat-submit")).toHaveText("Stop");
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${sessionB}`).click();
+  await expect.poll(() => snapshotRequestCounts.get(sessionB) ?? 0).toBe(2);
+  await expect(page.getByTestId("chat-submit")).toBeEnabled();
+  await expect(page.getByTestId("chat-submit")).toHaveText("Stop");
+  expect(stoppedSessionIds).toEqual([sessionA]);
+});
+
+test("migrates the legacy scope draft only after the real local target is ready", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const legacyStorageKey = "expense-tracker-chat-draft:v1:demo:local";
+  await page.addInitScript((storageKey: string): void => {
+    window.sessionStorage.setItem(storageKey, "legacy draft text");
+  }, legacyStorageKey);
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "chat-open", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+
+  await page.goto("/transactions", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toHaveValue(
+    "legacy draft text",
+  );
+  const storedDrafts = await page.evaluate((storageKey: string): Readonly<{
+    legacyValue: string | null;
+    currentValues: ReadonlyArray<string | null>;
+  }> => ({
+    legacyValue: window.sessionStorage.getItem(storageKey),
+    currentValues: Array.from(
+      { length: window.sessionStorage.length },
+      (_value: undefined, index: number): string | null =>
+        window.sessionStorage.key(index),
+    )
+      .filter(
+        (key: string | null): key is string =>
+          key?.startsWith("expense-tracker-chat-draft:v2:demo:local:") ?? false,
+      )
+      .map((key: string): string | null => window.sessionStorage.getItem(key)),
+  }), legacyStorageKey);
+
+  expect(storedDrafts.legacyValue).toBeNull();
+  expect(storedDrafts.currentValues).toEqual(["legacy draft text"]);
+});
+
+type AdoptionStorageFailureCase = Readonly<{
+  slug: string;
+  name: string;
+  method: "setItem" | "removeItem";
+  getStorageKey: (
+    sourceStorageKey: string,
+    sessionId: string,
+  ) => string;
+}>;
+
+const adoptionStorageFailureCases: ReadonlyArray<
+  AdoptionStorageFailureCase
+> = [
+  {
+    slug: "destination",
+    name: "destination draft write",
+    method: "setItem",
+    getStorageKey: (
+      _sourceStorageKey: string,
+      sessionId: string,
+    ): string =>
+      `expense-tracker-chat-draft:v2:workspace:local:local:${
+        encodeURIComponent(`session:${sessionId}`)
+      }`,
+  },
+  {
+    slug: "source",
+    name: "source draft clear",
+    method: "removeItem",
+    getStorageKey: (
+      sourceStorageKey: string,
+      _sessionId: string,
+    ): string => sourceStorageKey,
+  },
+  {
+    slug: "active",
+    name: "active draft clear",
+    method: "removeItem",
+    getStorageKey: (
+      _sourceStorageKey: string,
+      _sessionId: string,
+    ): string =>
+      "expense-tracker-chat-active-draft:v1:workspace:local:local",
+  },
+  {
+    slug: "selection",
+    name: "explicit session selection write",
+    method: "setItem",
+    getStorageKey: (
+      _sourceStorageKey: string,
+      _sessionId: string,
+    ): string =>
+      "expense-tracker-chat-selection:v1:workspace:local:local",
+  },
+];
+
+for (const failureCase of adoptionStorageFailureCases) {
+  test(`rolls back ${failureCase.name} failure during draft adoption`, async ({
+    page,
+    baseURL,
+    context,
+  }) => {
+    if (baseURL === undefined) {
+      throw new Error("Local Demo Playwright baseURL is required");
+    }
+
+    const sessionId = `session-storage-failure-${failureCase.slug}`;
+    const createRequestReceived = createDeferred();
+    const releaseCreateResponse = createDeferred();
+    let snapshotRequestCount = 0;
+
+    await mockWorkspaceClientDependencies(page);
+    await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessions: [],
+          nextCursor: null,
+        }),
+      });
+    });
+    await page.route(
+      /\/api\/chat\?sessionId=/u,
+      async (route): Promise<void> => {
+        snapshotRequestCount += 1;
+        await route.fulfill({
+          status: 500,
+          contentType: "text/plain",
+          body: "Adoption failure must not request a session snapshot",
+        });
+      },
+    );
+    await page.route("**/api/chat/new", async (route): Promise<void> => {
+      createRequestReceived.resolve();
+      await releaseCreateResponse.promise;
+      await route.fulfill({
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "X-Chat-Session-Id": sessionId,
+        },
+        body: [
+          `data: {"type":"session","sessionId":"${sessionId}"}`,
+          "data: {\"type\":\"done\"}",
+          "",
+        ].join("\n\n"),
+      });
+    });
+
+    const origin = new URL(baseURL);
+    await context.addCookies([
+      {
+        name: "locale",
+        value: "en",
+        domain: origin.hostname,
+        path: "/",
+        sameSite: "Lax",
+      },
+    ]);
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+    const composer = page.getByTestId("chat-composer-input");
+    await expect(composer).toBeEditable();
+    await composer.fill(`submitted before ${failureCase.name}`);
+    await page.getByTestId("chat-submit").click();
+    await createRequestReceived.promise;
+
+    const retainedText = `retained after ${failureCase.name}`;
+    const retainedAttachmentName = `retained-${failureCase.slug}.txt`;
+    await composer.fill(retainedText);
+    await page.getByTestId("chat-file-input").setInputFiles({
+      name: retainedAttachmentName,
+      mimeType: "text/plain",
+      buffer: Buffer.from(`attachment retained after ${failureCase.name}`),
+    });
+    await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+      retainedAttachmentName,
+    );
+
+    const storageBeforeAdoption = await page.evaluate(
+      (expectedText: string): Readonly<{
+        sourceStorageKey: string;
+        sourceText: string | null;
+        activeDraft: string | null;
+        selection: string | null;
+      }> => {
+        for (
+          let index = 0;
+          index < window.sessionStorage.length;
+          index += 1
+        ) {
+          const storageKey = window.sessionStorage.key(index);
+          if (
+            storageKey?.startsWith(
+              "expense-tracker-chat-draft:v2:workspace:local:local:",
+            ) === true
+            && window.sessionStorage.getItem(storageKey) === expectedText
+          ) {
+            return {
+              sourceStorageKey: storageKey,
+              sourceText: window.sessionStorage.getItem(storageKey),
+              activeDraft: window.sessionStorage.getItem(
+                "expense-tracker-chat-active-draft:v1:workspace:local:local",
+              ),
+              selection: window.sessionStorage.getItem(
+                "expense-tracker-chat-selection:v1:workspace:local:local",
+              ),
+            };
+          }
+        }
+        throw new Error("Adoption source draft storage key was not found");
+      },
+      retainedText,
+    );
+    const destinationStorageKey =
+      `expense-tracker-chat-draft:v2:workspace:local:local:${
+        encodeURIComponent(`session:${sessionId}`)
+      }`;
+    const failureStorageKey = failureCase.getStorageKey(
+      storageBeforeAdoption.sourceStorageKey,
+      sessionId,
+    );
+    await page.evaluate(
+      ({ method, storageKey }): void => {
+        type StorageFailureWindow = Window & Readonly<{
+          __restoreChatStorageMutation?: () => void;
+          __chatStorageMutationFailed?: boolean;
+        }>;
+        const testWindow = window as StorageFailureWindow;
+        const storagePrototype = Storage.prototype;
+        const originalSetItem = storagePrototype.setItem;
+        const originalRemoveItem = storagePrototype.removeItem;
+        const originalMethod = method === "setItem"
+          ? originalSetItem
+          : originalRemoveItem;
+        let hasFailed = false;
+        const replacement = function (
+          this: Storage,
+          key: string,
+          value?: string,
+        ): void {
+          if (
+            this === window.sessionStorage
+            && key === storageKey
+            && !hasFailed
+          ) {
+            hasFailed = true;
+            Object.defineProperty(testWindow, "__chatStorageMutationFailed", {
+              configurable: true,
+              value: true,
+            });
+            throw new DOMException(
+              `Synthetic adoption storage failure for ${key}`,
+              "QuotaExceededError",
+            );
+          }
+          if (method === "setItem") {
+            if (value === undefined) {
+              throw new Error("Storage setItem replacement requires a value");
+            }
+            originalSetItem.call(this, key, value);
+            return;
+          }
+          originalRemoveItem.call(this, key);
+        };
+        Object.defineProperty(storagePrototype, method, {
+          configurable: true,
+          value: replacement,
+          writable: true,
+        });
+        Object.defineProperty(testWindow, "__restoreChatStorageMutation", {
+          configurable: true,
+          value: (): void => {
+            Object.defineProperty(storagePrototype, method, {
+              configurable: true,
+              value: originalMethod,
+              writable: true,
+            });
+          },
+        });
+      },
+      {
+        method: failureCase.method,
+        storageKey: failureStorageKey,
+      },
+    );
+
+    releaseCreateResponse.resolve();
+    await expect.poll(async (): Promise<boolean> =>
+      page.evaluate((): boolean =>
+        (window as Window & Readonly<{
+          __chatStorageMutationFailed?: boolean;
+        }>).__chatStorageMutationFailed === true)).toBe(true);
+    await expect.poll(async (): Promise<Readonly<{
+      sourceText: string | null;
+      destinationText: string | null;
+      activeDraft: string | null;
+      selection: string | null;
+    }>> => page.evaluate(
+      ({ sourceStorageKey, destinationKey }): Readonly<{
+        sourceText: string | null;
+        destinationText: string | null;
+        activeDraft: string | null;
+        selection: string | null;
+      }> => ({
+        sourceText: window.sessionStorage.getItem(sourceStorageKey),
+        destinationText: window.sessionStorage.getItem(destinationKey),
+        activeDraft: window.sessionStorage.getItem(
+          "expense-tracker-chat-active-draft:v1:workspace:local:local",
+        ),
+        selection: window.sessionStorage.getItem(
+          "expense-tracker-chat-selection:v1:workspace:local:local",
+        ),
+      }),
+      {
+        sourceStorageKey: storageBeforeAdoption.sourceStorageKey,
+        destinationKey: destinationStorageKey,
+      },
+    )).toEqual({
+      sourceText: storageBeforeAdoption.sourceText,
+      destinationText: null,
+      activeDraft: storageBeforeAdoption.activeDraft,
+      selection: storageBeforeAdoption.selection,
+    });
+    await expect(page).toHaveURL(
+      (url) => url.pathname === "/chat"
+        && !url.searchParams.has("session"),
+    );
+    await expect(composer).toBeEditable();
+    await expect(composer).toHaveValue(retainedText);
+    await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+      retainedAttachmentName,
+    );
+    expect(snapshotRequestCount).toBe(0);
+
+    await page.evaluate((): void => {
+      const restore = (window as Window & Readonly<{
+        __restoreChatStorageMutation?: () => void;
+      }>).__restoreChatStorageMutation;
+      if (restore === undefined) {
+        throw new Error("Storage mutation restore callback is missing");
+      }
+      restore();
+    });
+  });
+}
+
+test("preserves an edited destination when delayed draft adoption collides", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const collisionSessionId = "session-adoption-destination-collision";
+  const createRequestReceived = createDeferred();
+  const releaseCreateResponse = createDeferred();
+  const pageErrors: Array<string> = [];
+  let exposeCollisionSession = false;
+  page.on("pageerror", (error): void => {
+    pageErrors.push(error.message);
+  });
+
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: exposeCollisionSession
+          ? [{
+              sessionId: collisionSessionId,
+              title: collisionSessionId,
+              lastMessageAt: new Date().toISOString(),
+              status: "idle",
+              mainContentInvalidationVersion: 0,
+            }]
+          : [],
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== collisionSessionId) {
+        throw new Error(
+          `Unexpected collision snapshot sessionId: ${String(sessionId)}`,
+        );
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    exposeCollisionSession = true;
+    createRequestReceived.resolve();
+    await releaseCreateResponse.promise;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": collisionSessionId,
+      },
+      body: [
+        `data: {"type":"session","sessionId":"${collisionSessionId}"}`,
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "chat-open", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("first message before collision");
+  await page.getByTestId("chat-submit").click();
+  await createRequestReceived.promise;
+  await composer.fill("obsolete source follow-up");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "obsolete-source.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("obsolete source attachment"),
+  });
+  const sourceStorageKey = await page.evaluate(
+    (expectedText: string): string => {
+      for (let index = 0; index < window.sessionStorage.length; index += 1) {
+        const key = window.sessionStorage.key(index);
+        if (
+          key?.startsWith("expense-tracker-chat-draft:v2:workspace:") === true
+          && window.sessionStorage.getItem(key) === expectedText
+        ) {
+          return key;
+        }
+      }
+      throw new Error("Source collision draft storage key was not found");
+    },
+    "obsolete source follow-up",
+  );
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(
+    `chat-history-session-${collisionSessionId}`,
+  ).click();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === collisionSessionId,
+  );
+  await expect(composer).toBeEditable();
+  await composer.fill("authoritative destination text");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "authoritative-destination.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("authoritative destination attachment"),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "authoritative-destination.txt",
+  );
+
+  releaseCreateResponse.resolve();
+  await expect(composer).toHaveValue("authoritative destination text");
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "authoritative-destination.txt",
+  );
+  await expect(page.getByTestId("chat-prepared-attachment")).not.toContainText(
+    "obsolete-source.txt",
+  );
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (storageKey: string): string | null =>
+        window.sessionStorage.getItem(storageKey),
+      sourceStorageKey,
+    )).toBeNull();
+  expect(pageErrors).toEqual([]);
+});
+
+test("atomically adopts remounted composer work before the first session header", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  await page.addInitScript((): void => {
+    class MockMediaRecorder extends EventTarget {
+      public static isTypeSupported(_mimeType: string): boolean {
+        return true;
+      }
+
+      public state: RecordingState = "inactive";
+      public readonly mimeType: string;
+
+      public constructor(_stream: MediaStream, options?: MediaRecorderOptions) {
+        super();
+        this.mimeType = options?.mimeType ?? "audio/webm";
+      }
+
+      public start(): void {
+        this.state = "recording";
+      }
+
+      public stop(): void {
+        if (this.state === "inactive") {
+          return;
+        }
+        this.state = "inactive";
+        this.dispatchEvent(new BlobEvent("dataavailable", {
+          data: new Blob(["recorded audio"], { type: this.mimeType }),
+        }));
+        this.dispatchEvent(new Event("stop"));
+      }
+    }
+
+    const mediaStream = {
+      getTracks: (): ReadonlyArray<Readonly<{ stop: () => void }>> => [{
+        stop: (): void => undefined,
+      }],
+    };
+    let resolvePermission: ((stream: typeof mediaStream) => void) | null = null;
+    const permission = new Promise<typeof mediaStream>((resolve): void => {
+      resolvePermission = resolve;
+    });
+    if (resolvePermission === null) {
+      throw new Error("Failed to create deferred microphone permission");
+    }
+    Object.defineProperty(
+      window,
+      "__resolveChatMicrophonePermission",
+      {
+        configurable: true,
+        value: (): void => resolvePermission?.(mediaStream),
+      },
+    );
+    Object.defineProperty(window, "MediaRecorder", {
+      configurable: true,
+      value: MockMediaRecorder,
+    });
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: async (): Promise<typeof mediaStream> => permission,
+      },
+    });
+  });
+
+  const newChatRequestReceived = createDeferred();
+  const releaseNewChatResponse = createDeferred();
+  const transcriptionRequestReceived = createDeferred();
+  const releaseTranscriptionResponse = createDeferred();
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    newChatRequestReceived.resolve();
+    await releaseNewChatResponse.promise;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": "session-adopted",
+      },
+      body: [
+        "data: {\"type\":\"session\",\"sessionId\":\"session-adopted\"}",
+        "data: {\"type\":\"delta\",\"text\":\"Done\",\"itemId\":\"assistant-1\",\"outputIndex\":0,\"contentIndex\":0,\"sequenceNumber\":0}",
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+  await page.route("**/api/chat/transcriptions", async (route): Promise<void> => {
+    transcriptionRequestReceived.resolve();
+    await releaseTranscriptionResponse.promise;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ text: "dictated after send" }),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "chat-open", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("first message");
+  await page.getByTestId("chat-submit").click();
+  await newChatRequestReceived.promise;
+
+  await getNavigationLink(page, "/transactions").click();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/transactions",
+    { timeout: localNavigationTimeoutMs },
+  );
+  await expect(page.getByTestId("chat-panel")).toBeVisible();
+  await composer.fill("follow-up before adoption");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "follow-up.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("attachment after send"),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "follow-up.txt",
+  );
+
+  const dictationButton = page.getByTestId("chat-dictation");
+  await dictationButton.click();
+  await expect(dictationButton).toBeDisabled();
+  const expectedCaret = "follow-up before adoption".length;
+  await composer.evaluate((element): void => {
+    const textarea = element as HTMLTextAreaElement & {
+      __chatRemountAdoptionMarker?: string;
+    };
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    textarea.__chatRemountAdoptionMarker = "current-remounted-composer";
+  });
+
+  releaseNewChatResponse.resolve();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/transactions"
+      && url.searchParams.get("session") === null,
+  );
+  expect(await composer.evaluate((element): Readonly<{
+    marker: string | undefined;
+    selectionStart: number;
+    selectionEnd: number;
+  }> => {
+    const textarea = element as HTMLTextAreaElement & {
+      __chatRemountAdoptionMarker?: string;
+    };
+    return {
+      marker: textarea.__chatRemountAdoptionMarker,
+      selectionStart: textarea.selectionStart,
+      selectionEnd: textarea.selectionEnd,
+    };
+  })).toEqual({
+    marker: "current-remounted-composer",
+    selectionStart: expectedCaret,
+    selectionEnd: expectedCaret,
+  });
+  await page.evaluate((): void => {
+    const resolvePermission =
+      (window as DictationTestWindow).__resolveChatMicrophonePermission;
+    if (resolvePermission === undefined) {
+      throw new Error("Deferred microphone permission resolver is missing");
+    }
+    resolvePermission();
+  });
+  await expect(dictationButton).toHaveAttribute("aria-pressed", "true");
+  await dictationButton.click();
+  await transcriptionRequestReceived.promise;
+  releaseTranscriptionResponse.resolve();
+
+  await expect(composer).toHaveValue(/follow-up before adoption/u);
+  await expect(composer).toHaveValue(/dictated after send/u);
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "follow-up.txt",
+  );
+});
+
+test("preserves composer focus caret and mention state only across exact adoption", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const adoptedSessionId = "session-lifecycle-adopted";
+  const switchedSessionId = "session-lifecycle-switch";
+  const createRequestReceived = createDeferred();
+  const releaseCreateResponse = createDeferred();
+  const snapshotCounts = new Map<string, number>();
+  let exposeSessions = false;
+
+  await mockWorkspaceClientDependencies(page);
+  await page.route("**/api/account-suggestions", async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        { accountId: "cash", currency: "USD" },
+        { accountId: "card", currency: "EUR" },
+      ]),
+    });
+  });
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: exposeSessions
+          ? [adoptedSessionId, switchedSessionId].map((sessionId) => ({
+              sessionId,
+              title: sessionId,
+              lastMessageAt: new Date().toISOString(),
+              status: "idle",
+              mainContentInvalidationVersion: 0,
+            }))
+          : [],
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== adoptedSessionId && sessionId !== switchedSessionId) {
+        throw new Error(
+          `Unexpected lifecycle snapshot sessionId: ${String(sessionId)}`,
+        );
+      }
+      snapshotCounts.set(
+        sessionId,
+        (snapshotCounts.get(sessionId) ?? 0) + 1,
+      );
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestReceived.resolve();
+    await releaseCreateResponse.promise;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": adoptedSessionId,
+      },
+      body: [
+        `data: {"type":"session","sessionId":"${adoptedSessionId}"}`,
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("first lifecycle message");
+  await page.getByTestId("chat-submit").click();
+  await createRequestReceived.promise;
+
+  const followUpText = "follow-up @ca";
+  const mentionCaret = followUpText.length;
+  await composer.fill(followUpText);
+  await composer.evaluate((element): void => {
+    const textarea = element as HTMLTextAreaElement & {
+      __chatLifecycleMarker?: string;
+    };
+    textarea.focus();
+    textarea.__chatLifecycleMarker = "preserve-on-adoption";
+  });
+  await expect(
+    page.getByTestId("chat-account-mention-popover"),
+  ).toBeVisible();
+  await composer.press("ArrowDown");
+  const activeMentionId = await composer.getAttribute(
+    "aria-activedescendant",
+  );
+  if (activeMentionId === null) {
+    throw new Error("Mention selection did not expose an active descendant");
+  }
+
+  exposeSessions = true;
+  releaseCreateResponse.resolve();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === adoptedSessionId,
+  );
+  await expect(composer).toBeFocused();
+  await expect(composer).toHaveValue(followUpText);
+  await expect(composer).toHaveAttribute(
+    "aria-activedescendant",
+    activeMentionId,
+  );
+  expect(await composer.evaluate((element): Readonly<{
+    marker: string | undefined;
+    selectionStart: number;
+    selectionEnd: number;
+  }> => {
+    const textarea = element as HTMLTextAreaElement & {
+      __chatLifecycleMarker?: string;
+    };
+    return {
+      marker: textarea.__chatLifecycleMarker,
+      selectionStart: textarea.selectionStart,
+      selectionEnd: textarea.selectionEnd,
+    };
+  })).toEqual({
+    marker: "preserve-on-adoption",
+    selectionStart: mentionCaret,
+    selectionEnd: mentionCaret,
+  });
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(
+    `chat-history-session-${switchedSessionId}`,
+  ).click();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === switchedSessionId,
+  );
+  await expect(composer).toHaveValue("");
+  expect(await composer.evaluate((element): string | undefined =>
+    (element as HTMLTextAreaElement & {
+      __chatLifecycleMarker?: string;
+    }).__chatLifecycleMarker)).toBeUndefined();
+  await expect(
+    page.getByTestId("chat-account-mention-popover"),
+  ).toHaveCount(0);
+
+  const roundTripText = "round trip @ca";
+  await composer.fill(roundTripText);
+  await expect(
+    page.getByTestId("chat-account-mention-popover"),
+  ).toBeVisible();
+  await composer.press("ArrowDown");
+  await expect(composer).toHaveAttribute(
+    "aria-activedescendant",
+    /chat-account-mention-option/u,
+  );
+  await composer.evaluate((element): void => {
+    const textarea = element as HTMLTextAreaElement & {
+      __chatLifecycleMarker?: string;
+    };
+    textarea.focus();
+    textarea.setSelectionRange(2, 2);
+    textarea.__chatLifecycleMarker = "reset-after-new-epoch";
+  });
+  const previousSwitchedSnapshotCount =
+    snapshotCounts.get(switchedSessionId) ?? 0;
+  await page.evaluate(({ firstSessionId, secondSessionId }): void => {
+    window.history.pushState(
+      window.history.state,
+      "",
+      `/chat?session=${encodeURIComponent(firstSessionId)}`,
+    );
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    window.history.pushState(
+      window.history.state,
+      "",
+      `/chat?session=${encodeURIComponent(secondSessionId)}`,
+    );
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, {
+    firstSessionId: adoptedSessionId,
+    secondSessionId: switchedSessionId,
+  });
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === switchedSessionId,
+  );
+  await expect.poll((): number =>
+    snapshotCounts.get(switchedSessionId) ?? 0).toBeGreaterThan(
+      previousSwitchedSnapshotCount,
+    );
+  await expect(composer).toHaveValue(roundTripText);
+  await expect(composer).not.toBeFocused();
+  await expect(composer).not.toHaveAttribute("aria-activedescendant");
+  expect(await composer.evaluate((element): string | undefined =>
+    (element as HTMLTextAreaElement & {
+      __chatLifecycleMarker?: string;
+    }).__chatLifecycleMarker)).toBeUndefined();
 });

--- a/apps/web/e2e-local/chat-heic-attachments.local-demo.spec.ts
+++ b/apps/web/e2e-local/chat-heic-attachments.local-demo.spec.ts
@@ -14,12 +14,238 @@ type ImageEncodeObservation = Readonly<{
 
 type InstrumentedWindow = Window & Readonly<{
   __chatImageEncodeObservations?: ReadonlyArray<ImageEncodeObservation>;
+  __releaseChatImageEncoding?: () => void;
+  __releaseNextChatImageEncoding?: () => void;
+  __chatPendingImageEncodingCount?: number;
+  __chatImageEncodingCallbackCount?: number;
+  __captureNextDeferredPasteTimer?: () => void;
+  __deferredPasteTimerCaptured?: boolean;
+  __releaseDeferredPasteTimer?: () => void;
 }>;
+
+type Deferred = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+}>;
+
+const createDeferred = (): Deferred => {
+  let resolvePromise: (() => void) | null = null;
+  const promise = new Promise<void>((resolve): void => {
+    resolvePromise = resolve;
+  });
+  if (resolvePromise === null) {
+    throw new Error("Failed to create deferred HEIC browser-test operation");
+  }
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+};
 
 const fixturePath = resolve(process.cwd(), "e2e-local/fixtures/chat-image.heic");
 const encodeCallbackDelayMs = 500;
 const fixtureWidth = 48;
 const fixtureHeight = 80;
+
+const installDeferredImageEncoding = async (page: Page): Promise<void> => {
+  await page.addInitScript((): void => {
+    const testWindow = window as InstrumentedWindow;
+    const observations: Array<ImageEncodeObservation> = [];
+    Object.defineProperty(testWindow, "__chatImageEncodeObservations", {
+      value: observations,
+      writable: false,
+    });
+
+    let releaseEncoding: (() => void) | null = null;
+    const encodingRelease = new Promise<void>((resolve): void => {
+      releaseEncoding = resolve;
+    });
+    if (releaseEncoding === null) {
+      throw new Error("Failed to create deferred image encoding operation");
+    }
+    Object.defineProperty(testWindow, "__releaseChatImageEncoding", {
+      value: releaseEncoding,
+      writable: false,
+    });
+
+    const originalToBlob = HTMLCanvasElement.prototype.toBlob;
+    HTMLCanvasElement.prototype.toBlob = function toBlob(
+      callback: BlobCallback,
+      mediaType?: string,
+      quality?: number,
+    ): void {
+      const width = this.width;
+      const height = this.height;
+      originalToBlob.call(
+        this,
+        (blob: Blob | null): void => {
+          if (blob !== null) {
+            observations.push({
+              width,
+              height,
+              mediaType: blob.type,
+              bytes: blob.size,
+            });
+          }
+          void encodingRelease.then((): void => callback(blob));
+        },
+        mediaType,
+        quality,
+      );
+    };
+  });
+};
+
+const installControllableImageEncoding = async (page: Page): Promise<void> => {
+  await page.addInitScript((): void => {
+    const testWindow = window as InstrumentedWindow;
+    const observations: Array<ImageEncodeObservation> = [];
+    const pendingCallbacks: Array<() => void> = [];
+    Object.defineProperty(testWindow, "__chatImageEncodeObservations", {
+      value: observations,
+      writable: false,
+    });
+    Object.defineProperty(testWindow, "__chatPendingImageEncodingCount", {
+      configurable: true,
+      value: 0,
+    });
+    Object.defineProperty(testWindow, "__chatImageEncodingCallbackCount", {
+      configurable: true,
+      value: 0,
+    });
+
+    const publishPendingCount = (): void => {
+      Object.defineProperty(testWindow, "__chatPendingImageEncodingCount", {
+        configurable: true,
+        value: pendingCallbacks.length,
+      });
+    };
+    const originalToBlob = HTMLCanvasElement.prototype.toBlob;
+    HTMLCanvasElement.prototype.toBlob = function toBlob(
+      callback: BlobCallback,
+      mediaType?: string,
+      quality?: number,
+    ): void {
+      const width = this.width;
+      const height = this.height;
+      originalToBlob.call(
+        this,
+        (blob: Blob | null): void => {
+          if (blob !== null) {
+            observations.push({
+              width,
+              height,
+              mediaType: blob.type,
+              bytes: blob.size,
+            });
+          }
+          pendingCallbacks.push((): void => {
+            callback(blob);
+            Object.defineProperty(
+              testWindow,
+              "__chatImageEncodingCallbackCount",
+              {
+                configurable: true,
+                value:
+                  (testWindow.__chatImageEncodingCallbackCount ?? 0) + 1,
+              },
+            );
+          });
+          publishPendingCount();
+        },
+        mediaType,
+        quality,
+      );
+    };
+    Object.defineProperty(testWindow, "__releaseNextChatImageEncoding", {
+      configurable: true,
+      value: (): void => {
+        const callback = pendingCallbacks.shift();
+        if (callback === undefined) {
+          throw new Error("No pending chat image encoding callback exists");
+        }
+        publishPendingCount();
+        callback();
+      },
+    });
+  });
+};
+
+const installControllableDeferredPasteTimer = async (
+  page: Page,
+): Promise<void> => {
+  await page.addInitScript((): void => {
+    const testWindow = window as InstrumentedWindow;
+    const nativeSetTimeout = window.setTimeout.bind(window);
+    let shouldCaptureNextZeroDelayTimer = false;
+    let capturedTimer: (() => void) | null = null;
+    let syntheticTimerId = 2_000_000_000;
+
+    window.setTimeout = ((
+      handler: TimerHandler,
+      timeout?: number,
+      ...args: ReadonlyArray<unknown>
+    ): number => {
+      if (
+        shouldCaptureNextZeroDelayTimer
+        && timeout === 0
+        && typeof handler === "function"
+      ) {
+        shouldCaptureNextZeroDelayTimer = false;
+        capturedTimer = (): void => handler(...args);
+        Object.defineProperty(testWindow, "__deferredPasteTimerCaptured", {
+          configurable: true,
+          value: true,
+        });
+        syntheticTimerId += 1;
+        return syntheticTimerId;
+      }
+      return nativeSetTimeout(handler, timeout, ...args);
+    }) as typeof window.setTimeout;
+    Object.defineProperty(testWindow, "__captureNextDeferredPasteTimer", {
+      configurable: true,
+      value: (): void => {
+        shouldCaptureNextZeroDelayTimer = true;
+        capturedTimer = null;
+        Object.defineProperty(testWindow, "__deferredPasteTimerCaptured", {
+          configurable: true,
+          value: false,
+        });
+      },
+    });
+    Object.defineProperty(testWindow, "__releaseDeferredPasteTimer", {
+      configurable: true,
+      value: (): void => {
+        const timer = capturedTimer;
+        if (timer === null) {
+          throw new Error("Deferred paste timer was not captured");
+        }
+        capturedTimer = null;
+        nativeSetTimeout(timer, 0);
+      },
+    });
+  });
+};
+
+const mockWorkspaceClientDependencies = async (page: Page): Promise<void> => {
+  await page.route("**/api/categories", async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ categories: [] }),
+    });
+  });
+  await page.route(
+    "**/api/workspace-settings",
+    async (route): Promise<void> => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ filteredCategories: null }),
+      });
+    },
+  );
+};
 
 const openDemoChat = async (
   page: Page,
@@ -71,6 +297,25 @@ const openDemoChat = async (
     { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
   ]);
 
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await expect(page.getByTestId("chat-file-input")).toBeEnabled();
+};
+
+const openDemoChatWithControllableImageEncoding = async (
+  page: Page,
+  context: BrowserContext,
+  baseURL: string | undefined,
+): Promise<void> => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+  await installControllableImageEncoding(page);
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
   await page.goto("/chat", { waitUntil: "domcontentloaded" });
   await expect(page.getByTestId("chat-composer-input")).toBeEditable();
   await expect(page.getByTestId("chat-file-input")).toBeEnabled();
@@ -138,6 +383,607 @@ test("preprocesses picker HEIC files sequentially and keeps successes when anoth
     "data-file-name",
     "broken-photo.heic",
   );
+});
+
+test("discarding drafts invalidates delayed attachment preprocessing without retaining bytes", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  await openDemoChatWithControllableImageEncoding(
+    page,
+    context,
+    baseURL,
+  );
+  const fixture = await readFile(fixturePath);
+
+  for (const [index, fileName] of
+    ["discard-one.heic", "discard-two.heic"].entries()) {
+    await page.getByTestId("chat-file-input").setInputFiles({
+      name: fileName,
+      mimeType: "image/heic",
+      buffer: fixture,
+    });
+    await expect(page.getByTestId("chat-attachment-processing")).toBeVisible();
+    await expect.poll(async (): Promise<number> =>
+      page.evaluate((): number =>
+        (window as InstrumentedWindow)
+          .__chatPendingImageEncodingCount ?? 0)).toBe(1);
+    await page.getByTestId("chat-new").click();
+    await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
+    await page.evaluate((): void => {
+      const release =
+        (window as InstrumentedWindow).__releaseNextChatImageEncoding;
+      if (release === undefined) {
+        throw new Error(
+          "Controllable chat image encoding resolver is missing",
+        );
+      }
+      release();
+    });
+    await expect.poll(async (): Promise<number> =>
+      page.evaluate((): number =>
+        (window as InstrumentedWindow)
+          .__chatImageEncodingCallbackCount ?? 0)).toBe(index + 1);
+    await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+    await expect(page.getByTestId("chat-attachment-error")).toHaveCount(0);
+    await expect(page.getByTestId("chat-composer-input")).toHaveValue("");
+  }
+});
+
+test("detached terminal disposal wins over delayed attachment preprocessing", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+  const createRequestReceived = createDeferred();
+  const releaseCreateResponse = createDeferred();
+  await installDeferredImageEncoding(page);
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions: [], nextCursor: null }),
+    });
+  });
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestReceived.resolve();
+    await releaseCreateResponse.promise;
+    await route.fulfill({
+      status: 400,
+      contentType: "text/plain",
+      body: "Detached request rejected",
+    });
+  });
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("detached request with delayed preprocessing");
+  await page.getByTestId("chat-submit").click();
+  await createRequestReceived.promise;
+  const retainedText = "detached follow-up must be disposed";
+  await composer.fill(retainedText);
+  const fixture = await readFile(fixturePath);
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "detached-delayed.heic",
+    mimeType: "image/heic",
+    buffer: fixture,
+  });
+  await expect(page.getByTestId("chat-attachment-processing")).toBeVisible();
+  const detachedDraftStorageKey = await page.evaluate(
+    (expectedText: string): string | null =>
+      Object.keys(window.sessionStorage).find(
+        (storageKey: string): boolean =>
+          storageKey.startsWith("expense-tracker-chat-draft:v2:")
+          && window.sessionStorage.getItem(storageKey) === expectedText,
+      ) ?? null,
+    retainedText,
+  );
+  if (detachedDraftStorageKey === null) {
+    throw new Error("Detached preprocessing draft storage key was not found");
+  }
+
+  await page.getByTestId("chat-new").click();
+  await expect(composer).toHaveValue("");
+  await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
+  releaseCreateResponse.resolve();
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate(
+      (storageKey: string): string | null =>
+        window.sessionStorage.getItem(storageKey),
+      detachedDraftStorageKey,
+    )).toBeNull();
+
+  await page.evaluate((): void => {
+    const releaseEncoding =
+      (window as InstrumentedWindow).__releaseChatImageEncoding;
+    if (releaseEncoding === undefined) {
+      throw new Error("Deferred image encoding resolver is missing");
+    }
+    releaseEncoding();
+  });
+  await expect.poll(async (): Promise<number> =>
+    page.evaluate((): number =>
+      (window as InstrumentedWindow).__chatImageEncodeObservations?.length
+      ?? 0)).toBe(1);
+  await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+  await expect(page.getByTestId("chat-attachment-error")).toHaveCount(0);
+  await expect(composer).toHaveValue("");
+});
+
+test("retains delayed attachment preprocessing across history selection changes", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const sessionA = "session-preprocessing-a";
+  const sessionB = "session-preprocessing-b";
+  const lastMessageAt = new Date().toISOString();
+  await installDeferredImageEncoding(page);
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [sessionA, sessionB].map((sessionId) => ({
+          sessionId,
+          title: sessionId,
+          lastMessageAt,
+          status: "idle",
+          mainContentInvalidationVersion: 0,
+        })),
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== sessionA && sessionId !== sessionB) {
+        throw new Error(`Unexpected chat snapshot sessionId: ${String(sessionId)}`);
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto(`/chat?session=${sessionA}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+
+  const fixture = await readFile(fixturePath);
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "selection-owned.heic",
+    mimeType: "image/heic",
+    buffer: fixture,
+  });
+  await expect(page.getByTestId("chat-attachment-processing")).toBeVisible();
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${sessionB}`).click();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionB,
+  );
+  await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${sessionA}`).click();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionA,
+  );
+  await expect(page.getByTestId("chat-attachment-processing")).toBeVisible();
+  await page.evaluate((): void => {
+    const releaseEncoding =
+      (window as InstrumentedWindow).__releaseChatImageEncoding;
+    if (releaseEncoding === undefined) {
+      throw new Error("Deferred image encoding resolver is missing");
+    }
+    releaseEncoding();
+  });
+  await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
+  await assertPreparedPortraitJpeg(page, "selection-owned.jpg");
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${sessionB}`).click();
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${sessionA}`).click();
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "selection-owned.jpg",
+  );
+});
+
+test("isolates delayed attachment preprocessing across provider scopes", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  await installDeferredImageEncoding(page);
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [],
+        nextCursor: null,
+      }),
+    });
+  });
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-file-input")).toBeEnabled();
+
+  const fixture = await readFile(fixturePath);
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "old-workspace-scope.heic",
+    mimeType: "image/heic",
+    buffer: fixture,
+  });
+  await expect(page.getByTestId("chat-attachment-processing")).toBeVisible();
+
+  await page.evaluate((): void => {
+    document.cookie = "demo=true; path=/; max-age=31536000";
+    const channel = new BroadcastChannel(
+      "expense-tracker-main-content-invalidation",
+    );
+    channel.postMessage({
+      type: "main_content_invalidation",
+      workspaceId: "local",
+      version: 3,
+      sourceId: "attachment-scope-change-test",
+      emittedAt: Date.now(),
+    });
+    channel.close();
+  });
+  await expect(page.getByTestId("mode-demo")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
+  await expect(page.getByTestId("chat-file-input")).toBeEnabled();
+
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "new-demo-scope.heic",
+    mimeType: "image/heic",
+    buffer: fixture,
+  });
+  await expect(page.getByTestId("chat-attachment-processing")).toBeVisible();
+  await page.evaluate((): void => {
+    const releaseEncoding =
+      (window as InstrumentedWindow).__releaseChatImageEncoding;
+    if (releaseEncoding === undefined) {
+      throw new Error("Deferred image encoding resolver is missing");
+    }
+    releaseEncoding();
+  });
+
+  await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(1);
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "new-demo-scope.jpg",
+  );
+  await expect(page.getByTestId("chat-prepared-attachment")).not.toContainText(
+    "old-workspace-scope.jpg",
+  );
+  await expect(page.getByTestId("chat-attachment-error")).toHaveCount(0);
+  await expect.poll(async (): Promise<number> =>
+    page.evaluate((): number =>
+      (window as InstrumentedWindow).__chatImageEncodeObservations?.length
+      ?? 0)).toBe(2);
+});
+
+test("remounted attachment preprocessing follows the exact first-session adoption", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+  const newChatRequestReceived = createDeferred();
+  const releaseNewChatResponse = createDeferred();
+  const adoptedSnapshotRequestReceived = createDeferred();
+  const releaseAdoptedSnapshotResponse = createDeferred();
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    newChatRequestReceived.resolve();
+    await releaseNewChatResponse.promise;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": "session-heic-adopted",
+      },
+      body: [
+        "data: {\"type\":\"session\",\"sessionId\":\"session-heic-adopted\"}",
+        "data: {\"type\":\"delta\",\"text\":\"Done\",\"itemId\":\"assistant-1\",\"outputIndex\":0,\"contentIndex\":0,\"sequenceNumber\":0}",
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== "session-heic-adopted") {
+        throw new Error(
+          `Unexpected adopted HEIC snapshot sessionId: ${String(sessionId)}`,
+        );
+      }
+      adoptedSnapshotRequestReceived.resolve();
+      await releaseAdoptedSnapshotResponse.promise;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  await installDeferredImageEncoding(page);
+  await mockWorkspaceClientDependencies(page);
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "chat-open", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const fixture = await readFile(fixturePath);
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("first message");
+  await page.getByTestId("chat-submit").click();
+  await newChatRequestReceived.promise;
+
+  await page.getByRole("navigation").locator('a[href="/transactions"]').click();
+  await expect(page).toHaveURL((url) => url.pathname === "/transactions");
+  await expect(page.getByTestId("chat-panel")).toBeVisible();
+  await composer.fill("follow-up after remount");
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "pending-adoption.heic",
+    mimeType: "image/heic",
+    buffer: fixture,
+  });
+  await expect(page.getByTestId("chat-attachment-processing")).toBeVisible();
+  const expectedCaret = "follow-up after remount".length;
+  await composer.evaluate((element): void => {
+    const textarea = element as HTMLTextAreaElement & {
+      __chatRemountAttachmentMarker?: string;
+    };
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    textarea.__chatRemountAttachmentMarker = "remounted-attachment-owner";
+  });
+  releaseNewChatResponse.resolve();
+
+  await adoptedSnapshotRequestReceived.promise;
+  await expect.poll(async (): Promise<string | null> =>
+    page.evaluate((): string | null =>
+      window.sessionStorage.getItem(
+        "expense-tracker-chat-selection:v1:demo:local",
+      ))).toBe(JSON.stringify({
+    kind: "session",
+    sessionId: "session-heic-adopted",
+    selectionReason: "explicit",
+  }));
+  await expect(composer).toBeEditable();
+  await expect(composer).toBeFocused();
+  await expect(page.getByTestId("chat-submit")).toBeDisabled();
+  await expect(page.getByTestId("chat-file-input")).toBeDisabled();
+  await expect(page.getByTestId("chat-dictation")).toBeDisabled();
+  expect(await composer.evaluate((element): Readonly<{
+    marker: string | undefined;
+    selectionStart: number;
+    selectionEnd: number;
+  }> => {
+    const textarea = element as HTMLTextAreaElement & {
+      __chatRemountAttachmentMarker?: string;
+    };
+    return {
+      marker: textarea.__chatRemountAttachmentMarker,
+      selectionStart: textarea.selectionStart,
+      selectionEnd: textarea.selectionEnd,
+    };
+  })).toEqual({
+    marker: "remounted-attachment-owner",
+    selectionStart: expectedCaret,
+    selectionEnd: expectedCaret,
+  });
+  releaseAdoptedSnapshotResponse.resolve();
+  await page.evaluate((): void => {
+    const releaseEncoding =
+      (window as InstrumentedWindow).__releaseChatImageEncoding;
+    if (releaseEncoding === undefined) {
+      throw new Error("Deferred image encoding resolver is missing");
+    }
+    releaseEncoding();
+  });
+  await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
+  await expect(page.getByTestId("chat-prepared-attachment")).toContainText(
+    "pending-adoption.jpg",
+  );
+  await expect(composer).toHaveValue("follow-up after remount");
+});
+
+test("deferred ambiguous paste follows exact adoption and cancels on navigation", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  const fixture = await readFile(fixturePath);
+  const createRequestReceived = createDeferred();
+  const releaseCreateResponse = createDeferred();
+  const pageErrors: Array<string> = [];
+  page.on("pageerror", (error): void => {
+    pageErrors.push(error.message);
+  });
+  await installControllableDeferredPasteTimer(page);
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    createRequestReceived.resolve();
+    await releaseCreateResponse.promise;
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": "session-deferred-paste-adopted",
+      },
+      body: [
+        "data: {\"type\":\"session\",\"sessionId\":\"session-deferred-paste-adopted\"}",
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+  await openDemoChat(page, context, baseURL);
+
+  const composer = page.getByTestId("chat-composer-input");
+  await composer.fill("create before deferred paste");
+  await page.getByTestId("chat-submit").click();
+  await createRequestReceived.promise;
+
+  const adoptedPasteAccepted = await composer.evaluate(
+    (element, bytes: ReadonlyArray<number>): boolean => {
+      const testWindow = window as InstrumentedWindow;
+      const captureTimer = testWindow.__captureNextDeferredPasteTimer;
+      if (captureTimer === undefined) {
+        throw new Error("Deferred paste timer capture is unavailable");
+      }
+      captureTimer();
+      const clipboardData = new DataTransfer();
+      clipboardData.setData("text/plain", "native adopted paste text");
+      clipboardData.items.add(new File(
+        [Uint8Array.from(bytes)],
+        "",
+        { type: "application/octet-stream" },
+      ));
+      return element.dispatchEvent(new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData,
+      }));
+    },
+    Array.from(fixture),
+  );
+  expect(adoptedPasteAccepted).toBe(true);
+  await expect.poll(async (): Promise<boolean> =>
+    page.evaluate((): boolean =>
+      (window as InstrumentedWindow).__deferredPasteTimerCaptured === true),
+  ).toBe(true);
+  await expect(page.getByTestId("chat-attachment-processing")).toBeVisible();
+
+  releaseCreateResponse.resolve();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session")
+      === "session-deferred-paste-adopted",
+  );
+  await page.evaluate((): void => {
+    const releaseTimer =
+      (window as InstrumentedWindow).__releaseDeferredPasteTimer;
+    if (releaseTimer === undefined) {
+      throw new Error("Deferred paste timer release is unavailable");
+    }
+    releaseTimer();
+  });
+  await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
+  await assertPreparedPortraitJpeg(page, "clipboard-image.jpg");
+
+  await page.getByTestId("chat-new").click();
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+  const canceledPasteAccepted = await composer.evaluate(
+    (element, bytes: ReadonlyArray<number>): boolean => {
+      const testWindow = window as InstrumentedWindow;
+      const captureTimer = testWindow.__captureNextDeferredPasteTimer;
+      if (captureTimer === undefined) {
+        throw new Error("Deferred paste timer capture is unavailable");
+      }
+      captureTimer();
+      const clipboardData = new DataTransfer();
+      clipboardData.setData("text/plain", "native canceled paste text");
+      clipboardData.items.add(new File(
+        [Uint8Array.from(bytes)],
+        "",
+        { type: "application/octet-stream" },
+      ));
+      return element.dispatchEvent(new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData,
+      }));
+    },
+    Array.from(fixture),
+  );
+  expect(canceledPasteAccepted).toBe(true);
+  await expect.poll(async (): Promise<boolean> =>
+    page.evaluate((): boolean =>
+      (window as InstrumentedWindow).__deferredPasteTimerCaptured === true),
+  ).toBe(true);
+  await expect(page.getByTestId("chat-attachment-processing")).toBeVisible();
+
+  await page.getByTestId("chat-new").click();
+  await page.evaluate((): void => {
+    const releaseTimer =
+      (window as InstrumentedWindow).__releaseDeferredPasteTimer;
+    if (releaseTimer === undefined) {
+      throw new Error("Deferred paste timer release is unavailable");
+    }
+    releaseTimer();
+  });
+  await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+  await expect(page.getByTestId("chat-attachment-error")).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
 });
 
 test("preserves opaque clipboard text paste and preprocesses a generic HEIC file", async ({
@@ -273,4 +1119,125 @@ test("preprocesses a dropped HEIC and focuses the composer after success", async
   await expect(page.getByTestId("chat-attachment-processing")).toHaveCount(0);
   await assertPreparedPortraitJpeg(page, "drop-photo.jpg");
   await expect(composer).toBeFocused();
+});
+
+test("delayed dropped-file completion does not focus another selected chat", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+  const sessionA = "session-delayed-drop-a";
+  const sessionB = "session-delayed-drop-b";
+  const lastMessageAt = new Date().toISOString();
+  await installDeferredImageEncoding(page);
+  await mockWorkspaceClientDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        sessions: [sessionA, sessionB].map((sessionId) => ({
+          sessionId,
+          title: sessionId,
+          lastMessageAt,
+          status: "idle",
+          mainContentInvalidationVersion: 0,
+        })),
+        nextCursor: null,
+      }),
+    });
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== sessionA && sessionId !== sessionB) {
+        throw new Error(
+          `Unexpected delayed-drop snapshot sessionId: ${String(sessionId)}`,
+        );
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sessionId,
+          runState: "idle",
+          activeTurnId: null,
+          updatedAt: Date.now(),
+          mainContentInvalidationVersion: 0,
+          messages: [],
+        }),
+      });
+    },
+  );
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto(`/chat?session=${sessionA}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+
+  const fixture = await readFile(fixturePath);
+  const dataTransfer = await page.evaluateHandle(
+    (bytes: ReadonlyArray<number>): DataTransfer => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(
+        [Uint8Array.from(bytes)],
+        "delayed-drop.heic",
+        { type: "image/heic" },
+      ));
+      return transfer;
+    },
+    Array.from(fixture),
+  );
+  await page.getByTestId("chat-panel").evaluate(
+    (element, transfer: DataTransfer): void => {
+      element.dispatchEvent(new DragEvent("drop", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: transfer,
+      }));
+    },
+    dataTransfer,
+  );
+  await dataTransfer.dispose();
+  await expect(page.getByTestId("chat-attachment-processing")).toBeVisible();
+
+  await page.getByTestId("chat-history-open").click();
+  await page.getByTestId(`chat-history-session-${sessionB}`).click();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionB,
+  );
+  const historyButton = page.getByTestId("chat-history-open");
+  await historyButton.focus();
+  await expect(historyButton).toBeFocused();
+  await page.evaluate((): void => {
+    const releaseEncoding =
+      (window as InstrumentedWindow).__releaseChatImageEncoding;
+    if (releaseEncoding === undefined) {
+      throw new Error("Deferred image encoding resolver is missing");
+    }
+    releaseEncoding();
+  });
+  await expect.poll(async (): Promise<number> =>
+    page.evaluate((): number =>
+      (window as InstrumentedWindow).__chatImageEncodeObservations?.length
+      ?? 0)).toBe(1);
+  await expect(historyButton).toBeFocused();
+  await expect(page.getByTestId("chat-composer-input")).not.toBeFocused();
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(0);
+
+  await historyButton.click();
+  await page.getByTestId(`chat-history-session-${sessionA}`).click();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === sessionA,
+  );
+  await assertPreparedPortraitJpeg(page, "delayed-drop.jpg");
 });

--- a/apps/web/src/ui/chat/shell/layout/ChatLayoutProvider.tsx
+++ b/apps/web/src/ui/chat/shell/layout/ChatLayoutProvider.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -15,20 +16,33 @@ import {
 } from "react";
 
 import {
+  areChatTargetsEqual,
   getChatTargetKey,
   type ChatTarget,
 } from "../../workspace/chatWorkspaceState";
 import {
   useChatWorkspaceController,
+  type ChatDraftCreationPlan,
+  type ChatDraftSessionAdoption,
   type ChatWorkspaceController,
 } from "../../workspace/useChatWorkspaceController";
+import {
+  getChatActiveDraftStorageKey,
+  getChatSelectionStorageKey,
+  writeChatActiveDraftId,
+  writeChatSelection,
+} from "../../workspace/chatSelectionStorage";
 import {
   deleteTargetChatComposerMemory,
   isChatDraftUntouched,
   readTargetChatComposerMemory,
   rekeyTargetChatComposerMemory,
+  restoreFailedChatSubmissionMemory,
+  restoreFailedChatSubmissionText,
+  revealUnresolvedChatSubmissionMemory,
   updateTargetChatComposerMemory,
   type ChatComposerMemoryState,
+  type ChatPendingSubmission,
 } from "../panel/chatPanelRuntime";
 import {
   getChatDraftStorageKey,
@@ -43,6 +57,9 @@ type ChatLayoutContextValue = Readonly<{
   chatWidth: number;
   setChatWidth: (width: number) => void;
   chatWorkspace: ChatWorkspaceController;
+  chatLayoutScopeToken: ChatLayoutScopeToken;
+  isChatLayoutScopeCurrent: (token: ChatLayoutScopeToken) => boolean;
+  chatTargetAdoptionTransition: ChatTargetAdoptionTransition | null;
   isSelectedWorkspaceDraftUntouched: boolean;
   chatTargetKey: string;
   chatDraftText: string;
@@ -56,16 +73,152 @@ type ChatLayoutContextValue = Readonly<{
     target: ChatTarget,
     update: SetStateAction<ChatComposerMemoryState>,
   ) => void;
-  adoptChatTargetState: (
-    sourceTarget: ChatTarget,
-    destinationTarget: ChatTarget,
-  ) => void;
-  disposeChatTargetState: (target: ChatTarget) => void;
+  reuseSelectedChatDraft: () => ChatDraftCreationResult;
+  replaceSelectedChatTargetWithDraft: () => ChatDraftCreationResult;
+  registerChatPendingSubmissionOwnership: (
+    target: Extract<ChatTarget, { kind: "draft" }>,
+    selectionEpoch: number,
+    pendingSubmission: ChatPendingSubmission,
+    panelLifecycleToken: ChatPanelLifecycleToken,
+  ) => ChatPendingSubmissionOwnership;
+  releaseChatPendingSubmissionOwnership: (
+    ownership: ChatPendingSubmissionOwnership,
+  ) => boolean;
+  settleRejectedChatPendingSubmissionOwnership: (
+    ownership: ChatPendingSubmissionOwnership,
+  ) => boolean;
+  settleUnresolvedChatPendingSubmissionOwnership: (
+    ownership: ChatPendingSubmissionOwnership,
+  ) => boolean;
+  settleDetachedChatPendingSubmissionOwnership: (
+    ownership: ChatPendingSubmissionOwnership,
+  ) => boolean;
+  retryDetachedChatPendingSubmissionDisposals: () => void;
+  adoptChatPendingSubmissionSession: (
+    token: ChatLayoutScopeToken,
+    draftId: string,
+    sessionId: string,
+    expectedSelectionEpoch: number,
+  ) => ChatDraftSessionAdoption;
+  registerChatTargetOperationOwnership: (
+    kind: ChatTargetOperationKind,
+    target: ChatTarget,
+    selectionEpoch: number,
+  ) => ChatTargetOperationOwnership;
+  readChatTargetOperationOwnership: (
+    ownership: ChatTargetOperationOwnership,
+  ) => ChatTargetOperationSnapshot | null;
+  releaseChatTargetOperationOwnership: (
+    ownership: ChatTargetOperationOwnership,
+  ) => boolean;
 }>;
 
 const ChatLayoutContext = createContext<ChatLayoutContextValue | null>(null);
 
 const COOKIE_MAX_AGE = "max-age=31536000";
+
+export type ChatLayoutScopeToken = Readonly<{
+  tokenId: symbol;
+}>;
+
+export type ChatPanelLifecycleToken = Readonly<{
+  tokenId: symbol;
+}>;
+
+export type ChatTargetOperationKind =
+  | "attachment_preparation"
+  | "dictation";
+
+export type ChatTargetOperationOwnership = Readonly<{
+  ownershipId: symbol;
+  scopeToken: ChatLayoutScopeToken;
+  kind: ChatTargetOperationKind;
+  selectionEpoch: number;
+}>;
+
+export type ChatTargetOperationSnapshot = Readonly<{
+  target: ChatTarget;
+  selectionEpoch: number;
+}>;
+
+export type ChatTargetAdoptionTransition = Readonly<{
+  transitionId: symbol;
+  scopeToken: ChatLayoutScopeToken;
+  sourceTarget: Extract<ChatTarget, { kind: "draft" }>;
+  destinationTarget: Extract<ChatTarget, { kind: "session" }>;
+  selectionEpoch: number;
+  stateDisposition: ChatPendingSubmissionAdoptionDisposition;
+  originatingPanelLifecycleToken: ChatPanelLifecycleToken;
+}>;
+
+type ChatPendingSubmissionOwnership = Readonly<{
+  ownershipId: symbol;
+  scopeToken: ChatLayoutScopeToken;
+  target: Extract<ChatTarget, { kind: "draft" }>;
+  selectionEpoch: number;
+  pendingSubmission: ChatPendingSubmission;
+  panelLifecycleToken: ChatPanelLifecycleToken;
+}>;
+
+type ChatPendingSubmissionOwnershipRecord = Readonly<{
+  ownership: ChatPendingSubmissionOwnership;
+  isDetached: boolean;
+  isTerminalDisposalPending: boolean;
+}>;
+
+type ChatTargetOperationOwnershipRecord = Readonly<{
+  ownership: ChatTargetOperationOwnership;
+  target: ChatTarget;
+}>;
+
+type ChatPendingSubmissionAdoptionDisposition =
+  | "transferred"
+  | "destination_preserved";
+
+type ChatPendingSubmissionTargetAdoptionPlan = Readonly<{
+  stateDisposition: ChatPendingSubmissionAdoptionDisposition;
+  nextDraftTextByTarget: ReadonlyMap<string, string>;
+  nextComposerMemoryByTarget: ReadonlyMap<string, ChatComposerMemoryState>;
+  storageMutations: ReadonlyArray<ChatStorageMutation>;
+}>;
+
+type ChatTargetStateDisposalPlan = Readonly<{
+  target: ChatTarget;
+  nextDraftTextByTarget: ReadonlyMap<string, string>;
+  nextComposerMemoryByTarget: ReadonlyMap<string, ChatComposerMemoryState>;
+}>;
+
+export type ChatPendingSubmissionStateSettlementPlan = Readonly<{
+  nextText: string;
+  nextMemory: ChatComposerMemoryState;
+}>;
+
+type ChatPendingSubmissionSettlementSource = Readonly<{
+  storageKey: string;
+  currentText: string;
+  currentMemory: ChatComposerMemoryState;
+}>;
+
+type ChatPendingSubmissionSettlementCommit = Readonly<{
+  storageMutation: ChatStorageMutation;
+  nextDraftTextByTarget: ReadonlyMap<string, string>;
+  nextComposerMemoryByTarget: ReadonlyMap<string, ChatComposerMemoryState>;
+}>;
+
+type ChatDraftCreationTransitionPlan = Readonly<{
+  workspacePlan: ChatDraftCreationPlan;
+  ownershipToDetach: ChatPendingSubmissionOwnership | null;
+  targetDisposalPlan: ChatTargetStateDisposalPlan | null;
+  storageMutations: ReadonlyArray<ChatStorageMutation>;
+}>;
+
+export type ChatDraftCreationResult = Readonly<{
+  sourceTarget: ChatTarget;
+  sourceSelectionEpoch: number;
+  target: Extract<ChatTarget, { kind: "draft" }>;
+  selectionEpoch: number;
+  disposedTarget: ChatTarget | null;
+}>;
 
 const COMPATIBILITY_CHAT_COMPOSER_TARGET = {
   kind: "draft",
@@ -170,6 +323,239 @@ export const updateChatDraftTextForTarget = (
   return nextDraftTextByTarget;
 };
 
+export const planRejectedChatPendingSubmissionSettlement = (
+  currentText: string,
+  currentMemory: ChatComposerMemoryState,
+  pendingSubmission: ChatPendingSubmission,
+): ChatPendingSubmissionStateSettlementPlan | null => {
+  if (currentMemory.pendingSubmission !== pendingSubmission) {
+    return null;
+  }
+  return {
+    nextText: restoreFailedChatSubmissionText(
+      currentText,
+      pendingSubmission,
+      currentMemory.composerContentOwner,
+    ),
+    nextMemory: restoreFailedChatSubmissionMemory(currentMemory),
+  };
+};
+
+export const planUnresolvedChatPendingSubmissionSettlement = (
+  currentText: string,
+  currentMemory: ChatComposerMemoryState,
+  pendingSubmission: ChatPendingSubmission,
+): ChatPendingSubmissionStateSettlementPlan | null => {
+  if (currentMemory.pendingSubmission !== pendingSubmission) {
+    return null;
+  }
+  return {
+    nextText: restoreFailedChatSubmissionText(
+      currentText,
+      pendingSubmission,
+      currentMemory.composerContentOwner,
+    ),
+    nextMemory: revealUnresolvedChatSubmissionMemory(currentMemory),
+  };
+};
+
+const getChatPendingSubmissionScopeKey = (
+  draftScope: ChatDraftScope,
+): string =>
+  draftScope.mode === "demo"
+    ? JSON.stringify([draftScope.mode, draftScope.userId])
+    : JSON.stringify([
+        draftScope.mode,
+        draftScope.userId,
+        draftScope.workspaceId,
+      ]);
+
+const hasMeaningfulChatComposerMemory = (
+  memory: ChatComposerMemoryState | undefined,
+): boolean =>
+  memory !== undefined
+  && (
+    memory.pendingAttachments.length > 0
+    || memory.attachmentErrors.length > 0
+    || memory.isAttachmentProcessing
+    || memory.pendingSubmission !== null
+  );
+
+const restoreStorageValue = (
+  storage: Storage,
+  storageKey: string,
+  value: string | null,
+): void => {
+  if (value === null) {
+    storage.removeItem(storageKey);
+    return;
+  }
+  storage.setItem(storageKey, value);
+};
+
+export type ChatStorageMutation = Readonly<{
+  storageKey: string;
+  apply: () => void;
+}>;
+
+export type ChatStorageTransaction = Readonly<{
+  storage: Storage;
+  previousValues: ReadonlyArray<Readonly<{
+    storageKey: string;
+    value: string | null;
+  }>>;
+}>;
+
+export const rollbackChatStorageTransaction = (
+  transaction: ChatStorageTransaction,
+): void => {
+  let rollbackError: Error | null = null;
+  for (
+    let index = transaction.previousValues.length - 1;
+    index >= 0;
+    index -= 1
+  ) {
+    const previousValue = transaction.previousValues[index];
+    if (previousValue === undefined) {
+      throw new Error(
+        `Chat storage rollback is missing mutation at index ${index}`,
+      );
+    }
+    try {
+      restoreStorageValue(
+        transaction.storage,
+        previousValue.storageKey,
+        previousValue.value,
+      );
+    } catch (error) {
+      if (rollbackError === null) {
+        rollbackError = error instanceof Error
+          ? error
+          : new Error(String(error));
+      }
+    }
+  }
+  if (rollbackError !== null) {
+    throw new Error(
+      `Chat storage transaction rollback failed: ${rollbackError.message}`,
+    );
+  }
+};
+
+export const stageChatStorageTransaction = (
+  storage: Storage,
+  mutations: ReadonlyArray<ChatStorageMutation>,
+): ChatStorageTransaction => {
+  const storageKeys = new Set<string>();
+  for (const mutation of mutations) {
+    if (storageKeys.has(mutation.storageKey)) {
+      throw new Error(
+        `Chat storage transaction contains duplicate key `
+        + `"${mutation.storageKey}"`,
+      );
+    }
+    storageKeys.add(mutation.storageKey);
+  }
+  const transaction: ChatStorageTransaction = {
+    storage,
+    previousValues: mutations.map((mutation) => ({
+      storageKey: mutation.storageKey,
+      value: storage.getItem(mutation.storageKey),
+    })),
+  };
+
+  try {
+    for (const mutation of mutations) {
+      mutation.apply();
+    }
+  } catch (error) {
+    try {
+      rollbackChatStorageTransaction(transaction);
+    } catch (rollbackError) {
+      const transactionMessage = error instanceof Error
+        ? error.message
+        : String(error);
+      const rollbackMessage = rollbackError instanceof Error
+        ? rollbackError.message
+        : String(rollbackError);
+      throw new Error(
+        `Chat storage transaction failed and rollback also failed: `
+        + `${transactionMessage}; rollback: ${rollbackMessage}`,
+      );
+    }
+    throw error;
+  }
+  return transaction;
+};
+
+export const stageChatDraftStorageDisposal = (
+  storage: Storage,
+  draftScope: ChatDraftScope,
+  target: ChatTarget,
+): ChatStorageTransaction => {
+  const storageKey = getChatDraftStorageKey(draftScope, target);
+  return stageChatStorageTransaction(storage, [{
+    storageKey,
+    apply: (): void => {
+      writeChatDraft(storage, draftScope, target, "");
+    },
+  }]);
+};
+
+export const createChatPendingSubmissionSettlementStorageMutation = (
+  storage: Storage,
+  draftScope: ChatDraftScope,
+  target: ChatTarget,
+  nextText: string,
+): ChatStorageMutation => ({
+  storageKey: getChatDraftStorageKey(draftScope, target),
+  apply: (): void => {
+    writeChatDraft(storage, draftScope, target, nextText);
+  },
+});
+
+export const createChatDraftCreationStorageMutations = (
+  storage: Storage,
+  draftScope: ChatDraftScope,
+  workspacePlan: ChatDraftCreationPlan,
+  abandonedTarget: ChatTarget | null,
+): ReadonlyArray<ChatStorageMutation> => {
+  const mutations: Array<ChatStorageMutation> = [];
+  if (workspacePlan.shouldPersistActiveDraft) {
+    mutations.push({
+      storageKey: getChatActiveDraftStorageKey(draftScope),
+      apply: (): void => {
+        writeChatActiveDraftId(
+          storage,
+          draftScope,
+          workspacePlan.target.draftId,
+        );
+      },
+    });
+  }
+  if (workspacePlan.shouldPersistSelection) {
+    mutations.push({
+      storageKey: getChatSelectionStorageKey(draftScope),
+      apply: (): void => {
+        writeChatSelection(storage, draftScope, workspacePlan.target);
+      },
+    });
+  }
+  if (abandonedTarget !== null) {
+    const abandonedStorageKey = getChatDraftStorageKey(
+      draftScope,
+      abandonedTarget,
+    );
+    mutations.push({
+      storageKey: abandonedStorageKey,
+      apply: (): void => {
+        writeChatDraft(storage, draftScope, abandonedTarget, "");
+      },
+    });
+  }
+  return mutations;
+};
+
 const writeCookie = (name: string, value: string): void => {
   document.cookie = `${name}=${value}; path=/; ${COOKIE_MAX_AGE}`;
 };
@@ -180,6 +566,989 @@ type Props = Readonly<{
   initialChatWidth: number;
   draftScope: ChatDraftScope;
 }>;
+
+type ScopedChatLayoutProviderProps = Readonly<{
+  children: ReactNode;
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  chatWidth: number;
+  setChatWidth: (width: number) => void;
+  stableDraftScope: ChatDraftScope;
+  scopeKey: string;
+}>;
+
+const ScopedChatLayoutProvider = (
+  props: ScopedChatLayoutProviderProps,
+): ReactElement => {
+  const {
+    children,
+    isOpen,
+    setIsOpen,
+    chatWidth,
+    setChatWidth,
+    stableDraftScope,
+    scopeKey,
+  } = props;
+  const chatWorkspace = useChatWorkspaceController({ scope: stableDraftScope });
+  const selectedWorkspaceTarget = chatWorkspace.state.target;
+  const chatTargetKey = getChatTargetKey(selectedWorkspaceTarget);
+  const selectedDraftStorageKey = getChatDraftStorageKey(
+    stableDraftScope,
+    selectedWorkspaceTarget,
+  );
+  const [draftTextByTarget, setDraftTextByTarget] = useState<
+    ReadonlyMap<string, string>
+  >(new Map<string, string>());
+  const draftTextByTargetRef = useRef(draftTextByTarget);
+  const [composerMemoryByTarget, setComposerMemoryByTarget] = useState<
+    ReadonlyMap<string, ChatComposerMemoryState>
+  >(new Map<string, ChatComposerMemoryState>());
+  const composerMemoryByTargetRef = useRef(composerMemoryByTarget);
+  const chatLayoutScopeToken = useMemo<ChatLayoutScopeToken>(
+    (): ChatLayoutScopeToken => ({
+      tokenId: Symbol(scopeKey),
+    }),
+    [scopeKey],
+  );
+  const chatLayoutScopeTokenRef = useRef<ChatLayoutScopeToken>(
+    chatLayoutScopeToken,
+  );
+  const pendingSubmissionOwnershipsRef = useRef<
+    Map<symbol, ChatPendingSubmissionOwnershipRecord>
+  >(new Map<symbol, ChatPendingSubmissionOwnershipRecord>());
+  const chatTargetOperationOwnershipsRef = useRef<
+    Map<symbol, ChatTargetOperationOwnershipRecord>
+  >(new Map<symbol, ChatTargetOperationOwnershipRecord>());
+  const [
+    chatTargetAdoptionTransition,
+    setChatTargetAdoptionTransition,
+  ] = useState<ChatTargetAdoptionTransition | null>(null);
+  const isProviderMountedRef = useRef<boolean>(true);
+
+  useLayoutEffect(() => {
+    isProviderMountedRef.current = true;
+    chatLayoutScopeTokenRef.current = chatLayoutScopeToken;
+    pendingSubmissionOwnershipsRef.current.clear();
+    chatTargetOperationOwnershipsRef.current.clear();
+    setChatTargetAdoptionTransition(null);
+    return () => {
+      isProviderMountedRef.current = false;
+      pendingSubmissionOwnershipsRef.current.clear();
+      chatTargetOperationOwnershipsRef.current.clear();
+    };
+  }, [chatLayoutScopeToken]);
+
+  useEffect(() => {
+    if (!chatWorkspace.isReady) {
+      return;
+    }
+    const currentDraftTextByTarget = draftTextByTargetRef.current;
+    const nextDraftTextByTarget = restoreChatDraftTextForTarget(
+      window.sessionStorage,
+      currentDraftTextByTarget,
+      stableDraftScope,
+      selectedWorkspaceTarget,
+    );
+    if (nextDraftTextByTarget === currentDraftTextByTarget) {
+      return;
+    }
+    draftTextByTargetRef.current = nextDraftTextByTarget;
+    setDraftTextByTarget(nextDraftTextByTarget);
+  }, [
+    chatWorkspace.isReady,
+    selectedWorkspaceTarget,
+    stableDraftScope,
+  ]);
+
+  const setChatDraftTextForTarget = useCallback((
+    targetToUpdate: ChatTarget,
+    update: SetStateAction<string>,
+  ): void => {
+    const nextDraftTextByTarget = updateChatDraftTextForTarget(
+      window.sessionStorage,
+      draftTextByTargetRef.current,
+      stableDraftScope,
+      targetToUpdate,
+      update,
+    );
+    draftTextByTargetRef.current = nextDraftTextByTarget;
+    setDraftTextByTarget(nextDraftTextByTarget);
+  }, [stableDraftScope]);
+
+  const setChatDraftText = useCallback((
+    update: SetStateAction<string>,
+  ): void => {
+    setChatDraftTextForTarget(selectedWorkspaceTarget, update);
+  }, [selectedWorkspaceTarget, setChatDraftTextForTarget]);
+
+  const setChatComposerMemoryForTarget = useCallback((
+    targetToUpdate: ChatTarget,
+    update: SetStateAction<ChatComposerMemoryState>,
+  ): void => {
+    const targetKey = getChatTargetKey(targetToUpdate);
+    const nextMemoryByTarget = updateTargetChatComposerMemory(
+      composerMemoryByTargetRef.current,
+      targetKey,
+      update,
+    );
+    composerMemoryByTargetRef.current = nextMemoryByTarget;
+    setComposerMemoryByTarget(nextMemoryByTarget);
+  }, []);
+
+  const registerChatTargetOperationOwnership = useCallback((
+    kind: ChatTargetOperationKind,
+    target: ChatTarget,
+    selectionEpoch: number,
+  ): ChatTargetOperationOwnership => {
+    if (!isProviderMountedRef.current) {
+      throw new Error(
+        `Cannot register ${kind} ownership after chat provider disposal`,
+      );
+    }
+    const ownership: ChatTargetOperationOwnership = {
+      ownershipId: Symbol(`${kind}:${getChatTargetKey(target)}`),
+      scopeToken: chatLayoutScopeTokenRef.current,
+      kind,
+      selectionEpoch,
+    };
+    chatTargetOperationOwnershipsRef.current.set(ownership.ownershipId, {
+      ownership,
+      target,
+    });
+    return ownership;
+  }, []);
+
+  const readChatTargetOperationOwnership = useCallback((
+    ownership: ChatTargetOperationOwnership,
+  ): ChatTargetOperationSnapshot | null => {
+    const record =
+      chatTargetOperationOwnershipsRef.current.get(ownership.ownershipId);
+    if (
+      !isProviderMountedRef.current
+      || ownership.scopeToken !== chatLayoutScopeTokenRef.current
+      || record?.ownership !== ownership
+    ) {
+      return null;
+    }
+    return {
+      target: record.target,
+      selectionEpoch: ownership.selectionEpoch,
+    };
+  }, []);
+
+  const releaseChatTargetOperationOwnership = useCallback((
+    ownership: ChatTargetOperationOwnership,
+  ): boolean => {
+    if (readChatTargetOperationOwnership(ownership) === null) {
+      return false;
+    }
+    chatTargetOperationOwnershipsRef.current.delete(ownership.ownershipId);
+    return true;
+  }, [readChatTargetOperationOwnership]);
+
+  const readCurrentPendingSubmissionOwnership = useCallback((
+    ownership: ChatPendingSubmissionOwnership,
+  ): ChatPendingSubmissionOwnershipRecord | null => {
+    const record =
+      pendingSubmissionOwnershipsRef.current.get(ownership.ownershipId);
+    if (
+      !isProviderMountedRef.current
+      || ownership.scopeToken !== chatLayoutScopeTokenRef.current
+      || record?.ownership !== ownership
+    ) {
+      return null;
+    }
+    return record;
+  }, []);
+
+  const isChatLayoutScopeCurrent = useCallback((
+    token: ChatLayoutScopeToken,
+  ): boolean =>
+    isProviderMountedRef.current
+    && token === chatLayoutScopeTokenRef.current, []);
+
+  const registerChatPendingSubmissionOwnership = useCallback((
+    target: Extract<ChatTarget, { kind: "draft" }>,
+    selectionEpoch: number,
+    pendingSubmission: ChatPendingSubmission,
+    panelLifecycleToken: ChatPanelLifecycleToken,
+  ): ChatPendingSubmissionOwnership => {
+    if (!isProviderMountedRef.current) {
+      throw new Error(
+        "Cannot register chat submission ownership after provider disposal",
+      );
+    }
+    for (const record of pendingSubmissionOwnershipsRef.current.values()) {
+      const { ownership } = record;
+      if (
+        ownership.scopeToken === chatLayoutScopeTokenRef.current
+        && ownership.selectionEpoch === selectionEpoch
+        && areChatTargetsEqual(ownership.target, target)
+      ) {
+        throw new Error(
+          `Chat submission ownership already exists for `
+          + `"${getChatTargetKey(target)}" at selection epoch `
+          + `${selectionEpoch}`,
+        );
+      }
+    }
+
+    const ownership: ChatPendingSubmissionOwnership = {
+      ownershipId: Symbol(getChatTargetKey(target)),
+      scopeToken: chatLayoutScopeTokenRef.current,
+      target,
+      selectionEpoch,
+      pendingSubmission,
+      panelLifecycleToken,
+    };
+    pendingSubmissionOwnershipsRef.current.set(
+      ownership.ownershipId,
+      {
+        ownership,
+        isDetached: false,
+        isTerminalDisposalPending: false,
+      },
+    );
+    return ownership;
+  }, []);
+
+  const readChatPendingSubmissionOwnership = useCallback((
+    target: Extract<ChatTarget, { kind: "draft" }>,
+    selectionEpoch: number,
+  ): ChatPendingSubmissionOwnership | null => {
+    if (!isProviderMountedRef.current) {
+      return null;
+    }
+    for (const record of pendingSubmissionOwnershipsRef.current.values()) {
+      const { ownership } = record;
+      if (
+        ownership.scopeToken === chatLayoutScopeTokenRef.current
+        && ownership.selectionEpoch === selectionEpoch
+        && !record.isTerminalDisposalPending
+        && areChatTargetsEqual(ownership.target, target)
+      ) {
+        return ownership;
+      }
+    }
+    return null;
+  }, []);
+
+  const releaseChatPendingSubmissionOwnership = useCallback((
+    ownership: ChatPendingSubmissionOwnership,
+  ): boolean => {
+    const record = readCurrentPendingSubmissionOwnership(ownership);
+    if (record === null) {
+      return false;
+    }
+    if (record.isDetached) {
+      throw new Error(
+        "Detached chat submission ownership requires atomic terminal disposal",
+      );
+    }
+    pendingSubmissionOwnershipsRef.current.delete(ownership.ownershipId);
+    return true;
+  }, [readCurrentPendingSubmissionOwnership]);
+
+  const readChatPendingSubmissionSettlementSource = useCallback((
+    ownership: ChatPendingSubmissionOwnership,
+  ): ChatPendingSubmissionSettlementSource | null => {
+    const record = readCurrentPendingSubmissionOwnership(ownership);
+    if (
+      record === null
+      || record.isDetached
+      || record.isTerminalDisposalPending
+    ) {
+      return null;
+    }
+    const storageKey = getChatDraftStorageKey(
+      stableDraftScope,
+      ownership.target,
+    );
+    return {
+      storageKey,
+      currentText: draftTextByTargetRef.current.get(storageKey)
+        ?? window.sessionStorage.getItem(storageKey)
+        ?? "",
+      currentMemory: readTargetChatComposerMemory(
+        composerMemoryByTargetRef.current,
+        getChatTargetKey(ownership.target),
+      ),
+    };
+  }, [readCurrentPendingSubmissionOwnership, stableDraftScope]);
+
+  const planChatPendingSubmissionSettlementCommit = useCallback((
+    ownership: ChatPendingSubmissionOwnership,
+    source: ChatPendingSubmissionSettlementSource,
+    settlement: ChatPendingSubmissionStateSettlementPlan,
+  ): ChatPendingSubmissionSettlementCommit => {
+    const nextDraftTextByTarget = new Map(draftTextByTargetRef.current);
+    nextDraftTextByTarget.set(source.storageKey, settlement.nextText);
+    const nextComposerMemoryByTarget = updateTargetChatComposerMemory(
+      composerMemoryByTargetRef.current,
+      getChatTargetKey(ownership.target),
+      settlement.nextMemory,
+    );
+    return {
+      storageMutation: createChatPendingSubmissionSettlementStorageMutation(
+        window.sessionStorage,
+        stableDraftScope,
+        ownership.target,
+        settlement.nextText,
+      ),
+      nextDraftTextByTarget,
+      nextComposerMemoryByTarget,
+    };
+  }, [stableDraftScope]);
+
+  const commitChatPendingSubmissionSettlement = useCallback((
+    ownership: ChatPendingSubmissionOwnership,
+    commit: ChatPendingSubmissionSettlementCommit,
+  ): boolean => {
+    const record = readCurrentPendingSubmissionOwnership(ownership);
+    if (
+      record === null
+      || record.isDetached
+      || record.isTerminalDisposalPending
+    ) {
+      return false;
+    }
+    stageChatStorageTransaction(
+      window.sessionStorage,
+      [commit.storageMutation],
+    );
+    pendingSubmissionOwnershipsRef.current.delete(ownership.ownershipId);
+    draftTextByTargetRef.current = commit.nextDraftTextByTarget;
+    composerMemoryByTargetRef.current = commit.nextComposerMemoryByTarget;
+    setDraftTextByTarget(commit.nextDraftTextByTarget);
+    setComposerMemoryByTarget(commit.nextComposerMemoryByTarget);
+    return true;
+  }, [readCurrentPendingSubmissionOwnership]);
+
+  const settleRejectedChatPendingSubmissionOwnership = useCallback((
+    ownership: ChatPendingSubmissionOwnership,
+  ): boolean => {
+    const source = readChatPendingSubmissionSettlementSource(ownership);
+    if (source === null) {
+      return false;
+    }
+    const settlement = planRejectedChatPendingSubmissionSettlement(
+      source.currentText,
+      source.currentMemory,
+      ownership.pendingSubmission,
+    );
+    if (settlement === null) {
+      return releaseChatPendingSubmissionOwnership(ownership);
+    }
+    return commitChatPendingSubmissionSettlement(
+      ownership,
+      planChatPendingSubmissionSettlementCommit(
+        ownership,
+        source,
+        settlement,
+      ),
+    );
+  }, [
+    commitChatPendingSubmissionSettlement,
+    planChatPendingSubmissionSettlementCommit,
+    readChatPendingSubmissionSettlementSource,
+    releaseChatPendingSubmissionOwnership,
+  ]);
+
+  const settleUnresolvedChatPendingSubmissionOwnership = useCallback((
+    ownership: ChatPendingSubmissionOwnership,
+  ): boolean => {
+    const source = readChatPendingSubmissionSettlementSource(ownership);
+    if (source === null) {
+      return false;
+    }
+    const settlement = planUnresolvedChatPendingSubmissionSettlement(
+      source.currentText,
+      source.currentMemory,
+      ownership.pendingSubmission,
+    );
+    if (settlement === null) {
+      return releaseChatPendingSubmissionOwnership(ownership);
+    }
+    return commitChatPendingSubmissionSettlement(
+      ownership,
+      planChatPendingSubmissionSettlementCommit(
+        ownership,
+        source,
+        settlement,
+      ),
+    );
+  }, [
+    commitChatPendingSubmissionSettlement,
+    planChatPendingSubmissionSettlementCommit,
+    readChatPendingSubmissionSettlementSource,
+    releaseChatPendingSubmissionOwnership,
+  ]);
+
+  const settleChatPendingSubmissionOwnership = useCallback((
+    ownership: ChatPendingSubmissionOwnership,
+  ): boolean => {
+    if (!releaseChatPendingSubmissionOwnership(ownership)) {
+      return false;
+    }
+    setChatComposerMemoryForTarget(ownership.target, (currentMemory) =>
+      currentMemory.pendingSubmission === ownership.pendingSubmission
+        ? {
+            ...currentMemory,
+            pendingSubmission: null,
+          }
+        : currentMemory);
+    return true;
+  }, [
+    releaseChatPendingSubmissionOwnership,
+    setChatComposerMemoryForTarget,
+  ]);
+
+  const planChatPendingSubmissionTargetAdoption = useCallback((
+    ownership: ChatPendingSubmissionOwnership,
+    destinationTarget: ChatTarget,
+  ): ChatPendingSubmissionTargetAdoptionPlan | null => {
+    if (readCurrentPendingSubmissionOwnership(ownership) === null) {
+      return null;
+    }
+    const sourceTarget = ownership.target;
+    const sourceStorageKey = getChatDraftStorageKey(
+      stableDraftScope,
+      sourceTarget,
+    );
+    const destinationStorageKey = getChatDraftStorageKey(
+      stableDraftScope,
+      destinationTarget,
+    );
+    const sourceText = draftTextByTargetRef.current.get(sourceStorageKey)
+      ?? window.sessionStorage.getItem(sourceStorageKey)
+      ?? "";
+    const destinationText =
+      draftTextByTargetRef.current.get(destinationStorageKey)
+      ?? window.sessionStorage.getItem(destinationStorageKey)
+      ?? "";
+    const sourceTargetKey = getChatTargetKey(sourceTarget);
+    const destinationTargetKey = getChatTargetKey(destinationTarget);
+    const currentComposerMemoryByTarget = composerMemoryByTargetRef.current;
+    if (!currentComposerMemoryByTarget.has(sourceTargetKey)) {
+      throw new Error(
+        `Cannot adopt chat composer state from "${sourceTargetKey}" to `
+        + `"${destinationTargetKey}": source target state does not exist`,
+      );
+    }
+    const destinationMemory =
+      currentComposerMemoryByTarget.get(destinationTargetKey);
+    const shouldPreserveDestination =
+      destinationText !== ""
+      || hasMeaningfulChatComposerMemory(destinationMemory);
+    const nextComposerMemoryByTarget = shouldPreserveDestination
+      ? deleteTargetChatComposerMemory(
+          currentComposerMemoryByTarget,
+          sourceTargetKey,
+        )
+      : updateTargetChatComposerMemory(
+          rekeyTargetChatComposerMemory(
+            destinationMemory === undefined
+              ? currentComposerMemoryByTarget
+              : deleteTargetChatComposerMemory(
+                  currentComposerMemoryByTarget,
+                  destinationTargetKey,
+                ),
+            sourceTargetKey,
+            destinationTargetKey,
+          ),
+          destinationTargetKey,
+          (currentMemory) =>
+            currentMemory.pendingSubmission === ownership.pendingSubmission
+              ? {
+                  ...currentMemory,
+                  pendingSubmission: null,
+                }
+              : currentMemory,
+        );
+    const nextDraftTextByTarget = new Map(draftTextByTargetRef.current);
+    nextDraftTextByTarget.delete(sourceStorageKey);
+    if (!shouldPreserveDestination) {
+      nextDraftTextByTarget.set(destinationStorageKey, sourceText);
+    } else if (
+      !nextDraftTextByTarget.has(destinationStorageKey)
+      && destinationText !== ""
+    ) {
+      nextDraftTextByTarget.set(destinationStorageKey, destinationText);
+    }
+
+    const storageMutations: Array<ChatStorageMutation> = [];
+    if (!shouldPreserveDestination) {
+      storageMutations.push({
+        storageKey: destinationStorageKey,
+        apply: (): void => {
+          writeChatDraft(
+            window.sessionStorage,
+            stableDraftScope,
+            destinationTarget,
+            sourceText,
+          );
+        },
+      });
+    }
+    storageMutations.push({
+      storageKey: sourceStorageKey,
+      apply: (): void => {
+        writeChatDraft(
+          window.sessionStorage,
+          stableDraftScope,
+          sourceTarget,
+          "",
+        );
+      },
+    });
+    return {
+      stateDisposition: shouldPreserveDestination
+        ? "destination_preserved"
+        : "transferred",
+      nextDraftTextByTarget,
+      nextComposerMemoryByTarget,
+      storageMutations,
+    };
+  }, [readCurrentPendingSubmissionOwnership, stableDraftScope]);
+
+  const transitionChatTargetOperationsForAdoption = useCallback((
+    sourceTarget: ChatTarget,
+    destinationTarget: ChatTarget,
+    selectionEpoch: number,
+    stateDisposition: ChatPendingSubmissionAdoptionDisposition,
+  ): void => {
+    for (const [ownershipId, record] of
+      chatTargetOperationOwnershipsRef.current.entries()) {
+      if (
+        record.ownership.scopeToken !== chatLayoutScopeTokenRef.current
+        || record.ownership.selectionEpoch !== selectionEpoch
+        || !areChatTargetsEqual(record.target, sourceTarget)
+      ) {
+        continue;
+      }
+      if (stateDisposition === "destination_preserved") {
+        chatTargetOperationOwnershipsRef.current.delete(ownershipId);
+        continue;
+      }
+      chatTargetOperationOwnershipsRef.current.set(ownershipId, {
+        ownership: record.ownership,
+        target: destinationTarget,
+      });
+    }
+  }, []);
+
+  const invalidateChatTargetOperations = useCallback((
+    target: ChatTarget,
+  ): void => {
+    for (const [ownershipId, record] of
+      chatTargetOperationOwnershipsRef.current.entries()) {
+      if (
+        record.ownership.scopeToken === chatLayoutScopeTokenRef.current
+        && areChatTargetsEqual(record.target, target)
+      ) {
+        chatTargetOperationOwnershipsRef.current.delete(ownershipId);
+      }
+    }
+  }, []);
+
+  const planChatTargetStateDisposal = useCallback((
+    target: ChatTarget,
+  ): ChatTargetStateDisposalPlan => {
+    const storageKey = getChatDraftStorageKey(stableDraftScope, target);
+    const nextDraftTextByTarget = new Map(draftTextByTargetRef.current);
+    nextDraftTextByTarget.delete(storageKey);
+    return {
+      target,
+      nextDraftTextByTarget,
+      nextComposerMemoryByTarget: deleteTargetChatComposerMemory(
+        composerMemoryByTargetRef.current,
+        getChatTargetKey(target),
+      ),
+    };
+  }, [stableDraftScope]);
+
+  const commitChatTargetStateDisposal = useCallback((
+    plan: ChatTargetStateDisposalPlan,
+  ): void => {
+    invalidateChatTargetOperations(plan.target);
+    draftTextByTargetRef.current = plan.nextDraftTextByTarget;
+    composerMemoryByTargetRef.current = plan.nextComposerMemoryByTarget;
+    setDraftTextByTarget(plan.nextDraftTextByTarget);
+    setComposerMemoryByTarget(plan.nextComposerMemoryByTarget);
+  }, [invalidateChatTargetOperations]);
+
+  const commitChatDraftCreationTransition = useCallback((
+    plan: ChatDraftCreationTransitionPlan,
+  ): ChatDraftCreationResult => {
+    const ownershipRecord = plan.ownershipToDetach === null
+      ? null
+      : readCurrentPendingSubmissionOwnership(plan.ownershipToDetach);
+    if (
+      plan.ownershipToDetach !== null
+      && (
+        ownershipRecord === null
+        || ownershipRecord.isDetached
+        || ownershipRecord.isTerminalDisposalPending
+      )
+    ) {
+      throw new Error(
+        "Cannot detach stale chat submission ownership during New",
+      );
+    }
+    const storageTransaction = stageChatStorageTransaction(
+      window.sessionStorage,
+      plan.storageMutations,
+    );
+    try {
+      chatWorkspace.commitDraftCreation(plan.workspacePlan);
+    } catch (error) {
+      try {
+        rollbackChatStorageTransaction(storageTransaction);
+      } catch (rollbackError) {
+        const commitMessage = error instanceof Error
+          ? error.message
+          : String(error);
+        const rollbackMessage = rollbackError instanceof Error
+          ? rollbackError.message
+          : String(rollbackError);
+        throw new Error(
+          `Chat draft creation commit failed and storage rollback also `
+          + `failed: ${commitMessage}; rollback: ${rollbackMessage}`,
+        );
+      }
+      throw error;
+    }
+
+    if (plan.ownershipToDetach !== null && ownershipRecord !== null) {
+      pendingSubmissionOwnershipsRef.current.set(
+        plan.ownershipToDetach.ownershipId,
+        {
+          ownership: plan.ownershipToDetach,
+          isDetached: true,
+          isTerminalDisposalPending: false,
+        },
+      );
+    }
+    if (plan.targetDisposalPlan !== null) {
+      commitChatTargetStateDisposal(plan.targetDisposalPlan);
+    }
+    chatWorkspace.finalizeDraftCreation(plan.workspacePlan);
+    return {
+      sourceTarget: plan.workspacePlan.sourceTarget,
+      sourceSelectionEpoch: plan.workspacePlan.sourceSelectionEpoch,
+      target: plan.workspacePlan.target,
+      selectionEpoch: plan.workspacePlan.selectionEpoch,
+      disposedTarget: plan.targetDisposalPlan?.target ?? null,
+    };
+  }, [
+    chatWorkspace.commitDraftCreation,
+    chatWorkspace.finalizeDraftCreation,
+    commitChatTargetStateDisposal,
+    readCurrentPendingSubmissionOwnership,
+  ]);
+
+  const reuseSelectedChatDraft = useCallback((): ChatDraftCreationResult => {
+    const workspacePlan = chatWorkspace.planSelectedDraftReuse();
+    return commitChatDraftCreationTransition({
+      workspacePlan,
+      ownershipToDetach: null,
+      targetDisposalPlan: null,
+      storageMutations: createChatDraftCreationStorageMutations(
+        window.sessionStorage,
+        stableDraftScope,
+        workspacePlan,
+        null,
+      ),
+    });
+  }, [
+    chatWorkspace.planSelectedDraftReuse,
+    commitChatDraftCreationTransition,
+    stableDraftScope,
+  ]);
+
+  const replaceSelectedChatTargetWithDraft = useCallback(
+    (): ChatDraftCreationResult => {
+      const workspacePlan = chatWorkspace.planDraftReplacement();
+      const matchingOwnershipRecords = Array.from(
+        pendingSubmissionOwnershipsRef.current.values(),
+      ).filter((record): boolean =>
+        record.ownership.scopeToken === chatLayoutScopeTokenRef.current
+        && !record.isTerminalDisposalPending
+        && areChatTargetsEqual(
+          record.ownership.target,
+          workspacePlan.sourceTarget,
+        ));
+      if (matchingOwnershipRecords.length > 1) {
+        throw new Error(
+          `Multiple chat submission owners exist for `
+          + `"${getChatTargetKey(workspacePlan.sourceTarget)}"`,
+        );
+      }
+      const ownershipToDetach =
+        matchingOwnershipRecords[0]?.ownership ?? null;
+      const targetDisposalPlan =
+        workspacePlan.sourceTarget.kind === "draft"
+        && ownershipToDetach === null
+          ? planChatTargetStateDisposal(workspacePlan.sourceTarget)
+          : null;
+      return commitChatDraftCreationTransition({
+        workspacePlan,
+        ownershipToDetach,
+        targetDisposalPlan,
+        storageMutations: createChatDraftCreationStorageMutations(
+          window.sessionStorage,
+          stableDraftScope,
+          workspacePlan,
+          targetDisposalPlan?.target ?? null,
+        ),
+      });
+    },
+    [
+      chatWorkspace.planDraftReplacement,
+      commitChatDraftCreationTransition,
+      planChatTargetStateDisposal,
+      stableDraftScope,
+    ],
+  );
+
+  const settleDetachedChatPendingSubmissionOwnership = useCallback((
+    ownership: ChatPendingSubmissionOwnership,
+  ): boolean => {
+    const record = readCurrentPendingSubmissionOwnership(ownership);
+    if (record === null || !record.isDetached) {
+      return false;
+    }
+    const disposalPlan = planChatTargetStateDisposal(ownership.target);
+    pendingSubmissionOwnershipsRef.current.set(ownership.ownershipId, {
+      ...record,
+      isTerminalDisposalPending: true,
+    });
+    stageChatDraftStorageDisposal(
+      window.sessionStorage,
+      stableDraftScope,
+      ownership.target,
+    );
+    pendingSubmissionOwnershipsRef.current.delete(ownership.ownershipId);
+    commitChatTargetStateDisposal(disposalPlan);
+    return true;
+  }, [
+    commitChatTargetStateDisposal,
+    planChatTargetStateDisposal,
+    readCurrentPendingSubmissionOwnership,
+    stableDraftScope,
+  ]);
+
+  const retryDetachedChatPendingSubmissionDisposals = useCallback((): void => {
+    const ownerships = Array.from(
+      pendingSubmissionOwnershipsRef.current.values(),
+    )
+      .filter((record): boolean =>
+        record.isDetached && record.isTerminalDisposalPending)
+      .map((record): ChatPendingSubmissionOwnership => record.ownership);
+    for (const ownership of ownerships) {
+      if (!settleDetachedChatPendingSubmissionOwnership(ownership)) {
+        throw new Error(
+          "Cannot retry stale detached chat submission disposal",
+        );
+      }
+    }
+  }, [settleDetachedChatPendingSubmissionOwnership]);
+
+  const adoptChatPendingSubmissionSession = useCallback((
+    token: ChatLayoutScopeToken,
+    draftId: string,
+    sessionId: string,
+    expectedSelectionEpoch: number,
+  ): ChatDraftSessionAdoption => {
+    const draftTarget = { kind: "draft", draftId } as const;
+    const sessionTarget = { kind: "session", sessionId } as const;
+    if (
+      !isProviderMountedRef.current
+      || token !== chatLayoutScopeTokenRef.current
+    ) {
+      return {
+        kind: "background",
+        target: sessionTarget,
+        draftStateDisposition: "preserve",
+      };
+    }
+    const ownership = readChatPendingSubmissionOwnership(
+      draftTarget,
+      expectedSelectionEpoch,
+    );
+    if (ownership === null) {
+      return {
+        kind: "background",
+        target: sessionTarget,
+        draftStateDisposition: "preserve",
+      };
+    }
+    const workspacePlan = chatWorkspace.planDraftSessionAdoption(
+      draftId,
+      sessionId,
+      expectedSelectionEpoch,
+    );
+    if (
+      workspacePlan.adoption.kind === "background"
+      && workspacePlan.adoption.draftStateDisposition === "preserve"
+    ) {
+      if (!settleChatPendingSubmissionOwnership(ownership)) {
+        return {
+          kind: "background",
+          target: sessionTarget,
+          draftStateDisposition: "preserve",
+        };
+      }
+      chatWorkspace.finalizeDraftSessionAdoption(workspacePlan);
+      return workspacePlan.adoption;
+    }
+
+    const targetPlan = planChatPendingSubmissionTargetAdoption(
+      ownership,
+      sessionTarget,
+    );
+    if (targetPlan === null) {
+      return {
+        kind: "background",
+        target: sessionTarget,
+        draftStateDisposition: "preserve",
+      };
+    }
+    const storageMutations: Array<ChatStorageMutation> = [
+      ...targetPlan.storageMutations,
+    ];
+    if (workspacePlan.shouldClearActiveDraft) {
+      storageMutations.push({
+        storageKey: getChatActiveDraftStorageKey(stableDraftScope),
+        apply: (): void => {
+          writeChatActiveDraftId(
+            window.sessionStorage,
+            stableDraftScope,
+            null,
+          );
+        },
+      });
+    }
+    if (workspacePlan.shouldPersistSelection) {
+      storageMutations.push({
+        storageKey: getChatSelectionStorageKey(stableDraftScope),
+        apply: (): void => {
+          writeChatSelection(
+            window.sessionStorage,
+            stableDraftScope,
+            sessionTarget,
+          );
+        },
+      });
+    }
+    const storageTransaction = stageChatStorageTransaction(
+      window.sessionStorage,
+      storageMutations,
+    );
+    let workspaceAdoption: ChatDraftSessionAdoption;
+    try {
+      workspaceAdoption =
+        chatWorkspace.commitDraftSessionAdoption(workspacePlan);
+    } catch (error) {
+      try {
+        rollbackChatStorageTransaction(storageTransaction);
+      } catch (rollbackError) {
+        const commitMessage = error instanceof Error
+          ? error.message
+          : String(error);
+        const rollbackMessage = rollbackError instanceof Error
+          ? rollbackError.message
+          : String(rollbackError);
+        throw new Error(
+          `Chat draft adoption commit failed and storage rollback also `
+          + `failed: ${commitMessage}; rollback: ${rollbackMessage}`,
+        );
+      }
+      throw error;
+    }
+    draftTextByTargetRef.current = targetPlan.nextDraftTextByTarget;
+    setDraftTextByTarget(targetPlan.nextDraftTextByTarget);
+    composerMemoryByTargetRef.current =
+      targetPlan.nextComposerMemoryByTarget;
+    setComposerMemoryByTarget(targetPlan.nextComposerMemoryByTarget);
+    pendingSubmissionOwnershipsRef.current.delete(ownership.ownershipId);
+    transitionChatTargetOperationsForAdoption(
+      draftTarget,
+      sessionTarget,
+      expectedSelectionEpoch,
+      targetPlan.stateDisposition,
+    );
+    if (workspaceAdoption.kind === "selected") {
+      setChatTargetAdoptionTransition({
+        transitionId: Symbol(`${draftId}:${sessionId}`),
+        scopeToken: token,
+        sourceTarget: draftTarget,
+        destinationTarget: sessionTarget,
+        selectionEpoch: expectedSelectionEpoch,
+        stateDisposition: targetPlan.stateDisposition,
+        originatingPanelLifecycleToken: ownership.panelLifecycleToken,
+      });
+    }
+    chatWorkspace.finalizeDraftSessionAdoption(workspacePlan);
+    return workspaceAdoption;
+  }, [
+    chatWorkspace.commitDraftSessionAdoption,
+    chatWorkspace.finalizeDraftSessionAdoption,
+    chatWorkspace.planDraftSessionAdoption,
+    planChatPendingSubmissionTargetAdoption,
+    readChatPendingSubmissionOwnership,
+    settleChatPendingSubmissionOwnership,
+    stableDraftScope,
+    transitionChatTargetOperationsForAdoption,
+  ]);
+
+  const chatDraftText = draftTextByTarget.get(selectedDraftStorageKey) ?? "";
+  const chatComposerMemory = readTargetChatComposerMemory(
+    composerMemoryByTarget,
+    chatTargetKey,
+  );
+  const isSelectedWorkspaceDraftUntouched = resolveSelectedChatDraftUntouched(
+    chatWorkspace.isReady,
+    selectedWorkspaceTarget,
+    draftTextByTarget,
+    composerMemoryByTarget,
+    stableDraftScope,
+  );
+
+  return (
+    <ChatLayoutContext.Provider value={{
+      isOpen,
+      setIsOpen,
+      chatWidth,
+      setChatWidth,
+      chatWorkspace,
+      chatLayoutScopeToken,
+      isChatLayoutScopeCurrent,
+      chatTargetAdoptionTransition,
+      isSelectedWorkspaceDraftUntouched,
+      chatTargetKey,
+      chatDraftText,
+      setChatDraftText,
+      setChatDraftTextForTarget,
+      chatComposerMemory,
+      setChatComposerMemoryForTarget,
+      reuseSelectedChatDraft,
+      replaceSelectedChatTargetWithDraft,
+      registerChatPendingSubmissionOwnership,
+      releaseChatPendingSubmissionOwnership,
+      settleRejectedChatPendingSubmissionOwnership,
+      settleUnresolvedChatPendingSubmissionOwnership,
+      settleDetachedChatPendingSubmissionOwnership,
+      retryDetachedChatPendingSubmissionDisposals,
+      adoptChatPendingSubmissionSession,
+      registerChatTargetOperationOwnership,
+      readChatTargetOperationOwnership,
+      releaseChatTargetOperationOwnership,
+    }}>
+      {children}
+    </ChatLayoutContext.Provider>
+  );
+};
 
 export const ChatLayoutProvider = (props: Props): ReactElement => {
   const {
@@ -206,207 +1575,28 @@ export const ChatLayoutProvider = (props: Props): ReactElement => {
         },
     [draftScope.mode, draftScope.userId, draftWorkspaceId],
   );
-  const chatWorkspace = useChatWorkspaceController({ scope: stableDraftScope });
-  const mountedChatComposerTarget = getMountedChatComposerTarget();
-  const chatTargetKey = getChatTargetKey(mountedChatComposerTarget);
-  const [draftTextByTarget, setDraftTextByTarget] = useState<
-    ReadonlyMap<string, string>
-  >(new Map<string, string>());
-  const draftTextByTargetRef = useRef(draftTextByTarget);
-  const [composerMemoryByTarget, setComposerMemoryByTarget] = useState<
-    ReadonlyMap<string, ChatComposerMemoryState>
-  >(new Map<string, ChatComposerMemoryState>());
-  const composerMemoryByTargetRef = useRef(composerMemoryByTarget);
-
-  useEffect(() => {
-    const restoredDraftTextByTarget = restoreMountedChatDraftText(
-      window.sessionStorage,
-      new Map<string, string>(),
-      stableDraftScope,
-    );
-    draftTextByTargetRef.current = restoredDraftTextByTarget;
-    setDraftTextByTarget(restoredDraftTextByTarget);
-    const emptyComposerMemoryByTarget =
-      new Map<string, ChatComposerMemoryState>();
-    composerMemoryByTargetRef.current = emptyComposerMemoryByTarget;
-    setComposerMemoryByTarget(emptyComposerMemoryByTarget);
-  }, [stableDraftScope]);
-
-  const selectedWorkspaceTarget = chatWorkspace.state.target;
-  useEffect(() => {
-    if (!chatWorkspace.isReady || selectedWorkspaceTarget.kind !== "draft") {
-      return;
-    }
-    const currentDraftTextByTarget = draftTextByTargetRef.current;
-    const nextDraftTextByTarget = restoreChatDraftTextForTarget(
-      window.sessionStorage,
-      currentDraftTextByTarget,
-      stableDraftScope,
-      selectedWorkspaceTarget,
-    );
-    if (nextDraftTextByTarget === currentDraftTextByTarget) {
-      return;
-    }
-    draftTextByTargetRef.current = nextDraftTextByTarget;
-    setDraftTextByTarget(nextDraftTextByTarget);
-  }, [
-    chatWorkspace.isReady,
-    selectedWorkspaceTarget,
-    stableDraftScope,
-  ]);
-
-  const setIsOpen = (open: boolean): void => {
+  const scopeKey = getChatPendingSubmissionScopeKey(stableDraftScope);
+  const setIsOpen = useCallback((open: boolean): void => {
     setIsOpenState(open);
     writeCookie("chat-open", String(open));
-  };
-
-  const setChatWidth = (width: number): void => {
+  }, []);
+  const setChatWidth = useCallback((width: number): void => {
     setChatWidthState(width);
     writeCookie("chat-width", String(Math.round(width)));
-  };
-
-  const setChatDraftTextForTarget = useCallback((
-    targetToUpdate: ChatTarget,
-    update: SetStateAction<string>,
-  ): void => {
-    const nextDraftTextByTarget = updateChatDraftTextForTarget(
-      window.sessionStorage,
-      draftTextByTargetRef.current,
-      stableDraftScope,
-      targetToUpdate,
-      update,
-    );
-    draftTextByTargetRef.current = nextDraftTextByTarget;
-    setDraftTextByTarget(nextDraftTextByTarget);
-  }, [stableDraftScope]);
-
-  const setChatDraftText = useCallback((
-    update: SetStateAction<string>,
-  ): void => {
-    setChatDraftTextForTarget(mountedChatComposerTarget, update);
-  }, [mountedChatComposerTarget, setChatDraftTextForTarget]);
-
-  const setChatComposerMemoryForTarget = useCallback((
-    targetToUpdate: ChatTarget,
-    update: SetStateAction<ChatComposerMemoryState>,
-  ): void => {
-    const targetKey = getChatTargetKey(targetToUpdate);
-    const nextMemoryByTarget = updateTargetChatComposerMemory(
-      composerMemoryByTargetRef.current,
-      targetKey,
-      update,
-    );
-    composerMemoryByTargetRef.current = nextMemoryByTarget;
-    setComposerMemoryByTarget(nextMemoryByTarget);
   }, []);
 
-  const adoptChatTargetState = useCallback((
-    sourceTarget: ChatTarget,
-    destinationTarget: ChatTarget,
-  ): void => {
-    const sourceStorageKey = getChatDraftStorageKey(
-      stableDraftScope,
-      sourceTarget,
-    );
-    const destinationStorageKey = getChatDraftStorageKey(
-      stableDraftScope,
-      destinationTarget,
-    );
-    const sourceText = draftTextByTargetRef.current.get(sourceStorageKey)
-      ?? readAndMigrateChatDraft(
-        window.sessionStorage,
-        stableDraftScope,
-        sourceTarget,
-      );
-    writeChatDraft(
-      window.sessionStorage,
-      stableDraftScope,
-      destinationTarget,
-      sourceText,
-    );
-    writeChatDraft(
-      window.sessionStorage,
-      stableDraftScope,
-      sourceTarget,
-      "",
-    );
-
-    const nextDraftTextByTarget = new Map(draftTextByTargetRef.current);
-    nextDraftTextByTarget.delete(sourceStorageKey);
-    nextDraftTextByTarget.set(destinationStorageKey, sourceText);
-    draftTextByTargetRef.current = nextDraftTextByTarget;
-    setDraftTextByTarget(nextDraftTextByTarget);
-
-    const nextComposerMemoryByTarget = rekeyTargetChatComposerMemory(
-      composerMemoryByTargetRef.current,
-      getChatTargetKey(sourceTarget),
-      getChatTargetKey(destinationTarget),
-    );
-    composerMemoryByTargetRef.current = nextComposerMemoryByTarget;
-    setComposerMemoryByTarget(nextComposerMemoryByTarget);
-  }, [stableDraftScope]);
-
-  const disposeChatTargetState = useCallback((
-    targetToDispose: ChatTarget,
-  ): void => {
-    const storageKey = getChatDraftStorageKey(
-      stableDraftScope,
-      targetToDispose,
-    );
-    writeChatDraft(
-      window.sessionStorage,
-      stableDraftScope,
-      targetToDispose,
-      "",
-    );
-    const nextDraftTextByTarget = new Map(draftTextByTargetRef.current);
-    nextDraftTextByTarget.delete(storageKey);
-    draftTextByTargetRef.current = nextDraftTextByTarget;
-    setDraftTextByTarget(nextDraftTextByTarget);
-
-    const nextComposerMemoryByTarget = deleteTargetChatComposerMemory(
-      composerMemoryByTargetRef.current,
-      getChatTargetKey(targetToDispose),
-    );
-    composerMemoryByTargetRef.current = nextComposerMemoryByTarget;
-    setComposerMemoryByTarget(nextComposerMemoryByTarget);
-  }, [stableDraftScope]);
-
-  const chatDraftText = readMountedChatDraftText(
-    draftTextByTarget,
-    stableDraftScope,
-  );
-  const chatComposerMemory = readTargetChatComposerMemory(
-    composerMemoryByTarget,
-    chatTargetKey,
-  );
-  const isSelectedWorkspaceDraftUntouched = resolveSelectedChatDraftUntouched(
-    chatWorkspace.isReady,
-    selectedWorkspaceTarget,
-    draftTextByTarget,
-    composerMemoryByTarget,
-    stableDraftScope,
-  );
-
   return (
-    <ChatLayoutContext.Provider value={{
-      isOpen,
-      setIsOpen,
-      chatWidth,
-      setChatWidth,
-      chatWorkspace,
-      isSelectedWorkspaceDraftUntouched,
-      chatTargetKey,
-      chatDraftText,
-      setChatDraftText,
-      setChatDraftTextForTarget,
-      chatComposerMemory,
-      setChatComposerMemoryForTarget,
-      adoptChatTargetState,
-      disposeChatTargetState,
-    }}>
+    <ScopedChatLayoutProvider
+      key={scopeKey}
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      chatWidth={chatWidth}
+      setChatWidth={setChatWidth}
+      stableDraftScope={stableDraftScope}
+      scopeKey={scopeKey}
+    >
       {children}
-    </ChatLayoutContext.Provider>
+    </ScopedChatLayoutProvider>
   );
 };
 

--- a/apps/web/src/ui/chat/shell/panel/ChatComposer.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatComposer.tsx
@@ -41,6 +41,8 @@ export type AttachmentPreparationError = Readonly<{
   message: string;
 }>;
 
+export type DeferredAttachmentIngestion = () => Promise<void>;
+
 const getBase64DecodedByteLength = (base64Data: string): number => {
   const paddingBytes = base64Data.endsWith("==")
     ? 2
@@ -61,6 +63,9 @@ type Props = Readonly<{
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   onInputChange: (value: string) => void;
   onIngestFiles: (files: ReadonlyArray<File>) => Promise<number>;
+  onPrepareDeferredIngestion: (
+    files: ReadonlyArray<File>,
+  ) => DeferredAttachmentIngestion | null;
   onRemoveAttachment: (index: number) => void;
   onToggleDictation: () => Promise<void>;
   onSend: () => Promise<void>;
@@ -81,6 +86,7 @@ export const ChatComposer = (props: Props): ReactElement => {
     textareaRef,
     onInputChange,
     onIngestFiles,
+    onPrepareDeferredIngestion,
     onRemoveAttachment,
     onToggleDictation,
     onSend,
@@ -269,8 +275,16 @@ export const ChatComposer = (props: Props): ReactElement => {
       return;
     }
 
+    const deferredIngestion = onPrepareDeferredIngestion(imageFiles);
+    if (deferredIngestion === null) {
+      return;
+    }
     window.setTimeout((): void => {
-      void onIngestFiles(imageFiles);
+      void deferredIngestion().catch((error: unknown): void => {
+        window.setTimeout((): void => {
+          throw error;
+        }, 0);
+      });
     }, 0);
   };
 
@@ -375,6 +389,7 @@ export const ChatComposer = (props: Props): ReactElement => {
         <div className={styles.controlsRight}>
           <button
             type="button"
+            data-testid="chat-dictation"
             className={styles.microphoneButton}
             disabled={capabilities.isMicrophoneButtonDisabled}
             aria-label={microphoneAriaLabel}

--- a/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
@@ -3,38 +3,56 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
-  type MutableRefObject,
   type DragEvent,
   type ReactElement,
 } from "react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
-import { useChatLayout } from "../layout/ChatLayoutProvider";
+import {
+  useChatLayout,
+  type ChatLayoutScopeToken,
+  type ChatPanelLifecycleToken,
+  type ChatTargetOperationOwnership,
+} from "../layout/ChatLayoutProvider";
 import {
   ChatComposer,
-  type AttachmentPreparationError,
+  type DeferredAttachmentIngestion,
 } from "./ChatComposer";
 import { ChatPanelHeader } from "./ChatPanelHeader";
 import { ChatTranscript } from "./ChatTranscript";
 import { prepareAttachment, type PendingAttachment } from "./FileAttachment";
 import {
+  createChatPendingSubmission,
   getAttachmentFailureReasonKey,
+  markChatComposerContentEdited,
   startMountedLifecycle,
 } from "./chatPanelRuntime";
 import { useAccountSuggestions } from "./useAccountSuggestions";
 import { getChatComposerCapabilities } from "../../stream/display/chatComposerCapabilities";
 import { buildChatTranscriptMarkdown } from "../../stream/display/chatTranscriptMarkdown";
 import {
+  getNextChatDictationOperationEpoch,
   insertDictationTranscriptIntoDraft,
+  isChatDictationOperationCurrent,
   transcribeChatAudio,
   type ChatDraftSelection,
   type ChatDictationState,
 } from "../../stream/hooks/chatDictation";
 import { useDesktopEnterToSend } from "../../stream/hooks/useDesktopEnterToSend";
-import { useChatSessionController } from "../../session/controller/legacyChatSessionController";
+import { useChatSessionController } from "../../session/controller/useChatSessionController";
+import {
+  areChatTargetsEqual,
+  getChatTargetKey,
+  type ChatTarget,
+} from "../../workspace/chatWorkspaceState";
+import type {
+  ChatDraftSessionAdoption,
+  ChatWorkspaceInvalidationSource,
+} from "../../workspace/useChatWorkspaceController";
 import styles from "./ChatPanel.module.css";
 
 type Props = Readonly<{
@@ -43,6 +61,58 @@ type Props = Readonly<{
 }>;
 
 type CopyStatus = "idle" | "success" | "error";
+
+type ChatDictationOperation = Readonly<{
+  epoch: number;
+  ownership: ChatTargetOperationOwnership;
+  selection: ChatDraftSelection | null;
+  shouldRestoreFocus: boolean;
+  recorder: MediaRecorder;
+  stream: MediaStream;
+  recordedChunks: Array<Blob>;
+}>;
+
+type ChatAttachmentPreparationOperation = Readonly<{
+  operationId: number;
+  ownership: ChatTargetOperationOwnership;
+  target: ChatTarget;
+  targetKey: string;
+  selectionEpoch: number;
+}>;
+
+type ChatAttachmentIngestionResult = Readonly<{
+  attachedFileCount: number;
+  target: ChatTarget;
+  selectionEpoch: number;
+}>;
+
+type ChatPreparedAttachmentIngestion = Readonly<{
+  files: ReadonlyArray<File>;
+  operationId: number;
+}>;
+
+type ChatComposerFocusRequest = Readonly<{
+  requestId: number;
+  scopeToken: ChatLayoutScopeToken;
+  sourceTarget: ChatTarget;
+  sourceSelectionEpoch: number;
+  destinationTarget: ChatTarget | null;
+  destinationSelectionEpoch: number | null;
+}>;
+
+type ChatComposerLifecycleSelection = Readonly<{
+  scopeToken: ChatLayoutScopeToken;
+  target: ChatTarget;
+  selectionEpoch: number;
+}>;
+
+type ChatTextareaAdoptionHandoff = Readonly<{
+  transitionId: symbol;
+  scopeToken: ChatLayoutScopeToken;
+  target: ChatTarget;
+  selectionEpoch: number;
+  hasObservedHistoryLoading: boolean;
+}>;
 
 const MIN_WIDTH = 280;
 const MAX_WIDTH = 600;
@@ -77,25 +147,23 @@ const chooseSupportedRecordingMimeType = (): string | null => {
   return null;
 };
 
-const cleanupDictationResources = (
-  mediaRecorderRef: MutableRefObject<MediaRecorder | null>,
-  mediaStreamRef: MutableRefObject<MediaStream | null>,
-  recordedChunksRef: MutableRefObject<Array<Blob>>,
+const stopDictationOperationResources = (
+  operation: ChatDictationOperation,
 ): void => {
-  stopMediaStream(mediaStreamRef.current);
-  mediaRecorderRef.current = null;
-  mediaStreamRef.current = null;
-  recordedChunksRef.current = [];
+  if (operation.recorder.state !== "inactive") {
+    operation.recorder.stop();
+  }
+  stopMediaStream(operation.stream);
 };
 
 const stopMediaRecorder = (
   recorder: MediaRecorder,
-  recordedChunksRef: MutableRefObject<Array<Blob>>,
+  recordedChunks: Array<Blob>,
 ): Promise<Blob> =>
   new Promise((resolve, reject) => {
     const handleStop = (): void => {
       recorder.removeEventListener("error", handleError as EventListener);
-      resolve(new Blob(recordedChunksRef.current, {
+      resolve(new Blob(recordedChunks, {
         type: recorder.mimeType === "" ? "audio/webm" : recorder.mimeType,
       }));
     };
@@ -138,9 +206,438 @@ export const ChatPanel = (props: Props): ReactElement => {
     setIsOpen,
     chatWidth,
     setChatWidth,
+    chatWorkspace,
+    chatLayoutScopeToken,
+    isChatLayoutScopeCurrent,
+    chatTargetAdoptionTransition,
+    isSelectedWorkspaceDraftUntouched,
+    chatTargetKey,
     chatDraftText: inputText,
     setChatDraftText: setInputText,
+    setChatDraftTextForTarget,
+    chatComposerMemory,
+    setChatComposerMemoryForTarget,
+    reuseSelectedChatDraft,
+    replaceSelectedChatTargetWithDraft,
+    registerChatPendingSubmissionOwnership,
+    releaseChatPendingSubmissionOwnership,
+    settleRejectedChatPendingSubmissionOwnership,
+    settleUnresolvedChatPendingSubmissionOwnership,
+    settleDetachedChatPendingSubmissionOwnership,
+    retryDetachedChatPendingSubmissionDisposals,
+    adoptChatPendingSubmissionSession,
+    registerChatTargetOperationOwnership,
+    readChatTargetOperationOwnership,
+    releaseChatTargetOperationOwnership,
   } = useChatLayout();
+
+  const [localWidth, setLocalWidth] = useState<number>(chatWidth);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const [isDragOver, setIsDragOver] = useState<boolean>(false);
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle");
+  const [dictationState, setDictationState] = useState<ChatDictationState>("idle");
+  const [composerLifecycleKey, setComposerLifecycleKey] = useState<number>(0);
+  const shouldSubmitOnEnter = useDesktopEnterToSend();
+  const {
+    pendingAttachments,
+    attachmentErrors,
+    isAttachmentProcessing,
+    pendingSubmission: activePendingSubmission,
+  } = chatComposerMemory;
+
+  const dragCounterRef = useRef<number>(0);
+  const nextAttachmentOperationIdRef = useRef<number>(0);
+  const attachmentOperationsRef = useRef<
+    Map<number, ChatAttachmentPreparationOperation>
+  >(new Map<number, ChatAttachmentPreparationOperation>());
+  const attachmentOperationIdsByTargetKeyRef = useRef<Map<string, number>>(
+    new Map<string, number>(),
+  );
+  const nextComposerFocusRequestIdRef = useRef<number>(0);
+  const pendingComposerFocusRequestRef =
+    useRef<ChatComposerFocusRequest | null>(null);
+  const composerFocusTimeoutRef =
+    useRef<ReturnType<typeof setTimeout> | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const panelLifecycleTokenRef = useRef<ChatPanelLifecycleToken>({
+    tokenId: Symbol("chat-panel"),
+  });
+  const copyStatusResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dictationOperationEpochRef = useRef<number>(0);
+  const activeDictationOperationRef = useRef<ChatDictationOperation | null>(null);
+  const dictationOperationOwnershipsRef = useRef<
+    Map<number, ChatTargetOperationOwnership>
+  >(new Map<number, ChatTargetOperationOwnership>());
+  const pendingTextareaSelectionRef = useRef<ChatDraftSelection | null>(null);
+  const pendingTextareaFocusRestoreRef = useRef<boolean>(false);
+  const isMountedRef = useRef<boolean>(true);
+  const selectedTargetRef = useRef<ChatTarget>(chatWorkspace.state.target);
+  const dictationSelectionRef = useRef<Readonly<{
+    scopeToken: ChatLayoutScopeToken;
+    target: ChatTarget;
+    selectionEpoch: number;
+  }>>({
+    scopeToken: chatLayoutScopeToken,
+    target: chatWorkspace.state.target,
+    selectionEpoch: chatWorkspace.selectionEpoch,
+  });
+  const historyOpenRef = useRef<boolean>(chatWorkspace.historyOpen);
+  const committedComposerSelectionRef =
+    useRef<ChatComposerLifecycleSelection>({
+      scopeToken: chatLayoutScopeToken,
+      target: chatWorkspace.state.target,
+      selectionEpoch: chatWorkspace.selectionEpoch,
+    });
+  const processedAdoptionTransitionIdRef = useRef<symbol | null>(null);
+  const textareaAdoptionHandoffRef =
+    useRef<ChatTextareaAdoptionHandoff | null>(null);
+
+  useLayoutEffect(() => {
+    selectedTargetRef.current = chatWorkspace.state.target;
+    historyOpenRef.current = chatWorkspace.historyOpen;
+  }, [
+    chatWorkspace.historyOpen,
+    chatWorkspace.state.target,
+  ]);
+
+  const isCurrentScopeSelection = useCallback((
+    target: ChatTarget,
+    selectionEpoch: number,
+  ): boolean =>
+    isChatLayoutScopeCurrent(chatLayoutScopeToken)
+    && chatWorkspace.isSelectionCurrent(target, selectionEpoch), [
+    chatLayoutScopeToken,
+    chatWorkspace.isSelectionCurrent,
+    isChatLayoutScopeCurrent,
+  ]);
+
+  const refreshCurrentScopeCatalog = useCallback(async (): Promise<void> => {
+    if (!isChatLayoutScopeCurrent(chatLayoutScopeToken)) {
+      return;
+    }
+    await chatWorkspace.refreshCatalog();
+  }, [
+    chatLayoutScopeToken,
+    chatWorkspace.refreshCatalog,
+    isChatLayoutScopeCurrent,
+  ]);
+
+  const recoverCurrentScopeInvalidSessionSelection = useCallback((
+    sessionId: string,
+    errorMessage: string,
+  ): boolean =>
+    isChatLayoutScopeCurrent(chatLayoutScopeToken)
+    && chatWorkspace.recoverInvalidSessionSelection(
+      sessionId,
+      errorMessage,
+    ), [
+    chatLayoutScopeToken,
+    chatWorkspace.recoverInvalidSessionSelection,
+    isChatLayoutScopeCurrent,
+  ]);
+
+  const promoteSelectedTargetToExplicit = useCallback((
+    target: ChatTarget,
+  ): number =>
+    chatWorkspace.promoteSelectedTargetToExplicit(target), [
+    chatWorkspace.promoteSelectedTargetToExplicit,
+  ]);
+
+  const scheduleComposerFocus = useCallback((
+    requestId: number,
+    target: ChatTarget,
+    selectionEpoch: number,
+  ): void => {
+    if (composerFocusTimeoutRef.current !== null) {
+      clearTimeout(composerFocusTimeoutRef.current);
+    }
+    composerFocusTimeoutRef.current = setTimeout((): void => {
+      composerFocusTimeoutRef.current = null;
+      const request = pendingComposerFocusRequestRef.current;
+      if (request?.requestId !== requestId) {
+        return;
+      }
+      if (
+        !isMountedRef.current
+        || !isCurrentScopeSelection(target, selectionEpoch)
+      ) {
+        pendingComposerFocusRequestRef.current = null;
+        return;
+      }
+      if (historyOpenRef.current) {
+        return;
+      }
+      const textarea = textareaRef.current;
+      if (textarea === null || textarea.disabled) {
+        return;
+      }
+      textarea.focus();
+      if (document.activeElement !== textarea) {
+        return;
+      }
+      pendingComposerFocusRequestRef.current = null;
+    }, 0);
+  }, [isCurrentScopeSelection]);
+
+  const requestComposerFocusAfterNew = useCallback((
+    sourceTarget: ChatTarget,
+    sourceSelectionEpoch: number,
+    destinationTarget: ChatTarget,
+    destinationSelectionEpoch: number,
+  ): void => {
+    const requestId = nextComposerFocusRequestIdRef.current + 1;
+    nextComposerFocusRequestIdRef.current = requestId;
+    pendingComposerFocusRequestRef.current = {
+      requestId,
+      scopeToken: chatLayoutScopeToken,
+      sourceTarget,
+      sourceSelectionEpoch,
+      destinationTarget,
+      destinationSelectionEpoch,
+    };
+    scheduleComposerFocus(
+      requestId,
+      destinationTarget,
+      destinationSelectionEpoch,
+    );
+  }, [
+    chatLayoutScopeToken,
+    scheduleComposerFocus,
+  ]);
+
+  const cancelComposerFocusRequest = useCallback((): void => {
+    pendingComposerFocusRequestRef.current = null;
+    if (composerFocusTimeoutRef.current !== null) {
+      clearTimeout(composerFocusTimeoutRef.current);
+      composerFocusTimeoutRef.current = null;
+    }
+  }, []);
+
+  const invalidateAttachmentOperationForTarget = useCallback((
+    target: ChatTarget,
+  ): void => {
+    const targetKey = getChatTargetKey(target);
+    const operationId =
+      attachmentOperationIdsByTargetKeyRef.current.get(targetKey);
+    if (operationId === undefined) {
+      return;
+    }
+
+    attachmentOperationIdsByTargetKeyRef.current.delete(targetKey);
+    const operation = attachmentOperationsRef.current.get(operationId);
+    attachmentOperationsRef.current.delete(operationId);
+    if (operation !== undefined) {
+      releaseChatTargetOperationOwnership(operation.ownership);
+    }
+  }, [releaseChatTargetOperationOwnership]);
+
+  const cancelAllAttachmentOperations = useCallback((): void => {
+    const operations = Array.from(attachmentOperationsRef.current.values());
+    attachmentOperationsRef.current.clear();
+    attachmentOperationIdsByTargetKeyRef.current.clear();
+    for (const operation of operations) {
+      const ownership = readChatTargetOperationOwnership(operation.ownership);
+      releaseChatTargetOperationOwnership(operation.ownership);
+      if (ownership !== null) {
+        setChatComposerMemoryForTarget(ownership.target, (currentMemory) => ({
+          ...currentMemory,
+          isAttachmentProcessing: false,
+        }));
+      }
+    }
+  }, [
+    readChatTargetOperationOwnership,
+    releaseChatTargetOperationOwnership,
+    setChatComposerMemoryForTarget,
+  ]);
+
+  const readCurrentAttachmentOperation = useCallback((
+    operationId: number,
+  ): ChatAttachmentPreparationOperation | null => {
+    const operation = attachmentOperationsRef.current.get(operationId);
+    if (operation === undefined) {
+      return null;
+    }
+    const ownership = readChatTargetOperationOwnership(operation.ownership);
+    if (ownership === null) {
+      return null;
+    }
+    const currentTargetKey = getChatTargetKey(ownership.target);
+    if (currentTargetKey === operation.targetKey) {
+      return operation;
+    }
+    if (
+      attachmentOperationIdsByTargetKeyRef.current.get(operation.targetKey)
+      === operationId
+    ) {
+      attachmentOperationIdsByTargetKeyRef.current.delete(operation.targetKey);
+    }
+    const conflictingOperationId =
+      attachmentOperationIdsByTargetKeyRef.current.get(currentTargetKey);
+    if (
+      conflictingOperationId !== undefined
+      && conflictingOperationId !== operationId
+    ) {
+      releaseChatTargetOperationOwnership(operation.ownership);
+      attachmentOperationsRef.current.delete(operationId);
+      return null;
+    }
+    const currentOperation: ChatAttachmentPreparationOperation = {
+      ...operation,
+      target: ownership.target,
+      targetKey: currentTargetKey,
+      selectionEpoch: ownership.selectionEpoch,
+    };
+    attachmentOperationsRef.current.set(operationId, currentOperation);
+    attachmentOperationIdsByTargetKeyRef.current.set(
+      currentTargetKey,
+      operationId,
+    );
+    return currentOperation;
+  }, [
+    readChatTargetOperationOwnership,
+    releaseChatTargetOperationOwnership,
+  ]);
+
+  const cancelDictationOperation = useCallback((): void => {
+    dictationOperationEpochRef.current = getNextChatDictationOperationEpoch(
+      dictationOperationEpochRef.current,
+    );
+    const operation = activeDictationOperationRef.current;
+    activeDictationOperationRef.current = null;
+    for (const ownership of dictationOperationOwnershipsRef.current.values()) {
+      releaseChatTargetOperationOwnership(ownership);
+    }
+    dictationOperationOwnershipsRef.current.clear();
+    if (operation !== null) {
+      stopDictationOperationResources(operation);
+    }
+    pendingTextareaSelectionRef.current = null;
+    pendingTextareaFocusRestoreRef.current = false;
+    if (isMountedRef.current) {
+      setDictationState("idle");
+    }
+  }, [releaseChatTargetOperationOwnership]);
+
+  useLayoutEffect(() => {
+    cancelAllAttachmentOperations();
+    cancelDictationOperation();
+  }, [
+    cancelAllAttachmentOperations,
+    cancelDictationOperation,
+    chatLayoutScopeToken,
+  ]);
+
+  const adoptDraftSession = useCallback((
+    draftId: string,
+    sessionId: string,
+    expectedSelectionEpoch: number,
+  ): ChatDraftSessionAdoption =>
+    adoptChatPendingSubmissionSession(
+      chatLayoutScopeToken,
+      draftId,
+      sessionId,
+      expectedSelectionEpoch,
+    ), [
+    adoptChatPendingSubmissionSession,
+    chatLayoutScopeToken,
+  ]);
+
+  useLayoutEffect(() => {
+    const previousSelection = committedComposerSelectionRef.current;
+    const currentSelection: ChatComposerLifecycleSelection = {
+      scopeToken: chatLayoutScopeToken,
+      target: chatWorkspace.state.target,
+      selectionEpoch: chatWorkspace.selectionEpoch,
+    };
+    const adoptionTransition = chatTargetAdoptionTransition;
+    const isUnconsumedAdoption =
+      adoptionTransition !== null
+      && adoptionTransition.transitionId
+        !== processedAdoptionTransitionIdRef.current;
+    const isExactSelectedAdoption =
+      isUnconsumedAdoption
+      && adoptionTransition.scopeToken === currentSelection.scopeToken
+      && adoptionTransition.selectionEpoch === previousSelection.selectionEpoch
+      && adoptionTransition.selectionEpoch === currentSelection.selectionEpoch
+      && areChatTargetsEqual(
+        adoptionTransition.sourceTarget,
+        previousSelection.target,
+      )
+      && areChatTargetsEqual(
+        adoptionTransition.destinationTarget,
+        currentSelection.target,
+      );
+
+    if (isUnconsumedAdoption) {
+      processedAdoptionTransitionIdRef.current =
+        adoptionTransition.transitionId;
+    }
+    if (isExactSelectedAdoption) {
+      if (adoptionTransition.stateDisposition === "destination_preserved") {
+        invalidateAttachmentOperationForTarget(
+          adoptionTransition.sourceTarget,
+        );
+        cancelDictationOperation();
+      } else {
+        for (const operationId of
+          attachmentOperationsRef.current.keys()) {
+          readCurrentAttachmentOperation(operationId);
+        }
+      }
+    }
+
+    const isSameCommittedTarget =
+      previousSelection.scopeToken === currentSelection.scopeToken
+      && previousSelection.selectionEpoch === currentSelection.selectionEpoch
+      && areChatTargetsEqual(previousSelection.target, currentSelection.target);
+    const preservesAdoptionLifecycle =
+      isExactSelectedAdoption
+      && adoptionTransition.stateDisposition === "transferred";
+    const requiresTextareaAdoptionHandoff =
+      preservesAdoptionLifecycle
+      && adoptionTransition.originatingPanelLifecycleToken
+        !== panelLifecycleTokenRef.current;
+    if (requiresTextareaAdoptionHandoff) {
+      textareaAdoptionHandoffRef.current = {
+        transitionId: adoptionTransition.transitionId,
+        scopeToken: currentSelection.scopeToken,
+        target: currentSelection.target,
+        selectionEpoch: currentSelection.selectionEpoch,
+        hasObservedHistoryLoading: false,
+      };
+    } else if (!isSameCommittedTarget) {
+      textareaAdoptionHandoffRef.current = null;
+    }
+    if (!isSameCommittedTarget && !preservesAdoptionLifecycle) {
+      setComposerLifecycleKey((currentKey) => currentKey + 1);
+    }
+    committedComposerSelectionRef.current = currentSelection;
+  }, [
+    cancelDictationOperation,
+    chatLayoutScopeToken,
+    chatTargetAdoptionTransition,
+    chatWorkspace.selectionEpoch,
+    chatWorkspace.state.target,
+    invalidateAttachmentOperationForTarget,
+    readCurrentAttachmentOperation,
+  ]);
+
+  const observeCurrentScopeSessionInvalidation = useCallback((
+    sessionId: string,
+    version: number,
+    source: ChatWorkspaceInvalidationSource,
+  ): void => {
+    if (!isChatLayoutScopeCurrent(chatLayoutScopeToken)) {
+      return;
+    }
+    chatWorkspace.observeSessionInvalidation(sessionId, version, source);
+  }, [
+    chatLayoutScopeToken,
+    chatWorkspace.observeSessionInvalidation,
+    isChatLayoutScopeCurrent,
+  ]);
+
   const {
     messages,
     runState,
@@ -149,34 +646,57 @@ export const ChatPanel = (props: Props): ReactElement => {
     isLiveStreamConnected,
     isStopping,
     composerAction,
-    acceptServerSessionId,
-    ensureWritableSessionId,
     sendMessage,
     stopMessage,
-    clearConversation,
-  } = useChatSessionController({ mode, workspaceId });
+  } = useChatSessionController({
+    workspaceId,
+    target: chatWorkspace.state.target,
+    selectionEpoch: chatWorkspace.selectionEpoch,
+    isWorkspaceReady: chatWorkspace.isReady,
+    isSelectionCurrent: isCurrentScopeSelection,
+    adoptDraftSession,
+    refreshCatalog: refreshCurrentScopeCatalog,
+    observeSessionInvalidation: observeCurrentScopeSessionInvalidation,
+    recoverInvalidSessionSelection:
+      recoverCurrentScopeInvalidSessionSelection,
+  });
 
-  const [localWidth, setLocalWidth] = useState<number>(chatWidth);
-  const [isDragging, setIsDragging] = useState<boolean>(false);
-  const [pendingAttachments, setPendingAttachments] = useState<ReadonlyArray<PendingAttachment>>([]);
-  const [attachmentErrors, setAttachmentErrors] = useState<ReadonlyArray<AttachmentPreparationError>>([]);
-  const [isAttachmentProcessing, setIsAttachmentProcessing] = useState<boolean>(false);
-  const [isDragOver, setIsDragOver] = useState<boolean>(false);
-  const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle");
-  const [dictationState, setDictationState] = useState<ChatDictationState>("idle");
-  const shouldSubmitOnEnter = useDesktopEnterToSend();
+  useLayoutEffect(() => {
+    const handoff = textareaAdoptionHandoffRef.current;
+    if (handoff === null) {
+      return;
+    }
+    const isCurrentHandoff =
+      handoff.scopeToken === chatLayoutScopeToken
+      && chatTargetAdoptionTransition?.transitionId === handoff.transitionId
+      && chatTargetAdoptionTransition.stateDisposition === "transferred"
+      && handoff.selectionEpoch === chatWorkspace.selectionEpoch
+      && areChatTargetsEqual(
+        handoff.target,
+        chatWorkspace.state.target,
+      );
+    if (!isCurrentHandoff) {
+      textareaAdoptionHandoffRef.current = null;
+      return;
+    }
+    if (!isHistoryLoaded && !handoff.hasObservedHistoryLoading) {
+      textareaAdoptionHandoffRef.current = {
+        ...handoff,
+        hasObservedHistoryLoading: true,
+      };
+      return;
+    }
+    if (isHistoryLoaded && handoff.hasObservedHistoryLoading) {
+      textareaAdoptionHandoffRef.current = null;
+    }
+  }, [
+    chatLayoutScopeToken,
+    chatTargetAdoptionTransition,
+    chatWorkspace.selectionEpoch,
+    chatWorkspace.state.target,
+    isHistoryLoaded,
+  ]);
 
-  const dragCounterRef = useRef<number>(0);
-  const isAttachmentProcessingRef = useRef<boolean>(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const copyStatusResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const mediaStreamRef = useRef<MediaStream | null>(null);
-  const recordedChunksRef = useRef<Array<Blob>>([]);
-  const draftSelectionRef = useRef<ChatDraftSelection | null>(null);
-  const pendingTextareaSelectionRef = useRef<ChatDraftSelection | null>(null);
-  const shouldRestoreTextareaFocusAfterDictationRef = useRef<boolean>(false);
-  const isMountedRef = useRef<boolean>(true);
   useEffect(() => {
     if (!isDragging) return;
 
@@ -213,13 +733,81 @@ export const ChatPanel = (props: Props): ReactElement => {
       if (copyStatusResetRef.current !== null) {
         clearTimeout(copyStatusResetRef.current);
       }
-      const recorder = mediaRecorderRef.current;
-      if (recorder !== null && recorder.state !== "inactive") {
-        recorder.stop();
+      if (composerFocusTimeoutRef.current !== null) {
+        clearTimeout(composerFocusTimeoutRef.current);
       }
-      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
+      pendingComposerFocusRequestRef.current = null;
+      cancelAllAttachmentOperations();
+      cancelDictationOperation();
     };
-  }, []);
+  }, [cancelAllAttachmentOperations, cancelDictationOperation]);
+
+  useEffect(() => {
+    const request = pendingComposerFocusRequestRef.current;
+    if (request === null) {
+      return;
+    }
+    const currentTarget = chatWorkspace.state.target;
+    const currentSelectionEpoch = chatWorkspace.selectionEpoch;
+    if (
+      request.scopeToken !== chatLayoutScopeToken
+      || !isChatLayoutScopeCurrent(request.scopeToken)
+    ) {
+      pendingComposerFocusRequestRef.current = null;
+      return;
+    }
+    if (
+      request.destinationTarget !== null
+      && request.destinationSelectionEpoch !== null
+    ) {
+      if (
+        !areChatTargetsEqual(request.destinationTarget, currentTarget)
+        || request.destinationSelectionEpoch !== currentSelectionEpoch
+      ) {
+        pendingComposerFocusRequestRef.current = null;
+        if (composerFocusTimeoutRef.current !== null) {
+          clearTimeout(composerFocusTimeoutRef.current);
+          composerFocusTimeoutRef.current = null;
+        }
+        return;
+      }
+      scheduleComposerFocus(
+        request.requestId,
+        currentTarget,
+        currentSelectionEpoch,
+      );
+      return;
+    }
+
+    const sourceIsStillCurrent =
+      currentSelectionEpoch === request.sourceSelectionEpoch
+      && areChatTargetsEqual(currentTarget, request.sourceTarget);
+    const isExpectedTargetTransition =
+      currentSelectionEpoch === request.sourceSelectionEpoch + 1;
+    if (!sourceIsStillCurrent && !isExpectedTargetTransition) {
+      pendingComposerFocusRequestRef.current = null;
+      return;
+    }
+    pendingComposerFocusRequestRef.current = {
+      ...request,
+      destinationTarget: currentTarget,
+      destinationSelectionEpoch: currentSelectionEpoch,
+    };
+    scheduleComposerFocus(
+      request.requestId,
+      currentTarget,
+      currentSelectionEpoch,
+    );
+  }, [
+    chatTargetKey,
+    chatLayoutScopeToken,
+    chatWorkspace.historyOpen,
+    chatWorkspace.selectionEpoch,
+    chatWorkspace.state.target,
+    isChatLayoutScopeCurrent,
+    isHistoryLoaded,
+    scheduleComposerFocus,
+  ]);
 
   useEffect(() => {
     if (dictationState !== "idle") {
@@ -235,71 +823,287 @@ export const ChatPanel = (props: Props): ReactElement => {
     const start = Math.max(0, Math.min(pendingSelection.start, textarea.value.length));
     const end = Math.max(0, Math.min(pendingSelection.end, textarea.value.length));
 
-    if (shouldRestoreTextareaFocusAfterDictationRef.current) {
+    if (pendingTextareaFocusRestoreRef.current) {
       textarea.focus();
     }
 
     textarea.setSelectionRange(start, end);
-    draftSelectionRef.current = { start, end };
     pendingTextareaSelectionRef.current = null;
-    shouldRestoreTextareaFocusAfterDictationRef.current = false;
+    pendingTextareaFocusRestoreRef.current = false;
   }, [dictationState, inputText]);
 
-  const ingestFiles = useCallback(async (files: ReadonlyArray<File>): Promise<number> => {
-    if (files.length === 0 || isAttachmentProcessingRef.current) {
-      return 0;
+  const prepareAttachmentIngestion = useCallback((
+    files: ReadonlyArray<File>,
+  ): ChatPreparedAttachmentIngestion | null => {
+    const target = chatWorkspace.state.target;
+    const targetKey = chatTargetKey;
+    if (
+      files.length === 0
+      || !isChatLayoutScopeCurrent(chatLayoutScopeToken)
+      || attachmentOperationIdsByTargetKeyRef.current.has(targetKey)
+    ) {
+      return null;
     }
 
-    isAttachmentProcessingRef.current = true;
-    setIsAttachmentProcessing(true);
-    setAttachmentErrors([]);
+    const selectionEpoch = promoteSelectedTargetToExplicit(target);
+    const operationId = nextAttachmentOperationIdRef.current + 1;
+    nextAttachmentOperationIdRef.current = operationId;
+    const ownership = registerChatTargetOperationOwnership(
+      "attachment_preparation",
+      target,
+      selectionEpoch,
+    );
+    attachmentOperationsRef.current.set(operationId, {
+      operationId,
+      ownership,
+      target,
+      targetKey,
+      selectionEpoch,
+    });
+    attachmentOperationIdsByTargetKeyRef.current.set(targetKey, operationId);
+    try {
+      setChatComposerMemoryForTarget(target, (currentMemory) => ({
+        ...currentMemory,
+        attachmentErrors: [],
+        isAttachmentProcessing: true,
+      }));
+    } catch (error) {
+      attachmentOperationsRef.current.delete(operationId);
+      attachmentOperationIdsByTargetKeyRef.current.delete(targetKey);
+      releaseChatTargetOperationOwnership(ownership);
+      throw error;
+    }
+    return {
+      files: [...files],
+      operationId,
+    };
+  }, [
+    chatTargetKey,
+    chatLayoutScopeToken,
+    chatWorkspace.state.target,
+    isChatLayoutScopeCurrent,
+    promoteSelectedTargetToExplicit,
+    registerChatTargetOperationOwnership,
+    releaseChatTargetOperationOwnership,
+    setChatComposerMemoryForTarget,
+  ]);
+
+  const finishAttachmentIngestion = useCallback((
+    operationId: number,
+  ): void => {
+    const registeredOperation =
+      attachmentOperationsRef.current.get(operationId);
+    const currentOperation = readCurrentAttachmentOperation(operationId);
+    attachmentOperationsRef.current.delete(operationId);
+    for (const [ownedTargetKey, ownedOperationId] of
+      attachmentOperationIdsByTargetKeyRef.current.entries()) {
+      if (ownedOperationId === operationId) {
+        attachmentOperationIdsByTargetKeyRef.current.delete(ownedTargetKey);
+      }
+    }
+    if (registeredOperation !== undefined) {
+      releaseChatTargetOperationOwnership(registeredOperation.ownership);
+    }
+    if (currentOperation !== null) {
+      setChatComposerMemoryForTarget(
+        currentOperation.target,
+        (currentMemory) => ({
+          ...currentMemory,
+          isAttachmentProcessing: false,
+        }),
+      );
+    }
+  }, [
+    readCurrentAttachmentOperation,
+    releaseChatTargetOperationOwnership,
+    setChatComposerMemoryForTarget,
+  ]);
+
+  const runPreparedAttachmentIngestion = useCallback(async (
+    ingestion: ChatPreparedAttachmentIngestion,
+  ): Promise<ChatAttachmentIngestionResult | null> => {
+    const initialOperation =
+      readCurrentAttachmentOperation(ingestion.operationId);
+    if (initialOperation === null) {
+      finishAttachmentIngestion(ingestion.operationId);
+      return null;
+    }
     let attachedFileCount = 0;
+    let resultTarget = initialOperation.target;
 
     try {
-      for (const file of files) {
+      for (const file of ingestion.files) {
         try {
           const attachment = await prepareAttachment(file);
-          if (isMountedRef.current) {
-            setPendingAttachments((prev) => [...prev, attachment]);
+          const currentOperation = readCurrentAttachmentOperation(
+            ingestion.operationId,
+          );
+          if (currentOperation === null) {
+            return null;
           }
+          resultTarget = currentOperation.target;
+          setChatComposerMemoryForTarget(
+            currentOperation.target,
+            (currentMemory) => markChatComposerContentEdited({
+              ...currentMemory,
+              pendingAttachments: [
+                ...currentMemory.pendingAttachments,
+                attachment,
+              ],
+            }),
+          );
           attachedFileCount += 1;
         } catch (error) {
-          const reason = t(getAttachmentFailureReasonKey(error));
-          if (isMountedRef.current) {
-            setAttachmentErrors((previousErrors) => [
-              ...previousErrors,
-              {
-                fileName: file.name,
-                message: t("chat.attachmentConversionFailed", {
-                  fileName: file.name,
-                  reason,
-                }),
-              },
-            ]);
+          const currentOperation = readCurrentAttachmentOperation(
+            ingestion.operationId,
+          );
+          if (currentOperation === null) {
+            return null;
           }
+          resultTarget = currentOperation.target;
+          const reason = t(getAttachmentFailureReasonKey(error));
+          setChatComposerMemoryForTarget(
+            currentOperation.target,
+            (currentMemory) => ({
+              ...currentMemory,
+              attachmentErrors: [
+                ...currentMemory.attachmentErrors,
+                {
+                  fileName: file.name,
+                  message: t("chat.attachmentConversionFailed", {
+                    fileName: file.name,
+                    reason,
+                  }),
+                },
+              ],
+            }),
+          );
         }
       }
     } finally {
-      isAttachmentProcessingRef.current = false;
-      if (isMountedRef.current) {
-        setIsAttachmentProcessing(false);
-      }
+      finishAttachmentIngestion(ingestion.operationId);
     }
 
-    return attachedFileCount;
-  }, [t]);
+    return {
+      attachedFileCount,
+      target: resultTarget,
+      selectionEpoch: initialOperation.selectionEpoch,
+    };
+  }, [
+    finishAttachmentIngestion,
+    readCurrentAttachmentOperation,
+    setChatComposerMemoryForTarget,
+    t,
+  ]);
+
+  const ingestFilesForSelectedTarget = useCallback(async (
+    files: ReadonlyArray<File>,
+  ): Promise<ChatAttachmentIngestionResult | null> => {
+    const ingestion = prepareAttachmentIngestion(files);
+    return ingestion === null
+      ? null
+      : runPreparedAttachmentIngestion(ingestion);
+  }, [prepareAttachmentIngestion, runPreparedAttachmentIngestion]);
+
+  const ingestFiles = useCallback(async (
+    files: ReadonlyArray<File>,
+  ): Promise<number> => {
+    const result = await ingestFilesForSelectedTarget(files);
+    return result?.attachedFileCount ?? 0;
+  }, [ingestFilesForSelectedTarget]);
+
+  const prepareDeferredAttachmentIngestion = useCallback((
+    files: ReadonlyArray<File>,
+  ): DeferredAttachmentIngestion | null => {
+    const ingestion = prepareAttachmentIngestion(files);
+    if (ingestion === null) {
+      return null;
+    }
+
+    return async (): Promise<void> => {
+      const operation = readCurrentAttachmentOperation(
+        ingestion.operationId,
+      );
+      if (
+        operation === null
+        || !isCurrentScopeSelection(
+          operation.target,
+          operation.selectionEpoch,
+        )
+      ) {
+        finishAttachmentIngestion(ingestion.operationId);
+        return;
+      }
+      await runPreparedAttachmentIngestion(ingestion);
+    };
+  }, [
+    finishAttachmentIngestion,
+    isCurrentScopeSelection,
+    prepareAttachmentIngestion,
+    readCurrentAttachmentOperation,
+    runPreparedAttachmentIngestion,
+  ]);
 
   const removeAttachment = useCallback((index: number): void => {
-    setPendingAttachments((prev) => [...prev.slice(0, index), ...prev.slice(index + 1)]);
-  }, []);
+    const target = chatWorkspace.state.target;
+    promoteSelectedTargetToExplicit(target);
+    setChatComposerMemoryForTarget(
+      target,
+      (currentMemory) => markChatComposerContentEdited({
+        ...currentMemory,
+        pendingAttachments: [
+          ...currentMemory.pendingAttachments.slice(0, index),
+          ...currentMemory.pendingAttachments.slice(index + 1),
+        ],
+      }),
+    );
+  }, [
+    chatWorkspace.state.target,
+    promoteSelectedTargetToExplicit,
+    setChatComposerMemoryForTarget,
+  ]);
 
   const hasPendingMessage = inputText.trim().length > 0 || pendingAttachments.length > 0;
+  const hasMeaningfulTargetActivity =
+    inputText.length > 0
+    || pendingAttachments.length > 0
+    || attachmentErrors.length > 0
+    || isAttachmentProcessing
+    || activePendingSubmission !== null;
+  useEffect(() => {
+    if (!chatWorkspace.isReady || !hasMeaningfulTargetActivity) {
+      return;
+    }
+    promoteSelectedTargetToExplicit(chatWorkspace.state.target);
+  }, [
+    chatWorkspace.isReady,
+    chatWorkspace.state.target,
+    hasMeaningfulTargetActivity,
+    promoteSelectedTargetToExplicit,
+  ]);
+  const textareaAdoptionHandoff = textareaAdoptionHandoffRef.current;
+  const isTextareaReady = isHistoryLoaded
+    || (
+      textareaAdoptionHandoff !== null
+      && textareaAdoptionHandoff.scopeToken === chatLayoutScopeToken
+      && chatTargetAdoptionTransition?.transitionId
+        === textareaAdoptionHandoff.transitionId
+      && chatTargetAdoptionTransition.stateDisposition === "transferred"
+      && textareaAdoptionHandoff.selectionEpoch
+        === chatWorkspace.selectionEpoch
+      && areChatTargetsEqual(
+        textareaAdoptionHandoff.target,
+        chatWorkspace.state.target,
+      )
+    );
   const composerCapabilities = getChatComposerCapabilities({
     composerAction,
     isHistoryLoaded,
+    isTextareaReady,
     isStopping,
     isLiveStreamConnected,
     isAttachmentProcessing,
+    isSubmissionPending: activePendingSubmission !== null,
     dictationState,
     hasPendingMessage,
     shouldSubmitOnEnter,
@@ -349,18 +1153,30 @@ export const ChatPanel = (props: Props): ReactElement => {
     }
 
     const files = Array.from(e.dataTransfer.files);
-    const attachedFileCount = await ingestFiles(files);
+    const ingestionResult = await ingestFilesForSelectedTarget(files);
 
-    if (attachedFileCount > 0) {
+    if (
+      ingestionResult !== null
+      && ingestionResult.attachedFileCount > 0
+      && isCurrentScopeSelection(
+        ingestionResult.target,
+        ingestionResult.selectionEpoch,
+      )
+    ) {
       textareaRef.current?.focus();
     }
-  }, [composerCapabilities.isDropTargetEnabled, ingestFiles]);
+  }, [
+    composerCapabilities.isDropTargetEnabled,
+    ingestFilesForSelectedTarget,
+    isCurrentScopeSelection,
+  ]);
 
   const canSendPendingMessage = isHistoryLoaded
     && !isStopping
     && !isAssistantRunActive
     && !isLiveStreamConnected
     && !isAttachmentProcessing
+    && activePendingSubmission === null
     && dictationState === "idle"
     && hasPendingMessage;
 
@@ -373,30 +1189,67 @@ export const ChatPanel = (props: Props): ReactElement => {
     setIsDragOver(false);
   }, [composerCapabilities.isDropTargetEnabled]);
 
-  const discardDictation = useCallback((): void => {
-    const recorder = mediaRecorderRef.current;
-    if (recorder !== null && recorder.state !== "inactive") {
-      recorder.stop();
+  useEffect(() => {
+    const previousSelection = dictationSelectionRef.current;
+    const currentSelection = {
+      scopeToken: chatLayoutScopeToken,
+      target: chatWorkspace.state.target,
+      selectionEpoch: chatWorkspace.selectionEpoch,
+    } as const;
+    dictationSelectionRef.current = currentSelection;
+    const hasCurrentAdoptedDictationOwnership = Array.from(
+      dictationOperationOwnershipsRef.current.values(),
+    ).some((ownership): boolean => {
+      const currentOwnership = readChatTargetOperationOwnership(ownership);
+      return currentOwnership !== null
+        && currentOwnership.selectionEpoch === currentSelection.selectionEpoch
+        && areChatTargetsEqual(
+          currentOwnership.target,
+          currentSelection.target,
+        );
+    });
+    if (
+      previousSelection.scopeToken === currentSelection.scopeToken
+      && previousSelection.selectionEpoch === currentSelection.selectionEpoch
+      && (
+        areChatTargetsEqual(
+          previousSelection.target,
+          currentSelection.target,
+        )
+        || hasCurrentAdoptedDictationOwnership
+      )
+    ) {
+      return;
     }
 
-    cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
-    draftSelectionRef.current = null;
-    pendingTextareaSelectionRef.current = null;
-    shouldRestoreTextareaFocusAfterDictationRef.current = false;
-    if (isMountedRef.current) {
-      setDictationState("idle");
-    }
-  }, []);
+    cancelDictationOperation();
+    dragCounterRef.current = 0;
+    setIsDragOver(false);
+  }, [
+    cancelDictationOperation,
+    chatLayoutScopeToken,
+    chatWorkspace.selectionEpoch,
+    chatWorkspace.state.target,
+    readChatTargetOperationOwnership,
+  ]);
 
   const startDictation = useCallback(async (): Promise<void> => {
-    if (dictationState !== "idle") {
+    if (
+      dictationState !== "idle"
+      || activeDictationOperationRef.current !== null
+    ) {
       return;
     }
 
     const textarea = textareaRef.current;
+    const operationEpoch = getNextChatDictationOperationEpoch(
+      dictationOperationEpochRef.current,
+    );
+    dictationOperationEpochRef.current = operationEpoch;
+    const target = chatWorkspace.state.target;
+    const selectionEpoch = promoteSelectedTargetToExplicit(target);
     const shouldRestoreFocus = textarea !== null && document.activeElement === textarea;
-    shouldRestoreTextareaFocusAfterDictationRef.current = shouldRestoreFocus;
-    draftSelectionRef.current = shouldRestoreFocus && textarea !== null
+    const selection = shouldRestoreFocus && textarea !== null
       ? {
         start: textarea.selectionStart,
         end: textarea.selectionEnd,
@@ -414,86 +1267,210 @@ export const ChatPanel = (props: Props): ReactElement => {
       return;
     }
 
+    const ownership = registerChatTargetOperationOwnership(
+      "dictation",
+      target,
+      selectionEpoch,
+    );
+    dictationOperationOwnershipsRef.current.set(operationEpoch, ownership);
     setDictationState("requesting_permission");
 
     let stream: MediaStream | null = null;
+    let operation: ChatDictationOperation | null = null;
     try {
       stream = await mediaDevices.getUserMedia({ audio: true, video: false });
+      const currentOwnership =
+        readChatTargetOperationOwnership(ownership);
+      if (
+        !isMountedRef.current
+        || currentOwnership === null
+        || !isChatDictationOperationCurrent(
+          operationEpoch,
+          dictationOperationEpochRef.current,
+        )
+        || !isCurrentScopeSelection(
+          currentOwnership.target,
+          currentOwnership.selectionEpoch,
+        )
+      ) {
+        dictationOperationOwnershipsRef.current.delete(operationEpoch);
+        releaseChatTargetOperationOwnership(ownership);
+        stopMediaStream(stream);
+        return;
+      }
+
       const recorderMimeType = chooseSupportedRecordingMimeType();
       const recorder = recorderMimeType === null
         ? new MediaRecorder(stream)
         : new MediaRecorder(stream, { mimeType: recorderMimeType });
-      recordedChunksRef.current = [];
+      const recordedChunks: Array<Blob> = [];
+      operation = {
+        epoch: operationEpoch,
+        ownership,
+        selection,
+        shouldRestoreFocus,
+        recorder,
+        stream,
+        recordedChunks,
+      };
       recorder.addEventListener("dataavailable", (event: BlobEvent) => {
         if (event.data.size > 0) {
-          recordedChunksRef.current.push(event.data);
+          recordedChunks.push(event.data);
         }
       });
       recorder.start();
-      mediaRecorderRef.current = recorder;
-      mediaStreamRef.current = stream;
-      if (isMountedRef.current) {
+      activeDictationOperationRef.current = operation;
+      if (
+        isMountedRef.current
+        && readChatTargetOperationOwnership(ownership) !== null
+        && isChatDictationOperationCurrent(
+          operationEpoch,
+          dictationOperationEpochRef.current,
+        )
+      ) {
         setDictationState("recording");
       }
     } catch (error) {
-      stopMediaStream(stream);
-      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
-      if (isMountedRef.current) {
+      if (operation === null) {
+        stopMediaStream(stream);
+      } else {
+        stopDictationOperationResources(operation);
+      }
+      if (activeDictationOperationRef.current?.epoch === operationEpoch) {
+        activeDictationOperationRef.current = null;
+      }
+      const wasOwnershipCurrent =
+        readChatTargetOperationOwnership(ownership) !== null;
+      dictationOperationOwnershipsRef.current.delete(operationEpoch);
+      releaseChatTargetOperationOwnership(ownership);
+      if (
+        isMountedRef.current
+        && wasOwnershipCurrent
+        && isChatDictationOperationCurrent(
+          operationEpoch,
+          dictationOperationEpochRef.current,
+        )
+      ) {
         alert(getMicrophoneErrorMessage(error, t));
         setDictationState("idle");
       }
     }
-  }, [dictationState, t]);
+  }, [
+    chatWorkspace.state.target,
+    dictationState,
+    isCurrentScopeSelection,
+    promoteSelectedTargetToExplicit,
+    readChatTargetOperationOwnership,
+    registerChatTargetOperationOwnership,
+    releaseChatTargetOperationOwnership,
+    t,
+  ]);
 
   const stopDictation = useCallback(async (): Promise<void> => {
-    const recorder = mediaRecorderRef.current;
-    if (recorder === null || recorder.state === "inactive") {
-      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
-      setDictationState("idle");
+    const operation = activeDictationOperationRef.current;
+    if (operation === null || operation.recorder.state === "inactive") {
+      cancelDictationOperation();
       return;
     }
 
     setDictationState("transcribing");
 
     try {
-      const audioBlob = await stopMediaRecorder(recorder, recordedChunksRef);
-      stopMediaStream(mediaStreamRef.current);
-      if (audioBlob.size <= 0) {
-        if (isMountedRef.current) {
-          setDictationState("idle");
+      const audioBlob = await stopMediaRecorder(
+        operation.recorder,
+        operation.recordedChunks,
+      );
+      stopMediaStream(operation.stream);
+      const readCurrentOperationTarget = (): ChatTarget | null => {
+        const ownership =
+          readChatTargetOperationOwnership(operation.ownership);
+        if (
+          !isMountedRef.current
+          || ownership === null
+          || !isChatDictationOperationCurrent(
+            operation.epoch,
+            dictationOperationEpochRef.current,
+          )
+          || activeDictationOperationRef.current?.epoch !== operation.epoch
+          || !isCurrentScopeSelection(
+            ownership.target,
+            ownership.selectionEpoch,
+          )
+        ) {
+          return null;
         }
+        return ownership.target;
+      };
+      if (readCurrentOperationTarget() === null) {
+        return;
+      }
+      if (audioBlob.size <= 0) {
         return;
       }
 
-      const sessionId = await ensureWritableSessionId();
-      const transcription = await transcribeChatAudio(audioBlob, sessionId, t);
-      if (isMountedRef.current) {
-        acceptServerSessionId(transcription.sessionId);
-        setInputText((currentText) => {
-          const insertionResult = insertDictationTranscriptIntoDraft(
-            currentText,
-            transcription.text,
-            draftSelectionRef.current,
-          );
-          const nextSelection = shouldRestoreTextareaFocusAfterDictationRef.current
-            ? insertionResult.selection
-            : null;
-          draftSelectionRef.current = nextSelection;
-          pendingTextareaSelectionRef.current = nextSelection;
-          return insertionResult.text;
-        });
+      const transcription = await transcribeChatAudio(audioBlob, t);
+      const currentTarget = readCurrentOperationTarget();
+      if (currentTarget === null) {
+        return;
       }
+      setChatDraftTextForTarget(currentTarget, (currentText) => {
+        const insertionResult = insertDictationTranscriptIntoDraft(
+          currentText,
+          transcription.text,
+          operation.selection,
+        );
+        const nextSelection = operation.shouldRestoreFocus
+          ? insertionResult.selection
+          : null;
+        pendingTextareaSelectionRef.current = nextSelection;
+        pendingTextareaFocusRestoreRef.current = operation.shouldRestoreFocus;
+        return insertionResult.text;
+      });
+      setChatComposerMemoryForTarget(
+        currentTarget,
+        markChatComposerContentEdited,
+      );
     } catch (error) {
-      if (isMountedRef.current) {
+      if (
+        isMountedRef.current
+        && readChatTargetOperationOwnership(operation.ownership) !== null
+        && isChatDictationOperationCurrent(
+          operation.epoch,
+          dictationOperationEpochRef.current,
+        )
+        && activeDictationOperationRef.current?.epoch === operation.epoch
+      ) {
         alert(getMicrophoneErrorMessage(error, t));
       }
     } finally {
-      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
-      if (isMountedRef.current) {
+      stopMediaStream(operation.stream);
+      if (activeDictationOperationRef.current?.epoch === operation.epoch) {
+        activeDictationOperationRef.current = null;
+      }
+      dictationOperationOwnershipsRef.current.delete(operation.epoch);
+      const wasOwnershipCurrent =
+        readChatTargetOperationOwnership(operation.ownership) !== null;
+      releaseChatTargetOperationOwnership(operation.ownership);
+      if (
+        isMountedRef.current
+        && wasOwnershipCurrent
+        && isChatDictationOperationCurrent(
+          operation.epoch,
+          dictationOperationEpochRef.current,
+        )
+      ) {
         setDictationState("idle");
       }
     }
-  }, [acceptServerSessionId, ensureWritableSessionId, t]);
+  }, [
+    cancelDictationOperation,
+    isCurrentScopeSelection,
+    readChatTargetOperationOwnership,
+    releaseChatTargetOperationOwnership,
+    setChatComposerMemoryForTarget,
+    setChatDraftTextForTarget,
+    t,
+  ]);
 
   const handleToggleDictation = useCallback(async (): Promise<void> => {
     if (dictationState === "recording") {
@@ -509,22 +1486,240 @@ export const ChatPanel = (props: Props): ReactElement => {
   }, [dictationState, startDictation, stopDictation]);
 
   const sendPendingMessage = useCallback(async (): Promise<void> => {
-    if (!canSendPendingMessage || isAttachmentProcessingRef.current) {
+    if (
+      !canSendPendingMessage
+      || attachmentOperationIdsByTargetKeyRef.current.has(chatTargetKey)
+    ) {
       return;
     }
 
+    const target = chatWorkspace.state.target;
+    const submissionSelectionEpoch = chatWorkspace.selectionEpoch;
     const nextText = inputText;
     const nextAttachments = pendingAttachments;
-    setInputText("");
-    setPendingAttachments([]);
+    const pendingSubmission = target.kind === "draft"
+      ? createChatPendingSubmission(nextText, nextAttachments)
+      : null;
+    const pendingSubmissionOwnership =
+      target.kind === "draft" && pendingSubmission !== null
+        ? registerChatPendingSubmissionOwnership(
+            target,
+            submissionSelectionEpoch,
+            pendingSubmission,
+            panelLifecycleTokenRef.current,
+          )
+        : null;
+    let didClearInput = false;
+    try {
+      setInputText("");
+      didClearInput = true;
+      setChatComposerMemoryForTarget(target, (currentMemory) => ({
+        ...currentMemory,
+        pendingAttachments: [],
+        attachmentErrors: [],
+        pendingSubmission,
+      }));
+    } catch (error) {
+      let rollbackError: Error | null = null;
+      if (didClearInput) {
+        try {
+          setInputText(nextText);
+        } catch (inputRollbackError) {
+          rollbackError = inputRollbackError instanceof Error
+            ? inputRollbackError
+            : new Error(String(inputRollbackError));
+        }
+      }
+      if (pendingSubmissionOwnership !== null) {
+        if (!releaseChatPendingSubmissionOwnership(
+          pendingSubmissionOwnership,
+        )) {
+          const ownershipError = new Error(
+            "Chat submission staging could not release its exact ownership",
+          );
+          rollbackError ??= ownershipError;
+        }
+      }
+      const stagingMessage = error instanceof Error
+        ? error.message
+        : String(error);
+      if (rollbackError !== null) {
+        throw new Error(
+          `Chat submission staging failed and rollback also failed: `
+          + `${stagingMessage}; rollback: ${rollbackError.message}`,
+        );
+      }
+      throw new Error(`Chat submission staging failed: ${stagingMessage}`);
+    }
 
+    const rejectedSettlementFailureRef: {
+      current: Readonly<{
+        error: Error;
+        retry: () => boolean;
+      }> | null;
+    } = { current: null };
+    const unresolvedSettlementFailureRef: {
+      current: Readonly<{
+        error: Error;
+        retry: () => boolean;
+      }> | null;
+    } = { current: null };
+    const detachedSettlementFailureRef: {
+      current: Error | null;
+    } = { current: null };
     await sendMessage({
       text: nextText,
       attachments: nextAttachments,
+      onSubmissionRejected: (): void => {
+        if (pendingSubmissionOwnership === null) {
+          return;
+        }
+        try {
+          if (settleDetachedChatPendingSubmissionOwnership(
+            pendingSubmissionOwnership,
+          )) {
+            return;
+          }
+        } catch (error) {
+          detachedSettlementFailureRef.current = error instanceof Error
+            ? error
+            : new Error(String(error));
+          return;
+        }
+        try {
+          settleRejectedChatPendingSubmissionOwnership(
+            pendingSubmissionOwnership,
+          );
+        } catch (error) {
+          rejectedSettlementFailureRef.current = {
+            error: error instanceof Error ? error : new Error(String(error)),
+            retry: (): boolean =>
+              settleRejectedChatPendingSubmissionOwnership(
+                pendingSubmissionOwnership,
+              ),
+          };
+        }
+      },
+      onSubmissionUnresolved: (): void => {
+        if (pendingSubmissionOwnership === null) {
+          return;
+        }
+        try {
+          if (settleDetachedChatPendingSubmissionOwnership(
+            pendingSubmissionOwnership,
+          )) {
+            return;
+          }
+        } catch (error) {
+          detachedSettlementFailureRef.current = error instanceof Error
+            ? error
+            : new Error(String(error));
+          return;
+        }
+        try {
+          settleUnresolvedChatPendingSubmissionOwnership(
+            pendingSubmissionOwnership,
+          );
+        } catch (error) {
+          unresolvedSettlementFailureRef.current = {
+            error: error instanceof Error ? error : new Error(String(error)),
+            retry: (): boolean =>
+              settleUnresolvedChatPendingSubmissionOwnership(
+                pendingSubmissionOwnership,
+              ),
+          };
+        }
+      },
     });
-  }, [canSendPendingMessage, inputText, pendingAttachments, sendMessage]);
+    const rejectedSettlementFailure =
+      rejectedSettlementFailureRef.current;
+    if (rejectedSettlementFailure !== null) {
+      let didRecover = rejectedSettlementFailure.retry();
+      if (!didRecover && pendingSubmissionOwnership !== null) {
+        didRecover = settleDetachedChatPendingSubmissionOwnership(
+          pendingSubmissionOwnership,
+        );
+      }
+      if (!didRecover) {
+        if (!isChatLayoutScopeCurrent(chatLayoutScopeToken)) {
+          return;
+        }
+        throw new Error(
+          "Rejected chat submission settlement became stale before recovery",
+        );
+      }
+      throw new Error(
+        `Rejected chat submission settlement failed after controller `
+        + `finalization and was recovered: `
+        + `${rejectedSettlementFailure.error.message}`,
+      );
+    }
+    const unresolvedSettlementFailure =
+      unresolvedSettlementFailureRef.current;
+    if (unresolvedSettlementFailure !== null) {
+      let didRecover = unresolvedSettlementFailure.retry();
+      if (!didRecover && pendingSubmissionOwnership !== null) {
+        didRecover = settleDetachedChatPendingSubmissionOwnership(
+          pendingSubmissionOwnership,
+        );
+      }
+      if (!didRecover) {
+        if (!isChatLayoutScopeCurrent(chatLayoutScopeToken)) {
+          return;
+        }
+        throw new Error(
+          "Unresolved chat submission settlement became stale before recovery",
+        );
+      }
+      throw new Error(
+        `Unresolved chat submission settlement failed after controller `
+        + `finalization and was recovered: `
+        + `${unresolvedSettlementFailure.error.message}`,
+      );
+    }
+    const detachedSettlementFailure = detachedSettlementFailureRef.current;
+    if (detachedSettlementFailure !== null) {
+      if (!isChatLayoutScopeCurrent(chatLayoutScopeToken)) {
+        return;
+      }
+      throw new Error(
+        `Detached chat submission settlement failed after controller `
+        + `finalization: ${detachedSettlementFailure.message}`,
+      );
+    }
+  }, [
+    canSendPendingMessage,
+    chatTargetKey,
+    chatLayoutScopeToken,
+    chatWorkspace.selectionEpoch,
+    chatWorkspace.state.target,
+    inputText,
+    isChatLayoutScopeCurrent,
+    pendingAttachments,
+    registerChatPendingSubmissionOwnership,
+    releaseChatPendingSubmissionOwnership,
+    settleRejectedChatPendingSubmissionOwnership,
+    settleUnresolvedChatPendingSubmissionOwnership,
+    settleDetachedChatPendingSubmissionOwnership,
+    sendMessage,
+    setChatComposerMemoryForTarget,
+    setInputText,
+  ]);
+
+  const handleInputChange = useCallback((value: string): void => {
+    const target = chatWorkspace.state.target;
+    promoteSelectedTargetToExplicit(target);
+    setChatDraftTextForTarget(target, value);
+    setChatComposerMemoryForTarget(target, markChatComposerContentEdited);
+  }, [
+    chatWorkspace.state.target,
+    promoteSelectedTargetToExplicit,
+    setChatComposerMemoryForTarget,
+    setChatDraftTextForTarget,
+  ]);
 
   const handleCopyTranscript = useCallback(async (): Promise<void> => {
+    const scopeToken = chatLayoutScopeToken;
     try {
       const { markdown } = await buildChatTranscriptMarkdown({
         messages,
@@ -533,8 +1728,14 @@ export const ChatPanel = (props: Props): ReactElement => {
         t: (key, params) => t(key, params),
       });
       await navigator.clipboard.writeText(markdown);
+      if (!isChatLayoutScopeCurrent(scopeToken)) {
+        return;
+      }
       setCopyStatus("success");
     } catch {
+      if (!isChatLayoutScopeCurrent(scopeToken)) {
+        return;
+      }
       setCopyStatus("error");
     }
 
@@ -542,16 +1743,47 @@ export const ChatPanel = (props: Props): ReactElement => {
       clearTimeout(copyStatusResetRef.current);
     }
     copyStatusResetRef.current = setTimeout(() => {
-      setCopyStatus("idle");
       copyStatusResetRef.current = null;
+      if (!isChatLayoutScopeCurrent(scopeToken)) {
+        return;
+      }
+      setCopyStatus("idle");
     }, 1500);
-  }, [messages, runState, t]);
+  }, [
+    chatLayoutScopeToken,
+    isChatLayoutScopeCurrent,
+    messages,
+    runState,
+    t,
+  ]);
 
-  const handleClearConversation = useCallback((): void => {
-    discardDictation();
-    textareaRef.current?.focus();
-    void clearConversation();
-  }, [clearConversation, discardDictation]);
+  const handleCreateDraft = useCallback((): void => {
+    retryDetachedChatPendingSubmissionDisposals();
+    const isUntouched =
+      isSelectedWorkspaceDraftUntouched && messages.length === 0;
+    const result = isUntouched
+      ? reuseSelectedChatDraft()
+      : replaceSelectedChatTargetWithDraft();
+    cancelDictationOperation();
+    if (result.disposedTarget !== null) {
+      invalidateAttachmentOperationForTarget(result.disposedTarget);
+    }
+    requestComposerFocusAfterNew(
+      result.sourceTarget,
+      result.sourceSelectionEpoch,
+      result.target,
+      result.selectionEpoch,
+    );
+  }, [
+    cancelDictationOperation,
+    invalidateAttachmentOperationForTarget,
+    isSelectedWorkspaceDraftUntouched,
+    messages.length,
+    replaceSelectedChatTargetWithDraft,
+    requestComposerFocusAfterNew,
+    reuseSelectedChatDraft,
+    retryDetachedChatPendingSubmissionDisposals,
+  ]);
 
   const copyButtonLabel = copyStatus === "success"
     ? t("chat.copied")
@@ -595,8 +1827,23 @@ export const ChatPanel = (props: Props): ReactElement => {
         mode={mode}
         transcriptActionsDisabled={transcriptActionsDisabled}
         copyButtonLabel={copyButtonLabel}
+        historyOpen={chatWorkspace.historyOpen}
+        historySessions={chatWorkspace.state.summaries}
+        selectedSessionId={chatWorkspace.state.target.kind === "session"
+          ? chatWorkspace.state.target.sessionId
+          : null}
+        runningCount={chatWorkspace.runningCount}
+        historyLoading={chatWorkspace.state.catalogRequest.isLoading}
+        historyHasLoadedFirstPage={
+          chatWorkspace.state.pagination.hasLoadedFirstPage
+        }
+        historyHasMore={chatWorkspace.state.pagination.nextCursor !== null}
+        historyErrorMessage={chatWorkspace.historyErrorMessage}
         onCopyTranscript={() => void handleCopyTranscript()}
-        onClearConversation={handleClearConversation}
+        onCreateDraft={handleCreateDraft}
+        onHistoryOpenChange={chatWorkspace.setHistoryOpen}
+        onSelectSession={chatWorkspace.selectSession}
+        onLoadMoreHistory={() => void chatWorkspace.loadNextCatalogPage()}
         onCloseSidebar={() => setIsOpen(false)}
       />
       <ChatTranscript
@@ -605,6 +1852,7 @@ export const ChatPanel = (props: Props): ReactElement => {
         isLiveStreamConnected={isLiveStreamConnected}
       />
       <ChatComposer
+        key={composerLifecycleKey}
         inputText={inputText}
         pendingAttachments={pendingAttachments}
         attachmentErrors={attachmentErrors}
@@ -615,8 +1863,9 @@ export const ChatPanel = (props: Props): ReactElement => {
         capabilities={composerCapabilities}
         accountSuggestionsState={accountSuggestionsState}
         textareaRef={textareaRef}
-        onInputChange={setInputText}
+        onInputChange={handleInputChange}
         onIngestFiles={ingestFiles}
+        onPrepareDeferredIngestion={prepareDeferredAttachmentIngestion}
         onRemoveAttachment={removeAttachment}
         onToggleDictation={handleToggleDictation}
         onSend={sendPendingMessage}

--- a/apps/web/src/ui/chat/shell/panel/ChatPanelHeader.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatPanelHeader.tsx
@@ -3,14 +3,29 @@
 import type { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
+import {
+  ChatHistoryDialog,
+  type ChatHistorySession,
+} from "../history/ChatHistoryDialog";
 import styles from "./ChatPanel.module.css";
 
 type Props = Readonly<{
   mode: "sidebar" | "fullscreen";
   transcriptActionsDisabled: boolean;
   copyButtonLabel: string;
+  historyOpen: boolean;
+  historySessions: ReadonlyArray<ChatHistorySession>;
+  selectedSessionId: string | null;
+  runningCount: number;
+  historyLoading: boolean;
+  historyHasLoadedFirstPage: boolean;
+  historyHasMore: boolean;
+  historyErrorMessage: string | null;
   onCopyTranscript: () => void;
-  onClearConversation: () => void;
+  onCreateDraft: () => void;
+  onHistoryOpenChange: (open: boolean) => void;
+  onSelectSession: (sessionId: string) => void;
+  onLoadMoreHistory: () => void;
   onCloseSidebar: () => void;
 }>;
 
@@ -19,8 +34,19 @@ export const ChatPanelHeader = (props: Props): ReactElement => {
     mode,
     transcriptActionsDisabled,
     copyButtonLabel,
+    historyOpen,
+    historySessions,
+    selectedSessionId,
+    runningCount,
+    historyLoading,
+    historyHasLoadedFirstPage,
+    historyHasMore,
+    historyErrorMessage,
     onCopyTranscript,
-    onClearConversation,
+    onCreateDraft,
+    onHistoryOpenChange,
+    onSelectSession,
+    onLoadMoreHistory,
     onCloseSidebar,
   } = props;
   const { t } = useTranslation();
@@ -29,6 +55,20 @@ export const ChatPanelHeader = (props: Props): ReactElement => {
     <div className={styles.header}>
       <span className={styles.headerTitle}>{t("chat.title")}</span>
       <div className={styles.headerActions}>
+        <ChatHistoryDialog
+          open={historyOpen}
+          sessions={historySessions}
+          selectedSessionId={selectedSessionId}
+          runningCount={runningCount}
+          isLoading={historyLoading}
+          hasLoadedFirstPage={historyHasLoadedFirstPage}
+          hasMore={historyHasMore}
+          errorMessage={historyErrorMessage}
+          onOpenChange={onHistoryOpenChange}
+          onSelectSession={onSelectSession}
+          onCreateDraft={onCreateDraft}
+          onLoadMore={onLoadMoreHistory}
+        />
         <button
           type="button"
           className={`${styles.closeButton} ${styles.copyButton}`}
@@ -53,9 +93,9 @@ export const ChatPanelHeader = (props: Props): ReactElement => {
         </button>
         <button
           type="button"
+          data-testid="chat-new"
           className={styles.closeButton}
-          onClick={onClearConversation}
-          disabled={transcriptActionsDisabled}
+          onClick={onCreateDraft}
         >
           {t("chat.new")}
         </button>

--- a/apps/web/src/ui/chat/stream/display/chatComposerCapabilities.test.ts
+++ b/apps/web/src/ui/chat/stream/display/chatComposerCapabilities.test.ts
@@ -9,13 +9,44 @@ import {
 const READY_TO_SEND_PARAMS: ChatComposerCapabilitiesParams = {
   composerAction: "send",
   isHistoryLoaded: true,
+  isTextareaReady: true,
   isStopping: false,
   isLiveStreamConnected: false,
   isAttachmentProcessing: false,
+  isSubmissionPending: false,
   dictationState: "idle",
   hasPendingMessage: true,
   shouldSubmitOnEnter: true,
 };
+
+test("disables the textarea until the selected target is ready", (): void => {
+  const capabilities = getChatComposerCapabilities({
+    ...READY_TO_SEND_PARAMS,
+    isHistoryLoaded: false,
+    isTextareaReady: false,
+  });
+
+  assert.equal(capabilities.isTextareaDisabled, true);
+  assert.equal(capabilities.isSubmitButtonDisabled, true);
+});
+
+test("keeps only the textarea ready during an exact adoption handoff", (): void => {
+  const capabilities = getChatComposerCapabilities({
+    ...READY_TO_SEND_PARAMS,
+    isHistoryLoaded: false,
+    isTextareaReady: true,
+  });
+
+  assert.deepEqual(capabilities, {
+    isTextareaDisabled: false,
+    isSubmitButtonDisabled: true,
+    isEnterSubmissionEnabled: false,
+    isAttachButtonDisabled: true,
+    isMicrophoneButtonDisabled: true,
+    isDropTargetEnabled: false,
+    shouldSubmitOnEnter: true,
+  });
+});
 
 test("disables attachment-conflicting actions while preprocessing", (): void => {
   const capabilities = getChatComposerCapabilities({
@@ -46,5 +77,27 @@ test("keeps the active-run stop action available while preprocessing", (): void 
   assert.equal(capabilities.isAttachButtonDisabled, true);
   assert.equal(capabilities.isMicrophoneButtonDisabled, true);
   assert.equal(capabilities.isDropTargetEnabled, false);
+  assert.equal(capabilities.isEnterSubmissionEnabled, false);
+});
+
+test("blocks another send while a draft create request is unresolved", (): void => {
+  const capabilities = getChatComposerCapabilities({
+    ...READY_TO_SEND_PARAMS,
+    isSubmissionPending: true,
+  });
+
+  assert.equal(capabilities.isTextareaDisabled, false);
+  assert.equal(capabilities.isSubmitButtonDisabled, true);
+  assert.equal(capabilities.isEnterSubmissionEnabled, false);
+  assert.equal(capabilities.isAttachButtonDisabled, false);
+});
+
+test("blocks Send while Stop remains pending after an idle snapshot", (): void => {
+  const capabilities = getChatComposerCapabilities({
+    ...READY_TO_SEND_PARAMS,
+    isStopping: true,
+  });
+
+  assert.equal(capabilities.isSubmitButtonDisabled, true);
   assert.equal(capabilities.isEnterSubmissionEnabled, false);
 });

--- a/apps/web/src/ui/chat/stream/display/chatComposerCapabilities.ts
+++ b/apps/web/src/ui/chat/stream/display/chatComposerCapabilities.ts
@@ -4,9 +4,11 @@ import type { ChatComposerAction } from "../streamRecovery";
 export type ChatComposerCapabilitiesParams = Readonly<{
   composerAction: ChatComposerAction;
   isHistoryLoaded: boolean;
+  isTextareaReady: boolean;
   isStopping: boolean;
   isLiveStreamConnected: boolean;
   isAttachmentProcessing: boolean;
+  isSubmissionPending: boolean;
   dictationState: ChatDictationState;
   hasPendingMessage: boolean;
   shouldSubmitOnEnter: boolean;
@@ -31,9 +33,11 @@ export const getChatComposerCapabilities = (
   const {
     composerAction,
     isHistoryLoaded,
+    isTextareaReady,
     isStopping,
     isLiveStreamConnected,
     isAttachmentProcessing,
+    isSubmissionPending,
     dictationState,
     hasPendingMessage,
     shouldSubmitOnEnter,
@@ -49,6 +53,7 @@ export const getChatComposerCapabilities = (
       || isStopping
       || isDictationActive
       || isAttachmentProcessing
+      || isSubmissionPending
       || isLiveStreamConnected
       || !hasPendingMessage;
   const isEnterSubmissionEnabled = shouldSubmitOnEnter
@@ -56,7 +61,7 @@ export const getChatComposerCapabilities = (
     && !isSubmitButtonDisabled;
 
   return {
-    isTextareaDisabled: isDictationActive,
+    isTextareaDisabled: !isTextareaReady || isDictationActive,
     isSubmitButtonDisabled,
     isEnterSubmissionEnabled,
     isAttachButtonDisabled: !canAttachFiles,

--- a/apps/web/src/ui/chat/stream/hooks/chatDictation.test.ts
+++ b/apps/web/src/ui/chat/stream/hooks/chatDictation.test.ts
@@ -1,6 +1,31 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { sanitizeChatTranscriptionErrorText } from "./chatDictation";
+import {
+  getNextChatDictationOperationEpoch,
+  isChatDictationOperationCurrent,
+  sanitizeChatTranscriptionErrorText,
+  transcribeChatAudio,
+} from "./chatDictation";
+
+type Deferred<Value> = Readonly<{
+  promise: Promise<Value>;
+  resolve: (value: Value) => void;
+}>;
+
+const createDeferred = <Value>(): Deferred<Value> => {
+  let resolvePromise: ((value: Value) => void) | null = null;
+  const promise = new Promise<Value>((resolve): void => {
+    resolvePromise = resolve;
+  });
+  if (resolvePromise === null) {
+    throw new Error("Failed to create deferred chat dictation test promise");
+  }
+
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+};
 
 const t = (key: string): string => {
   if (key === "chat.dictationFailed") {
@@ -48,4 +73,80 @@ test("sanitizeChatTranscriptionErrorText preserves plain route errors", (): void
   );
 
   assert.equal(sanitizedMessage, "Unsupported audio file type. Use m4a, wav, or webm.");
+});
+
+test("a delayed permission continuation is stale after a target switch", async (): Promise<void> => {
+  let currentEpoch = getNextChatDictationOperationEpoch(0);
+  const firstOperationEpoch = currentEpoch;
+  const permission = createDeferred<string>();
+  const isContinuationCurrent = permission.promise.then(
+    (): boolean => isChatDictationOperationCurrent(
+      firstOperationEpoch,
+      currentEpoch,
+    ),
+  );
+
+  currentEpoch = getNextChatDictationOperationEpoch(currentEpoch);
+  permission.resolve("granted");
+
+  assert.equal(await isContinuationCurrent, false);
+});
+
+test("a delayed transcription cannot overwrite a newer operation", async (): Promise<void> => {
+  let currentEpoch = getNextChatDictationOperationEpoch(0);
+  const firstOperationEpoch = currentEpoch;
+  const transcription = createDeferred<string>();
+  let selectedDraftText = "newer target";
+  const applyTranscription = transcription.promise.then((text): void => {
+    if (isChatDictationOperationCurrent(firstOperationEpoch, currentEpoch)) {
+      selectedDraftText = text;
+    }
+  });
+
+  currentEpoch = getNextChatDictationOperationEpoch(currentEpoch);
+  transcription.resolve("stale transcript");
+  await applyTranscription;
+
+  assert.equal(selectedDraftText, "newer target");
+});
+
+test("transcribeChatAudio sends audio without creating or naming a chat session", async (): Promise<void> => {
+  const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+  const submittedForms: Array<FormData> = [];
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { cookie: "__Host-csrf=test-token" },
+  });
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    value: async (_input: RequestInfo | URL, init: RequestInit): Promise<Response> => {
+      assert.ok(init.body instanceof FormData);
+      submittedForms.push(init.body);
+      return Response.json({ text: "hello" });
+    },
+  });
+
+  try {
+    const result = await transcribeChatAudio(
+      new Blob(["audio"], { type: "audio/webm" }),
+      t,
+    );
+
+    assert.deepEqual(result, { text: "hello" });
+    assert.equal(submittedForms[0]?.get("sessionId"), null);
+    assert.equal(submittedForms[0]?.get("source"), "web");
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    }
+    if (originalFetch === undefined) {
+      Reflect.deleteProperty(globalThis, "fetch");
+    } else {
+      Object.defineProperty(globalThis, "fetch", originalFetch);
+    }
+  }
 });

--- a/apps/web/src/ui/chat/stream/hooks/chatDictation.ts
+++ b/apps/web/src/ui/chat/stream/hooks/chatDictation.ts
@@ -16,6 +16,25 @@ export type ChatDraftInsertionResult = Readonly<{
   selection: ChatDraftSelection;
 }>;
 
+export const getNextChatDictationOperationEpoch = (
+  currentEpoch: number,
+): number => {
+  if (!Number.isSafeInteger(currentEpoch) || currentEpoch < 0) {
+    throw new Error("Chat dictation operation epoch must be a non-negative safe integer");
+  }
+  if (currentEpoch === Number.MAX_SAFE_INTEGER) {
+    throw new Error("Chat dictation operation epoch is exhausted");
+  }
+
+  return currentEpoch + 1;
+};
+
+export const isChatDictationOperationCurrent = (
+  operationEpoch: number,
+  currentEpoch: number,
+): boolean =>
+  operationEpoch === currentEpoch;
+
 const isWhitespaceCharacter = (value: string | undefined): boolean =>
   value !== undefined && /\s/.test(value);
 
@@ -98,7 +117,6 @@ const normalizeAudioMediaType = (mediaType: string): string => {
 
 type ChatTranscriptionResponse = Readonly<{
   text: string;
-  sessionId: string;
 }>;
 
 const isHtmlContentType = (contentType: string | null): boolean => {
@@ -135,7 +153,6 @@ export const sanitizeChatTranscriptionErrorText = (
 
 export const transcribeChatAudio = async (
   blob: Blob,
-  sessionId: string,
   t: ChatTranslation,
 ): Promise<ChatTranscriptionResponse> => {
   const mediaType = normalizeAudioMediaType(blob.type === "" ? "audio/webm" : blob.type);
@@ -145,7 +162,6 @@ export const transcribeChatAudio = async (
   const formData = new FormData();
   formData.append("file", file);
   formData.append("source", "web");
-  formData.append("sessionId", sessionId);
 
   const response = await fetchWithCsrf("/api/chat/transcriptions", {
     method: "POST",
@@ -164,9 +180,5 @@ export const transcribeChatAudio = async (
   if (typeof payload.text !== "string" || payload.text.trim() === "") {
     throw new Error(t("chat.dictationFailed"));
   }
-  if (typeof payload.sessionId !== "string" || payload.sessionId.trim() === "") {
-    throw new Error(t("chat.dictationFailed"));
-  }
-
   return payload;
 };

--- a/apps/web/src/ui/chat/workspace/chatWorkspaceState.test.ts
+++ b/apps/web/src/ui/chat/workspace/chatWorkspaceState.test.ts
@@ -16,20 +16,32 @@ import {
 } from "./chatWorkspaceState";
 import type { ChatSessionSummary } from "./chatSessionSummaryTransport";
 import {
+  createChatDraftCreationStorageMutations,
+  createChatPendingSubmissionSettlementStorageMutation,
   getMountedChatComposerTarget,
+  planRejectedChatPendingSubmissionSettlement,
+  planUnresolvedChatPendingSubmissionSettlement,
   readMountedChatDraftText,
+  rollbackChatStorageTransaction,
   resolveSelectedChatDraftUntouched,
   restoreChatDraftTextForTarget,
   restoreMountedChatDraftText,
+  stageChatDraftStorageDisposal,
+  stageChatStorageTransaction,
   updateChatDraftTextForTarget,
+  type ChatStorageMutation,
 } from "../shell/layout/ChatLayoutProvider";
 import {
   getChatDraftStorageKey,
   writeChatDraft,
 } from "../shell/layout/chatDraftStorage";
-import { isChatDraftUntouched } from "../shell/panel/chatPanelRuntime";
+import {
+  isChatDraftUntouched,
+  type ChatComposerMemoryState,
+} from "../shell/panel/chatPanelRuntime";
 import {
   clearChatSelection,
+  getChatActiveDraftStorageKey,
   getChatSelectionStorageKey,
   writeChatSelection,
 } from "./chatSelectionStorage";
@@ -38,6 +50,8 @@ import {
   resolveChatBootstrapSelection,
   resolveChatControllerNavigationObservation,
   resolveChatControllerNavigationWrite,
+  resolveChatDraftSessionAdoption,
+  resolveChatDraftCreationPlan,
   resolveChatHistoryErrorMessage,
   resolveChatHistoryPaginationFocus,
   resolveChatHistoryStatusVisibility,
@@ -45,6 +59,7 @@ import {
   resolveChatPopStateNavigation,
   resolvePostReadyAutomaticCatalogSelection,
   resolveChatUrlSynchronization,
+  promoteSelectedChatWorkspaceTargetToExplicit,
   shouldReuseSelectedChatDraft,
 } from "./useChatWorkspaceController";
 
@@ -79,6 +94,397 @@ const createStorage = (): Storage => {
   };
 };
 
+const createFailingMutationStorage = (
+  baseStorage: Storage,
+  failureMutationIndex: number,
+): Storage => {
+  let mutationIndex = 0;
+  const runMutation = (mutation: () => void): void => {
+    const currentMutationIndex = mutationIndex;
+    mutationIndex += 1;
+    if (currentMutationIndex === failureMutationIndex) {
+      throw new Error(
+        `Synthetic chat storage failure at mutation ${failureMutationIndex}`,
+      );
+    }
+    mutation();
+  };
+
+  return {
+    get length(): number {
+      return baseStorage.length;
+    },
+    clear: (): void => runMutation(() => baseStorage.clear()),
+    getItem: (key: string): string | null => baseStorage.getItem(key),
+    key: (index: number): string | null => baseStorage.key(index),
+    removeItem: (key: string): void =>
+      runMutation(() => baseStorage.removeItem(key)),
+    setItem: (key: string, value: string): void =>
+      runMutation(() => baseStorage.setItem(key, value)),
+  };
+};
+
+const createAdoptionStorageMutations = (
+  storage: Storage,
+  storageKeys: readonly [string, string, string, string],
+): ReadonlyArray<ChatStorageMutation> => [
+  {
+    storageKey: storageKeys[0],
+    apply: (): void => storage.setItem(storageKeys[0], "destination"),
+  },
+  {
+    storageKey: storageKeys[1],
+    apply: (): void => storage.removeItem(storageKeys[1]),
+  },
+  {
+    storageKey: storageKeys[2],
+    apply: (): void => storage.removeItem(storageKeys[2]),
+  },
+  {
+    storageKey: storageKeys[3],
+    apply: (): void => storage.setItem(storageKeys[3], "selection"),
+  },
+];
+
+test("chat adoption storage staging restores every key after each commit-phase failure", (): void => {
+  const storageKeys = [
+    "destination-draft",
+    "source-draft",
+    "active-draft",
+    "selection",
+  ] as const;
+  const initialValues = [
+    "previous destination",
+    "source follow-up",
+    "draft-source",
+    "previous selection",
+  ] as const;
+
+  for (
+    let failureMutationIndex = 0;
+    failureMutationIndex < storageKeys.length;
+    failureMutationIndex += 1
+  ) {
+    const baseStorage = createStorage();
+    storageKeys.forEach((storageKey, index): void => {
+      const initialValue = initialValues[index];
+      if (initialValue === undefined) {
+        throw new Error(`Missing initial storage value at index ${index}`);
+      }
+      baseStorage.setItem(storageKey, initialValue);
+    });
+    const failingStorage = createFailingMutationStorage(
+      baseStorage,
+      failureMutationIndex,
+    );
+
+    assert.throws(
+      () => stageChatStorageTransaction(
+        failingStorage,
+        createAdoptionStorageMutations(failingStorage, storageKeys),
+      ),
+      new RegExp(`mutation ${failureMutationIndex}`, "u"),
+    );
+    assert.deepEqual(
+      storageKeys.map((storageKey): string | null =>
+        baseStorage.getItem(storageKey)),
+      initialValues,
+    );
+  }
+});
+
+test("chat adoption storage staging can be rolled back after a successful stage", (): void => {
+  const storage = createStorage();
+  const storageKeys = [
+    "destination-draft",
+    "source-draft",
+    "active-draft",
+    "selection",
+  ] as const;
+  const initialValues = [
+    "previous destination",
+    "source follow-up",
+    "draft-source",
+    "previous selection",
+  ] as const;
+  storageKeys.forEach((storageKey, index): void => {
+    const initialValue = initialValues[index];
+    if (initialValue === undefined) {
+      throw new Error(`Missing initial storage value at index ${index}`);
+    }
+    storage.setItem(storageKey, initialValue);
+  });
+
+  const transaction = stageChatStorageTransaction(
+    storage,
+    createAdoptionStorageMutations(storage, storageKeys),
+  );
+  assert.deepEqual(
+    storageKeys.map((storageKey): string | null => storage.getItem(storageKey)),
+    ["destination", null, null, "selection"],
+  );
+
+  rollbackChatStorageTransaction(transaction);
+  assert.deepEqual(
+    storageKeys.map((storageKey): string | null => storage.getItem(storageKey)),
+    initialValues,
+  );
+});
+
+test("chat draft disposal retains storage on failure and succeeds on retry", (): void => {
+  const storage = createStorage();
+  const scope = {
+    mode: "demo",
+    userId: "local",
+  } as const;
+  const target = {
+    kind: "draft",
+    draftId: "draft-disposal-retry",
+  } as const;
+  const storageKey = getChatDraftStorageKey(scope, target);
+  writeChatDraft(storage, scope, target, "retained draft");
+
+  assert.throws(
+    () => stageChatDraftStorageDisposal(
+      createFailingMutationStorage(storage, 0),
+      scope,
+      target,
+    ),
+    /Synthetic chat storage failure at mutation 0/u,
+  );
+  assert.equal(storage.getItem(storageKey), "retained draft");
+
+  stageChatDraftStorageDisposal(storage, scope, target);
+  assert.equal(storage.getItem(storageKey), null);
+});
+
+test("rejected submission settlement stages restored text before memory can commit", (): void => {
+  const scope = { mode: "demo", userId: "local" } as const;
+  const target = {
+    kind: "draft",
+    draftId: "draft-rejected-settlement",
+  } as const;
+  const pendingSubmission = {
+    text: "retry rejected submission",
+    attachments: [],
+  } as const;
+  const currentMemory: ChatComposerMemoryState = {
+    pendingAttachments: [],
+    attachmentErrors: [],
+    isAttachmentProcessing: false,
+    pendingSubmission,
+    composerContentOwner: "pending_submission",
+  };
+  const settlement = planRejectedChatPendingSubmissionSettlement(
+    "",
+    currentMemory,
+    pendingSubmission,
+  );
+  assert.notEqual(settlement, null);
+  if (settlement === null) {
+    throw new Error("Rejected submission settlement plan is missing");
+  }
+  const storage = createStorage();
+  const storageKey = getChatDraftStorageKey(scope, target);
+  const failingStorage = createFailingMutationStorage(storage, 0);
+
+  assert.throws(
+    () => stageChatStorageTransaction(failingStorage, [
+      createChatPendingSubmissionSettlementStorageMutation(
+        failingStorage,
+        scope,
+        target,
+        settlement.nextText,
+      ),
+    ]),
+    /Synthetic chat storage failure at mutation 0/u,
+  );
+  assert.equal(storage.getItem(storageKey), null);
+  assert.equal(currentMemory.pendingSubmission, pendingSubmission);
+
+  stageChatStorageTransaction(storage, [
+    createChatPendingSubmissionSettlementStorageMutation(
+      storage,
+      scope,
+      target,
+      settlement.nextText,
+    ),
+  ]);
+  assert.equal(storage.getItem(storageKey), pendingSubmission.text);
+  assert.equal(settlement.nextMemory.pendingSubmission, null);
+});
+
+test("unresolved submission settlement stages restored text before ownership release", (): void => {
+  const scope = { mode: "demo", userId: "local" } as const;
+  const target = {
+    kind: "draft",
+    draftId: "draft-unresolved-settlement",
+  } as const;
+  const pendingSubmission = {
+    text: "recover unresolved submission",
+    attachments: [],
+  } as const;
+  const currentMemory: ChatComposerMemoryState = {
+    pendingAttachments: [],
+    attachmentErrors: [],
+    isAttachmentProcessing: false,
+    pendingSubmission,
+    composerContentOwner: "pending_submission",
+  };
+  const settlement = planUnresolvedChatPendingSubmissionSettlement(
+    "",
+    currentMemory,
+    pendingSubmission,
+  );
+  assert.notEqual(settlement, null);
+  if (settlement === null) {
+    throw new Error("Unresolved submission settlement plan is missing");
+  }
+  const storage = createStorage();
+  const storageKey = getChatDraftStorageKey(scope, target);
+  const failingStorage = createFailingMutationStorage(storage, 0);
+
+  assert.throws(
+    () => stageChatStorageTransaction(failingStorage, [
+      createChatPendingSubmissionSettlementStorageMutation(
+        failingStorage,
+        scope,
+        target,
+        settlement.nextText,
+      ),
+    ]),
+    /Synthetic chat storage failure at mutation 0/u,
+  );
+  assert.equal(storage.getItem(storageKey), null);
+  assert.equal(currentMemory.pendingSubmission, pendingSubmission);
+
+  stageChatStorageTransaction(storage, [
+    createChatPendingSubmissionSettlementStorageMutation(
+      storage,
+      scope,
+      target,
+      settlement.nextText,
+    ),
+  ]);
+  assert.equal(storage.getItem(storageKey), pendingSubmission.text);
+  assert.equal(
+    settlement.nextMemory.pendingSubmission,
+    pendingSubmission,
+  );
+});
+
+test("explicit history selection storage staging retains the prior selection on failure", (): void => {
+  const storage = createStorage();
+  const scope = {
+    mode: "workspace",
+    userId: "user-history-failure",
+    workspaceId: "workspace-history-failure",
+  } as const;
+  const previousTarget = {
+    kind: "session",
+    sessionId: "session-history-previous",
+  } as const;
+  const nextTarget = {
+    kind: "session",
+    sessionId: "session-history-next",
+  } as const;
+  const selectionStorageKey = getChatSelectionStorageKey(scope);
+  writeChatSelection(storage, scope, previousTarget);
+  const previousSelection = storage.getItem(selectionStorageKey);
+
+  const failingStorage = createFailingMutationStorage(storage, 0);
+  assert.throws(
+    () => writeChatSelection(failingStorage, scope, nextTarget),
+    /Synthetic chat storage failure at mutation 0/u,
+  );
+  assert.equal(storage.getItem(selectionStorageKey), previousSelection);
+});
+
+test("New stages active draft, selection, and abandoned text as one transaction", (): void => {
+  const scope = {
+    mode: "demo",
+    userId: "local",
+  } as const;
+  const sourceTarget = {
+    kind: "draft",
+    draftId: "draft-new-transaction-source",
+  } as const;
+  const nextTarget = {
+    kind: "draft",
+    draftId: "draft-new-transaction-next",
+  } as const;
+  const workspacePlan = resolveChatDraftCreationPlan({
+    kind: "replace_selected_target",
+    currentState: createChatWorkspaceState(sourceTarget, "explicit"),
+    currentSelectionEpoch: 14,
+    currentActiveDraftId: sourceTarget.draftId,
+    nextDraftId: nextTarget.draftId,
+  });
+  const activeDraftStorageKey = getChatActiveDraftStorageKey(scope);
+  const selectionStorageKey = getChatSelectionStorageKey(scope);
+  const sourceDraftStorageKey = getChatDraftStorageKey(scope, sourceTarget);
+  const initialValues = [
+    sourceTarget.draftId,
+    JSON.stringify({
+      ...sourceTarget,
+      selectionReason: "explicit",
+    }),
+    "unsent source text",
+  ] as const;
+
+  for (let failureIndex = 0; failureIndex < 3; failureIndex += 1) {
+    const storage = createStorage();
+    storage.setItem(activeDraftStorageKey, initialValues[0]);
+    storage.setItem(selectionStorageKey, initialValues[1]);
+    storage.setItem(sourceDraftStorageKey, initialValues[2]);
+    const failingStorage = createFailingMutationStorage(storage, failureIndex);
+
+    assert.throws(
+      () => stageChatStorageTransaction(
+        failingStorage,
+        createChatDraftCreationStorageMutations(
+          failingStorage,
+          scope,
+          workspacePlan,
+          sourceTarget,
+        ),
+      ),
+      new RegExp(`mutation ${failureIndex}`, "u"),
+    );
+    assert.deepEqual(
+      [
+        storage.getItem(activeDraftStorageKey),
+        storage.getItem(selectionStorageKey),
+        storage.getItem(sourceDraftStorageKey),
+      ],
+      initialValues,
+    );
+  }
+
+  const storage = createStorage();
+  storage.setItem(activeDraftStorageKey, initialValues[0]);
+  storage.setItem(selectionStorageKey, initialValues[1]);
+  storage.setItem(sourceDraftStorageKey, initialValues[2]);
+  stageChatStorageTransaction(
+    storage,
+    createChatDraftCreationStorageMutations(
+      storage,
+      scope,
+      workspacePlan,
+      sourceTarget,
+    ),
+  );
+  assert.equal(storage.getItem(activeDraftStorageKey), nextTarget.draftId);
+  assert.equal(
+    storage.getItem(selectionStorageKey),
+    JSON.stringify({
+      ...nextTarget,
+      selectionReason: "explicit",
+    }),
+  );
+  assert.equal(storage.getItem(sourceDraftStorageKey), null);
+});
+
 test("chat workspace state keeps an explicit target and selection reason", (): void => {
   const draftState = createChatWorkspaceState(
     { kind: "draft", draftId: "draft-1" },
@@ -96,6 +502,89 @@ test("chat workspace state keeps an explicit target and selection reason", (): v
     sessionId: "session-1",
   });
   assert.equal(sessionState.selectionReason, "explicit");
+});
+
+test("meaningful activity promotes only the selection reason at the exact epoch", (): void => {
+  const selectionEpoch = 12;
+  const automaticState = createChatWorkspaceState(
+    { kind: "session", sessionId: "session-automatic" },
+    "automatic",
+  );
+  const explicitState = promoteSelectedChatWorkspaceTargetToExplicit(
+    automaticState,
+    automaticState.target,
+  );
+
+  assert.equal(explicitState.selectionReason, "explicit");
+  assert.equal(explicitState.target, automaticState.target);
+  assert.equal(selectionEpoch, 12);
+  assert.equal(
+    resolvePostReadyAutomaticCatalogSelection({
+      requestStartedReady: true,
+      requestSelectionEpoch: selectionEpoch,
+      requestSelectionReason: "automatic",
+      currentSelectionEpoch: selectionEpoch,
+      currentSelectionReason: explicitState.selectionReason,
+      currentTarget: explicitState.target,
+      summaries: [createSummary("session-new", "running", 0)],
+      unavailableSessionIds: new Set<string>(),
+      currentTimeMs: Date.parse("2026-07-26T13:00:00.000Z"),
+      draftId: "draft-active",
+    }),
+    null,
+  );
+  assert.throws(
+    () => promoteSelectedChatWorkspaceTargetToExplicit(
+      explicitState,
+      { kind: "session", sessionId: "session-other" },
+    ),
+    /Cannot promote unselected chat target/u,
+  );
+});
+
+test("draft adoption uses one authoritative target and epoch snapshot", (): void => {
+  assert.deepEqual(
+    resolveChatDraftSessionAdoption({
+      currentTarget: { kind: "draft", draftId: "draft-a" },
+      currentSelectionEpoch: 4,
+      draftId: "draft-a",
+      sessionId: "session-a",
+      expectedSelectionEpoch: 4,
+    }),
+    {
+      kind: "selected",
+      target: { kind: "session", sessionId: "session-a" },
+      selectionEpoch: 4,
+    },
+  );
+  assert.deepEqual(
+    resolveChatDraftSessionAdoption({
+      currentTarget: { kind: "session", sessionId: "session-b" },
+      currentSelectionEpoch: 5,
+      draftId: "draft-a",
+      sessionId: "session-a",
+      expectedSelectionEpoch: 4,
+    }),
+    {
+      kind: "background",
+      target: { kind: "session", sessionId: "session-a" },
+      draftStateDisposition: "transfer",
+    },
+  );
+  assert.deepEqual(
+    resolveChatDraftSessionAdoption({
+      currentTarget: { kind: "draft", draftId: "draft-a" },
+      currentSelectionEpoch: 6,
+      draftId: "draft-a",
+      sessionId: "session-a",
+      expectedSelectionEpoch: 4,
+    }),
+    {
+      kind: "background",
+      target: { kind: "session", sessionId: "session-a" },
+      draftStateDisposition: "preserve",
+    },
+  );
 });
 
 test("catalog page state preserves ordering, pagination, and known summaries on failure", (): void => {
@@ -879,27 +1368,27 @@ test("New reuses an untouched automatic draft as an explicit selection and fence
     { kind: "draft", draftId: "draft-reused" },
     "automatic",
   );
-  const reusedTarget = resolveNewChatDraftTarget(
-    automaticState.target,
-    "draft-reused",
-    shouldReuseSelectedChatDraft(
-      true,
-      automaticState.target,
-      true,
-    ),
-    "draft-unused",
-  );
+  const reusePlan = resolveChatDraftCreationPlan({
+    kind: "reuse_selected_draft",
+    currentState: automaticState,
+    currentSelectionEpoch: requestSelectionEpoch,
+    currentActiveDraftId: "draft-reused",
+  });
+  const reusedTarget = reusePlan.target;
   const explicitState = selectChatWorkspaceTarget(
     automaticState,
     reusedTarget,
     "explicit",
   );
-  const explicitSelectionEpoch = requestSelectionEpoch + 1;
+  const explicitSelectionEpoch = reusePlan.selectionEpoch;
 
+  assert.equal(reusePlan.kind, "transition");
   assert.deepEqual(reusedTarget, {
     kind: "draft",
     draftId: "draft-reused",
   });
+  assert.equal(reusePlan.shouldPersistActiveDraft, true);
+  assert.equal(reusePlan.shouldPersistSelection, true);
   assert.deepEqual(explicitState.target, reusedTarget);
   assert.equal(explicitState.selectionReason, "explicit");
   assert.equal(explicitSelectionEpoch, 9);
@@ -1004,8 +1493,18 @@ test("New reuses only a completely untouched mounted draft", (): void => {
     messageCount: 0,
   } as const;
   const currentDraft = { kind: "draft", draftId: "draft-current" } as const;
+  const explicitReusePlan = resolveChatDraftCreationPlan({
+    kind: "reuse_selected_draft",
+    currentState: createChatWorkspaceState(currentDraft, "explicit"),
+    currentSelectionEpoch: 21,
+    currentActiveDraftId: currentDraft.draftId,
+  });
 
   assert.equal(isChatDraftUntouched(untouchedInput), true);
+  assert.equal(explicitReusePlan.kind, "reuse");
+  assert.equal(explicitReusePlan.selectionEpoch, 21);
+  assert.equal(explicitReusePlan.shouldPersistActiveDraft, false);
+  assert.equal(explicitReusePlan.shouldPersistSelection, false);
   assert.equal(
     shouldReuseSelectedChatDraft(true, currentDraft, true),
     true,

--- a/apps/web/src/ui/chat/workspace/useChatWorkspaceController.ts
+++ b/apps/web/src/ui/chat/workspace/useChatWorkspaceController.ts
@@ -22,6 +22,7 @@ import {
 import {
   buildChatTargetUrl,
   clearChatSelection,
+  getChatActiveDraftStorageKey,
   getChatSelectionStorageKey,
   parseStoredChatTarget,
   readChatActiveDraftId,
@@ -42,6 +43,7 @@ import {
   createChatWorkspaceState,
   failChatSessionCatalogLoad,
   findChatSessionInvalidationIncrements,
+  getChatTargetKey,
   getRunningChatSessionCount,
   observeChatSessionInvalidationVersion,
   replaceChatSessionCatalog,
@@ -70,11 +72,128 @@ export type ChatDraftSessionAdoption =
   | Readonly<{
     kind: "background";
     target: Extract<ChatTarget, { kind: "session" }>;
+    draftStateDisposition: "transfer" | "preserve";
+  }>;
+
+export type ChatDraftSessionAdoptionPlan = Readonly<{
+  draftId: string;
+  sessionId: string;
+  expectedSelectionEpoch: number;
+  controllerTarget: ChatTarget;
+  controllerSelectionEpoch: number;
+  controllerActiveDraftId: string | null;
+  shouldClearActiveDraft: boolean;
+  shouldPersistSelection: boolean;
+  adoption: ChatDraftSessionAdoption;
+}>;
+
+export type ChatDraftCreationPlan = Readonly<{
+  kind: "reuse" | "transition";
+  sourceTarget: ChatTarget;
+  sourceSelectionReason: ChatSelectionReason;
+  sourceSelectionEpoch: number;
+  sourceActiveDraftId: string | null;
+  target: Extract<ChatTarget, { kind: "draft" }>;
+  selectionEpoch: number;
+  shouldPersistActiveDraft: boolean;
+  shouldPersistSelection: boolean;
+  navigationMode: Extract<NavigationMode, "push" | "replace">;
+}>;
+
+type ChatDraftCreationInput =
+  | Readonly<{
+    kind: "reuse_selected_draft";
+    currentState: ChatWorkspaceState;
+    currentSelectionEpoch: number;
+    currentActiveDraftId: string | null;
+  }>
+  | Readonly<{
+    kind: "replace_selected_target";
+    currentState: ChatWorkspaceState;
+    currentSelectionEpoch: number;
+    currentActiveDraftId: string | null;
+    nextDraftId: string;
   }>;
 
 type UseChatWorkspaceControllerParams = Readonly<{
   scope: ChatSelectionScope;
 }>;
+
+export const promoteSelectedChatWorkspaceTargetToExplicit = (
+  state: ChatWorkspaceState,
+  target: ChatTarget,
+): ChatWorkspaceState => {
+  if (!areChatTargetsEqual(state.target, target)) {
+    throw new Error(
+      `Cannot promote unselected chat target `
+      + `"${getChatTargetKey(target)}" to explicit`,
+    );
+  }
+  if (state.selectionReason === "explicit") {
+    return state;
+  }
+
+  return {
+    ...state,
+    selectionReason: "explicit",
+  };
+};
+
+export const resolveChatDraftCreationPlan = (
+  input: ChatDraftCreationInput,
+): ChatDraftCreationPlan => {
+  const sourceTarget = input.currentState.target;
+  if (input.kind === "reuse_selected_draft") {
+    if (sourceTarget.kind !== "draft") {
+      throw new Error(
+        `Cannot reuse non-draft chat target "${getChatTargetKey(sourceTarget)}"`,
+      );
+    }
+    const isAlreadyExplicit =
+      input.currentState.selectionReason === "explicit";
+    return {
+      kind: isAlreadyExplicit ? "reuse" : "transition",
+      sourceTarget,
+      sourceSelectionReason: input.currentState.selectionReason,
+      sourceSelectionEpoch: input.currentSelectionEpoch,
+      sourceActiveDraftId: input.currentActiveDraftId,
+      target: sourceTarget,
+      selectionEpoch: isAlreadyExplicit
+        ? input.currentSelectionEpoch
+        : input.currentSelectionEpoch + 1,
+      shouldPersistActiveDraft: !isAlreadyExplicit,
+      shouldPersistSelection: !isAlreadyExplicit,
+      navigationMode: "replace",
+    };
+  }
+
+  const activeDraftIdForResolution =
+    sourceTarget.kind === "draft"
+    && input.currentActiveDraftId === sourceTarget.draftId
+      ? null
+      : input.currentActiveDraftId;
+  const target = resolveNewChatDraftTarget(
+    sourceTarget,
+    activeDraftIdForResolution,
+    false,
+    input.nextDraftId,
+  );
+  if (target.kind !== "draft") {
+    throw new Error("New chat draft resolution returned a server session");
+  }
+  return {
+    kind: "transition",
+    sourceTarget,
+    sourceSelectionReason: input.currentState.selectionReason,
+    sourceSelectionEpoch: input.currentSelectionEpoch,
+    sourceActiveDraftId: input.currentActiveDraftId,
+    target,
+    selectionEpoch: input.currentSelectionEpoch + 1,
+    shouldPersistActiveDraft: true,
+    shouldPersistSelection: true,
+    navigationMode: "push",
+  };
+};
 
 export type ChatWorkspaceController = Readonly<{
   state: ChatWorkspaceState;
@@ -85,11 +204,22 @@ export type ChatWorkspaceController = Readonly<{
   runningCount: number;
   setHistoryOpen: (open: boolean) => void;
   selectSession: (sessionId: string) => void;
-  createDraft: (isSelectedDraftUntouched: boolean) => void;
-  adoptDraftSession: (
+  planSelectedDraftReuse: () => ChatDraftCreationPlan;
+  planDraftReplacement: () => ChatDraftCreationPlan;
+  commitDraftCreation: (plan: ChatDraftCreationPlan) => void;
+  finalizeDraftCreation: (plan: ChatDraftCreationPlan) => void;
+  promoteSelectedTargetToExplicit: (target: ChatTarget) => number;
+  planDraftSessionAdoption: (
     draftId: string,
     sessionId: string,
+    expectedSelectionEpoch: number,
+  ) => ChatDraftSessionAdoptionPlan;
+  commitDraftSessionAdoption: (
+    plan: ChatDraftSessionAdoptionPlan,
   ) => ChatDraftSessionAdoption;
+  finalizeDraftSessionAdoption: (
+    plan: ChatDraftSessionAdoptionPlan,
+  ) => void;
   isSelectionCurrent: (
     target: ChatTarget,
     selectionEpoch: number,
@@ -124,6 +254,47 @@ type ChatBootstrapSelectionInput = Readonly<{
   storedTarget: ChatTarget | null;
   automaticTarget: ChatTarget;
 }>;
+
+type ChatDraftSessionAdoptionInput = Readonly<{
+  currentTarget: ChatTarget;
+  currentSelectionEpoch: number;
+  draftId: string;
+  sessionId: string;
+  expectedSelectionEpoch: number;
+}>;
+
+export const resolveChatDraftSessionAdoption = (
+  input: ChatDraftSessionAdoptionInput,
+): ChatDraftSessionAdoption => {
+  const draftTarget = {
+    kind: "draft",
+    draftId: input.draftId,
+  } as const;
+  const sessionTarget = {
+    kind: "session",
+    sessionId: input.sessionId,
+  } as const;
+  const isSourceTargetSelected = areChatTargetsEqual(
+    input.currentTarget,
+    draftTarget,
+  );
+  if (
+    isSourceTargetSelected
+    && input.currentSelectionEpoch === input.expectedSelectionEpoch
+  ) {
+    return {
+      kind: "selected",
+      target: sessionTarget,
+      selectionEpoch: input.currentSelectionEpoch,
+    };
+  }
+
+  return {
+    kind: "background",
+    target: sessionTarget,
+    draftStateDisposition: isSourceTargetSelected ? "preserve" : "transfer",
+  };
+};
 
 export type ChatBootstrapSelection = Readonly<{
   target: ChatTarget;
@@ -702,13 +873,14 @@ export const useChatWorkspaceController = (
     }
 
     const nextEpoch = selectionEpochRef.current + 1;
-    commitSelectionEpoch(nextEpoch);
-    commitState(selectChatWorkspaceTarget(
+    const nextState = selectChatWorkspaceTarget(
       currentState,
       target,
       selectionReason,
-    ));
+    );
     persistSelectedTarget(target, selectionReason);
+    commitSelectionEpoch(nextEpoch);
+    commitState(nextState);
     navigateToTarget(target, navigationMode);
   }, [
     commitSelectionEpoch,
@@ -1268,6 +1440,11 @@ export const useChatWorkspaceController = (
   }, [loadCatalogPage]);
 
   const selectSession = useCallback((sessionId: string): void => {
+    selectTarget(
+      { kind: "session", sessionId },
+      "explicit",
+      "push",
+    );
     if (unavailableSessionIdsRef.current.has(sessionId)) {
       const nextUnavailableSessionIds = new Set(
         unavailableSessionIdsRef.current,
@@ -1278,48 +1455,85 @@ export const useChatWorkspaceController = (
         hasRefreshedUnavailableSessionsRef.current = false;
       }
     }
-    selectTarget(
-      { kind: "session", sessionId },
-      "explicit",
-      "push",
-    );
   }, [selectTarget]);
 
-  const createDraft = useCallback((
-    isSelectedDraftUntouched: boolean,
-  ): void => {
-    const currentTarget = stateRef.current.target;
-    const shouldReuseCurrentDraft = shouldReuseSelectedChatDraft(
-      isReadyRef.current,
-      currentTarget,
-      isSelectedDraftUntouched,
+  const promoteSelectedTargetToExplicit = useCallback((
+    target: ChatTarget,
+  ): number => {
+    const currentState = stateRef.current;
+    const currentSelectionEpoch = selectionEpochRef.current;
+    const nextState = promoteSelectedChatWorkspaceTargetToExplicit(
+      currentState,
+      target,
     );
-    if (shouldReuseCurrentDraft) {
-      selectTarget(currentTarget, "explicit", "replace");
+    if (nextState === currentState) {
+      return currentSelectionEpoch;
+    }
+
+    persistSelectedTarget(target, "explicit");
+    commitState(nextState);
+    return currentSelectionEpoch;
+  }, [commitState, persistSelectedTarget]);
+
+  const planSelectedDraftReuse = useCallback((): ChatDraftCreationPlan => {
+    if (!isReadyRef.current) {
+      throw new Error("Cannot reuse a chat draft before workspace readiness");
+    }
+    const currentState = stateRef.current;
+    return resolveChatDraftCreationPlan({
+      kind: "reuse_selected_draft",
+      currentState,
+      currentSelectionEpoch: selectionEpochRef.current,
+      currentActiveDraftId: activeDraftIdRef.current,
+    });
+  }, []);
+
+  const planDraftReplacement = useCallback((): ChatDraftCreationPlan =>
+    resolveChatDraftCreationPlan({
+      kind: "replace_selected_target",
+      currentState: stateRef.current,
+      currentSelectionEpoch: selectionEpochRef.current,
+      currentActiveDraftId: activeDraftIdRef.current,
+      nextDraftId: createDraftId(),
+    }), []);
+
+  const commitDraftCreation = useCallback((
+    plan: ChatDraftCreationPlan,
+  ): void => {
+    const currentState = stateRef.current;
+    if (
+      selectionEpochRef.current !== plan.sourceSelectionEpoch
+      || activeDraftIdRef.current !== plan.sourceActiveDraftId
+      || currentState.selectionReason !== plan.sourceSelectionReason
+      || !areChatTargetsEqual(currentState.target, plan.sourceTarget)
+    ) {
+      throw new Error(
+        `Cannot commit stale chat draft creation plan from `
+        + `"${getChatTargetKey(plan.sourceTarget)}" at selection epoch `
+        + `${plan.sourceSelectionEpoch}`,
+      );
+    }
+    if (plan.kind === "reuse") {
       return;
     }
-    if (
-      currentTarget.kind === "draft"
-      && activeDraftIdRef.current === currentTarget.draftId
-    ) {
-      commitActiveDraftId(null);
-    }
-    const draftTarget = resolveNewChatDraftTarget(
-      currentTarget,
-      activeDraftIdRef.current,
-      shouldReuseCurrentDraft,
-      createDraftId(),
-    );
-    if (draftTarget.kind !== "draft") {
-      throw new Error("New chat draft resolution returned a server session");
-    }
-    commitActiveDraftId(draftTarget.draftId);
-    selectTarget(
-      draftTarget,
+
+    activeDraftIdRef.current = plan.target.draftId;
+    commitSelectionEpoch(plan.selectionEpoch);
+    commitState(selectChatWorkspaceTarget(
+      currentState,
+      plan.target,
       "explicit",
-      "push",
-    );
-  }, [commitActiveDraftId, selectTarget]);
+    ));
+  }, [
+    commitSelectionEpoch,
+    commitState,
+  ]);
+
+  const finalizeDraftCreation = useCallback((
+    plan: ChatDraftCreationPlan,
+  ): void => {
+    navigateToTarget(plan.target, plan.navigationMode);
+  }, [navigateToTarget]);
 
   const isSelectionCurrent = useCallback((
     target: ChatTarget,
@@ -1328,47 +1542,81 @@ export const useChatWorkspaceController = (
     selectionEpochRef.current === expectedSelectionEpoch
     && areChatTargetsEqual(stateRef.current.target, target), []);
 
-  const adoptDraftSession = useCallback((
+  const planDraftSessionAdoption = useCallback((
     draftId: string,
     sessionId: string,
+    expectedSelectionEpoch: number,
+  ): ChatDraftSessionAdoptionPlan => {
+    const controllerTarget = stateRef.current.target;
+    const controllerSelectionEpoch = selectionEpochRef.current;
+    const controllerActiveDraftId = activeDraftIdRef.current;
+    const adoption = resolveChatDraftSessionAdoption({
+      currentTarget: controllerTarget,
+      currentSelectionEpoch: controllerSelectionEpoch,
+      draftId,
+      sessionId,
+      expectedSelectionEpoch,
+    });
+    const shouldTransferDraftState =
+      adoption.kind === "selected"
+      || adoption.draftStateDisposition === "transfer";
+    return {
+      draftId,
+      sessionId,
+      expectedSelectionEpoch,
+      controllerTarget,
+      controllerSelectionEpoch,
+      controllerActiveDraftId,
+      shouldClearActiveDraft:
+        shouldTransferDraftState && controllerActiveDraftId === draftId,
+      shouldPersistSelection: adoption.kind === "selected",
+      adoption,
+    };
+  }, []);
+
+  const commitDraftSessionAdoption = useCallback((
+    plan: ChatDraftSessionAdoptionPlan,
   ): ChatDraftSessionAdoption => {
-    const draftTarget = { kind: "draft", draftId } as const;
-    const sessionTarget = { kind: "session", sessionId } as const;
-    const isSelected = areChatTargetsEqual(
-      stateRef.current.target,
-      draftTarget,
-    );
-    if (isSelected) {
+    if (
+      selectionEpochRef.current !== plan.controllerSelectionEpoch
+      || !areChatTargetsEqual(
+        stateRef.current.target,
+        plan.controllerTarget,
+      )
+      || activeDraftIdRef.current !== plan.controllerActiveDraftId
+    ) {
+      throw new Error(
+        `Cannot commit stale chat draft adoption plan for `
+        + `"${plan.draftId}" at selection epoch `
+        + `${plan.expectedSelectionEpoch}`,
+      );
+    }
+
+    if (plan.adoption.kind === "selected") {
       commitState(selectChatWorkspaceTarget(
         stateRef.current,
-        sessionTarget,
+        plan.adoption.target,
         "explicit",
       ));
     }
-    if (activeDraftIdRef.current === draftId) {
-      commitActiveDraftId(null);
+    if (plan.shouldClearActiveDraft) {
+      activeDraftIdRef.current = null;
     }
-    if (isSelected) {
-      persistSelectedTarget(sessionTarget, "explicit");
-      navigateToTarget(sessionTarget, "replace");
-    }
-    void loadCatalogPage();
-    return isSelected
-      ? {
-        kind: "selected",
-        target: sessionTarget,
-        selectionEpoch: selectionEpochRef.current,
-      }
-      : {
-        kind: "background",
-        target: sessionTarget,
-      };
+    return plan.adoption;
   }, [
     commitState,
-    commitActiveDraftId,
+  ]);
+
+  const finalizeDraftSessionAdoption = useCallback((
+    plan: ChatDraftSessionAdoptionPlan,
+  ): void => {
+    if (plan.adoption.kind === "selected") {
+      navigateToTarget(plan.adoption.target, "replace");
+    }
+    void loadCatalogPage();
+  }, [
     loadCatalogPage,
     navigateToTarget,
-    persistSelectedTarget,
   ]);
 
   const observeSessionInvalidation = useCallback((
@@ -1429,8 +1677,14 @@ export const useChatWorkspaceController = (
     runningCount,
     setHistoryOpen,
     selectSession,
-    createDraft,
-    adoptDraftSession,
+    planSelectedDraftReuse,
+    planDraftReplacement,
+    commitDraftCreation,
+    finalizeDraftCreation,
+    promoteSelectedTargetToExplicit,
+    planDraftSessionAdoption,
+    commitDraftSessionAdoption,
+    finalizeDraftSessionAdoption,
     isSelectionCurrent,
     refreshCatalog,
     loadNextCatalogPage,


### PR DESCRIPTION
## Summary
- activate multi-chat history, New, and target-scoped composer state
- preserve exact attachment, dictation, submission, adoption, Stop, and navigation ownership across chat switches and remounts
- add owned browser coverage for lifecycle, storage-failure, HEIC, and concurrent-session races

## Validation
- 210/210 direct chat tests
- 49/49 owned activation browser scenarios
- 2/2 account mention browser scenarios
- 45/45 critical race stress repetitions
- npm run lint
- npm run build (40 pages)