### PR TITLE
Batch Langfuse export and own the container shutdown sequence

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -49,6 +49,17 @@ EXPOSE 8080
 ENV PORT=8080
 ENV HOSTNAME="0.0.0.0"
 
+# Stop the Next standalone server from registering its own SIGTERM/SIGINT
+# handlers: its cleanup ends in an unconditional process.exit(), which killed
+# the process before the batched Langfuse span queue could be flushed. The
+# application owns the sequence instead (src/server/shutdownCoordinator.ts),
+# which registers its handlers only when this flag is set, so the image that
+# disables Next's handler is the image that provides the replacement. The
+# replacement flushes telemetry and then exits with the signal exit code; the
+# in-flight HTTP request wait that Next's cleanup performed via server.close()
+# is intentionally not reproduced, since adding it would change deploy timing.
+ENV NEXT_MANUAL_SIG_HANDLE=1
+
 # Shell form: HOSTNAME= overrides the ECS Fargate-injected HOSTNAME
 # (ECS sets HOSTNAME to the task ID, breaking Next.js localhost binding).
 # See https://github.com/vercel/next.js/issues/58657

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -15,8 +15,9 @@
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { getAuthModeValidationErrors } from "@/server/authMode";
 import { createLangfuseSpanProcessor } from "@/server/chat/openai/langfuse";
+import { ensureShutdownCoordinatorRegistered } from "@/server/shutdownCoordinator";
+import { registerTelemetrySdk } from "@/server/telemetry";
 
