### PR TITLE
Anchor chat history popover to the toolbar

### DIFF
--- a/apps/web/e2e-local/chat-history.local-demo.spec.ts
+++ b/apps/web/e2e-local/chat-history.local-demo.spec.ts
@@ -2,6 +2,7 @@ import {
   expect,
   test,
   type BrowserContext,
+  type Locator,
   type Page,
   type Route,
 } from "@playwright/test";
@@ -37,6 +38,13 @@ type Deferred = Readonly<{
   resolve: () => void;
 }>;
 
+type ElementBounds = Readonly<{
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}>;
+
 const RUNNING_TURN_ID = "00000000-0000-4000-8000-000000000001";
 const INVALIDATION_STORAGE_KEY =
   "expense-tracker-main-content-invalidation";
@@ -54,6 +62,14 @@ const createDeferred = (): Deferred => {
     promise,
     resolve: resolvePromise,
   };
+};
+
+const getElementBounds = async (locator: Locator): Promise<ElementBounds> => {
+  const bounds = await locator.boundingBox();
+  if (bounds === null) {
+    throw new Error("Cannot inspect chat history geometry: element is not visible");
+  }
+  return bounds;
 };
 
 const setWorkspaceCookies = async (
@@ -126,18 +142,26 @@ const setTestVisibility = async (
   }, visibility);
 };
 
