### PR TITLE
Mark failed chat roots as Langfuse errors

### DIFF
--- a/apps/web/src/server/chat/openai/langfuse.test.ts
+++ b/apps/web/src/server/chat/openai/langfuse.test.ts
@@ -1,12 +1,168 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { sanitizeLangfuseSerializedTelemetry } from "@/server/chat/openai/langfuse";
+import type { LangfuseObservation } from "@langfuse/tracing";
+import {
+  sanitizeLangfuseSerializedTelemetry,
+  startChatTranscriptionObservationWithDeps,
+  startChatTurnObservationWithDeps,
+} from "@/server/chat/openai/langfuse";
 
 const MEDIA_DATA_URI = "data:image/png;base64,1234567890123456";
 const UNPADDED_MEDIA_DATA_URI_MOD_2 = "data:application/octet-stream;base64,12345678901234";
 const UNPADDED_MEDIA_DATA_URI_MOD_3 = "data:application/octet-stream;base64,123456789012345";
 const PADDED_MEDIA_DATA_URI_ONE = "data:application/octet-stream;base64,123456789012345=";
 const PADDED_MEDIA_DATA_URI_TWO = "data:application/octet-stream;base64,12345678901234==";
+const TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+type StartObservationDependencies = Parameters<typeof startChatTurnObservationWithDeps>[2];
+type ObservationUpdate = Parameters<LangfuseObservation["updateOtelSpanAttributes"]>[0];
+
+type RecordingObservation = Readonly<{
+  observation: LangfuseObservation;
+  updates: Array<ObservationUpdate>;
+  getEndCount: () => number;
+}>;
+
+const createRecordingObservation = (): RecordingObservation => {
+  const updates: Array<ObservationUpdate> = [];
+  let endCount = 0;
+  const observation = {
+    updateOtelSpanAttributes: (attributes: ObservationUpdate): void => {
+      updates.push(attributes);
+    },
+    end: (): void => {
+      endCount += 1;
+    },
+  } as LangfuseObservation;
+
+  return {
+    observation,
+    updates,
+    getEndCount: (): number => endCount,
+  };
+};
+
+const createObservationDependencies = (
+  observation: LangfuseObservation,
+): StartObservationDependencies => ({
+  createTraceId: (() => TRACE_ID) as StartObservationDependencies["createTraceId"],
+  propagateAttributes: (async (_attributes, callback): Promise<unknown> =>
+    await callback()) as StartObservationDependencies["propagateAttributes"],
+  startObservation: (() => observation) as StartObservationDependencies["startObservation"],
+});
+
+const CHAT_TURN_PARAMS: Parameters<typeof startChatTurnObservationWithDeps>[0] = {
+  requestId: "request-1",
+  userId: "user-1",
+  workspaceId: "workspace-1",
+  sessionId: "session-1",
+  model: "gpt-5",
+  turnIndex: 1,
+  runState: "running",
+  turnInput: [{ type: "text", text: "Hello" }],
+};
+
+const CHAT_TRANSCRIPTION_PARAMS: Parameters<typeof startChatTranscriptionObservationWithDeps>[0] = {
+  requestId: "request-1",
+  userId: "user-1",
+  workspaceId: "workspace-1",
+  source: "web",
+  fileName: "recording.webm",
+  mediaType: "audio/webm",
+  fileSize: 1024,
+};
+
+test("startChatTurnObservationWithDeps leaves successful roots at the default level", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+
+  await startChatTurnObservationWithDeps(
+    CHAT_TURN_PARAMS,
+    async (rootObservation): Promise<void> => {
+      assert.equal(rootObservation, recording.observation);
+    },
+    createObservationDependencies(recording.observation),
+  );
+
+  assert.deepEqual(recording.updates, [{
+    output: {
+      result: "success",
+    },
+  }]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
+test("startChatTurnObservationWithDeps marks failed roots as errors and rethrows", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const callbackError = new Error("Chat turn failed");
+  const propagatedError = await startChatTurnObservationWithDeps(
+    CHAT_TURN_PARAMS,
+    async (): Promise<void> => {
+      throw callbackError;
+    },
+    createObservationDependencies(recording.observation),
+  ).then(
+    (): null => null,
+    (error: unknown): unknown => error,
+  );
+
+  assert.equal(propagatedError, callbackError);
+  assert.deepEqual(recording.updates, [{
+    level: "ERROR",
+    statusMessage: "Chat turn failed",
+    output: {
+      result: "error",
+      message: "Chat turn failed",
+    },
+  }]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
+test("startChatTranscriptionObservationWithDeps leaves successful roots at the default level", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+
+  const result = await startChatTranscriptionObservationWithDeps(
+    CHAT_TRANSCRIPTION_PARAMS,
+    async (rootObservation): Promise<string> => {
+      assert.equal(rootObservation, recording.observation);
+      return "transcript";
+    },
+    createObservationDependencies(recording.observation),
+  );
+
+  assert.equal(result, "transcript");
+  assert.deepEqual(recording.updates, [{
+    output: {
+      result: "success",
+    },
+  }]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
+test("startChatTranscriptionObservationWithDeps marks failed roots as errors and rethrows", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const callbackError = new Error("Transcription failed");
+  const propagatedError = await startChatTranscriptionObservationWithDeps(
+    CHAT_TRANSCRIPTION_PARAMS,
+    async (): Promise<string> => {
+      throw callbackError;
+    },
+    createObservationDependencies(recording.observation),
+  ).then(
+    (): null => null,
+    (error: unknown): unknown => error,
+  );
+
+  assert.equal(propagatedError, callbackError);
+  assert.deepEqual(recording.updates, [{
+    level: "ERROR",
+    statusMessage: "Transcription failed",
+    output: {
+      result: "error",
+      message: "Transcription failed",
+    },
+  }]);
+  assert.equal(recording.getEndCount(), 1);
+});
 
 test("sanitizeLangfuseSerializedTelemetry masks nested text while preserving media", (): void => {
   const telemetry = {

--- a/apps/web/src/server/chat/openai/langfuse.ts
+++ b/apps/web/src/server/chat/openai/langfuse.ts
@@ -313,6 +313,8 @@ export const startChatTurnObservationWithDeps = async (
         } catch (error) {
           callbackError = error;
           rootObservation.updateOtelSpanAttributes({
+            level: "ERROR",
+            statusMessage: error instanceof Error ? error.message : String(error),
             output: {
               result: "error",
               message: error instanceof Error ? error.message : String(error),
@@ -411,6 +413,8 @@ export const startChatTranscriptionObservationWithDeps = async <TResult>(
         } catch (error) {
           callbackError = error;
           rootObservation.updateOtelSpanAttributes({
+            level: "ERROR",
+            statusMessage: error instanceof Error ? error.message : String(error),
             output: {
               result: "error",
               message: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary
- mark failed chat-turn and transcription root observations as Langfuse errors
- preserve successful default levels and existing root output shapes
- cover both injected wrappers with lifecycle and propagation tests

## Testing
- Not run locally, per integration PR policy