### PR TITLE
Activate chat session history

### DIFF
--- a/apps/web/e2e-local/chat-draft.local-demo.spec.ts
+++ b/apps/web/e2e-local/chat-draft.local-demo.spec.ts
@@ -3479,7 +3479,10 @@ test("repairs an unavailable sidebar history selection outside fullscreen chat",
     selectionStorageKey,
   )).toBeNull();
 
-  await page.getByTestId("chat-history-open").click();
+  await expect(page.getByTestId("chat-history-dialog")).toBeVisible();
+  await expect(page.getByTestId("chat-history-error")).toHaveText(
+    "This chat is unavailable. A safe chat was selected.",
+  );
   await expect(
     page.getByTestId(`chat-history-session-${safeSessionId}`),
   ).toHaveAttribute("aria-current", "true");

--- a/apps/web/e2e-local/chat-history.local-demo.spec.ts
+++ b/apps/web/e2e-local/chat-history.local-demo.spec.ts
@@ -1,0 +1,728 @@
+import {
+  expect,
+  test,
+  type BrowserContext,
+  type Page,
+  type Route,
+} from "@playwright/test";
+
+type CatalogStatus = "idle" | "running" | "interrupted";
+
+type CatalogSession = Readonly<{
+  sessionId: string;
+  title: string;
+  lastMessageAt: string;
+  status: CatalogStatus;
+  mainContentInvalidationVersion: number;
+}>;
+
+type InvalidationMessage = Readonly<{
+  type: "main_content_invalidation";
+  workspaceId: string;
+  version: number;
+  sourceId: string;
+  emittedAt: number;
+}>;
+
+type InvalidationTestWindow = Window & {
+  __chatHistoryInvalidations?: Array<InvalidationMessage>;
+};
+
+type VisibilityTestWindow = Window & {
+  __setChatHistoryVisibility?: (visibility: DocumentVisibilityState) => void;
+};
+
+type Deferred = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+}>;
+
+const RUNNING_TURN_ID = "00000000-0000-4000-8000-000000000001";
+const INVALIDATION_STORAGE_KEY =
+  "expense-tracker-main-content-invalidation";
+
+const createDeferred = (): Deferred => {
+  let resolvePromise: (() => void) | null = null;
+  const promise = new Promise<void>((resolve): void => {
+    resolvePromise = resolve;
+  });
+  if (resolvePromise === null) {
+    throw new Error("Failed to create deferred browser-test operation");
+  }
+
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+};
+
+const setWorkspaceCookies = async (
+  context: BrowserContext,
+  baseURL: string,
+  locale: string,
+): Promise<void> => {
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    {
+      name: "locale",
+      value: locale,
+      domain: origin.hostname,
+      path: "/",
+      sameSite: "Lax",
+    },
+  ]);
+};
+
+const mockWorkspaceDependencies = async (page: Page): Promise<void> => {
+  await page.route("**/api/categories", async (route): Promise<void> => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ categories: [] }),
+    });
+  });
+  await page.route(
+    "**/api/workspace-settings",
+    async (route): Promise<void> => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ filteredCategories: null }),
+      });
+    },
+  );
+};
+
+const installVisibilityControl = async (
+  page: Page,
+  initialVisibility: DocumentVisibilityState,
+): Promise<void> => {
+  await page.addInitScript((visibilityAtStartup: DocumentVisibilityState): void => {
+    let visibility = visibilityAtStartup;
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: (): DocumentVisibilityState => visibility,
+    });
+    (window as VisibilityTestWindow).__setChatHistoryVisibility = (
+      nextVisibility: DocumentVisibilityState,
+    ): void => {
+      visibility = nextVisibility;
+      document.dispatchEvent(new Event("visibilitychange"));
+    };
+  }, initialVisibility);
+};
+
+const setTestVisibility = async (
+  page: Page,
+  visibility: DocumentVisibilityState,
+): Promise<void> => {
+  await page.evaluate((nextVisibility: DocumentVisibilityState): void => {
+    const setVisibility =
+      (window as VisibilityTestWindow).__setChatHistoryVisibility;
+    if (setVisibility === undefined) {
+      throw new Error("Chat history visibility test control is unavailable");
+    }
+    setVisibility(nextVisibility);
+  }, visibility);
+};
+
+const fulfillCatalog = async (
+  route: Route,
+  sessions: ReadonlyArray<CatalogSession>,
+): Promise<void> => {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      sessions,
+      nextCursor: null,
+    }),
+  });
+};
+
+const fulfillSnapshot = async (
+  route: Route,
+  sessionId: string,
+  runState: CatalogStatus,
+): Promise<void> => {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      sessionId,
+      runState,
+      activeTurnId: runState === "running" ? RUNNING_TURN_ID : null,
+      updatedAt: Date.now(),
+      mainContentInvalidationVersion: 0,
+      messages: [],
+    }),
+  });
+};
+
+test("activates accessible history, local New, and fullscreen navigation without stopping another run", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const runningSessionId = "session-history-running";
+  const recentSessionId = "session-history-recent";
+  const oldActivity = new Date(
+    Date.now() - (8 * 60 * 60 * 1000),
+  ).toISOString();
+  const sessions: ReadonlyArray<CatalogSession> = [
+    {
+      sessionId: runningSessionId,
+      title: "Running session with a deliberately long one-line title",
+      lastMessageAt: oldActivity,
+      status: "running",
+      mainContentInvalidationVersion: 0,
+    },
+    {
+      sessionId: recentSessionId,
+      title: "Recent historical session",
+      lastMessageAt: oldActivity,
+      status: "idle",
+      mainContentInvalidationVersion: 0,
+    },
+  ];
+  let catalogRequestCount = 0;
+  let createRequestCount = 0;
+  let stopRequestCount = 0;
+
+  await mockWorkspaceDependencies(page);
+  page.on("request", (request): void => {
+    const requestUrl = new URL(request.url());
+    if (request.method() === "POST" && requestUrl.pathname === "/api/chat") {
+      createRequestCount += 1;
+    }
+    if (
+      request.method() === "POST"
+      && requestUrl.pathname === "/api/chat/stop"
+    ) {
+      stopRequestCount += 1;
+    }
+  });
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    catalogRequestCount += 1;
+    if (catalogRequestCount === 2) {
+      await route.fulfill({
+        status: 503,
+        contentType: "text/plain",
+        body: "Temporary catalog failure",
+      });
+      return;
+    }
+    await fulfillCatalog(route, sessions);
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== runningSessionId && sessionId !== recentSessionId) {
+        throw new Error(
+          `Unexpected chat history snapshot sessionId: ${String(sessionId)}`,
+        );
+      }
+      await fulfillSnapshot(
+        route,
+        sessionId,
+        sessionId === runningSessionId ? "running" : "idle",
+      );
+    },
+  );
+
+  await setWorkspaceCookies(context, baseURL, "en");
+  await page.goto(`/chat?session=${runningSessionId}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+
+  const historyButton = page.getByTestId("chat-history-open");
+  await expect(historyButton).toHaveAccessibleName(/1 running/u);
+  await expect(page.getByTestId("chat-history-running-count")).toHaveText("1");
+  await historyButton.click();
+
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await expect(page.getByTestId("chat-history-error")).toBeVisible();
+  await expect(page.getByTestId("chat-history-running")).toBeVisible();
+  await expect(page.getByTestId("chat-history-recent")).toBeVisible();
+  const runningRow = page.getByTestId(
+    `chat-history-session-${runningSessionId}`,
+  );
+  const recentRow = page.getByTestId(
+    `chat-history-session-${recentSessionId}`,
+  );
+  await expect(runningRow).toHaveAttribute("aria-current", "true");
+  await expect(recentRow).toBeVisible();
+  expect(await runningRow.evaluate(
+    (element): string => getComputedStyle(element).whiteSpace,
+  )).toBe("nowrap");
+
+  await recentRow.click();
+  await expect(page.getByTestId("chat-history-dialog")).not.toBeVisible();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && url.searchParams.get("session") === recentSessionId,
+  );
+  expect(stopRequestCount).toBe(0);
+
+  await historyButton.click();
+  await page.getByTestId("chat-history-new").click();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && !url.searchParams.has("session"),
+  );
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  expect(createRequestCount).toBe(0);
+
+  await page.goBack();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === recentSessionId,
+  );
+  await page.goBack();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === runningSessionId,
+  );
+  await page.goForward();
+  await expect(page).toHaveURL(
+    (url) => url.searchParams.get("session") === recentSessionId,
+  );
+  expect(stopRequestCount).toBe(0);
+});
+
+test("a successful catalog retry restores an eligible automatic session after bootstrap failure", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const recoveredSessionId = "session-catalog-recovered";
+  const currentActivity = new Date().toISOString();
+  let catalogRequestCount = 0;
+  let snapshotRequestCount = 0;
+  let createRequestCount = 0;
+
+  await mockWorkspaceDependencies(page);
+  page.on("request", (request): void => {
+    const requestUrl = new URL(request.url());
+    if (request.method() === "POST" && requestUrl.pathname === "/api/chat") {
+      createRequestCount += 1;
+    }
+  });
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    catalogRequestCount += 1;
+    if (catalogRequestCount === 1) {
+      await route.fulfill({
+        status: 503,
+        contentType: "text/plain",
+        body: "Catalog unavailable during bootstrap",
+      });
+      return;
+    }
+    await fulfillCatalog(route, [{
+      sessionId: recoveredSessionId,
+      title: "Recovered session",
+      lastMessageAt: currentActivity,
+      status: "idle",
+      mainContentInvalidationVersion: 0,
+    }]);
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId !== recoveredSessionId) {
+        throw new Error(
+          `Unexpected recovered snapshot sessionId: ${String(sessionId)}`,
+        );
+      }
+      snapshotRequestCount += 1;
+      await fulfillSnapshot(route, sessionId, "idle");
+    },
+  );
+
+  await setWorkspaceCookies(context, baseURL, "en");
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await expect(page.getByTestId("chat-history-error")).toContainText(
+    "Chat session catalog request failed: status=503",
+  );
+  expect(catalogRequestCount).toBe(1);
+  expect(snapshotRequestCount).toBe(0);
+
+  await page.getByTestId("chat-history-open").click();
+  await expect.poll((): number => catalogRequestCount).toBe(2);
+  await expect.poll((): number => snapshotRequestCount).toBe(1);
+  await expect(page.getByTestId("chat-history-error")).toHaveCount(0);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && url.searchParams.get("session") === recoveredSessionId,
+  );
+  await expect(
+    page.getByTestId(`chat-history-session-${recoveredSessionId}`),
+  ).toHaveAttribute("aria-current", "true");
+  expect(createRequestCount).toBe(0);
+  await page.getByTestId("chat-history-close").click();
+});
+
+test("an explicit New selection fences an in-flight catalog recovery", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const recoveredSessionId = "session-catalog-fenced";
+  const recoveryRequestReceived = createDeferred();
+  const releaseRecovery = createDeferred();
+  let catalogRequestCount = 0;
+  let snapshotRequestCount = 0;
+
+  await mockWorkspaceDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    catalogRequestCount += 1;
+    if (catalogRequestCount === 1) {
+      await route.fulfill({
+        status: 503,
+        contentType: "text/plain",
+        body: "Catalog unavailable during bootstrap",
+      });
+      return;
+    }
+    if (catalogRequestCount === 2) {
+      recoveryRequestReceived.resolve();
+      await releaseRecovery.promise;
+    }
+    await fulfillCatalog(route, [{
+      sessionId: recoveredSessionId,
+      title: "Fenced recovered session",
+      lastMessageAt: new Date().toISOString(),
+      status: "idle",
+      mainContentInvalidationVersion: 0,
+    }]);
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      snapshotRequestCount += 1;
+      await fulfillSnapshot(route, recoveredSessionId, "idle");
+    },
+  );
+
+  await setWorkspaceCookies(context, baseURL, "en");
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+
+  await page.getByTestId("chat-history-open").click();
+  await recoveryRequestReceived.promise;
+  await page.getByTestId("chat-history-new").click();
+  await expect(page.getByTestId("chat-history-dialog")).not.toBeVisible();
+
+  releaseRecovery.resolve();
+  await expect.poll((): number => catalogRequestCount).toBe(2);
+  await page.getByTestId("chat-history-open").click();
+  await expect(
+    page.getByTestId(`chat-history-session-${recoveredSessionId}`),
+  ).toBeVisible();
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && url.searchParams.get("session") === null,
+  );
+  expect(snapshotRequestCount).toBe(0);
+  await page.getByTestId("chat-history-close").click();
+});
+
+test("polls a closed catalog only while background sessions run and invalidates once per version", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const backgroundSessionA = "session-background-a";
+  const backgroundSessionC = "session-background-c";
+  const selectedSessionB = "session-selected-b";
+  const currentActivity = new Date().toISOString();
+  let catalogRequestCount = 0;
+  const snapshotRequestCounts = new Map<string, number>();
+
+  await page.clock.install({ time: new Date() });
+  await installVisibilityControl(page, "hidden");
+  await page.addInitScript((storageKey: string): void => {
+    const originalSetItem = Storage.prototype.setItem;
+    Object.defineProperty(Storage.prototype, "setItem", {
+      configurable: true,
+      writable: true,
+      value: function (
+        this: Storage,
+        key: string,
+        value: string,
+      ): void {
+        if (this === window.localStorage && key === storageKey) {
+          const parsed = JSON.parse(value) as InvalidationMessage;
+          const testWindow = window as InvalidationTestWindow;
+          const invalidations = testWindow.__chatHistoryInvalidations ?? [];
+          invalidations.push(parsed);
+          testWindow.__chatHistoryInvalidations = invalidations;
+        }
+        originalSetItem.call(this, key, value);
+      },
+    });
+  }, INVALIDATION_STORAGE_KEY);
+  await mockWorkspaceDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    catalogRequestCount += 1;
+    const terminal = catalogRequestCount >= 3;
+    const invalidationVersion = catalogRequestCount >= 2 ? 1 : 0;
+    await fulfillCatalog(route, [
+      {
+        sessionId: backgroundSessionA,
+        title: "Background A",
+        lastMessageAt: currentActivity,
+        status: terminal ? "idle" : "running",
+        mainContentInvalidationVersion: invalidationVersion,
+      },
+      {
+        sessionId: backgroundSessionC,
+        title: "Background C",
+        lastMessageAt: currentActivity,
+        status: terminal ? "idle" : "running",
+        mainContentInvalidationVersion: 0,
+      },
+      {
+        sessionId: selectedSessionB,
+        title: "Selected B",
+        lastMessageAt: currentActivity,
+        status: "idle",
+        mainContentInvalidationVersion: 0,
+      },
+    ]);
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId === null) {
+        throw new Error("Chat history snapshot request is missing sessionId");
+      }
+      snapshotRequestCounts.set(
+        sessionId,
+        (snapshotRequestCounts.get(sessionId) ?? 0) + 1,
+      );
+      if (sessionId !== selectedSessionB) {
+        throw new Error(
+          `Background session unexpectedly received snapshot polling: ${sessionId}`,
+        );
+      }
+      await fulfillSnapshot(route, sessionId, "idle");
+    },
+  );
+
+  await setWorkspaceCookies(context, baseURL, "en");
+  await page.goto(`/chat?session=${selectedSessionB}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await expect(page.getByTestId("chat-history-running-count")).toHaveText("2");
+  expect(catalogRequestCount).toBe(1);
+  expect(snapshotRequestCounts.get(selectedSessionB)).toBe(1);
+
+  await page.clock.fastForward(30_000);
+  expect(catalogRequestCount).toBe(1);
+
+  await setTestVisibility(page, "visible");
+  await expect.poll((): number => catalogRequestCount).toBe(2);
+  await expect.poll(async (): Promise<ReadonlyArray<number>> =>
+    page.evaluate((): ReadonlyArray<number> =>
+      ((window as InvalidationTestWindow).__chatHistoryInvalidations ?? [])
+        .map((message): number => message.version),
+    )).toEqual([1]);
+
+  await page.clock.fastForward(10_000);
+  await expect.poll((): number => catalogRequestCount).toBe(3);
+  await expect(page.getByTestId("chat-history-running-count")).toHaveCount(0);
+  await page.clock.fastForward(30_000);
+  expect(catalogRequestCount).toBe(3);
+  expect(snapshotRequestCounts.get(selectedSessionB)).toBe(1);
+  expect(snapshotRequestCounts.has(backgroundSessionA)).toBe(false);
+  expect(snapshotRequestCounts.has(backgroundSessionC)).toBe(false);
+  expect(await page.evaluate((): ReadonlyArray<number> =>
+    ((window as InvalidationTestWindow).__chatHistoryInvalidations ?? [])
+      .map((message): number => message.version),
+  )).toEqual([1]);
+});
+
+test("visibility return rolls an old automatic idle session to a draft and keeps RTL badge placement", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const sessionId = "session-visibility-policy";
+  const oldActivity = new Date(
+    Date.now() - (8 * 60 * 60 * 1000),
+  ).toISOString();
+  let catalogRequestCount = 0;
+  let createRequestCount = 0;
+
+  await installVisibilityControl(page, "visible");
+  await mockWorkspaceDependencies(page);
+  page.on("request", (request): void => {
+    const requestUrl = new URL(request.url());
+    if (request.method() === "POST" && requestUrl.pathname === "/api/chat") {
+      createRequestCount += 1;
+    }
+  });
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    catalogRequestCount += 1;
+    await fulfillCatalog(route, [{
+      sessionId,
+      title: "Visibility policy",
+      lastMessageAt: oldActivity,
+      status: catalogRequestCount === 1 ? "running" : "idle",
+      mainContentInvalidationVersion: 0,
+    }]);
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      await fulfillSnapshot(route, sessionId, "running");
+    },
+  );
+
+  await setWorkspaceCookies(context, baseURL, "ar");
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await expect(page.getByTestId("chat-history-running-count")).toHaveText("1");
+  await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+
+  const badgePlacement = await page.evaluate((): Readonly<{
+    buttonCenter: number;
+    badgeCenter: number;
+  }> => {
+    const button = document.querySelector<HTMLElement>(
+      '[data-testid="chat-history-open"]',
+    );
+    const badge = document.querySelector<HTMLElement>(
+      '[data-testid="chat-history-running-count"]',
+    );
+    if (button === null || badge === null) {
+      throw new Error("RTL chat history badge is not mounted");
+    }
+    const buttonBounds = button.getBoundingClientRect();
+    const badgeBounds = badge.getBoundingClientRect();
+    return {
+      buttonCenter: buttonBounds.left + (buttonBounds.width / 2),
+      badgeCenter: badgeBounds.left + (badgeBounds.width / 2),
+    };
+  });
+  expect(badgePlacement.badgeCenter).toBeLessThan(
+    badgePlacement.buttonCenter,
+  );
+
+  await setTestVisibility(page, "hidden");
+  await setTestVisibility(page, "visible");
+
+  await expect.poll((): number => catalogRequestCount).toBe(2);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && !url.searchParams.has("session"),
+  );
+  await expect(page.getByTestId("chat-history-running-count")).toHaveCount(0);
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  expect(createRequestCount).toBe(0);
+});
+
+test("surfaces an unauthorized explicit session and resolves to a safe catalog row", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const unavailableSessionId = "session-unauthorized";
+  const safeSessionId = "session-safe";
+  const currentActivity = new Date().toISOString();
+  let unavailableSnapshotRequestCount = 0;
+  let safeSnapshotRequestCount = 0;
+
+  await mockWorkspaceDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await fulfillCatalog(route, [{
+      sessionId: safeSessionId,
+      title: "Safe session",
+      lastMessageAt: currentActivity,
+      status: "idle",
+      mainContentInvalidationVersion: 0,
+    }]);
+  });
+  await page.route(
+    /\/api\/chat\?sessionId=/u,
+    async (route): Promise<void> => {
+      const sessionId = new URL(route.request().url()).searchParams.get(
+        "sessionId",
+      );
+      if (sessionId === unavailableSessionId) {
+        unavailableSnapshotRequestCount += 1;
+        await route.fulfill({
+          status: 403,
+          contentType: "text/plain",
+          body: "Forbidden",
+        });
+        return;
+      }
+      if (sessionId !== safeSessionId) {
+        throw new Error(
+          `Unexpected unauthorized-recovery snapshot sessionId: ${String(sessionId)}`,
+        );
+      }
+      safeSnapshotRequestCount += 1;
+      await fulfillSnapshot(route, safeSessionId, "idle");
+    },
+  );
+
+  await setWorkspaceCookies(context, baseURL, "en");
+  await page.goto(`/chat?session=${unavailableSessionId}`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  await expect.poll((): number => unavailableSnapshotRequestCount).toBe(1);
+  await expect.poll((): number => safeSnapshotRequestCount).toBe(1);
+  await expect(page).toHaveURL(
+    (url) => url.pathname === "/chat"
+      && url.searchParams.get("session") === safeSessionId,
+  );
+  await expect(page.getByTestId("chat-history-dialog")).toBeVisible();
+  await expect(page.getByTestId("chat-history-error")).toHaveText(
+    "This chat is unavailable. A safe chat was selected.",
+  );
+  await expect(
+    page.getByTestId(`chat-history-session-${safeSessionId}`),
+  ).toHaveAttribute("aria-current", "true");
+
+  await page.getByTestId("chat-history-close").click();
+  await expect(page.getByTestId("chat-history-dialog")).not.toBeVisible();
+  await expect(page.getByTestId("chat-history-error")).toHaveCount(0);
+});

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.test.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.test.ts
@@ -4226,6 +4226,11 @@ test("snapshot recovery distinguishes missing sessions from valid 409 contracts"
     "Error 404: Chat session not found: session-missing",
     "not_found",
   );
