### PR TITLE
Batch Langfuse span export

### DIFF
--- a/apps/web/src/server/chat/openai/langfuse.ts
+++ b/apps/web/src/server/chat/openai/langfuse.ts
@@ -215,11 +215,20 @@ export const createLangfuseSpanProcessor = (): LangfuseSpanProcessor | null => {
     return null;
   }
 
+  // Batched export (the @langfuse/otel default) moves OTLP serialization and the
+  // export HTTP POST off the chat request path: ended spans wait for the
+  // OpenTelemetry batch processor schedule (5s by default) instead of being
+  // serialized and sent the moment each span ends.
+  // Masking and media processing still run in the processor's `onEnd` for every
+  // span in both export modes, so this option does not reduce the cost of
+  // sanitizing large payloads.
+  // Spans still queued when the task stops are dropped, because nothing flushes
+  // this SDK on exit. That is an accepted trade-off for leaving the Next server's
+  // own shutdown and in-flight request draining untouched, not an oversight.
   return new LangfuseSpanProcessor({
     publicKey,
     secretKey,
     baseUrl,
-    exportMode: "immediate",
     environment: process.env.NODE_ENV,
     release: process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA,
     shouldExportSpan: ({ otelSpan }: Readonly<{ otelSpan: ReadableSpan }>): boolean =>

--- a/docs/langfuse-operations.md
+++ b/docs/langfuse-operations.md
@@ -25,6 +25,17 @@ The web container needs all of these values together:
 
 If only part of the Langfuse config is present, production startup validation fails.
 
+## Export mode
+
+Spans are exported in batches, not one by one:
+
+- the span processor uses the `@langfuse/otel` default `batched` export mode
+- the OpenTelemetry batch processor schedules a flush every 5 seconds by default, so a finished turn can take a few seconds to appear in Langfuse
+- batching keeps OTLP serialization and the export request off the chat request path, so telemetry competes less with request handling for the event loop
+- spans still queued when a web task stops are lost, because nothing flushes the SDK on exit; this is an accepted trade-off, not a misconfiguration
+
+Treat a trace that is missing for only a few seconds after a turn as normal batching latency.
+
 ## What a healthy trace looks like
 
 For every user turn in the web chat, Langfuse should show:
@@ -70,14 +81,16 @@ After deploying or rotating secrets:
 
 1. Open the web chat as a normal user.
 2. Send a plain question that should not use tools.
-3. Confirm a `chat_turn` trace appears in Langfuse with the expected tags and metadata.
+3. Wait a few seconds for the batch export, then confirm a `chat_turn` trace appears in Langfuse with the expected tags and metadata.
 4. Send a question that should trigger `query_database`.
-5. Confirm the same shape appears, now with a nested tool observation.
+5. Confirm the same shape appears after the same batch delay, now with a nested tool observation.
 
 ## What to check when telemetry is missing
 
 If no traces appear at all:
 
+- wait out the batch delay described in `## Export mode` before treating a missing trace as a configuration problem
+- if the web task was replaced or restarted right after the turn, expect the queued spans for that turn to be gone for good
 - confirm the ECS web task has all `LANGFUSE_*` environment values
 - confirm the web service was restarted after writing Secrets Manager values
 - check web container logs for startup validation failures about partial Langfuse configuration


### PR DESCRIPTION
## Goal

Keep Langfuse telemetry off the chat request path. The span processor was configured with the non-default `immediate` export mode, so every ended span was serialized to OTLP and sent over HTTP the moment it ended, inside the request that produced it.

## Change

- `apps/web/src/server/chat/openai/langfuse.ts`: drop the explicit `exportMode: "immediate"` and use the `@langfuse/otel` default `batched` mode, so OTLP serialization and the export POST run on the OpenTelemetry batch schedule instead of the request path. Comments record what batching does and does not buy: masking and media processing still run in `onEnd` for every span in both modes, and spans still queued when the task stops are dropped because nothing flushes the SDK on exit. That drop is an accepted trade-off for leaving the Next server's shutdown and in-flight request draining untouched.
- `docs/langfuse-operations.md`: add an `Export mode` section, and adjust the post-deploy verification steps and the missing-telemetry checklist so the few-second batch delay and the shutdown span loss are expected behaviour rather than suspected misconfiguration.

## Validation

This repository has no PR-triggered CI — GitHub Actions only runs on push to `main`. Production validation therefore happens after merge: send a plain chat turn and a `query_database` turn in the web chat, wait out the batch delay, and confirm the `chat_turn` traces appear in Langfuse with the expected tags, metadata, and nested tool observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)