### PR TITLE
Preserve prepared chat attachments

### DIFF
--- a/apps/web/e2e-local/chat-draft.local-demo.spec.ts
+++ b/apps/web/e2e-local/chat-draft.local-demo.spec.ts
@@ -171,6 +171,60 @@ const mockWorkspaceClientDependencies = async (page: Page): Promise<void> => {
   );
 };
 
+test("sends a prepared attachment when text is filled afterwards", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  if (baseURL === undefined) {
+    throw new Error("Local Demo Playwright baseURL is required");
+  }
+
+  let requestContentTypes: ReadonlyArray<string> | null = null;
+  await mockWorkspaceClientDependencies(page);
+  await page.route("**/api/chat/new", async (route): Promise<void> => {
+    const body = route.request().postDataJSON() as Readonly<{
+      content: ReadonlyArray<Readonly<{ type: string }>>;
+    }>;
+    requestContentTypes = body.content.map((part) => part.type);
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Chat-Session-Id": "session-attachment-after-fill",
+      },
+      body: [
+        "data: {\"type\":\"session\",\"sessionId\":\"session-attachment-after-fill\"}",
+        "data: {\"type\":\"done\"}",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  const origin = new URL(baseURL);
+  await context.addCookies([
+    { name: "demo", value: "true", domain: origin.hostname, path: "/", sameSite: "Lax" },
+    { name: "locale", value: "en", domain: origin.hostname, path: "/", sameSite: "Lax" },
+  ]);
+  await page.goto("/chat", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-composer-input")).toBeEditable();
+  await expect(page.getByTestId("chat-file-input")).toBeEnabled();
+
+  await page.getByTestId("chat-file-input").setInputFiles({
+    name: "prepared.png",
+    mimeType: "image/png",
+    buffer: Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAADAAAABQCAYAAABf9vbdAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAuElEQVRoge2TwQ0AMBCC2H9pOga51Id/IYrg5VAXcAD0Ft2E6E26E3Mz1AUcAL1FNyF6k+7E3Ax1AQdAb9FNiN6kOzE3Q13AAdBbdBOiN+lOzM1QF3AA9BbdhOhNuhNzM9QFHAC9RTchepPuxNwMdQEHQG/RTYjepDsxN0NdwAHQW3QTojfpTszNUBdwAPQW3YToTboTczPUBRwAvUU3IXqT7sTcDHUBB0Bv0U2I3qQ7MTdDXcDfAR5ctOO0Ki9gXgAAAABJRU5ErkJggg==",
+      "base64",
+    ),
+  });
+  await expect(page.getByTestId("chat-prepared-attachment")).toHaveCount(1);
+  await page.getByTestId("chat-composer-input").fill("describe this image");
+  await page.getByTestId("chat-submit").click();
+
+  await expect.poll(() => requestContentTypes).toEqual(["image", "text"]);
+});
+
 type DelayedChatBootstrap = Readonly<{
   catalogRequestReceived: Promise<void>;
   releaseCatalog: () => void;

--- a/apps/web/src/ui/chat/shell/layout/ChatLayoutProvider.tsx
+++ b/apps/web/src/ui/chat/shell/layout/ChatLayoutProvider.tsx
@@ -33,6 +33,7 @@ import {
   writeChatSelection,
 } from "../../workspace/chatSelectionStorage";
 import {
+  createTargetChatPendingSubmission,
   deleteTargetChatComposerMemory,
   isChatDraftUntouched,
   readTargetChatComposerMemory,
@@ -69,6 +70,10 @@ type ChatLayoutContextValue = Readonly<{
     update: SetStateAction<string>,
   ) => void;
   chatComposerMemory: ChatComposerMemoryState;
+  createChatPendingSubmissionForTarget: (
+    target: ChatTarget,
+    text: string,
+  ) => ChatPendingSubmission;
   setChatComposerMemoryForTarget: (
     target: ChatTarget,
     update: SetStateAction<ChatComposerMemoryState>,
@@ -694,6 +699,16 @@ const ScopedChatLayoutProvider = (
     composerMemoryByTargetRef.current = nextMemoryByTarget;
     setComposerMemoryByTarget(nextMemoryByTarget);
   }, []);
+
+  const createChatPendingSubmissionForTarget = useCallback((
+    targetToRead: ChatTarget,
+    text: string,
+  ): ChatPendingSubmission =>
+    createTargetChatPendingSubmission(
+      composerMemoryByTargetRef.current,
+      getChatTargetKey(targetToRead),
+      text,
+    ), []);
 
   const registerChatTargetOperationOwnership = useCallback((
     kind: ChatTargetOperationKind,
@@ -1531,6 +1546,7 @@ const ScopedChatLayoutProvider = (
       setChatDraftText,
       setChatDraftTextForTarget,
       chatComposerMemory,
+      createChatPendingSubmissionForTarget,
       setChatComposerMemoryForTarget,
       reuseSelectedChatDraft,
       replaceSelectedChatTargetWithDraft,

--- a/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
@@ -26,7 +26,6 @@ import { ChatPanelHeader } from "./ChatPanelHeader";
 import { ChatTranscript } from "./ChatTranscript";
 import { prepareAttachment, type PendingAttachment } from "./FileAttachment";
 import {
-  createChatPendingSubmission,
   getAttachmentFailureReasonKey,
   markChatComposerContentEdited,
   startMountedLifecycle,
@@ -216,6 +215,7 @@ export const ChatPanel = (props: Props): ReactElement => {
     setChatDraftText: setInputText,
     setChatDraftTextForTarget,
     chatComposerMemory,
+    createChatPendingSubmissionForTarget,
     setChatComposerMemoryForTarget,
     reuseSelectedChatDraft,
     replaceSelectedChatTargetWithDraft,
@@ -1496,9 +1496,13 @@ export const ChatPanel = (props: Props): ReactElement => {
     const target = chatWorkspace.state.target;
     const submissionSelectionEpoch = chatWorkspace.selectionEpoch;
     const nextText = inputText;
-    const nextAttachments = pendingAttachments;
+    const submissionSnapshot = createChatPendingSubmissionForTarget(
+      target,
+      nextText,
+    );
+    const nextAttachments = submissionSnapshot.attachments;
     const pendingSubmission = target.kind === "draft"
-      ? createChatPendingSubmission(nextText, nextAttachments)
+      ? submissionSnapshot
       : null;
     const pendingSubmissionOwnership =
       target.kind === "draft" && pendingSubmission !== null
@@ -1695,7 +1699,7 @@ export const ChatPanel = (props: Props): ReactElement => {
     chatWorkspace.state.target,
     inputText,
     isChatLayoutScopeCurrent,
-    pendingAttachments,
+    createChatPendingSubmissionForTarget,
     registerChatPendingSubmissionOwnership,
     releaseChatPendingSubmissionOwnership,
     settleRejectedChatPendingSubmissionOwnership,

--- a/apps/web/src/ui/chat/shell/panel/chatPanelRuntime.test.ts
+++ b/apps/web/src/ui/chat/shell/panel/chatPanelRuntime.test.ts
@@ -16,6 +16,7 @@ import {
   AttachmentReadError,
   ChatComposerMemoryTransitionError,
   createEmptyChatComposerMemory,
+  createTargetChatPendingSubmission,
   deleteTargetChatComposerMemory,
   getAttachmentFailureReasonKey,
   hasSupportedImageAttachmentSignature,
@@ -43,6 +44,49 @@ const PNG_PREFIX: ReadonlyArray<number> = [
   0x89, 0x50, 0x4e, 0x47,
   0x0d, 0x0a, 0x1a, 0x0a,
 ];
+
+test("submission snapshots read every attachment from current target memory", (): void => {
+  const renderedMemory = createEmptyChatComposerMemory();
+  const draftTargetKey = "draft:draft-1";
+  const sessionTargetKey = "session:session-1";
+  const preparedAttachments = [{
+    fileName: "receipt.png",
+    mediaType: "image/png",
+    base64Data: "png-bytes",
+  }, {
+    fileName: "statement.csv",
+    mediaType: "text/csv",
+    base64Data: "csv-bytes",
+  }] as const;
+  let memoryByTarget: ReadonlyMap<string, ChatComposerMemoryState> =
+    new Map<string, ChatComposerMemoryState>();
+
+  for (const targetKey of [draftTargetKey, sessionTargetKey]) {
+    memoryByTarget = updateTargetChatComposerMemory(
+      memoryByTarget,
+      targetKey,
+      {
+        ...renderedMemory,
+        pendingAttachments: preparedAttachments,
+      },
+    );
+  }
+
+  assert.deepEqual(renderedMemory.pendingAttachments, []);
+  for (const targetKey of [draftTargetKey, sessionTargetKey]) {
+    assert.deepEqual(
+      createTargetChatPendingSubmission(
+        memoryByTarget,
+        targetKey,
+        "summarize the attachments",
+      ),
+      {
+        text: "summarize the attachments",
+        attachments: preparedAttachments,
+      },
+    );
+  }
+});
 
 test("restores mounted state after a Strict Mode setup-cleanup-setup cycle", (): void => {
   const mountedRef = { current: false };

--- a/apps/web/src/ui/chat/shell/panel/chatPanelRuntime.ts
+++ b/apps/web/src/ui/chat/shell/panel/chatPanelRuntime.ts
@@ -67,6 +67,19 @@ export const createChatPendingSubmission = (
   attachments: [...attachments],
 });
 
+export const createTargetChatPendingSubmission = (
+  memoryByTarget: ReadonlyMap<string, ChatComposerMemoryState>,
+  targetKey: string,
+  text: string,
+): ChatPendingSubmission =>
+  createChatPendingSubmission(
+    text,
+    readTargetChatComposerMemory(
+      memoryByTarget,
+      targetKey,
+    ).pendingAttachments,
+  );
+
 export const restoreFailedChatSubmissionText = (
   currentText: string,
   pendingSubmission: ChatPendingSubmission,


### PR DESCRIPTION
## Summary
- snapshot prepared attachments from authoritative per-target composer state when sending
- preserve the same attachment snapshot for draft and existing-session requests
- add state/controller and browser request-body regression coverage

## Validation
- 82 focused chat state/controller tests passed
- focused local-demo Playwright regression passed
- web lint passed
- web production build passed
- static review: No P0-P4 issues found