### PR TITLE
Preserve Langfuse media during telemetry masking

### DIFF
--- a/apps/web/src/server/chat/openai/langfuse.test.ts
+++ b/apps/web/src/server/chat/openai/langfuse.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sanitizeLangfuseSerializedTelemetry } from "@/server/chat/openai/langfuse";
+
+const MEDIA_DATA_URI = "data:image/png;base64,1234567890123456";
+const UNPADDED_MEDIA_DATA_URI_MOD_2 = "data:application/octet-stream;base64,12345678901234";
+const UNPADDED_MEDIA_DATA_URI_MOD_3 = "data:application/octet-stream;base64,123456789012345";
+const PADDED_MEDIA_DATA_URI_ONE = "data:application/octet-stream;base64,123456789012345=";
+const PADDED_MEDIA_DATA_URI_TWO = "data:application/octet-stream;base64,12345678901234==";
+
+test("sanitizeLangfuseSerializedTelemetry masks nested text while preserving media", (): void => {
+  const telemetry = {
+    contact: "alice@example.com",
+    nested: [
+      { phone: "Call 415-555-2671" },
+      { apiKey: "sk_1234567890abcdef" },
+      { media: MEDIA_DATA_URI },
+      { unpaddedMedia: UNPADDED_MEDIA_DATA_URI_MOD_3 },
+    ],
+  };
+
+  const sanitized = sanitizeLangfuseSerializedTelemetry(JSON.stringify(telemetry));
+
+  assert.deepEqual(JSON.parse(sanitized), {
+    contact: "<masked-email>",
+    nested: [
+      { phone: "Call <masked-phone>" },
+      { apiKey: "<masked-api-key>" },
+      { media: MEDIA_DATA_URI },
+      { unpaddedMedia: UNPADDED_MEDIA_DATA_URI_MOD_3 },
+    ],
+  });
+  assert.equal(sanitized.includes(JSON.stringify(MEDIA_DATA_URI)), true);
+});
+
+test("sanitizeLangfuseSerializedTelemetry masks malformed media and ordinary text", (): void => {
+  const sanitized = sanitizeLangfuseSerializedTelemetry(JSON.stringify({
+    malformedMedia: "data:image/png;base64,123456789012345!",
+    nonMedia: "Account 1234567890123456",
+  }));
+
+  assert.deepEqual(JSON.parse(sanitized), {
+    malformedMedia: "data:image/png;base64,<masked-phone>!",
+    nonMedia: "Account <masked-phone>",
+  });
+});
+
+test("sanitizeLangfuseSerializedTelemetry masks a raw assistant output", (): void => {
+  assert.equal(
+    sanitizeLangfuseSerializedTelemetry("Receipt owner: alice@example.com"),
+    "Receipt owner: <masked-email>",
+  );
+});
+
+test("sanitizeLangfuseSerializedTelemetry preserves a raw unpadded media data URI", (): void => {
+  assert.equal(
+    sanitizeLangfuseSerializedTelemetry(UNPADDED_MEDIA_DATA_URI_MOD_2),
+    UNPADDED_MEDIA_DATA_URI_MOD_2,
+  );
+});
+
+test("sanitizeLangfuseSerializedTelemetry preserves canonically padded media", (): void => {
+  const sanitized = sanitizeLangfuseSerializedTelemetry(JSON.stringify({
+    onePaddingCharacter: PADDED_MEDIA_DATA_URI_ONE,
+    nested: [{ twoPaddingCharacters: PADDED_MEDIA_DATA_URI_TWO }],
+  }));
+
+  assert.deepEqual(JSON.parse(sanitized), {
+    onePaddingCharacter: PADDED_MEDIA_DATA_URI_ONE,
+    nested: [{ twoPaddingCharacters: PADDED_MEDIA_DATA_URI_TWO }],
+  });
+});
+
+test("sanitizeLangfuseSerializedTelemetry masks invalid Base64 lengths and padding", (): void => {
+  const invalidMediaDataUris = [
+    "data:application/octet-stream;base64,1234567890123",
+    "data:application/octet-stream;base64,12345678901234=",
+    "data:application/octet-stream;base64,123456789012=34",
+    "data:application/octet-stream;base64,123456789012===",
+  ];
+
+  for (const invalidMediaDataUri of invalidMediaDataUris) {
+    const sanitized = sanitizeLangfuseSerializedTelemetry(invalidMediaDataUri);
+
+    assert.notEqual(sanitized, invalidMediaDataUri);
+    assert.match(sanitized, /<masked-phone>/);
+  }
+});
+
+test("sanitizeLangfuseSerializedTelemetry rejects non-string contract input", (): void => {
+  assert.throws(
+    () => sanitizeLangfuseSerializedTelemetry({ value: "alice@example.com" }),
+    {
+      name: "TypeError",
+      message: "Langfuse mask expected a string attribute, but received object",
+    },
+  );
+});
+
+test("sanitizeLangfuseSerializedTelemetry treats malformed JSON-like text as raw", (): void => {
+  assert.equal(
+    sanitizeLangfuseSerializedTelemetry('{"contact":"alice@example.com"'),
+    '{"contact":"<masked-email>"',
+  );
+});
+
+test("sanitizeLangfuseSerializedTelemetry masks object keys and numeric PII deterministically", (): void => {
+  const sanitized = sanitizeLangfuseSerializedTelemetry(JSON.stringify({
+    "alice@example.com": "first",
+    "bob@example.com": "second",
+    account: 1234567890123456,
+    count: 42,
+    enabled: true,
+    missing: null,
+  }));
+
+  assert.deepEqual(JSON.parse(sanitized), {
+    "<masked-email>": "second",
+    account: "<masked-phone>",
+    count: 42,
+    enabled: true,
+    missing: null,
+  });
+});
+
+test("sanitizeLangfuseSerializedTelemetry does not mutate its source value", (): void => {
+  const telemetry = {
+    contact: "alice@example.com",
+    nested: [{ media: MEDIA_DATA_URI }],
+  };
+  const originalTelemetry = structuredClone(telemetry);
+  const serializedTelemetry = JSON.stringify(telemetry);
+
+  sanitizeLangfuseSerializedTelemetry(serializedTelemetry);
+
+  assert.deepEqual(telemetry, originalTelemetry);
+  assert.equal(serializedTelemetry, JSON.stringify(originalTelemetry));
+});