+  const forbiddenSessionError = new ChatSessionSnapshotRequestError(
+    403,
+    "Error 403: Forbidden",
+    "forbidden",
+  );
   const activeRunConflict = new ChatSessionSnapshotRequestError(
     409,
     "Error 409: Chat session already has an active response",
@@ -4246,11 +4251,19 @@ test("snapshot recovery distinguishes missing sessions from valid 409 contracts"
     false,
   );
   assert.equal(
+    isUnavailableChatSessionSnapshotError(forbiddenSessionError),
+    true,
+  );
+  assert.equal(
     isUnavailableChatSessionSnapshotError(workspaceReload),
     false,
   );
   assert.equal(
     resolveChatSnapshotFailureDisposition(missingSessionError),
+    "recover_unavailable",
+  );
+  assert.equal(
+    resolveChatSnapshotFailureDisposition(forbiddenSessionError),
     "recover_unavailable",
   );
   assert.equal(

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
@@ -1094,6 +1094,7 @@ export const createChatSendTransport = (
 
 export type ChatSessionSnapshotRequestErrorKind =
   | "not_found"
+  | "forbidden"
   | "active_response_conflict"
   | "workspace_reload_required"
   | "other";
@@ -1394,6 +1395,9 @@ const classifyChatSessionSnapshotRequestError = (
   if (status === 404) {
     return "not_found";
   }
+  if (status === 403) {
+    return "forbidden";
+  }
   if (status !== 409) {
     return "other";
   }
@@ -1488,7 +1492,10 @@ export const isUnavailableChatSessionSnapshotError = (
   error: unknown,
 ): error is ChatSessionSnapshotRequestError =>
   error instanceof ChatSessionSnapshotRequestError
-  && error.kind === "not_found";
+  && (
+    error.kind === "not_found"
+    || error.kind === "forbidden"
+  );
 
 export const resolveChatSnapshotFailureDisposition = (
   error: unknown,
@@ -1499,6 +1506,7 @@ export const resolveChatSnapshotFailureDisposition = (
 
   switch (error.kind) {
     case "not_found":
+    case "forbidden":
       return "recover_unavailable";
     case "active_response_conflict":
       return "retry_active_response";

--- a/apps/web/src/ui/chat/workspace/chatActivityPolicy.test.ts
+++ b/apps/web/src/ui/chat/workspace/chatActivityPolicy.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   CHAT_INACTIVITY_THRESHOLD_MS,
   resolveChatActivityPolicy,
+  shouldPollChatSessionCatalog,
   shouldReevaluateChatActivityAfterVisibilityChange,
   type SelectedChatSessionActivity,
 } from "./chatActivityPolicy";
@@ -114,6 +115,16 @@ test("visibility return requests re-evaluation without an inactivity timer", ():
   assert.equal(
     shouldReevaluateChatActivityAfterVisibilityChange("visible", "visible"),
     false,
+  );
+});
+
+test("catalog polling runs only while visible sessions are running", (): void => {
+  assert.equal(shouldPollChatSessionCatalog(2, "visible"), true);
+  assert.equal(shouldPollChatSessionCatalog(2, "hidden"), false);
+  assert.equal(shouldPollChatSessionCatalog(0, "visible"), false);
+  assert.throws(
+    () => shouldPollChatSessionCatalog(-1, "visible"),
+    /running session count must be a non-negative safe integer/u,
   );
 });
 

--- a/apps/web/src/ui/chat/workspace/chatActivityPolicy.ts
+++ b/apps/web/src/ui/chat/workspace/chatActivityPolicy.ts
@@ -80,3 +80,19 @@ export const shouldReevaluateChatActivityAfterVisibilityChange = (
   nextVisibility: ChatPageVisibility,
 ): boolean =>
   previousVisibility === "hidden" && nextVisibility === "visible";
+
+export const shouldPollChatSessionCatalog = (
+  runningSessionCount: number,
+  visibility: ChatPageVisibility,
+): boolean => {
+  if (
+    !Number.isSafeInteger(runningSessionCount)
+    || runningSessionCount < 0
+  ) {
+    throw new Error(
+      "Chat catalog running session count must be a non-negative safe integer",
+    );
+  }
+
+  return runningSessionCount > 0 && visibility === "visible";
+};

--- a/apps/web/src/ui/chat/workspace/chatWorkspaceState.test.ts
+++ b/apps/web/src/ui/chat/workspace/chatWorkspaceState.test.ts
@@ -1207,13 +1207,17 @@ test("bootstrap recovery follows the highest-precedence source", (): void => {
   }
 });
 
-test("post-ready first-page refresh reconciles only the request's current automatic selection", (): void => {
+test("recovery and visibility refreshes reconcile only their current automatic selection", (): void => {
   const automaticDraft = {
     kind: "draft",
     draftId: "draft-automatic",
   } as const;
   const recentSession = createSummary("session-recent", "idle", 0);
   const runningSession = createSummary("session-running", "running", 0);
+  const newerSession = {
+    ...createSummary("session-newer", "idle", 0),
+    lastMessageAt: "2026-07-26T12:30:00.000Z",
+  };
   const cases = [
     {
       name: "successful refresh after an initial failure selects a recent session",
@@ -1248,7 +1252,45 @@ test("post-ready first-page refresh reconciles only the request's current automa
       expected: { kind: "session", sessionId: "session-running" },
     },
     {
-      name: "New during the request fences the automatic response",
+      name: "visibility refresh keeps the selected running session when another row is newer",
+      input: {
+        requestStartedReady: true,
+        requestSelectionEpoch: 2,
+        requestSelectionReason: "automatic",
+        currentSelectionEpoch: 2,
+        currentSelectionReason: "automatic",
+        currentTarget: {
+          kind: "session",
+          sessionId: runningSession.sessionId,
+        },
+        summaries: [newerSession, runningSession],
+        unavailableSessionIds: new Set<string>(),
+        currentTimeMs: Date.parse("2026-07-27T13:00:00.000Z"),
+        draftId: automaticDraft.draftId,
+      },
+      expected: null,
+    },
+    {
+      name: "visibility refresh keeps the selected recent session when another row is newer",
+      input: {
+        requestStartedReady: true,
+        requestSelectionEpoch: 2,
+        requestSelectionReason: "automatic",
+        currentSelectionEpoch: 2,
+        currentSelectionReason: "automatic",
+        currentTarget: {
+          kind: "session",
+          sessionId: recentSession.sessionId,
+        },
+        summaries: [newerSession, recentSession],
+        unavailableSessionIds: new Set<string>(),
+        currentTimeMs: Date.parse("2026-07-26T13:00:00.000Z"),
+        draftId: automaticDraft.draftId,
+      },
+      expected: null,
+    },
+    {
+      name: "an explicit draft selected during recovery fences the automatic response",
       input: {
         requestStartedReady: true,
         requestSelectionEpoch: 3,

--- a/apps/web/src/ui/chat/workspace/chatWorkspaceState.ts
+++ b/apps/web/src/ui/chat/workspace/chatWorkspaceState.ts
@@ -105,6 +105,34 @@ export const resolveAutomaticChatTarget = (
     : requireChatTarget({ kind: "session", sessionId: decision.sessionId });
 };
 
+export const resolveAutomaticChatTargetAfterRefresh = (
+  summaries: ReadonlyArray<ChatSessionSummary>,
+  currentTarget: ChatTarget,
+  currentTimeMs: number,
+  draftId: string,
+): ChatTarget => {
+  const validCurrentTarget = requireChatTarget(currentTarget);
+  if (validCurrentTarget.kind === "session") {
+    const selectedSession = summaries.find(
+      (summary): boolean =>
+        summary.sessionId === validCurrentTarget.sessionId,
+    );
+    if (selectedSession !== undefined) {
+      const decision = resolveChatActivityPolicy({
+        currentTimeMs,
+        selectedSession,
+        selectionReason: "automatic",
+        inactivityThresholdMs: CHAT_INACTIVITY_THRESHOLD_MS,
+      });
+      return decision.kind === "select_draft"
+        ? requireChatTarget({ kind: "draft", draftId })
+        : validCurrentTarget;
+    }
+  }
+
+  return resolveAutomaticChatTarget(summaries, currentTimeMs, draftId);
+};
+
 export const resolveFailedSessionRecoveryTarget = (
   summaries: ReadonlyArray<ChatSessionSummary>,
   failedSessionIds: ReadonlySet<string>,

--- a/apps/web/src/ui/chat/workspace/useChatWorkspaceController.ts
+++ b/apps/web/src/ui/chat/workspace/useChatWorkspaceController.ts
@@ -38,6 +38,11 @@ import {
   type ChatSessionSummaryPage,
 } from "./chatSessionSummaryTransport";
 import {
+  shouldPollChatSessionCatalog,
+  shouldReevaluateChatActivityAfterVisibilityChange,
+  type ChatPageVisibility,
+} from "./chatActivityPolicy";
+import {
   areChatTargetsEqual,
   appendChatSessionCatalogPage,
   createChatWorkspaceState,
@@ -48,6 +53,7 @@ import {
   observeChatSessionInvalidationVersion,
   replaceChatSessionCatalog,
   resolveAutomaticChatTarget,
+  resolveAutomaticChatTargetAfterRefresh,
   resolveFailedSessionRecoveryTarget,
   resolveNewChatDraftTarget,
   selectChatWorkspaceTarget,
@@ -58,6 +64,12 @@ import {
 } from "./chatWorkspaceState";
 
 const CHAT_SESSION_CATALOG_LIMIT = 100;
+const CHAT_SESSION_CATALOG_POLL_INTERVAL_MS = 10_000;
+
+const getInitialChatPageVisibility = (): ChatPageVisibility =>
+  typeof document === "undefined"
+    ? "visible"
+    : document.visibilityState;
 
 type NavigationMode = "none" | "push" | "replace";
 
@@ -516,11 +528,12 @@ export const resolvePostReadyAutomaticCatalogSelection = (
     return null;
   }
 
-  const target = resolveAutomaticChatTarget(
+  const target = resolveAutomaticChatTargetAfterRefresh(
     input.summaries.filter(
       (summary): boolean =>
         !input.unavailableSessionIds.has(summary.sessionId),
     ),
+    input.currentTarget,
     input.currentTimeMs,
     input.draftId,
   );
@@ -765,12 +778,16 @@ export const useChatWorkspaceController = (
   const [isReady, setIsReady] = useState<boolean>(false);
   const [historyOpen, setHistoryOpenState] = useState<boolean>(false);
   const [recoveryNotice, setRecoveryNotice] = useState<string | null>(null);
+  const [pageVisibility, setPageVisibility] = useState<ChatPageVisibility>(
+    getInitialChatPageVisibility,
+  );
   const stateRef = useRef<ChatWorkspaceState>(state);
   const selectionEpochRef = useRef<number>(selectionEpoch);
   const isReadyRef = useRef<boolean>(isReady);
   const activeDraftIdRef = useRef<string | null>(null);
   const unavailableSessionIdsRef = useRef<Set<string>>(new Set<string>());
   const hasRefreshedUnavailableSessionsRef = useRef<boolean>(false);
+  const automaticCatalogRecoveryPendingRef = useRef<boolean>(false);
   const catalogRequestIdRef = useRef<number>(0);
   const catalogAbortRef = useRef<AbortController | null>(null);
   const navigationGenerationRef = useRef<number>(0);
@@ -805,6 +822,13 @@ export const useChatWorkspaceController = (
     nextRecoveryNotice: string | null,
   ): void => {
     setRecoveryNotice(nextRecoveryNotice);
+  }, []);
+
+  const surfaceRecoveryNotice = useCallback((
+    nextRecoveryNotice: string,
+  ): void => {
+    setRecoveryNotice(nextRecoveryNotice);
+    setHistoryOpenState(true);
   }, []);
 
   const commitActiveDraftId = useCallback((
@@ -936,7 +960,6 @@ export const useChatWorkspaceController = (
       replaceChatSessionCatalog(currentState, page),
       page,
     );
-    commitRecoveryNotice(null);
     if (unavailableSessionIdsRef.current.size > 0) {
       const catalogSessionIds = new Set(
         page.sessions.map((summary): string => summary.sessionId),
@@ -951,7 +974,7 @@ export const useChatWorkspaceController = (
         hasRefreshedUnavailableSessionsRef.current = false;
       }
     }
-  }, [commitRecoveryNotice, publishCatalogPageInvalidations]);
+  }, [publishCatalogPageInvalidations]);
 
   const applyNextCatalogPage = useCallback((
     page: ChatSessionSummaryPage,
@@ -962,48 +985,15 @@ export const useChatWorkspaceController = (
       appendChatSessionCatalogPage(currentState, page),
       page,
     );
-    commitRecoveryNotice(null);
-  }, [commitRecoveryNotice, publishCatalogPageInvalidations]);
+  }, [publishCatalogPageInvalidations]);
 
   const loadCatalogPage = useCallback(async (): Promise<ChatSessionSummaryPage | null> => {
-    const requestStartedReady = isReadyRef.current;
-    const requestSelectionEpoch = selectionEpochRef.current;
-    const requestSelectionReason = stateRef.current.selectionReason;
-    const reconcilePostReadyAutomaticSelection = (
-      page: ChatSessionSummaryPage,
-    ): void => {
-      const draftId = activeDraftIdRef.current ?? createDraftId();
-      const target = resolvePostReadyAutomaticCatalogSelection({
-        requestStartedReady,
-        requestSelectionEpoch,
-        requestSelectionReason,
-        currentSelectionEpoch: selectionEpochRef.current,
-        currentSelectionReason: stateRef.current.selectionReason,
-        currentTarget: stateRef.current.target,
-        summaries: page.sessions,
-        unavailableSessionIds: unavailableSessionIdsRef.current,
-        currentTimeMs: Date.now(),
-        draftId,
-      });
-      if (target === null) {
-        return;
-      }
-      if (
-        activeDraftIdRef.current === null
-        || target.kind === "draft"
-      ) {
-        commitActiveDraftId(draftId);
-      }
-      selectTarget(target, "automatic", "replace");
-    };
-
     if (stableScope.mode === "demo") {
       const page: ChatSessionSummaryPage = {
         sessions: [],
         nextCursor: null,
       };
       applyFirstCatalogPage(page);
-      reconcilePostReadyAutomaticSelection(page);
       return page;
     }
 
@@ -1028,7 +1018,6 @@ export const useChatWorkspaceController = (
       }
 
       applyFirstCatalogPage(page);
-      reconcilePostReadyAutomaticSelection(page);
       return page;
     } catch (error) {
       if (
@@ -1039,7 +1028,6 @@ export const useChatWorkspaceController = (
       }
 
       const message = error instanceof Error ? error.message : String(error);
-      commitRecoveryNotice(null);
       commitState(failChatSessionCatalogLoad(stateRef.current, message));
       return null;
     } finally {
@@ -1049,16 +1037,63 @@ export const useChatWorkspaceController = (
     }
   }, [
     applyFirstCatalogPage,
-    commitActiveDraftId,
-    commitRecoveryNotice,
     commitState,
-    selectTarget,
     stableScope.mode,
   ]);
 
+  const refreshCatalogAndReconcileAutomaticSelection = useCallback(
+    async (): Promise<void> => {
+      const requestStartedReady = isReadyRef.current;
+      const requestSelectionEpoch = selectionEpochRef.current;
+      const requestSelectionReason = stateRef.current.selectionReason;
+      const page = await loadCatalogPage();
+      if (page === null) {
+        return;
+      }
+
+      const draftId = activeDraftIdRef.current ?? createDraftId();
+      const target = resolvePostReadyAutomaticCatalogSelection({
+        requestStartedReady,
+        requestSelectionEpoch,
+        requestSelectionReason,
+        currentSelectionEpoch: selectionEpochRef.current,
+        currentSelectionReason: stateRef.current.selectionReason,
+        currentTarget: stateRef.current.target,
+        summaries: page.sessions,
+        unavailableSessionIds: unavailableSessionIdsRef.current,
+        currentTimeMs: Date.now(),
+        draftId,
+      });
+      automaticCatalogRecoveryPendingRef.current = false;
+      if (target === null) {
+        return;
+      }
+      if (
+        activeDraftIdRef.current === null
+        || target.kind === "draft"
+      ) {
+        commitActiveDraftId(draftId);
+      }
+      selectTarget(target, "automatic", "replace");
+    },
+    [
+      commitActiveDraftId,
+      loadCatalogPage,
+      selectTarget,
+    ],
+  );
+
   const refreshCatalog = useCallback(async (): Promise<void> => {
+    if (automaticCatalogRecoveryPendingRef.current) {
+      await refreshCatalogAndReconcileAutomaticSelection();
+      return;
+    }
+
     await loadCatalogPage();
-  }, [loadCatalogPage]);
+  }, [
+    loadCatalogPage,
+    refreshCatalogAndReconcileAutomaticSelection,
+  ]);
 
   const loadNextCatalogPage = useCallback(async (): Promise<void> => {
     if (stableScope.mode === "demo" || catalogAbortRef.current !== null) {
@@ -1099,7 +1134,6 @@ export const useChatWorkspaceController = (
       }
 
       const message = error instanceof Error ? error.message : String(error);
-      commitRecoveryNotice(null);
       commitState(failChatSessionCatalogLoad(stateRef.current, message));
     } finally {
       if (catalogAbortRef.current === abortController) {
@@ -1108,7 +1142,6 @@ export const useChatWorkspaceController = (
     }
   }, [
     applyNextCatalogPage,
-    commitRecoveryNotice,
     commitState,
     stableScope.mode,
   ]);
@@ -1138,13 +1171,13 @@ export const useChatWorkspaceController = (
     }
 
     clearChatSelection(window.sessionStorage, stableScope);
-    commitRecoveryNotice(errorMessage);
+    surfaceRecoveryNotice(errorMessage);
     selectTarget(safeTarget, "automatic", "replace");
   }, [
     commitActiveDraftId,
-    commitRecoveryNotice,
     selectTarget,
     stableScope,
+    surfaceRecoveryNotice,
   ]);
 
   const recoverInvalidUrlSelection = useCallback((
@@ -1172,7 +1205,7 @@ export const useChatWorkspaceController = (
       );
     }
 
-    commitRecoveryNotice(errorMessage);
+    surfaceRecoveryNotice(errorMessage);
     selectTarget(
       decision.target,
       decision.selectionReason,
@@ -1180,9 +1213,9 @@ export const useChatWorkspaceController = (
     );
   }, [
     commitActiveDraftId,
-    commitRecoveryNotice,
     selectTarget,
     stableScope,
+    surfaceRecoveryNotice,
   ]);
 
   useEffect(() => {
@@ -1192,6 +1225,7 @@ export const useChatWorkspaceController = (
     activeDraftIdRef.current = null;
     unavailableSessionIdsRef.current = new Set<string>();
     hasRefreshedUnavailableSessionsRef.current = false;
+    automaticCatalogRecoveryPendingRef.current = false;
     controllerNavigationRef.current = null;
     commitReady(false);
     commitRecoveryNotice(null);
@@ -1277,10 +1311,14 @@ export const useChatWorkspaceController = (
           : urlTarget === null && reason === "explicit" ? "replace" : "none",
       );
       if (bootstrapRecovery.showRecoveryNotice) {
-        commitRecoveryNotice(
+        surfaceRecoveryNotice(
           translationRef.current("chat.sessionUnavailable"),
         );
       }
+      automaticCatalogRecoveryPendingRef.current =
+        page === null
+        && !bootstrapSelection.selectionChangedDuringBootstrap
+        && reason === "automatic";
       commitReady(true);
     })();
 
@@ -1292,16 +1330,75 @@ export const useChatWorkspaceController = (
   }, [
     commitReady,
     commitActiveDraftId,
-    commitRecoveryNotice,
     commitSelectionEpoch,
     commitState,
     loadCatalogPage,
     scopeKey,
     stableScope,
+    surfaceRecoveryNotice,
     selectTarget,
   ]);
 
   const runningCount = getRunningChatSessionCount(state.summaries);
+
+  useEffect(() => {
+    if (
+      !isReady
+      || !shouldPollChatSessionCatalog(
+        runningCount,
+        pageVisibility,
+      )
+    ) {
+      return;
+    }
+
+    const intervalId = window.setInterval((): void => {
+      if (
+        catalogAbortRef.current !== null
+        || !shouldPollChatSessionCatalog(
+          runningCount,
+          document.visibilityState,
+        )
+      ) {
+        return;
+      }
+      void loadCatalogPage();
+    }, CHAT_SESSION_CATALOG_POLL_INTERVAL_MS);
+
+    return () => window.clearInterval(intervalId);
+  }, [
+    isReady,
+    loadCatalogPage,
+    pageVisibility,
+    runningCount,
+  ]);
+
+  useEffect(() => {
+    let previousVisibility: ChatPageVisibility = document.visibilityState;
+    setPageVisibility(previousVisibility);
+    const handleVisibilityChange = (): void => {
+      const nextVisibility: ChatPageVisibility = document.visibilityState;
+      const shouldRefresh =
+        shouldReevaluateChatActivityAfterVisibilityChange(
+          previousVisibility,
+          nextVisibility,
+        );
+      previousVisibility = nextVisibility;
+      setPageVisibility(nextVisibility);
+      if (!shouldRefresh || !isReadyRef.current) {
+        return;
+      }
+
+      void refreshCatalogAndReconcileAutomaticSelection();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () =>
+      document.removeEventListener(
+        "visibilitychange",
+        handleVisibilityChange,
+      );
+  }, [refreshCatalogAndReconcileAutomaticSelection]);
 
   useEffect(() => {
     const handlePopState = (): void => {
@@ -1434,10 +1531,13 @@ export const useChatWorkspaceController = (
 
   const setHistoryOpen = useCallback((open: boolean): void => {
     setHistoryOpenState(open);
-    if (open && isReadyRef.current) {
-      void loadCatalogPage();
+    if (!open) {
+      commitRecoveryNotice(null);
     }
-  }, [loadCatalogPage]);
+    if (open && isReadyRef.current) {
+      void refreshCatalog();
+    }
+  }, [commitRecoveryNotice, refreshCatalog]);
 
   const selectSession = useCallback((sessionId: string): void => {
     selectTarget(
@@ -1655,13 +1755,14 @@ export const useChatWorkspaceController = (
     );
     unavailableSessionIds.add(sessionId);
     unavailableSessionIdsRef.current = unavailableSessionIds;
+    automaticCatalogRecoveryPendingRef.current = true;
     recoverToSafeTarget(errorMessage, unavailableSessionIds);
     if (!hasRefreshedUnavailableSessionsRef.current) {
       hasRefreshedUnavailableSessionsRef.current = true;
-      void loadCatalogPage();
+      void refreshCatalog();
     }
     return true;
-  }, [loadCatalogPage, recoverToSafeTarget]);
+  }, [recoverToSafeTarget, refreshCatalog]);
 
   const historyErrorMessage = resolveChatHistoryErrorMessage(
     state.catalogRequest.errorMessage,


### PR DESCRIPTION
Summary
- activate chat history selection, local drafts, URL restoration, and safe unavailable-session recovery
- refresh and poll the catalog only under the intended lifecycle policy while publishing background invalidations
- add focused controller coverage and local-demo E2E coverage for navigation, recovery fences, visibility, polling, RTL, and accessibility

Validation
- focused controller/workspace Node tests: 158 passed
- chat-history local-demo E2E: 6 passed
- existing unavailable-sidebar recovery E2E: 1 passed
- npm run lint
- npm run build
- git diff --check
- full local-demo suite: 75 passed; 2 unchanged budget-adjustments tests timed out waiting for budget-grid range responses and reproduced alone