### PR TITLE
Allow large attachments in new chats

### DIFF
--- a/infra/aws/lib/ingress.ts
+++ b/infra/aws/lib/ingress.ts
@@ -236,6 +236,11 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
   // WAF is kept for managed rule sets (SQLi, XSS, known bad inputs) which inspect
   // request content and work correctly regardless of source IP.
   const chatJsonRequest = postRequestToApp(props.appDomain, "/api/chat", "application/json");
+  const newChatJsonRequest = postRequestToApp(
+    props.appDomain,
+    "/api/chat/new",
+    "application/json",
+  );
   const chatTranscriptionUploadRequest = postRequestToApp(
     props.appDomain,
     "/api/chat/transcriptions",
@@ -290,7 +295,7 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
         "BlockUnexpectedBodySizeMatches",
         2,
         "awswaf:managed:aws:core-rule-set:SizeRestrictions_Body",
-        orStatement([chatJsonRequest, chatTranscriptionUploadRequest]),
+        orStatement([chatJsonRequest, newChatJsonRequest, chatTranscriptionUploadRequest]),
         "expense-tracker-size-body-reblock",
       ),
       {


### PR DESCRIPTION
## Summary
- allow large JSON request bodies for first messages sent to `/api/chat/new`
- preserve the existing exact method, host, origin, and content-type constraints
- keep the XSS exception unchanged

## Validation
- `npm --prefix infra/aws run build`
- CDK synth with the matching deployment profile and context
- synthesized WebACL assertion for the exact allowed routes and unchanged XSS behavior
- `git diff HEAD --check`
- fresh empty-history review: no P0-P4 findings