--- a/apps/web/src/server/chat/openai/langfuse.ts
+++ b/apps/web/src/server/chat/openai/langfuse.ts
@@ -29,6 +29,18 @@ export type ChatTranscriptionTraceMetadata = Readonly<{
 
 type TelemetryMetadata = Readonly<Record<string, string>>;
 
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ReadonlyArray<JsonValue>
+  | Readonly<{ [key: string]: JsonValue }>;
+
+type JsonContainer =
+  | ReadonlyArray<JsonValue>
+  | Readonly<{ [key: string]: JsonValue }>;
+
 type StartObservationDependencies = Readonly<{
   createTraceId: typeof createTraceId;
   propagateAttributes: typeof propagateAttributes;
@@ -56,6 +68,8 @@ const MASK_PATTERNS: ReadonlyArray<Readonly<{
     replacement: "<masked-number>",
   },
 ];
+
+const MEDIA_DATA_URI_PATTERN = /^data:[A-Za-z0-9!#$%&'*+.^_`|~-]+\/[A-Za-z0-9!#$%&'*+.^_`|~-]+;base64,([A-Za-z0-9+/]*={0,2})$/;
 
 const metadataValue = (value: string | number | boolean): string =>
   String(value).slice(0, 200);
@@ -85,15 +99,54 @@ const buildChatTranscriptionTraceMetadata = (
   fileSize: metadataValue(params.fileSize),
 });
 
-const sanitizeString = (value: string): string =>
-  MASK_PATTERNS.reduce(
+const isValidBase64Payload = (payload: string): boolean => {
+  const paddingLength = payload.endsWith("==")
+    ? 2
+    : payload.endsWith("=")
+      ? 1
+      : 0;
+  const contentLength = payload.length - paddingLength;
+
+  if (contentLength === 0) {
+    return false;
+  }
+
+  return paddingLength === 0
+    ? contentLength % 4 !== 1
+    : payload.length % 4 === 0;
+};
+
+const isBase64DataUri = (value: string): boolean => {
+  const payload = MEDIA_DATA_URI_PATTERN.exec(value)?.[1];
+
+  return payload !== undefined && isValidBase64Payload(payload);
+};
+
+const sanitizeString = (value: string): string => {
+  if (isBase64DataUri(value)) {
+    return value;
+  }
+
+  return MASK_PATTERNS.reduce(
     (currentValue, rule) => currentValue.replace(rule.pattern, rule.replacement),
     value,
   );
+};
 
-export const sanitizeLangfuseTelemetryValue = (value: unknown): unknown => {
+const sanitizeNumber = (value: number): number | string => {
+  const stringValue = String(value);
+  const sanitizedValue = sanitizeString(stringValue);
+
+  return sanitizedValue === stringValue ? value : sanitizedValue;
+};
+
+const sanitizeLangfuseTelemetryValue = (value: JsonValue): JsonValue => {
   if (typeof value === "string") {
     return sanitizeString(value);
+  }
+
+  if (typeof value === "number") {
+    return sanitizeNumber(value);
   }
 
   if (Array.isArray(value)) {
@@ -102,11 +155,48 @@ export const sanitizeLangfuseTelemetryValue = (value: unknown): unknown => {
 
   if (typeof value === "object" && value !== null) {
     return Object.fromEntries(
-      Object.entries(value).map(([key, childValue]) => [key, sanitizeLangfuseTelemetryValue(childValue)]),
+      Object.entries(value).map(
+        ([key, childValue]): readonly [string, JsonValue] => [
+          sanitizeString(key),
+          sanitizeLangfuseTelemetryValue(childValue),
+        ],
+      ),
     );
   }
 
   return value;
+};
+
+const parseLangfuseSerializedContainer = (data: string): JsonContainer | null => {
+  try {
+    const parsedValue = JSON.parse(data) as JsonValue;
+
+    return typeof parsedValue === "object" && parsedValue !== null
+      ? parsedValue
+      : null;
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      throw error;
+    }
+
+    return null;
+  }
+};
+
+export const sanitizeLangfuseSerializedTelemetry = (data: unknown): string => {
+  if (typeof data !== "string") {
+    throw new TypeError(
+      `Langfuse mask expected a string attribute, but received ${data === null ? "null" : typeof data}`,
+    );
+  }
+
+  const serializedContainer = parseLangfuseSerializedContainer(data);
+
+  return serializedContainer === null
+    ? sanitizeString(data)
+    : JSON.stringify(
+      sanitizeLangfuseTelemetryValue(serializedContainer),
+    );
 };
 
 export const createLangfuseSpanProcessor = (): LangfuseSpanProcessor | null => {
@@ -134,8 +224,8 @@ export const createLangfuseSpanProcessor = (): LangfuseSpanProcessor | null => {
     release: process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA,
     shouldExportSpan: ({ otelSpan }: Readonly<{ otelSpan: ReadableSpan }>): boolean =>
       isDefaultExportSpan(otelSpan),
-    mask: ({ data }: Readonly<{ data: unknown }>): unknown =>
-      sanitizeLangfuseTelemetryValue(data),
+    mask: ({ data }: Readonly<{ data: unknown }>): string =>
+      sanitizeLangfuseSerializedTelemetry(data),
   });
 };
 


### PR DESCRIPTION
## Summary
- honor Langfuse raw-string and serialized-container mask inputs
- mask textual and numeric PII while preserving valid Base64 media data URIs
- cover padded, unpadded, malformed, nested, and contract cases

## Validation
- focused Langfuse tests: 10/10 passed
- web lint passed
- web production build passed with 40/40 pages
- git diff check passed
- final fresh review: no P0-P4 findings