### PR TITLE
Mark failed database tools as Langfuse errors

### DIFF
--- a/apps/web/src/server/chat/openai/loop.test.ts
+++ b/apps/web/src/server/chat/openai/loop.test.ts
@@ -264,7 +264,8 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
       runOneToolCall: async (toolParams): Promise<Readonly<{
         output: string;
         isMutating: boolean;
-        succeeded: boolean;
+        succeeded: true;
+        error: null;
       }>> => {
         executedToolScope = {
           sessionId: toolParams.sessionId,
@@ -274,6 +275,7 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
           output: toolOutput,
           isMutating: false,
           succeeded: true,
+          error: null,
         };
       },
     }),
@@ -362,11 +364,13 @@ test("runOpenAILoop emits a synthetic final delta and returns the summary replay
       runOneToolCall: async ({ item }): Promise<Readonly<{
         output: string;
         isMutating: boolean;
-        succeeded: boolean;
+        succeeded: true;
+        error: null;
       }>> => ({
         output: `{\"tool\":\"${item.call_id}\"}`,
         isMutating: false,
         succeeded: true,
+        error: null,
       }),
     }),
   );

--- a/apps/web/src/server/chat/openai/tooling/toolExecutor.test.ts
+++ b/apps/web/src/server/chat/openai/tooling/toolExecutor.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { LangfuseObservation } from "@langfuse/tracing";
+import { runOneToolCallWithDependencies } from "./toolExecutor";
+import type { ExecutedChatToolCall } from "./tools";
+
+type ToolExecutorParams = Parameters<typeof runOneToolCallWithDependencies>[0];
+type ToolExecutorDependencies = Parameters<typeof runOneToolCallWithDependencies>[1];
+type ObservationUpdate = Parameters<LangfuseObservation["update"]>[0];
+type ObservationOtelUpdate = Parameters<LangfuseObservation["updateOtelSpanAttributes"]>[0];
+type ObservationLifecycleEvent = "attributes" | "update" | "end";
+
+type RecordingObservation = Readonly<{
+  rootObservation: LangfuseObservation;
+  updates: ReadonlyArray<ObservationUpdate>;
+  otelUpdates: ReadonlyArray<ObservationOtelUpdate>;
+  lifecycle: ReadonlyArray<ObservationLifecycleEvent>;
+  getEndCount: () => number;
+}>;
+
+const createRecordingObservation = (): RecordingObservation => {
+  const updates: Array<ObservationUpdate> = [];
+  const otelUpdates: Array<ObservationOtelUpdate> = [];
+  const lifecycle: Array<ObservationLifecycleEvent> = [];
+  let endCount = 0;
+
+  const toolObservation = {
+    update: (attributes: ObservationUpdate): void => {
+      updates.push(attributes);
+      lifecycle.push("update");
+    },
+    updateOtelSpanAttributes: (attributes: ObservationOtelUpdate): void => {
+      otelUpdates.push(attributes);
+      lifecycle.push("attributes");
+    },
+    end: (): void => {
+      endCount += 1;
+      lifecycle.push("end");
+    },
+  } as unknown as LangfuseObservation;
+
+  const rootObservation = {
+    startObservation: (): LangfuseObservation => toolObservation,
+  } as unknown as LangfuseObservation;
+
+  return {
+    rootObservation,
+    updates,
+    otelUpdates,
+    lifecycle,
+    getEndCount: (): number => endCount,
+  };
+};
+
+const createToolExecutorParams = (
+  rootObservation: LangfuseObservation,
+): ToolExecutorParams => ({
+  item: {
+    type: "function_call",
+    id: "tool-item-1",
+    call_id: "tool-call-1",
+    name: "query_database",
+    arguments: JSON.stringify({ sql: "SELECT 1" }),
+    status: "completed",
+  },
+  userId: "user-1",
+  workspaceId: "workspace-1",
+  sessionId: "session-1",
+  turnId: "turn-1",
+  rootObservation,
+});
+
+test("successful tools keep the default observation level and end once", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const toolOutput = "x".repeat(4_001);
+  const expectedResult: ExecutedChatToolCall = {
+    output: toolOutput,
+    isMutating: false,
+    succeeded: true,
+    error: null,
+  };
+  const dependencies: ToolExecutorDependencies = {
+    executeChatToolCall: async (): Promise<ExecutedChatToolCall> => expectedResult,
+  };
+
+  const result = await runOneToolCallWithDependencies(
+    createToolExecutorParams(recording.rootObservation),
+    dependencies,
+  );
+
+  assert.equal(result, expectedResult);
+  assert.deepEqual(recording.updates, []);
+  assert.deepEqual(recording.otelUpdates[0]?.output, {
+    output: `${"x".repeat(4_000)}...`,
+  });
+  assert.deepEqual(recording.lifecycle, ["attributes", "end"]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
+test("returned tool failures set the observation error level and end once", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const error = {
+    name: "DatabaseError",
+    message: "relation accounts does not exist",
+  };
+  const expectedResult: ExecutedChatToolCall = {
+    output: JSON.stringify({
+      ok: false,
+      tool: "query_database",
+      sql: "SELECT 1",
+      error,
+    }),
+    isMutating: false,
+    succeeded: false,
+    error,
+  };
+  const dependencies: ToolExecutorDependencies = {
+    executeChatToolCall: async (): Promise<ExecutedChatToolCall> => expectedResult,
+  };
+
+  const result = await runOneToolCallWithDependencies(
+    createToolExecutorParams(recording.rootObservation),
+    dependencies,
+  );
+
+  assert.equal(result, expectedResult);
+  assert.deepEqual(recording.otelUpdates[0]?.output, {
+    output: expectedResult.output,
+  });
+  assert.deepEqual(recording.updates, [{
+    level: "ERROR",
+    statusMessage: "DatabaseError: relation accounts does not exist",
+  }]);
+  assert.deepEqual(recording.lifecycle, ["attributes", "update", "end"]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
+test("thrown tool failures set the observation error level and rethrow", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const expectedError = new TypeError("database connection closed");
+  const dependencies: ToolExecutorDependencies = {
+    executeChatToolCall: async (): Promise<never> => {
+      throw expectedError;
+    },
+  };
+
+  await assert.rejects(
+    runOneToolCallWithDependencies(
+      createToolExecutorParams(recording.rootObservation),
+      dependencies,
+    ),
+    (error: unknown): boolean => error === expectedError,
+  );
+
+  assert.deepEqual(recording.otelUpdates[0]?.output, {
+    error: "database connection closed",
+  });
+  assert.deepEqual(recording.updates, [{
+    level: "ERROR",
+    statusMessage: "TypeError: database connection closed",
+  }]);
+  assert.deepEqual(recording.lifecycle, ["attributes", "update", "end"]);
+  assert.equal(recording.getEndCount(), 1);
+});

--- a/apps/web/src/server/chat/openai/tooling/toolExecutor.ts
+++ b/apps/web/src/server/chat/openai/tooling/toolExecutor.ts
@@ -2,8 +2,17 @@ import type OpenAI from "openai";
 import type { LangfuseObservation } from "@langfuse/tracing";
 import {
   executeChatToolCall,
+  type ChatToolExecutionError,
   type ExecutedChatToolCall,
 } from "@/server/chat/openai/tooling/tools";
+
+type ToolExecutorDependencies = Readonly<{
+  executeChatToolCall: typeof executeChatToolCall;
+}>;
+
+const DEFAULT_TOOL_EXECUTOR_DEPENDENCIES: ToolExecutorDependencies = {
+  executeChatToolCall,
+};
 
 const sanitizeToolOutputForTelemetry = (
   output: string,
@@ -12,6 +21,22 @@ const sanitizeToolOutputForTelemetry = (
     ? output
     : `${output.slice(0, 4_000)}...`;
 
+const formatToolErrorStatusMessage = (
+  error: ChatToolExecutionError,
+): string => `${error.name}: ${error.message}`;
+
+const serializeThrownToolError = (
+  error: unknown,
+): ChatToolExecutionError => error instanceof Error
+  ? {
+    name: error.name,
+    message: error.message,
+  }
+  : {
+    name: "Error",
+    message: String(error),
+  };
+
 /**
  * Executes a single local tool call and returns both the serialized tool
  * output and the canonical metadata later used for route invalidation.
@@ -19,7 +44,7 @@ const sanitizeToolOutputForTelemetry = (
  * This keeps the refresh contract grounded in the executed SQL/result pair
  * instead of in earlier streamed tool-call snapshots.
  */
-export const runOneToolCall = async (
+export const runOneToolCallWithDependencies = async (
   params: Readonly<{
     item: OpenAI.Responses.ResponseFunctionToolCall;
     userId: string;
@@ -28,6 +53,7 @@ export const runOneToolCall = async (
     turnId: string;
     rootObservation: LangfuseObservation | null;
   }>,
+  dependencies: ToolExecutorDependencies,
 ): Promise<ExecutedChatToolCall> => {
   const toolObservation = params.rootObservation?.startObservation(
     params.item.name,
@@ -47,16 +73,37 @@ export const runOneToolCall = async (
 
   const startedAt = Date.now();
   try {
-    const output = await executeChatToolCall(
-      params.item.name,
-      params.item.arguments,
-      {
-        userId: params.userId,
-        workspaceId: params.workspaceId,
-        sessionId: params.sessionId,
-        turnId: params.turnId,
-      },
-    );
+    let output: ExecutedChatToolCall;
+    try {
+      output = await dependencies.executeChatToolCall(
+        params.item.name,
+        params.item.arguments,
+        {
+          userId: params.userId,
+          workspaceId: params.workspaceId,
+          sessionId: params.sessionId,
+          turnId: params.turnId,
+        },
+      );
+    } catch (error) {
+      const serializedError = serializeThrownToolError(error);
+      toolObservation?.updateOtelSpanAttributes({
+        output: {
+          error: serializedError.message,
+        },
+        metadata: {
+          toolName: params.item.name,
+          toolCallId: params.item.call_id,
+          durationMs: String(Date.now() - startedAt),
+        },
+      });
+      toolObservation?.update({
+        level: "ERROR",
+        statusMessage: formatToolErrorStatusMessage(serializedError),
+      });
+      throw error;
+    }
+
     toolObservation?.updateOtelSpanAttributes({
       output: {
         output: sanitizeToolOutputForTelemetry(output.output),
@@ -67,20 +114,22 @@ export const runOneToolCall = async (
         durationMs: String(Date.now() - startedAt),
       },
     });
-    toolObservation?.end();
+    if (!output.succeeded) {
+      toolObservation?.update({
+        level: "ERROR",
+        statusMessage: formatToolErrorStatusMessage(output.error),
+      });
+    }
     return output;
-  } catch (error) {
-    toolObservation?.updateOtelSpanAttributes({
-      output: {
-        error: error instanceof Error ? error.message : String(error),
-      },
-      metadata: {
-        toolName: params.item.name,
-        toolCallId: params.item.call_id,
-        durationMs: String(Date.now() - startedAt),
-      },
-    });
+  } finally {
     toolObservation?.end();
-    throw error;
   }
 };
+
+export const runOneToolCall = async (
+  params: Parameters<typeof runOneToolCallWithDependencies>[0],
+): Promise<ExecutedChatToolCall> =>
+  runOneToolCallWithDependencies(
+    params,
+    DEFAULT_TOOL_EXECUTOR_DEPENDENCIES,
+  );

--- a/apps/web/src/server/chat/openai/tooling/tools.test.ts
+++ b/apps/web/src/server/chat/openai/tooling/tools.test.ts
@@ -29,6 +29,39 @@ test("query_database forwards the exact session and turn scope to SQL execution"
   );
 
   assert.equal(result.succeeded, true);
+  assert.equal(result.error, null);
   assert.equal(result.isMutating, false);
   assert.deepEqual(receivedContext, context);
+});
+
+test("query_database exposes the same structured error returned to OpenAI", async (): Promise<void> => {
+  const sql = "SELECT account_id FROM missing_accounts";
+  const result = await executeChatToolCallWithDependencies(
+    "query_database",
+    JSON.stringify({ sql }),
+    {
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+    },
+    {
+      execQuery: async (): Promise<never> => {
+        throw new RangeError("relation missing_accounts does not exist");
+      },
+    },
+  );
+
+  assert.equal(result.succeeded, false);
+  assert.equal(result.isMutating, false);
+  assert.deepEqual(result.error, {
+    name: "RangeError",
+    message: "relation missing_accounts does not exist",
+  });
+  assert.deepEqual(JSON.parse(result.output), {
+    ok: false,
+    tool: "query_database",
+    sql,
+    error: result.error,
+  });
 });

--- a/apps/web/src/server/chat/openai/tooling/tools.ts
+++ b/apps/web/src/server/chat/openai/tooling/tools.ts
@@ -20,13 +20,30 @@ const DEFAULT_CHAT_TOOL_DEPENDENCIES: ChatToolDependencies = {
 
 type ToolSuccessPayload = Readonly<Record<string, unknown>>;
 
+export type ChatToolExecutionError = Readonly<{
+  name: string;
+  message: string;
+}>;
+
 type ToolErrorPayload = Readonly<{
   sql: string | null;
-  error: Readonly<{
-    name: string;
-    message: string;
-  }>;
+  error: ChatToolExecutionError;
 }>;
+
+/**
+ * A completed transcript item refreshes route-backed content only when the
+ * execution succeeded and mutated data. Failed executions retain their
+ * structured error separately from the serialized model-facing output.
+ */
+type ExecutedChatToolCallResult =
+  | Readonly<{
+    succeeded: true;
+    error: null;
+  }>
+  | Readonly<{
+    succeeded: false;
+    error: ChatToolExecutionError;
+  }>;
 
 export type ExecutedChatToolCall = Readonly<{
   /**
@@ -40,13 +57,7 @@ export type ExecutedChatToolCall = Readonly<{
    * inferring mutability from earlier streamed tool snapshots.
    */
   isMutating: boolean;
-  /**
-   * Whether the tool execution itself succeeded. A completed transcript item is
-   * not enough to refresh route-backed content; the runtime only invalidates
-   * main content when a completed tool call both succeeded and mutated data.
-   */
-  succeeded: boolean;
-}>;
+}> & ExecutedChatToolCallResult;
 
 type QueryDatabaseToolInput = Readonly<{
   sql?: unknown;
@@ -78,10 +89,7 @@ const createToolErrorResult = (
 
 const serializeToolError = (
   error: unknown,
-): Readonly<{
-  name: string;
-  message: string;
-}> => {
+): ChatToolExecutionError => {
   if (error instanceof Error) {
     return {
       name: error.name,
@@ -177,16 +185,19 @@ export const executeChatToolCallWithDependencies = async (
       }),
       isMutating,
       succeeded: true,
+      error: null,
     };
   } catch (error) {
+    const serializedError = serializeToolError(error);
     const payload: ToolErrorPayload = {
       sql,
-      error: serializeToolError(error),
+      error: serializedError,
     };
     return {
       output: createToolErrorResult("query_database", payload),
       isMutating,
       succeeded: false,
+      error: serializedError,
     };
   }
 };


### PR DESCRIPTION
## Summary
- expose structured database-tool execution failures without reparsing model output
- mark returned and thrown tool failures as first-class Langfuse errors
- preserve successful default levels and exactly-once observation lifecycle

## Validation
- not run locally; integration PRs rely on the later trunk promotion gate