-let telemetrySdk: NodeSDK | null = null;
 let telemetryStarted = false;
 
 const validateLangfuseConfig = (): ReadonlyArray<string> => {
@@ -46,15 +47,22 @@ const startTelemetryIfConfigured = (): void => {
     return;
   }
 
-  telemetrySdk = new NodeSDK({
+  const sdk = new NodeSDK({
     spanProcessors: [spanProcessor],
   });
-  void telemetrySdk.start();
+  void sdk.start();
+  registerTelemetrySdk(sdk);
   telemetryStarted = true;
 };
 
 export const register = (): void => {
   if (process.env.NODE_ENV !== "production") return;
+
+  // The runner image sets NEXT_MANUAL_SIG_HANDLE=1, so Next no longer owns
+  // SIGTERM/SIGINT. Register the application handler at boot: relying on a
+  // route to import the coordinator lazily would leave a container that never
+  // served a chat request with no handler at all.
+  ensureShutdownCoordinatorRegistered();
 
   const errors = Array.from(getAuthModeValidationErrors(process.env));
   const authMode = process.env.AUTH_MODE;

--- a/apps/web/src/server/chat/openai/langfuse.ts
+++ b/apps/web/src/server/chat/openai/langfuse.ts
@@ -215,11 +215,19 @@ export const createLangfuseSpanProcessor = (): LangfuseSpanProcessor | null => {
     return null;
   }
 
+  // exportMode is intentionally omitted: @langfuse/otel wraps the OTLP exporter
+  // in a BatchSpanProcessor unless exportMode is "immediate", which wrapped it
+  // in a SimpleSpanProcessor and serialized plus POSTed each span to Langfuse
+  // the moment it ended. Batching moves only that OTLP serialization and HTTP
+  // export off the request path, into queued batches.
+  // Masking and media processing are deliberately unaffected: LangfuseSpanProcessor
+  // runs both in onEnd for every span regardless of export mode, so the CPU cost
+  // of sanitizing multi-megabyte payloads is unchanged by this option and is out
+  // of scope here.
   return new LangfuseSpanProcessor({
     publicKey,
     secretKey,
     baseUrl,
-    exportMode: "immediate",
     environment: process.env.NODE_ENV,
     release: process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA,
     shouldExportSpan: ({ otelSpan }: Readonly<{ otelSpan: ReadableSpan }>): boolean =>

--- a/apps/web/src/server/logger.ts
+++ b/apps/web/src/server/logger.ts
@@ -190,7 +190,23 @@ type AuthEvent =
   | Readonly<{ domain: "auth"; action: "proxy_auth_error"; error: string }>
   | Readonly<{ domain: "auth"; action: "error"; error: string }>;
 
-type LogEvent = ChatEvent | ChatTranscriptionEvent | ApiEvent | SqlApiEvent | AuthEvent;
+type TelemetryEvent =
+  | Readonly<{ domain: "telemetry"; action: "shutdown_completed"; durationMs: number }>
+  | Readonly<{ domain: "telemetry"; action: "shutdown_failed"; durationMs: number; error: string }>
+  | Readonly<{
+    domain: "telemetry";
+    action: "shutdown_sequence_error";
+    signal: string;
+    error: string;
+  }>;
+
+type LogEvent =
+  | ChatEvent
+  | ChatTranscriptionEvent
+  | ApiEvent
+  | SqlApiEvent
+  | AuthEvent
+  | TelemetryEvent;
 
 export const log = (event: LogEvent): void => {
   console.log(JSON.stringify(event));

--- a/apps/web/src/server/shutdownCoordinator.test.ts
+++ b/apps/web/src/server/shutdownCoordinator.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isServerDraining,
+  runShutdownSequenceWithDeps,
+  setServerDrainingForTests,
+  type ShutdownSequenceDependencies,
+} from "./shutdownCoordinator";
+
+type LogCapture = Readonly<{
+  lines: ReadonlyArray<string>;
+  restore: () => void;
+}>;
+
+const captureLogLines = (): LogCapture => {
+  const lines: Array<string> = [];
+  const originalLog = console.log;
+  console.log = (message?: unknown): void => {
+    lines.push(String(message));
+  };
+
+  return {
+    lines,
+    restore: (): void => {
+      console.log = originalLog;
+    },
+  };
+};
+
+type ExitRecorder = Readonly<{
+  codes: ReadonlyArray<number>;
+  exitProcess: (code: number) => void;
+}>;
+
+const createExitRecorder = (): ExitRecorder => {
+  const codes: Array<number> = [];
+
+  return {
+    codes,
+    exitProcess: (code: number): void => {
+      codes.push(code);
+    },
+  };
+};
+
+type Deferred = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+}>;
+
+const createDeferred = (): Deferred => {
+  let resolvePromise: () => void = (): void => undefined;
+  const promise = new Promise<void>((resolve): void => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve: (): void => {
+      resolvePromise();
+    },
+  };
+};
+
+type ParsedEvent = Readonly<{
+  domain: string;
+  action: string;
+  signal?: string;
+  error?: string;
+}>;
+
+const parseEvents = (lines: ReadonlyArray<string>): ReadonlyArray<ParsedEvent> =>
+  lines.map((line) => JSON.parse(line) as ParsedEvent);
+
+const eventNames = (lines: ReadonlyArray<string>): ReadonlyArray<string> =>
+  parseEvents(lines).map((event) => `${event.domain}:${event.action}`);
+
+/**
+ * Base dependencies with an instantly draining telemetry SDK and an instantly
+ * settling log flush. Each test overrides only the parts it exercises.
+ */
+const createDependencies = (
+  overrides: Partial<ShutdownSequenceDependencies>,
+): ShutdownSequenceDependencies => ({
+  shutdownTelemetry: overrides.shutdownTelemetry ?? ((): Promise<void> => Promise.resolve()),
+  settleLogWrites: overrides.settleLogWrites ?? ((): Promise<void> => Promise.resolve()),
+  exitProcess: overrides.exitProcess ?? ((): void => undefined),
+});
+
+test("SIGTERM marks draining synchronously, then exits 143 after telemetry drained", async (): Promise<void> => {
+  setServerDrainingForTests(false);
+  const exitRecorder = createExitRecorder();
+  const order: Array<string> = [];
+  const telemetryDrain = createDeferred();
+  const dependencies = createDependencies({
+    shutdownTelemetry: (): Promise<void> => telemetryDrain.promise,
+    exitProcess: (code: number): void => {
+      order.push("exit");
+      exitRecorder.exitProcess(code);
+    },
+  });
+  const logCapture = captureLogLines();
+
+  try {
+    const sequence = runShutdownSequenceWithDeps("SIGTERM", dependencies);
+
+    // Draining must be observable before the telemetry drain resolves so
+    // in-flight chat requests start rejecting immediately.
+    assert.equal(isServerDraining(), true);
+    assert.deepEqual(exitRecorder.codes, []);
+
+    order.push("telemetry_drained");
+    telemetryDrain.resolve();
+    await sequence;
+
+    assert.deepEqual(order, ["telemetry_drained", "exit"]);
+    assert.deepEqual(exitRecorder.codes, [143]);
+
+    const events = parseEvents(logCapture.lines);
+    assert.deepEqual(
+      events.map((event) => `${event.domain}:${event.action}`),
+      ["api:shutdown_draining"],
+    );
+    assert.equal(events[0].signal, "SIGTERM");
+  } finally {
+    logCapture.restore();
+    setServerDrainingForTests(false);
+  }
+});
+
+test("SIGINT exits with 130", async (): Promise<void> => {
+  setServerDrainingForTests(false);
+  const exitRecorder = createExitRecorder();
+  const dependencies = createDependencies({
+    exitProcess: exitRecorder.exitProcess,
+  });
+  const logCapture = captureLogLines();
+
+  try {
+    await runShutdownSequenceWithDeps("SIGINT", dependencies);
+
+    assert.deepEqual(exitRecorder.codes, [130]);
+    assert.equal(parseEvents(logCapture.lines)[0].signal, "SIGINT");
+  } finally {
+    logCapture.restore();
+    setServerDrainingForTests(false);
+  }
+});
+
+test("a second signal while draining does not drain or exit again", async (): Promise<void> => {
+  setServerDrainingForTests(false);
+  const exitRecorder = createExitRecorder();
+  let telemetryCallCount = 0;
+  const dependencies = createDependencies({
+    shutdownTelemetry: (): Promise<void> => {
+      telemetryCallCount += 1;
+      return Promise.resolve();
+    },
+    exitProcess: exitRecorder.exitProcess,
+  });
+  const logCapture = captureLogLines();
+
+  try {
+    await runShutdownSequenceWithDeps("SIGTERM", dependencies);
+    await runShutdownSequenceWithDeps("SIGINT", dependencies);
+    await runShutdownSequenceWithDeps("SIGTERM", dependencies);
+
+    assert.equal(telemetryCallCount, 1);
+    assert.deepEqual(exitRecorder.codes, [143]);
+    assert.equal(logCapture.lines.length, 1);
+  } finally {
+    logCapture.restore();
+    setServerDrainingForTests(false);
+  }
+});
+
+test("the process exits only after queued log writes settle", async (): Promise<void> => {
+  setServerDrainingForTests(false);
+  const exitRecorder = createExitRecorder();
+  const order: Array<string> = [];
+  const logWritesSettled = createDeferred();
+  const dependencies = createDependencies({
+    settleLogWrites: (): Promise<void> => logWritesSettled.promise,
+    exitProcess: (code: number): void => {
+      order.push("exit");
+      exitRecorder.exitProcess(code);
+    },
+  });
+  const logCapture = captureLogLines();
+
+  try {
+    const sequence = runShutdownSequenceWithDeps("SIGTERM", dependencies);
+    await Promise.resolve();
+
+    assert.deepEqual(exitRecorder.codes, []);
+
+    order.push("log_writes_settled");
+    logWritesSettled.resolve();
+    await sequence;
+
+    assert.deepEqual(order, ["log_writes_settled", "exit"]);
+    assert.deepEqual(exitRecorder.codes, [143]);
+  } finally {
+    logCapture.restore();
+    setServerDrainingForTests(false);
+  }
+});
+
+test("a rejecting telemetry drain still exits with the signal exit code", async (): Promise<void> => {
+  setServerDrainingForTests(false);
+  const exitRecorder = createExitRecorder();
+  const dependencies = createDependencies({
+    shutdownTelemetry: (): Promise<void> =>
+      Promise.reject(new Error("telemetry shutdown contract broken")),
+    exitProcess: exitRecorder.exitProcess,
+  });
+  const logCapture = captureLogLines();
+
+  try {
+    await runShutdownSequenceWithDeps("SIGTERM", dependencies);
+
+    assert.deepEqual(exitRecorder.codes, [143]);
+
+    const events = parseEvents(logCapture.lines);
+    assert.deepEqual(eventNames(logCapture.lines), [
+      "api:shutdown_draining",
+      "telemetry:shutdown_sequence_error",
+    ]);
+    assert.equal(events[1].error, "telemetry shutdown contract broken");
+  } finally {
+    logCapture.restore();
+    setServerDrainingForTests(false);
+  }
+});
+
+test("a synchronously throwing telemetry drain still exits", async (): Promise<void> => {
+  setServerDrainingForTests(false);
+  const exitRecorder = createExitRecorder();
+  const dependencies = createDependencies({
+    shutdownTelemetry: (): Promise<void> => {
+      throw new Error("telemetry drain threw");
+    },
+    exitProcess: exitRecorder.exitProcess,
+  });
+  const logCapture = captureLogLines();
+
+  try {
+    await runShutdownSequenceWithDeps("SIGTERM", dependencies);
+
+    assert.deepEqual(exitRecorder.codes, [143]);
+    assert.equal(
+      parseEvents(logCapture.lines)[1].action,
+      "shutdown_sequence_error",
+    );
+  } finally {
+    logCapture.restore();
+    setServerDrainingForTests(false);
+  }
+});

--- a/apps/web/src/server/shutdownCoordinator.ts
+++ b/apps/web/src/server/shutdownCoordinator.ts
@@ -1,11 +1,54 @@
 import { log } from "@/server/logger";
+import { shutdownTelemetry } from "@/server/telemetry";
 
 export const CHAT_SERVER_DRAINING_MESSAGE = "Chat server is restarting, please retry";
+
+/**
+ * Signals this process owns, mapped to the `128 + signal number` exit codes the
+ * Next standalone server used before the application took the sequence over.
+ * Docker and ECS keep seeing a signal termination.
+ */
+const OWNED_SIGNAL_EXIT_CODES: Readonly<Record<"SIGTERM" | "SIGINT", number>> = {
+  SIGTERM: 143,
+  SIGINT: 130,
+};
+
+type OwnedSignal = keyof typeof OWNED_SIGNAL_EXIT_CODES;
+
+const OWNED_SIGNALS: ReadonlyArray<OwnedSignal> = ["SIGTERM", "SIGINT"];
+
+export type ShutdownSequenceDependencies = Readonly<{
+  shutdownTelemetry: () => Promise<void>;
+  /**
+   * Yields one event loop turn so queued stdout writes reach the log driver
+   * before the process exits.
+   */
+  settleLogWrites: () => Promise<void>;
+  exitProcess: (code: number) => void;
+}>;
 
 let draining = false;
 let signalHandlersRegistered = false;
 
-const handleSigterm = (): void => {
+/**
+ * Owns the whole shutdown sequence for one signal:
+ * 1. mark draining and log synchronously, so new chat requests are rejected
+ *    before any awaiting starts;
+ * 2. drain telemetry within the bound enforced by shutdownTelemetry();
+ * 3. exit with the signal's exit code.
+ *
+ * The exit is in `finally` so no failure along the way can leave the container
+ * alive until the ECS 120s stopTimeout.
+ *
+ * HTTP connection draining and `server.close()` are intentionally not part of
+ * this sequence: Next's own cleanup did await `server.close()`, and that
+ * in-flight wait is deliberately not reproduced here, because adding it would
+ * change deploy timing beyond the scope of this change.
+ */
+export const runShutdownSequenceWithDeps = async (
+  signal: OwnedSignal,
+  dependencies: ShutdownSequenceDependencies,
+): Promise<void> => {
   if (draining) {
     return;
   }
@@ -14,17 +57,67 @@ const handleSigterm = (): void => {
   log({
     domain: "api",
     action: "shutdown_draining",
-    signal: "SIGTERM",
+    signal,
   });
+
+  try {
+    await dependencies.shutdownTelemetry();
+  } catch (error: unknown) {
+    // shutdownTelemetry reports its own timeout and failure outcomes, so
+    // reaching here means it broke its contract. Log it instead of hiding it.
+    log({
+      domain: "telemetry",
+      action: "shutdown_sequence_error",
+      signal,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    // log() writes through console.log, and under the ECS awslogs driver stdout
+    // is a pipe, so those writes are asynchronous. Exiting in the same microtask
+    // chain would discard the shutdown outcome lines that make this rollout
+    // observable. The nested finally keeps the exit unconditional.
+    try {
+      await dependencies.settleLogWrites();
+    } finally {
+      dependencies.exitProcess(OWNED_SIGNAL_EXIT_CODES[signal]);
+    }
+  }
 };
 
+const DEFAULT_SHUTDOWN_SEQUENCE_DEPENDENCIES: ShutdownSequenceDependencies = {
+  shutdownTelemetry,
+  settleLogWrites: (): Promise<void> =>
+    new Promise<void>((resolve): void => {
+      setImmediate(resolve);
+    }),
+  exitProcess: (code: number): void => {
+    process.exit(code);
+  },
+};
+
+/**
+ * Registers the signal handlers only when NEXT_MANUAL_SIG_HANDLE is set, which
+ * is the same flag that stops the Next standalone server from registering its
+ * own handlers (see next/dist/server/lib/start-server.js). The production
+ * runner image sets it in apps/web/Dockerfile, so exactly one owner of
+ * SIGTERM/SIGINT exists: with the flag the application sequence runs, without
+ * it (for example `next dev`) Next's own cleanup stays untouched.
+ */
 export const ensureShutdownCoordinatorRegistered = (): void => {
   if (signalHandlersRegistered) {
     return;
   }
 
+  if (!process.env.NEXT_MANUAL_SIG_HANDLE) {
+    return;
+  }
+
   signalHandlersRegistered = true;
-  process.once("SIGTERM", handleSigterm);
+  for (const signal of OWNED_SIGNALS) {
+    process.once(signal, (): void => {
+      void runShutdownSequenceWithDeps(signal, DEFAULT_SHUTDOWN_SEQUENCE_DEPENDENCIES);
+    });
+  }
 };
 
 export const isServerDraining = (): boolean => {

--- a/apps/web/src/server/telemetry.test.ts
+++ b/apps/web/src/server/telemetry.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createTelemetryControllerWithDeps,
+  type TelemetryController,
+  type TelemetrySdkHandle,
+} from "./telemetry";
+
+type LogCapture = Readonly<{
+  lines: ReadonlyArray<string>;
+  restore: () => void;
+}>;
+
+const captureLogLines = (): LogCapture => {
+  const lines: Array<string> = [];
+  const originalLog = console.log;
+  console.log = (message?: unknown): void => {
+    lines.push(String(message));
+  };
+
+  return {
+    lines,
+    restore: (): void => {
+      console.log = originalLog;
+    },
+  };
+};
+
+const createController = (timeoutMs: number): TelemetryController =>
+  createTelemetryControllerWithDeps({
+    timeoutMs,
+    now: (): number => 0,
+  });
+
+test("shutdownTelemetry shuts the registered SDK down once for concurrent and repeated calls", async (): Promise<void> => {
+  let shutdownCallCount = 0;
+  const sdk: TelemetrySdkHandle = {
+    shutdown: async (): Promise<void> => {
+      shutdownCallCount += 1;
+    },
+  };
+  const controller = createController(10_000);
+  const logCapture = captureLogLines();
+
+  try {
+    controller.registerTelemetrySdk(sdk);
+
+    const firstShutdown = controller.shutdownTelemetry();
+    const secondShutdown = controller.shutdownTelemetry();
+    assert.equal(firstShutdown, secondShutdown);
+
+    await Promise.all([firstShutdown, secondShutdown]);
+    await controller.shutdownTelemetry();
+
+    assert.equal(shutdownCallCount, 1);
+    assert.equal(
+      logCapture.lines.filter((line) => line.includes("\"shutdown_completed\"")).length,
+      1,
+    );
+  } finally {
+    logCapture.restore();
+  }
+});
+
+test("shutdownTelemetry is a no-op when no SDK was registered", async (): Promise<void> => {
+  const controller = createController(10_000);
+  const logCapture = captureLogLines();
+
+  try {
+    await controller.shutdownTelemetry();
+
+    assert.deepEqual(logCapture.lines, []);
+  } finally {
+    logCapture.restore();
+  }
+});
+
+test("shutdownTelemetry resolves and logs the underlying failure when the flush rejects", async (): Promise<void> => {
+  const sdk: TelemetrySdkHandle = {
+    shutdown: (): Promise<void> => Promise.reject(new Error("exporter refused the batch")),
+  };
+  const controller = createController(10_000);
+  const logCapture = captureLogLines();
+
+  try {
+    controller.registerTelemetrySdk(sdk);
+
+    await controller.shutdownTelemetry();
+
+    assert.equal(logCapture.lines.length, 1);
+    const event = JSON.parse(logCapture.lines[0]) as Readonly<{
+      domain: string;
+      action: string;
+      error: string;
+    }>;
+    assert.equal(event.domain, "telemetry");
+    assert.equal(event.action, "shutdown_failed");
+    assert.equal(event.error.includes("exporter refused the batch"), true);
+  } finally {
+    logCapture.restore();
+  }
+});
+
+test("shutdownTelemetry logs an explicit error when the flush exceeds the bound", async (): Promise<void> => {
+  const sdk: TelemetrySdkHandle = {
+    shutdown: (): Promise<void> => new Promise<void>((): void => undefined),
+  };
+  const controller = createController(5);
+  const logCapture = captureLogLines();
+
+  try {
+    controller.registerTelemetrySdk(sdk);
+
+    await controller.shutdownTelemetry();
+
+    assert.equal(logCapture.lines.length, 1);
+    const event = JSON.parse(logCapture.lines[0]) as Readonly<{
+      domain: string;
+      action: string;
+      error: string;
+    }>;
+    assert.equal(event.domain, "telemetry");
+    assert.equal(event.action, "shutdown_failed");
+    assert.equal(event.error.includes("exceeded the 5ms bound"), true);
+  } finally {
+    logCapture.restore();
+  }
+});

--- a/apps/web/src/server/telemetry.ts
+++ b/apps/web/src/server/telemetry.ts
@@ -1,0 +1,131 @@
+import { log } from "@/server/logger";
+
+/**
+ * Upper bound on draining telemetry during shutdown. The ECS web task
+ * definition stops containers with stopTimeout 120s, so the flush must finish
+ * well before SIGKILL and must never block shutdown indefinitely.
+ */
+const TELEMETRY_SHUTDOWN_TIMEOUT_MS = 10_000;
+
+/**
+ * Minimal shape of the started OpenTelemetry NodeSDK handle owned by this
+ * module. NodeSDK.shutdown() shuts down the registered span processors, and
+ * LangfuseSpanProcessor.shutdown() flushes queued spans and media uploads
+ * before resolving.
+ */
+export type TelemetrySdkHandle = Readonly<{
+  shutdown: () => Promise<void>;
+}>;
+
+export type TelemetryControllerDependencies = Readonly<{
+  timeoutMs: number;
+  now: () => number;
+}>;
+
+export type TelemetryController = Readonly<{
+  registerTelemetrySdk: (sdk: TelemetrySdkHandle) => void;
+  shutdownTelemetry: () => Promise<void>;
+}>;
+
+type TelemetryShutdownOutcome =
+  | Readonly<{ status: "completed" }>
+  | Readonly<{ status: "failed"; error: unknown }>
+  | Readonly<{ status: "timed_out" }>;
+
+const raceTelemetryShutdown = async (
+  sdk: TelemetrySdkHandle,
+  timeoutMs: number,
+): Promise<TelemetryShutdownOutcome> => {
+  // Settle both branches into outcomes so a late SDK rejection after the
+  // timeout can never surface as an unhandled rejection while the process exits.
+  const shutdownOutcome: Promise<TelemetryShutdownOutcome> = sdk.shutdown().then(
+    (): TelemetryShutdownOutcome => ({ status: "completed" }),
+    (error: unknown): TelemetryShutdownOutcome => ({ status: "failed", error }),
+  );
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const timeoutOutcome = new Promise<TelemetryShutdownOutcome>((resolve): void => {
+    timeoutHandle = setTimeout((): void => {
+      resolve({ status: "timed_out" });
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([shutdownOutcome, timeoutOutcome]);
+  } finally {
+    if (timeoutHandle !== null) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+};
+
+export const createTelemetryControllerWithDeps = (
+  dependencies: TelemetryControllerDependencies,
+): TelemetryController => {
+  let registeredSdk: TelemetrySdkHandle | null = null;
+  let shutdownPromise: Promise<void> | null = null;
+
+  const registerTelemetrySdk = (sdk: TelemetrySdkHandle): void => {
+    if (registeredSdk !== null && registeredSdk !== sdk) {
+      throw new Error(
+        "A different telemetry SDK is already registered; only one NodeSDK instance may own telemetry shutdown",
+      );
+    }
+
+    registeredSdk = sdk;
+  };
+
+  const runShutdown = async (sdk: TelemetrySdkHandle): Promise<void> => {
+    const startedAt = dependencies.now();
+    const outcome = await raceTelemetryShutdown(sdk, dependencies.timeoutMs);
+    const durationMs = dependencies.now() - startedAt;
+
+    if (outcome.status === "completed") {
+      log({
+        domain: "telemetry",
+        action: "shutdown_completed",
+        durationMs,
+      });
+      return;
+    }
+
+    log({
+      domain: "telemetry",
+      action: "shutdown_failed",
+      durationMs,
+      error: outcome.status === "timed_out"
+        ? `Telemetry shutdown exceeded the ${String(dependencies.timeoutMs)}ms bound; queued Langfuse spans were dropped`
+        : `Telemetry shutdown failed: ${outcome.error instanceof Error ? outcome.error.message : String(outcome.error)}`,
+    });
+  };
+
+  const shutdownTelemetry = (): Promise<void> => {
+    const sdk = registeredSdk;
+    if (sdk === null) {
+      return Promise.resolve();
+    }
+
+    if (shutdownPromise === null) {
+      shutdownPromise = runShutdown(sdk);
+    }
+
+    return shutdownPromise;
+  };
+
+  return {
+    registerTelemetrySdk,
+    shutdownTelemetry,
+  };
+};
+
+const sharedTelemetryController = createTelemetryControllerWithDeps({
+  timeoutMs: TELEMETRY_SHUTDOWN_TIMEOUT_MS,
+  now: (): number => Date.now(),
+});
+
+export const registerTelemetrySdk = (sdk: TelemetrySdkHandle): void => {
+  sharedTelemetryController.registerTelemetrySdk(sdk);
+};
+
+export const shutdownTelemetry = async (): Promise<void> =>
+  sharedTelemetryController.shutdownTelemetry();


### PR DESCRIPTION
## Goal

Take the Langfuse OTLP serialization and HTTP export off the chat request path, without losing spans when a container is replaced.

## Change

- `apps/web/src/server/chat/openai/langfuse.ts`: drop `exportMode: "immediate"` so `@langfuse/otel` wraps the OTLP exporter in a `BatchSpanProcessor` instead of a `SimpleSpanProcessor`. Masking and media processing run in `onEnd` regardless of export mode and are unchanged.
- `apps/web/Dockerfile`: set `NEXT_MANUAL_SIG_HANDLE=1` so the Next standalone server stops registering its own SIGTERM/SIGINT handlers. Its cleanup ended in an unconditional `process.exit()`, which killed the process before the batched span queue could flush.
- `apps/web/src/server/shutdownCoordinator.ts`: the application now owns the sequence — mark draining and log synchronously, flush telemetry under a bound, let queued stdout writes settle, then exit with the signal's `128 + signum` exit code so Docker and ECS still observe a signal termination. The exit is unconditional so no failure can keep the container alive until the ECS 120s `stopTimeout`.
- `apps/web/src/server/telemetry.ts`: new module holding the registered `NodeSDK` and the bounded `shutdownTelemetry()` used by the sequence.
- `apps/web/src/instrumentation.ts`: register the coordinator at boot, so a container that never serves a chat request still has a handler.
- `apps/web/src/server/logger.ts`: add the `telemetry` domain events for the shutdown outcomes.
- Tests for the shutdown sequence and the telemetry shutdown bound.

HTTP connection draining and `server.close()` are intentionally not reproduced here; adding an in-flight request wait would change deploy timing beyond the scope of this change.

## Validation

This repository has no PR-triggered CI, so production validation happens after merge: the deploy workflow runs on push to `main`, and the shutdown outcome is confirmed from the `telemetry` log events and Langfuse span completeness on the next container replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)