-const fulfillCatalog = async (
+const fulfillCatalogPage = async (
   route: Route,
   sessions: ReadonlyArray<CatalogSession>,
+  nextCursor: string | null,
 ): Promise<void> => {
   await route.fulfill({
     status: 200,
     contentType: "application/json",
     body: JSON.stringify({
       sessions,
-      nextCursor: null,
+      nextCursor,
     }),
   });
+};
+
+const fulfillCatalog = async (
+  route: Route,
+  sessions: ReadonlyArray<CatalogSession>,
+): Promise<void> => {
+  await fulfillCatalogPage(route, sessions, null);
 };
 
 const fulfillSnapshot = async (
@@ -294,6 +318,280 @@ test("activates accessible history, local New, and fullscreen navigation without
     (url) => url.searchParams.get("session") === recentSessionId,
   );
   expect(stopRequestCount).toBe(0);
+});
+
+test("uses an anchored non-modal desktop popover and a fullscreen mobile surface", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await mockWorkspaceDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    await fulfillCatalog(route, []);
+  });
+  const pageErrors: Array<string> = [];
+  page.on("pageerror", (error): void => {
+    pageErrors.push(error.message);
+  });
+  await setWorkspaceCookies(context, baseURL, "en");
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    {
+      name: "demo",
+      value: "true",
+      domain: origin.hostname,
+      path: "/",
+      sameSite: "Lax",
+    },
+    {
+      name: "chat-open",
+      value: "true",
+      domain: origin.hostname,
+      path: "/",
+      sameSite: "Lax",
+    },
+  ]);
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  const historyButton = page.getByTestId("chat-history-open");
+  const copyButton = page.getByRole("button", { name: "Copy chat" });
+  const newButton = page.getByTestId("chat-new");
+  const sidebarCloseButton = page.getByTestId("chat-sidebar-close");
+  const dialog = page.getByTestId("chat-history-dialog");
+  const controlHeights = await Promise.all([
+    historyButton,
+    copyButton,
+    newButton,
+    sidebarCloseButton,
+  ].map(async (control): Promise<number> =>
+    (await getElementBounds(control)).height));
+  expect(new Set(controlHeights).size).toBe(1);
+
+  const chatPanel = page.getByTestId("chat-panel");
+  const initialPanelBounds = await getElementBounds(chatPanel);
+  const resizeHandleX =
+    initialPanelBounds.x + initialPanelBounds.width - 2;
+  const resizeHandleY = initialPanelBounds.y + (initialPanelBounds.height / 2);
+  await page.mouse.move(resizeHandleX, resizeHandleY);
+  await page.mouse.down();
+  await historyButton.press("Enter");
+  await expect(dialog).toBeVisible();
+  await page.mouse.move(resizeHandleX + 260, resizeHandleY, { steps: 5 });
+  await expect.poll(async (): Promise<number> =>
+    (await getElementBounds(chatPanel)).width,
+  ).toBeGreaterThan(initialPanelBounds.width + 200);
+  await expect.poll(async (): Promise<number> => {
+    const buttonBounds = await getElementBounds(historyButton);
+    const dialogBounds = await getElementBounds(dialog);
+    return Math.abs(
+      (dialogBounds.x + dialogBounds.width)
+      - (buttonBounds.x + buttonBounds.width),
+    );
+  }).toBeLessThanOrEqual(1);
+  await page.mouse.up();
+  await page.getByTestId("chat-history-close").click();
+
+  await page.getByRole("navigation").locator('a[href="/chat"]').click();
+  await expect(page).toHaveURL((url) => url.pathname === "/chat");
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await historyButton.click();
+  await expect(dialog).toBeVisible();
+  await expect(historyButton).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByTestId("chat-history-new")).toBeFocused();
+
+  await page.goBack();
+  await expect(page).toHaveURL((url) => url.pathname === "/");
+  await expect(dialog).toBeVisible();
+  await expect(historyButton).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByTestId("chat-history-new")).toBeFocused();
+
+  await page.goForward();
+  await expect(page).toHaveURL((url) => url.pathname === "/chat");
+  await expect(dialog).toBeVisible();
+  await expect(historyButton).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByTestId("chat-history-new")).toBeFocused();
+  expect(pageErrors).toEqual([]);
+
+  const desktopButtonBounds = await getElementBounds(historyButton);
+  const desktopDialogBounds = await getElementBounds(dialog);
+  expect(desktopDialogBounds.y).toBeCloseTo(
+    desktopButtonBounds.y + desktopButtonBounds.height + 6,
+    0,
+  );
+  expect(desktopDialogBounds.x + desktopDialogBounds.width).toBeCloseTo(
+    desktopButtonBounds.x + desktopButtonBounds.width,
+    0,
+  );
+  expect(await dialog.evaluate(
+    (element): boolean => element.matches(":modal"),
+  )).toBe(false);
+  expect(await dialog.evaluate(
+    (element): string => getComputedStyle(element).backgroundColor,
+  )).toBe("rgb(255, 255, 255)");
+  expect(await page.locator("[inert]").count()).toBe(0);
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).not.toBeVisible();
+  await expect(historyButton).toBeFocused();
+  await historyButton.click();
+  await page.getByTestId("chat-history-close").click();
+  await expect(dialog).not.toBeVisible();
+  await expect(historyButton).toBeFocused();
+
+  const composer = page.getByTestId("chat-composer-input");
+  await composer.fill("outside pointer action must still run");
+  await historyButton.click();
+  await newButton.click();
+  await expect(dialog).not.toBeVisible();
+  await expect(composer).toHaveValue("");
+  await expect(composer).toBeFocused();
+
+  await page.setViewportSize({ width: 500, height: 700 });
+  await historyButton.click();
+  const clampedDialogBounds = await getElementBounds(dialog);
+  expect(clampedDialogBounds.x).toBeGreaterThanOrEqual(8);
+  expect(
+    clampedDialogBounds.x + clampedDialogBounds.width,
+  ).toBeLessThanOrEqual(492);
+
+  await page.setViewportSize({ width: 390, height: 720 });
+  await expect.poll(async (): Promise<Readonly<{
+    width: number;
+    height: number;
+  }>> => {
+    const bounds = await getElementBounds(dialog);
+    return { width: bounds.width, height: bounds.height };
+  }).toEqual({ width: 390, height: 720 });
+  const mobileDialogBounds = await getElementBounds(dialog);
+  expect(mobileDialogBounds.x).toBeCloseTo(0, 0);
+  expect(mobileDialogBounds.y).toBeCloseTo(0, 0);
+  expect(mobileDialogBounds.width).toBeCloseTo(390, 0);
+  expect(mobileDialogBounds.height).toBeCloseTo(720, 0);
+  await page.getByTestId("chat-history-close").click();
+
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await setWorkspaceCookies(context, baseURL, "ar");
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+  await historyButton.click();
+  const rtlButtonBounds = await getElementBounds(historyButton);
+  const rtlDialogBounds = await getElementBounds(dialog);
+  expect(rtlDialogBounds.x).toBeCloseTo(rtlButtonBounds.x, 0);
+  expect(rtlDialogBounds.x).toBeGreaterThanOrEqual(8);
+  expect(rtlDialogBounds.x + rtlDialogBounds.width).toBeLessThanOrEqual(1272);
+});
+
+test("keeps intentional outside focus and repairs focus when an owned control is removed", async ({
+  page,
+  context,
+  baseURL,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  const firstCursor = "focus-page-1";
+  const secondCursor = "focus-page-2";
+  const firstPageRequestReceived = createDeferred();
+  const releaseFirstPage = createDeferred();
+  const secondPageRequestReceived = createDeferred();
+  const releaseSecondPage = createDeferred();
+  const oldActivity = new Date(
+    Date.now() - (8 * 60 * 60 * 1000),
+  ).toISOString();
+  const createSession = (
+    sessionId: string,
+    title: string,
+  ): CatalogSession => ({
+    sessionId,
+    title,
+    lastMessageAt: oldActivity,
+    status: "idle",
+    mainContentInvalidationVersion: 0,
+  });
+
+  await mockWorkspaceDependencies(page);
+  await page.route(/\/api\/chat\/sessions\?/u, async (route): Promise<void> => {
+    const cursor = new URL(route.request().url()).searchParams.get("cursor");
+    if (cursor === null) {
+      await fulfillCatalogPage(
+        route,
+        [createSession("session-focus-page-1", "Focus page one")],
+        firstCursor,
+      );
+      return;
+    }
+    if (cursor === firstCursor) {
+      firstPageRequestReceived.resolve();
+      await releaseFirstPage.promise;
+      await fulfillCatalogPage(
+        route,
+        [createSession("session-focus-page-2", "Focus page two")],
+        secondCursor,
+      );
+      return;
+    }
+    if (cursor === secondCursor) {
+      secondPageRequestReceived.resolve();
+      await releaseSecondPage.promise;
+      await fulfillCatalogPage(
+        route,
+        [createSession("session-focus-page-3", "Focus page three")],
+        null,
+      );
+      return;
+    }
+    throw new Error(`Unexpected focus pagination cursor: ${cursor}`);
+  });
+
+  await setWorkspaceCookies(context, baseURL, "en");
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  const composer = page.getByTestId("chat-composer-input");
+  await expect(composer).toBeEditable();
+  await composer.fill("keep focus outside history");
+  await page.getByTestId("chat-history-open").click();
+
+  const dialog = page.getByTestId("chat-history-dialog");
+  const loadMore = page.getByTestId("chat-history-load-more");
+  await expect(loadMore).toBeVisible();
+  await loadMore.click();
+  await firstPageRequestReceived.promise;
+  await expect(loadMore).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect.poll(async (): Promise<boolean> => page.evaluate((): boolean => {
+    const historyDialog = document.querySelector(
+      '[data-testid="chat-history-dialog"]',
+    );
+    return historyDialog !== null
+      && document.activeElement !== null
+      && !historyDialog.contains(document.activeElement);
+  })).toBe(true);
+
+  const submitButton = page.getByTestId("chat-submit");
+  await submitButton.focus();
+  await expect(submitButton).toBeFocused();
+  releaseFirstPage.resolve();
+  await expect(
+    page.getByTestId("chat-history-session-session-focus-page-2"),
+  ).toBeVisible();
+  await expect(loadMore).toBeVisible();
+  await expect(submitButton).toBeFocused();
+
+  await loadMore.click();
+  await secondPageRequestReceived.promise;
+  await expect(loadMore).toBeFocused();
+  releaseSecondPage.resolve();
+  await expect(
+    page.getByTestId("chat-history-session-session-focus-page-3"),
+  ).toBeVisible();
+  await expect(loadMore).toHaveCount(0);
+  await expect(page.getByTestId("chat-history-new")).toBeFocused();
+  await expect(dialog).toBeVisible();
 });
 
 test("a successful catalog retry restores an eligible automatic session after bootstrap failure", async ({

--- a/apps/web/src/ui/chat/shell/history/ChatHistoryDialog.module.css
+++ b/apps/web/src/ui/chat/shell/history/ChatHistoryDialog.module.css
@@ -4,7 +4,8 @@
   align-items: center;
   justify-content: center;
   inline-size: 28px;
-  block-size: 24px;
+  block-size: var(--chat-header-control-block-size, 24px);
+  box-sizing: border-box;
   padding: 0;
   border: 1px solid var(--panel-border);
   background: var(--bg);
@@ -53,11 +54,14 @@
 
 .dialog {
   position: fixed;
-  inset: 0;
+  inset-block-start: var(--chat-history-inset-block-start);
+  inset-inline-start: var(--chat-history-inset-inline-start);
+  z-index: 210;
   box-sizing: border-box;
-  inline-size: min(400px, calc(100vw - 24px));
-  max-block-size: min(560px, calc(100dvh - 24px));
-  margin: auto;
+  inline-size: var(--chat-history-width);
+  max-inline-size: none;
+  max-block-size: var(--chat-history-max-height);
+  margin: 0;
   padding: 0;
   overflow: hidden;
   border: 1px solid var(--panel-border);
@@ -71,10 +75,6 @@
 .dialog[open] {
   display: flex;
   flex-direction: column;
-}
-
-.dialog::backdrop {
-  background: rgba(0, 0, 0, 0.4);
 }
 
 .dialogHeader {
@@ -311,8 +311,12 @@
 
 @media (max-width: 480px) {
   .dialog {
-    inline-size: calc(100vw - 16px);
-    max-block-size: calc(100dvh - 16px);
+    inset-block-start: var(--chat-history-viewport-inset-block-start);
+    inset-inline-start: var(--chat-history-viewport-inset-inline-start);
+    inline-size: var(--chat-history-viewport-width, 100vw);
+    block-size: var(--chat-history-viewport-height, 100dvh);
+    max-block-size: none;
+    border: 0;
   }
 
   .dialogHeader,

--- a/apps/web/src/ui/chat/shell/history/ChatHistoryDialog.tsx
+++ b/apps/web/src/ui/chat/shell/history/ChatHistoryDialog.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import {
+  type CSSProperties,
   type FocusEvent,
-  type KeyboardEvent,
   type ReactElement,
-  type SyntheticEvent,
+  useCallback,
   useEffect,
   useId,
   useLayoutEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
@@ -56,6 +58,147 @@ type SessionListProps = Readonly<{
   testId: string;
   onSelectSession: (sessionId: string) => void;
 }>;
+
+type VisibleViewport = Readonly<{
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}>;
+
+type DialogPosition = Readonly<{
+  insetBlockStart: number;
+  insetInlineStart: number;
+  width: number;
+  maxHeight: number;
+  viewportInsetBlockStart: number;
+  viewportInsetInlineStart: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}>;
+
+type AnchorRect = Readonly<{
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}>;
+
+type DialogStyle = CSSProperties & {
+  "--chat-history-inset-block-start": string;
+  "--chat-history-inset-inline-start": string;
+  "--chat-history-width": string;
+  "--chat-history-max-height": string;
+  "--chat-history-viewport-inset-block-start": string;
+  "--chat-history-viewport-inset-inline-start": string;
+  "--chat-history-viewport-width": string;
+  "--chat-history-viewport-height": string;
+};
+
+const VIEWPORT_MARGIN_PX = 8;
+const ANCHOR_GAP_PX = 6;
+const MAX_DIALOG_WIDTH_PX = 400;
+const MAX_DIALOG_HEIGHT_PX = 560;
+
+const getAnchorRect = (anchor: HTMLButtonElement): AnchorRect => {
+  const rect = anchor.getBoundingClientRect();
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+  };
+};
+
+const anchorRectsMatch = (
+  first: AnchorRect,
+  second: AnchorRect,
+): boolean =>
+  first.x === second.x
+  && first.y === second.y
+  && first.width === second.width
+  && first.height === second.height;
+
+const dialogPositionsMatch = (
+  first: DialogPosition,
+  second: DialogPosition,
+): boolean =>
+  first.insetBlockStart === second.insetBlockStart
+  && first.insetInlineStart === second.insetInlineStart
+  && first.width === second.width
+  && first.maxHeight === second.maxHeight
+  && first.viewportInsetBlockStart === second.viewportInsetBlockStart
+  && first.viewportInsetInlineStart === second.viewportInsetInlineStart
+  && first.viewportWidth === second.viewportWidth
+  && first.viewportHeight === second.viewportHeight;
+
+const getVisibleViewport = (): VisibleViewport => {
+  const visualViewport = window.visualViewport;
+  if (visualViewport === null) {
+    return {
+      top: 0,
+      left: 0,
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+  }
+
+  return {
+    top: visualViewport.offsetTop,
+    left: visualViewport.offsetLeft,
+    width: visualViewport.width,
+    height: visualViewport.height,
+  };
+};
+
+const getDialogPosition = (anchor: HTMLButtonElement): DialogPosition => {
+  const anchorRect = anchor.getBoundingClientRect();
+  const viewport = getVisibleViewport();
+  const viewportInlineEnd = viewport.left + viewport.width;
+  const viewportBlockEnd = viewport.top + viewport.height;
+  const availableWidth = Math.max(
+    0,
+    viewport.width - (VIEWPORT_MARGIN_PX * 2),
+  );
+  const width = Math.min(MAX_DIALOG_WIDTH_PX, availableWidth);
+  const minimumLeft = viewport.left + VIEWPORT_MARGIN_PX;
+  const maximumLeft = viewportInlineEnd - VIEWPORT_MARGIN_PX - width;
+  const isRtl = getComputedStyle(anchor).direction === "rtl";
+  const preferredLeft = isRtl
+    ? anchorRect.left
+    : anchorRect.right - width;
+  const left = Math.min(Math.max(preferredLeft, minimumLeft), maximumLeft);
+  const minimumTop = viewport.top + VIEWPORT_MARGIN_PX;
+  const maximumTop = Math.max(
+    minimumTop,
+    viewportBlockEnd - VIEWPORT_MARGIN_PX,
+  );
+  const top = Math.min(
+    Math.max(anchorRect.bottom + ANCHOR_GAP_PX, minimumTop),
+    maximumTop,
+  );
+  const maxHeight = Math.min(
+    MAX_DIALOG_HEIGHT_PX,
+    Math.max(0, viewportBlockEnd - VIEWPORT_MARGIN_PX - top),
+  );
+  const insetInlineStart = isRtl
+    ? window.innerWidth - left - width
+    : left;
+  const viewportInsetInlineStart = isRtl
+    ? window.innerWidth - viewport.left - viewport.width
+    : viewport.left;
+
+  return {
+    insetBlockStart: top,
+    insetInlineStart,
+    width,
+    maxHeight,
+    viewportInsetBlockStart: viewport.top,
+    viewportInsetInlineStart,
+    viewportWidth: viewport.width,
+    viewportHeight: viewport.height,
+  };
+};
 
 const formatLastActivity = (
   session: ChatHistorySession,
@@ -151,9 +294,13 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
   const historyButtonRef = useRef<HTMLButtonElement | null>(null);
   const createDraftButtonRef = useRef<HTMLButtonElement | null>(null);
   const loadMoreButtonRef = useRef<HTMLButtonElement | null>(null);
-  const previousOpenRef = useRef<boolean>(false);
+  const renderedOpenRef = useRef<boolean>(false);
+  const restoreTriggerFocusRef = useRef<boolean>(false);
   const focusedSessionIdRef = useRef<string | null>(null);
   const loadMoreOwnsFocusRef = useRef<boolean>(false);
+  const focusedDialogElementRef = useRef<HTMLElement | null>(null);
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  const [position, setPosition] = useState<DialogPosition | null>(null);
   const runningSessions = sessions.filter((session) => session.status === "running");
   const recentSessions = sessions.filter((session) => session.status !== "running");
   const statusVisibility = resolveChatHistoryStatusVisibility(
@@ -175,16 +322,159 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
     [i18n.language, i18n.resolvedLanguage],
   );
 
+  const updatePosition = useCallback((): void => {
+    const historyButton = historyButtonRef.current;
+    if (historyButton === null) {
+      throw new Error("Cannot position chat history dialog: history button is not mounted");
+    }
+    const nextPosition = getDialogPosition(historyButton);
+    setPosition((currentPosition) => (
+      currentPosition !== null
+      && dialogPositionsMatch(currentPosition, nextPosition)
+        ? currentPosition
+        : nextPosition
+    ));
+  }, []);
+
+  useEffect(() => {
+    setPortalTarget(document.body);
+  }, []);
+
   useLayoutEffect(() => {
     if (!open) {
-      focusedSessionIdRef.current = null;
-      loadMoreOwnsFocusRef.current = false;
+      setPosition(null);
       return;
     }
+    updatePosition();
+  }, [open, updatePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleViewportChange = (): void => updatePosition();
+    const historyButton = historyButtonRef.current;
+    if (historyButton === null) {
+      throw new Error(
+        "Cannot observe chat history dialog anchor: history button is not mounted",
+      );
+    }
+    let previousAnchorRect = getAnchorRect(historyButton);
+    let animationFrameId = 0;
+    const trackAnchorRect = (): void => {
+      const currentHistoryButton = historyButtonRef.current;
+      if (currentHistoryButton === null) {
+        throw new Error(
+          "Cannot track chat history dialog anchor: history button is not mounted",
+        );
+      }
+      const currentAnchorRect = getAnchorRect(currentHistoryButton);
+      if (!anchorRectsMatch(previousAnchorRect, currentAnchorRect)) {
+        previousAnchorRect = currentAnchorRect;
+        updatePosition();
+      }
+      animationFrameId = window.requestAnimationFrame(trackAnchorRect);
+    };
+    animationFrameId = window.requestAnimationFrame(trackAnchorRect);
+    window.addEventListener("resize", handleViewportChange);
+    window.addEventListener("scroll", handleViewportChange, true);
+    window.visualViewport?.addEventListener("resize", handleViewportChange);
+    window.visualViewport?.addEventListener("scroll", handleViewportChange);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("scroll", handleViewportChange, true);
+      window.visualViewport?.removeEventListener("resize", handleViewportChange);
+      window.visualViewport?.removeEventListener("scroll", handleViewportChange);
+    };
+  }, [open, updatePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: globalThis.PointerEvent): void => {
+      const target = event.target;
+      if (!(target instanceof Node)) {
+        throw new TypeError(
+          "Cannot dismiss chat history dialog: pointer target is not a DOM node",
+        );
+      }
+      const dialog = dialogRef.current;
+      const historyButton = historyButtonRef.current;
+      if (dialog === null || historyButton === null) {
+        throw new Error(
+          "Cannot dismiss chat history dialog: dialog or history button is not mounted",
+        );
+      }
+      if (dialog.contains(target) || historyButton.contains(target)) return;
+
+      restoreTriggerFocusRef.current = false;
+      onOpenChange(false);
+    };
+    const handleEscape = (event: globalThis.KeyboardEvent): void => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      restoreTriggerFocusRef.current = true;
+      onOpenChange(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [onOpenChange, open]);
+
+  const dialogOpen = open && position !== null && portalTarget !== null;
+
+  const clearDialogFocusOwner = useCallback((): void => {
+    focusedDialogElementRef.current = null;
+    focusedSessionIdRef.current = null;
+    loadMoreOwnsFocusRef.current = false;
+  }, []);
+
+  useLayoutEffect(() => {
+    const wasOpen = renderedOpenRef.current;
+    if (dialogOpen && !wasOpen) {
+      const createDraftButton = createDraftButtonRef.current;
+      if (createDraftButton === null) {
+        throw new Error("Cannot focus chat history dialog: New chat button is not mounted");
+      }
+      createDraftButton.focus();
+    }
+    if (!dialogOpen && wasOpen && restoreTriggerFocusRef.current) {
+      const historyButton = historyButtonRef.current;
+      if (historyButton === null) {
+        throw new Error("Cannot restore chat history focus: history button is not mounted");
+      }
+      historyButton.focus();
+    }
+    if (!dialogOpen) {
+      restoreTriggerFocusRef.current = false;
+    }
+    renderedOpenRef.current = dialogOpen;
+  }, [dialogOpen]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      clearDialogFocusOwner();
+      return;
+    }
+    if (!dialogOpen) return;
 
     const dialog = dialogRef.current;
     if (dialog === null) {
       throw new Error("Cannot restore chat history focus: dialog is not mounted");
+    }
+    if (document.activeElement !== null && dialog.contains(document.activeElement)) {
+      return;
+    }
+    const focusedDialogElement = focusedDialogElementRef.current;
+    if (focusedDialogElement === null) return;
+    if (focusedDialogElement.isConnected) {
+      clearDialogFocusOwner();
+      return;
     }
     const paginationFocusTarget = resolveChatHistoryPaginationFocus(
       loadMoreOwnsFocusRef.current,
@@ -199,9 +489,6 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
       }
       loadMoreOwnsFocusRef.current = false;
       createDraftButton.focus();
-      return;
-    }
-    if (document.activeElement !== null && dialog.contains(document.activeElement)) {
       return;
     }
     if (paginationFocusTarget === "load_more") {
@@ -244,52 +531,30 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
       );
     }
     sessionButton.focus();
-  }, [hasMore, isLoading, open, sessions]);
+  }, [
+    clearDialogFocusOwner,
+    dialogOpen,
+    hasMore,
+    isLoading,
+    open,
+    sessions,
+  ]);
 
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (dialog === null) {
-      throw new Error("Cannot synchronize chat history dialog: dialog is not mounted");
-    }
-
-    if (open) {
-      if (!dialog.open) dialog.showModal();
-      const createDraftButton = createDraftButtonRef.current;
-      if (createDraftButton === null) {
-        throw new Error("Cannot focus chat history dialog: New chat button is not mounted");
-      }
-      createDraftButton.focus();
-    } else {
-      if (dialog.open) dialog.close();
-      if (previousOpenRef.current) {
-        const historyButton = historyButtonRef.current;
-        if (historyButton === null) {
-          throw new Error("Cannot restore chat history focus: history button is not mounted");
-        }
-        historyButton.focus();
-      }
-    }
-
-    previousOpenRef.current = open;
-  }, [open]);
-
-  const closeDialog = (): void => {
+  const closeAndRestoreTriggerFocus = (): void => {
+    restoreTriggerFocusRef.current = true;
     onOpenChange(false);
   };
 
   const handleCreateDraft = (): void => {
+    restoreTriggerFocusRef.current = false;
     onCreateDraft();
-    closeDialog();
+    onOpenChange(false);
   };
 
   const handleSelectSession = (sessionId: string): void => {
+    restoreTriggerFocusRef.current = false;
     onSelectSession(sessionId);
-    closeDialog();
-  };
-
-  const handleCancel = (event: SyntheticEvent<HTMLDialogElement>): void => {
-    event.preventDefault();
-    closeDialog();
+    onOpenChange(false);
   };
 
   const handleFocusCapture = (event: FocusEvent<HTMLDialogElement>): void => {
@@ -297,41 +562,41 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
     if (!(target instanceof HTMLElement)) {
       throw new TypeError("Cannot track chat history focus: focused target is not an element");
     }
+    focusedDialogElementRef.current = target;
     focusedSessionIdRef.current = target.dataset.chatHistorySessionId ?? null;
     loadMoreOwnsFocusRef.current =
       target.dataset.chatHistoryFocusOwner === "load-more";
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLDialogElement>): void => {
-    if (event.key !== "Tab") return;
-
-    const dialog = dialogRef.current;
-    if (dialog === null) {
-      throw new Error("Cannot contain chat history focus: dialog is not mounted");
+  const handleBlurCapture = (event: FocusEvent<HTMLDialogElement>): void => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      throw new TypeError("Cannot release chat history focus: blurred target is not an element");
     }
-    const focusableElements = [...dialog.querySelectorAll<HTMLButtonElement>(
-      "button:not(:disabled)",
-    )];
-    if (focusableElements.length === 0) {
-      event.preventDefault();
-      dialog.focus();
-      return;
-    }
-
-    const firstElement = focusableElements[0];
-    const lastElement = focusableElements[focusableElements.length - 1];
-    const activeElement = document.activeElement;
-    const focusIsOutside = activeElement === null || !dialog.contains(activeElement);
-    if (event.shiftKey && (activeElement === firstElement || focusIsOutside)) {
-      event.preventDefault();
-      lastElement.focus();
-      return;
-    }
-    if (!event.shiftKey && (activeElement === lastElement || focusIsOutside)) {
-      event.preventDefault();
-      firstElement.focus();
+    const nextTarget = event.relatedTarget;
+    if (
+      nextTarget instanceof Node
+      && !event.currentTarget.contains(nextTarget)
+      && target.isConnected
+    ) {
+      clearDialogFocusOwner();
     }
   };
+
+  const dialogStyle: DialogStyle | undefined = position === null
+    ? undefined
+    : {
+        "--chat-history-inset-block-start": `${position.insetBlockStart}px`,
+        "--chat-history-inset-inline-start": `${position.insetInlineStart}px`,
+        "--chat-history-width": `${position.width}px`,
+        "--chat-history-max-height": `${position.maxHeight}px`,
+        "--chat-history-viewport-inset-block-start":
+          `${position.viewportInsetBlockStart}px`,
+        "--chat-history-viewport-inset-inline-start":
+          `${position.viewportInsetInlineStart}px`,
+        "--chat-history-viewport-width": `${position.viewportWidth}px`,
+        "--chat-history-viewport-height": `${position.viewportHeight}px`,
+      };
 
   return (
     <>
@@ -342,121 +607,125 @@ export const ChatHistoryDialog = (props: Props): ReactElement => {
         buttonRef={historyButtonRef}
         onOpenChange={onOpenChange}
       />
-      <dialog
-        ref={dialogRef}
-        id={dialogId}
-        className={styles.dialog}
-        data-testid="chat-history-dialog"
-        aria-labelledby={titleId}
-        aria-busy={isLoading}
-        tabIndex={-1}
-        onCancel={handleCancel}
-        onFocusCapture={handleFocusCapture}
-        onKeyDown={handleKeyDown}
-      >
-        <header className={styles.dialogHeader}>
-          <h2 id={titleId} className={styles.dialogTitle}>{t("chat.historyTitle")}</h2>
-          <div className={styles.dialogActions}>
-            <button
-              ref={createDraftButtonRef}
-              type="button"
-              className={styles.dialogAction}
-              data-testid="chat-history-new"
-              onClick={handleCreateDraft}
-            >
-              {t("chat.new")}
-            </button>
-            <button
-              type="button"
-              className={cn(styles.dialogAction, styles.closeAction)}
-              data-testid="chat-history-close"
-              aria-label={t("chat.historyClose")}
-              title={t("chat.historyClose")}
-              onClick={closeDialog}
-            >
-              <svg
-                className={styles.closeIcon}
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                aria-hidden="true"
-              >
-                <path d="m4 4 8 8" />
-                <path d="m12 4-8 8" />
-              </svg>
-            </button>
-          </div>
-        </header>
-        <div className={styles.dialogBody}>
-          {errorMessage !== null && (
-            <p
-              className={styles.errorState}
-              data-testid="chat-history-error"
-              role="alert"
-            >
-              {errorMessage}
-            </p>
-          )}
-          {statusVisibility.showLoading && (
-            <p
-              className={styles.loadingState}
-              data-testid="chat-history-loading"
-              role="status"
-              aria-live="polite"
-            >
-              {t("common.loading")}
-            </p>
-          )}
-          {runningSessions.length > 0 && (
-            <SessionList
-              headingId={runningHeadingId}
-              heading={t("chat.historyRunningGroup")}
-              sessions={runningSessions}
-              selectedSessionId={selectedSessionId}
-              activityFormatter={activityFormatter}
-              runningStatus={t("chat.historyRunningStatus")}
-              testId="chat-history-running"
-              onSelectSession={handleSelectSession}
-            />
-          )}
-          {recentSessions.length > 0 && (
-            <SessionList
-              headingId={recentHeadingId}
-              heading={t("chat.historyRecent")}
-              sessions={recentSessions}
-              selectedSessionId={selectedSessionId}
-              activityFormatter={activityFormatter}
-              runningStatus={t("chat.historyRunningStatus")}
-              testId="chat-history-recent"
-              onSelectSession={handleSelectSession}
-            />
-          )}
-          {statusVisibility.showEmpty && (
-            <p className={styles.emptyState} data-testid="chat-history-empty">
-              {t("chat.historyEmpty")}
-            </p>
-          )}
-          {hasMore && (
-            <div className={styles.loadMoreRow}>
+      {portalTarget !== null && createPortal(
+        <dialog
+          ref={dialogRef}
+          id={dialogId}
+          className={styles.dialog}
+          data-testid="chat-history-dialog"
+          aria-labelledby={titleId}
+          aria-busy={isLoading}
+          tabIndex={-1}
+          open={dialogOpen}
+          style={dialogStyle}
+          onBlurCapture={handleBlurCapture}
+          onFocusCapture={handleFocusCapture}
+        >
+          <header className={styles.dialogHeader}>
+            <h2 id={titleId} className={styles.dialogTitle}>{t("chat.historyTitle")}</h2>
+            <div className={styles.dialogActions}>
               <button
-                ref={loadMoreButtonRef}
+                ref={createDraftButtonRef}
                 type="button"
-                className={styles.loadMoreButton}
-                data-testid="chat-history-load-more"
-                data-chat-history-focus-owner="load-more"
-                aria-disabled={isLoading}
-                onClick={() => {
-                  if (!isLoading) onLoadMore();
-                }}
+                className={styles.dialogAction}
+                data-testid="chat-history-new"
+                onClick={handleCreateDraft}
               >
-                {isLoading ? t("common.loading") : t("chat.historyLoadMore")}
+                {t("chat.new")}
+              </button>
+              <button
+                type="button"
+                className={cn(styles.dialogAction, styles.closeAction)}
+                data-testid="chat-history-close"
+                aria-label={t("chat.historyClose")}
+                title={t("chat.historyClose")}
+                onClick={closeAndRestoreTriggerFocus}
+              >
+                <svg
+                  className={styles.closeIcon}
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  aria-hidden="true"
+                >
+                  <path d="m4 4 8 8" />
+                  <path d="m12 4-8 8" />
+                </svg>
               </button>
             </div>
-          )}
-        </div>
-      </dialog>
+          </header>
+          <div className={styles.dialogBody}>
+            {errorMessage !== null && (
+              <p
+                className={styles.errorState}
+                data-testid="chat-history-error"
+                role="alert"
+              >
+                {errorMessage}
+              </p>
+            )}
+            {statusVisibility.showLoading && (
+              <p
+                className={styles.loadingState}
+                data-testid="chat-history-loading"
+                role="status"
+                aria-live="polite"
+              >
+                {t("common.loading")}
+              </p>
+            )}
+            {runningSessions.length > 0 && (
+              <SessionList
+                headingId={runningHeadingId}
+                heading={t("chat.historyRunningGroup")}
+                sessions={runningSessions}
+                selectedSessionId={selectedSessionId}
+                activityFormatter={activityFormatter}
+                runningStatus={t("chat.historyRunningStatus")}
+                testId="chat-history-running"
+                onSelectSession={handleSelectSession}
+              />
+            )}
+            {recentSessions.length > 0 && (
+              <SessionList
+                headingId={recentHeadingId}
+                heading={t("chat.historyRecent")}
+                sessions={recentSessions}
+                selectedSessionId={selectedSessionId}
+                activityFormatter={activityFormatter}
+                runningStatus={t("chat.historyRunningStatus")}
+                testId="chat-history-recent"
+                onSelectSession={handleSelectSession}
+              />
+            )}
+            {statusVisibility.showEmpty && (
+              <p className={styles.emptyState} data-testid="chat-history-empty">
+                {t("chat.historyEmpty")}
+              </p>
+            )}
+            {hasMore && (
+              <div className={styles.loadMoreRow}>
+                <button
+                  ref={loadMoreButtonRef}
+                  type="button"
+                  className={styles.loadMoreButton}
+                  data-testid="chat-history-load-more"
+                  data-chat-history-focus-owner="load-more"
+                  aria-disabled={isLoading}
+                  onClick={() => {
+                    if (!isLoading) onLoadMore();
+                  }}
+                >
+                  {isLoading ? t("common.loading") : t("chat.historyLoadMore")}
+                </button>
+              </div>
+            )}
+          </div>
+        </dialog>,
+        portalTarget,
+      )}
     </>
   );
 };

--- a/apps/web/src/ui/chat/shell/panel/ChatPanel.module.css
+++ b/apps/web/src/ui/chat/shell/panel/ChatPanel.module.css
@@ -49,6 +49,8 @@
 }
 
 .headerActions {
+  --chat-header-control-block-size: 24px;
+
   display: flex;
   gap: 6px;
   align-items: center;
@@ -66,6 +68,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
+  block-size: var(--chat-header-control-block-size);
   background: none;
   border: 1px solid var(--panel-border);
   padding: 2px 8px;


### PR DESCRIPTION
## Summary

- match the chat history trigger height to adjacent toolbar controls
- render desktop history as a solid non-modal popover anchored to the trigger, with viewport tracking, RTL clamping, and light-dismiss behavior
- use a full-viewport mobile surface and preserve focus across async updates and panel remounts
- extend local-demo E2E coverage for geometry, resize tracking, dismissal, focus, RTL, mobile, and Back/Forward remounts

## Validation

- `npm run test:e2e:local-demo -- chat-history.local-demo.spec.ts` (8 passed)
- `npm run test:e2e:local-demo -- chat-draft.local-demo.spec.ts --grep "focuses the new composer from the header and History dialog"` (1 passed)
- `npm run lint`
- `npm run build`
- `git diff --check`