### PR TITLE
Scale web Fargate task vertically

### DIFF
--- a/infra/aws/lib/compute.ts
+++ b/infra/aws/lib/compute.ts
@@ -124,8 +124,8 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
   const cluster = new ecs.Cluster(scope, "Cluster", { vpc: props.vpc });
 
   const webTaskDef = new ecs.FargateTaskDefinition(scope, "WebTask", {
-    cpu: 512,
-    memoryLimitMiB: 1024,
+    cpu: 1024,
+    memoryLimitMiB: 2048,
     runtimePlatform: {
       cpuArchitecture: ecs.CpuArchitecture.ARM64,
       operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,


### PR DESCRIPTION
## Summary
- increase the production web Fargate task from 0.5 vCPU / 1 GB to 1 vCPU / 2 GB
- retain the existing ARM64 runtime and service autoscaling topology

## Validation
- npm --workspace expense-budget-tracker-aws run build
- git diff --check
- fresh staging-agnostic review: no P0-P4 issues found