### PR TITLE
Expose web monitoring signal resources

### DIFF
--- a/infra/aws/lib/compute.ts
+++ b/infra/aws/lib/compute.ts
@@ -32,6 +32,7 @@ export interface ComputeResult {
   cluster: ecs.Cluster;
   webService: ecs.FargateService;
   webContainer: ecs.ContainerDefinition;
+  webLogGroup: logs.LogGroup;
   authService: ecs.FargateService;
   migrateTaskDef: ecs.FargateTaskDefinition;
   migrateLogGroup: logs.LogGroup;
@@ -323,5 +324,5 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
     }),
   });
 
-  return { cluster, webService, webContainer, authService, migrateTaskDef, migrateLogGroup };
+  return { cluster, webService, webContainer, webLogGroup, authService, migrateTaskDef, migrateLogGroup };
 }

--- a/infra/aws/lib/ingress.ts
+++ b/infra/aws/lib/ingress.ts
@@ -21,6 +21,8 @@ export interface IngressProps {
 export interface IngressResult {
   alb: elbv2.ApplicationLoadBalancer;
   accessLogsBucket: s3.Bucket;
+  webTargetGroup: elbv2.ApplicationTargetGroup;
+  webAclName: string;
 }
 
 type ByteMatchPositionalConstraint = "EXACTLY" | "STARTS_WITH";
@@ -164,7 +166,7 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
   });
   alb.logAccessLogs(accessLogsBucket);
 
-  const targetGroup = new elbv2.ApplicationTargetGroup(scope, "WebTg", {
+  const webTargetGroup = new elbv2.ApplicationTargetGroup(scope, "WebTg", {
     vpc: props.vpc,
     port: 8080,
     protocol: elbv2.ApplicationProtocol.HTTP,
@@ -174,13 +176,13 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
       interval: cdk.Duration.seconds(30),
     },
   });
-  props.webService.attachToApplicationTargetGroup(targetGroup);
+  props.webService.attachToApplicationTargetGroup(webTargetGroup);
 
   // ALB listeners: HTTPS forwards to app, HTTP → HTTPS redirect
   const httpsListener = alb.addListener("HttpsListener", {
     port: 443,
     certificates: [props.certificate],
-    defaultAction: elbv2.ListenerAction.forward([targetGroup]),
+    defaultAction: elbv2.ListenerAction.forward([webTargetGroup]),
   });
 
   // Auth service target group (port 8081)
@@ -316,11 +318,12 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
       },
     ],
   });
+  const webAclName = cdk.Fn.select(0, cdk.Fn.split("|", waf.ref));
 
   new wafv2.CfnWebACLAssociation(scope, "WafAlbAssociation", {
     resourceArn: alb.loadBalancerArn,
     webAclArn: waf.attrArn,
   });
 
-  return { alb, accessLogsBucket };
+  return { alb, accessLogsBucket, webTargetGroup, webAclName };
 }


### PR DESCRIPTION
## Summary
- expose the existing web log group from the compute construct
- expose the existing web target group from the ingress construct
- derive and expose the WAF Web ACL name from its CloudFormation Ref

## Validation
- npm --prefix infra/aws run build
- AWS_PROFILE=expense-tracker AWS_REGION=eu-central-1 npm --prefix infra/aws run synth -- --quiet
- git diff --check