### PR TITLE
feat(aws): promote monitoring alerts

### DIFF
--- a/infra/aws/lib/compute.ts
+++ b/infra/aws/lib/compute.ts
@@ -32,6 +32,7 @@ export interface ComputeResult {
   cluster: ecs.Cluster;
   webService: ecs.FargateService;
   webContainer: ecs.ContainerDefinition;
+  webLogGroup: logs.LogGroup;
   authService: ecs.FargateService;
   migrateTaskDef: ecs.FargateTaskDefinition;
   migrateLogGroup: logs.LogGroup;
@@ -323,5 +324,5 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
     }),
   });
 
-  return { cluster, webService, webContainer, authService, migrateTaskDef, migrateLogGroup };
+  return { cluster, webService, webContainer, webLogGroup, authService, migrateTaskDef, migrateLogGroup };
 }

--- a/infra/aws/lib/ingress.ts
+++ b/infra/aws/lib/ingress.ts
@@ -21,6 +21,8 @@ export interface IngressProps {
 export interface IngressResult {
   alb: elbv2.ApplicationLoadBalancer;
   accessLogsBucket: s3.Bucket;
+  webTargetGroup: elbv2.ApplicationTargetGroup;
+  webAclName: string;
 }
 
 type ByteMatchPositionalConstraint = "EXACTLY" | "STARTS_WITH";
@@ -164,7 +166,7 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
   });
   alb.logAccessLogs(accessLogsBucket);
 
-  const targetGroup = new elbv2.ApplicationTargetGroup(scope, "WebTg", {
+  const webTargetGroup = new elbv2.ApplicationTargetGroup(scope, "WebTg", {
     vpc: props.vpc,
     port: 8080,
     protocol: elbv2.ApplicationProtocol.HTTP,
@@ -174,13 +176,13 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
       interval: cdk.Duration.seconds(30),
     },
   });
-  props.webService.attachToApplicationTargetGroup(targetGroup);
+  props.webService.attachToApplicationTargetGroup(webTargetGroup);
 
   // ALB listeners: HTTPS forwards to app, HTTP → HTTPS redirect
   const httpsListener = alb.addListener("HttpsListener", {
     port: 443,
     certificates: [props.certificate],
-    defaultAction: elbv2.ListenerAction.forward([targetGroup]),
+    defaultAction: elbv2.ListenerAction.forward([webTargetGroup]),
   });
 
   // Auth service target group (port 8081)
@@ -316,11 +318,12 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
       },
     ],
   });
+  const webAclName = cdk.Fn.select(0, cdk.Fn.split("|", waf.ref));
 
   new wafv2.CfnWebACLAssociation(scope, "WafAlbAssociation", {
     resourceArn: alb.loadBalancerArn,
     webAclArn: waf.attrArn,
   });
 
-  return { alb, accessLogsBucket };
+  return { alb, accessLogsBucket, webTargetGroup, webAclName };
 }

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -6,13 +6,16 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as cloudwatch_actions from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as logs from "aws-cdk-lib/aws-logs";
 import * as sns from "aws-cdk-lib/aws-sns";
-import * as sns_subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
 import { Construct } from "constructs";
 
 export interface MonitoringProps {
   alertEmail: string;
   alb: elbv2.ApplicationLoadBalancer;
+  webTargetGroup: elbv2.ApplicationTargetGroup;
+  webLogGroup: logs.LogGroup;
+  webAclName: string;
   webService: ecs.FargateService;
   cluster: ecs.Cluster;
   db: rds.DatabaseInstance;
@@ -32,9 +35,11 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
   const alertTopic = new sns.Topic(scope, "AlertTopic", {
     topicName: "expense-tracker-alerts",
   });
-  alertTopic.addSubscription(
-    new sns_subscriptions.EmailSubscription(props.alertEmail),
-  );
+  new sns.Subscription(scope, "AlertEmailSubscriptionV2", {
+    topic: alertTopic,
+    protocol: sns.SubscriptionProtocol.EMAIL,
+    endpoint: props.alertEmail,
+  });
 
   // --- CloudWatch Alarms ---
   // ALB 5xx errors
@@ -46,6 +51,77 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     threshold: 5,
     evaluationPeriods: 1,
     alarmDescription: "ALB returned 5+ server errors in 5 minutes",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+
+  // Web target 5xx errors
+  new cloudwatch.Alarm(scope, "WebTarget5xxAlarm", {
+    metric: props.webTargetGroup.metrics.httpCodeTarget(
+      elbv2.HttpCodeTarget.TARGET_5XX_COUNT,
+      {
+        period: cdk.Duration.minutes(5),
+        statistic: "Sum",
+      },
+    ),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription: "Web target returned server errors",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+
+  // Web target health
+  new cloudwatch.Alarm(scope, "WebTargetHealthAlarm", {
+    metric: props.webTargetGroup.metrics.healthyHostCount({
+      period: cdk.Duration.minutes(1),
+      statistic: "Minimum",
+    }),
+    threshold: 1,
+    comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+    evaluationPeriods: 2,
+    alarmDescription: "Web target group had no healthy hosts for 2 minutes",
+    treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+
+  // WAF blocks by the request body size re-block rule
+  new cloudwatch.Alarm(scope, "WafSizeBodyBlockedAlarm", {
+    metric: new cloudwatch.Metric({
+      namespace: "AWS/WAFV2",
+      metricName: "BlockedRequests",
+      dimensionsMap: {
+        WebACL: props.webAclName,
+        Region: cdk.Aws.REGION,
+        Rule: "expense-tracker-size-body-reblock",
+      },
+      period: cdk.Duration.minutes(5),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription: "WAF blocked a request because of an unexpected large body",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+
+  const webErrorMetricFilter = new logs.MetricFilter(scope, "WebErrorMetricFilter", {
+    logGroup: props.webLogGroup,
+    filterPattern: logs.FilterPattern.any(
+      logs.FilterPattern.stringValue("$.action", "=", "error"),
+      logs.FilterPattern.stringValue("$.action", "=", "transcription_failed"),
+      logs.FilterPattern.stringValue("$.action", "=", "task_protection_enable_failed"),
+      logs.FilterPattern.stringValue("$.action", "=", "task_protection_disable_failed"),
+    ),
+    metricNamespace: "ExpenseBudgetTracker/Web",
+    metricName: "ErrorEvents",
+    metricValue: "1",
+  });
+
+  new cloudwatch.Alarm(scope, "WebErrorEventsAlarm", {
+    metric: webErrorMetricFilter.metric({
+      period: cdk.Duration.minutes(5),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription: "Web application logged an error event",
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
 

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -105,6 +105,9 @@ export class ExpenseBudgetTrackerStack extends cdk.Stack {
     const mon = monitoring(this, {
       alertEmail,
       alb: ing.alb,
+      webTargetGroup: ing.webTargetGroup,
+      webLogGroup: comp.webLogGroup,
+      webAclName: ing.webAclName,
       webService: comp.webService,
       cluster: comp.cluster,
       db: dbResult.db,


### PR DESCRIPTION
## Summary

- expose existing web monitoring resources to the monitoring construct
- restore the production alert email subscription
- add target, WAF body-block, and structured web-error alarms

## Validation

- TypeScript build passed
- production-context CDK synth passed
- synthesized-template assertions passed
- diff checks passed
- accumulated promotion review completed with no upheld P0/P1 findings