### PR TITLE
Fix restricted SQL token context

### DIFF
--- a/packages/agent-shared/src/sql-policy.test.ts
+++ b/packages/agent-shared/src/sql-policy.test.ts
@@ -18,6 +18,13 @@ const assertFunctionCallRejected = (sql: string): void => {
   );
 };
 
+const assertPolicyError = (sql: string, expectedCode: SqlPolicyError["code"]): void => {
+  assert.throws(
+    () => validateExpenseSql(sql),
+    (error: unknown) => error instanceof SqlPolicyError && error.code === expectedCode,
+  );
+};
+
 test("validateExpenseSql allows allowlisted aggregate functions", (): void => {
   const acceptedSql: ReadonlyArray<string> = [
     "SELECT SUM(amount) AS balance FROM ledger_entries WHERE account_id = 'a-main-usd'",
@@ -59,6 +66,125 @@ test("validateExpenseSql still allows direct relation queries without function c
   const validated = validateExpenseSql("SELECT account_id FROM ledger_entries ORDER BY account_id LIMIT 1");
   assert.equal(validated.statements.length, 1);
   assert.deepEqual(validated.statements[0]?.referencedRelations, ["ledger_entries"]);
+});
+
+test("validateExpenseSql allows grouping and derived subqueries after SQL keywords", (): void => {
+  const acceptedSql: ReadonlyArray<string> = [
+    "SELECT account_id FROM ledger_entries WHERE account_id = 'a-main-usd' AND (kind = 'expense')",
+    "SELECT account_id FROM ledger_entries WHERE (kind = 'expense')",
+    "SELECT account_id FROM ledger_entries WHERE kind = 'expense' OR (kind = 'income')",
+    "SELECT account_id FROM (SELECT account_id FROM ledger_entries) AS entries",
+    "SELECT entries.account_id FROM ledger_entries AS entries JOIN (SELECT account_id FROM accounts) AS account_rows ON entries.account_id = account_rows.account_id",
+  ];
+
+  for (const sql of acceptedSql) {
+    assert.equal(validateExpenseSql(sql).statements.length, 1);
+  }
+});
+
+test("validateExpenseSql inspects functions nested in grouping and derived subqueries", (): void => {
+  const rejectedSql: ReadonlyArray<string> = [
+    "SELECT account_id FROM ledger_entries WHERE account_id = 'a-main-usd' AND (lower(kind) = 'expense')",
+    "SELECT account_id FROM ledger_entries WHERE (lower(kind) = 'expense')",
+    "SELECT account_id FROM ledger_entries WHERE kind = 'expense' OR (lower(kind) = 'income')",
+    "SELECT account_id FROM (SELECT lower(account_id) AS account_id FROM ledger_entries) AS entries",
+    "SELECT entries.account_id FROM ledger_entries AS entries JOIN (SELECT lower(account_id) AS account_id FROM accounts) AS account_rows ON entries.account_id = account_rows.account_id",
+  ];
+
+  for (const sql of rejectedSql) {
+    assertFunctionCallRejected(sql);
+  }
+});
+
+test("validateExpenseSql rejects schema-qualified grammar keywords as function calls", (): void => {
+  const rejectedSql: ReadonlyArray<string> = [
+    "SELECT custom.and(1)",
+    "SELECT custom.or(1)",
+    "SELECT custom.where(1)",
+    "SELECT custom.from(1)",
+    "SELECT custom.join(1)",
+  ];
+
+  for (const sql of rejectedSql) {
+    assertFunctionCallRejected(sql);
+  }
+});
+
+test("validateExpenseSql inspects relations nested in grouping and derived subqueries", (): void => {
+  const rejectedSql: ReadonlyArray<string> = [
+    "SELECT account_id FROM ledger_entries WHERE account_id = 'a-main-usd' AND (EXISTS (SELECT 1 FROM private_accounts))",
+    "SELECT account_id FROM ledger_entries WHERE (EXISTS (SELECT 1 FROM private_accounts))",
+    "SELECT account_id FROM ledger_entries WHERE kind = 'expense' OR (EXISTS (SELECT 1 FROM private_accounts))",
+    "SELECT account_id FROM (SELECT account_id FROM private_accounts) AS entries",
+    "SELECT entries.account_id FROM ledger_entries AS entries JOIN (SELECT account_id FROM private_accounts) AS account_rows ON entries.account_id = account_rows.account_id",
+  ];
+
+  for (const sql of rejectedSql) {
+    assertPolicyError(sql, "relation_not_allowed");
+  }
+});
+
+test("validateExpenseSql rejects parenthesized joined tables", (): void => {
+  const rejectedSql: ReadonlyArray<string> = [
+    "SELECT * FROM (private_accounts JOIN accounts ON true)",
+    "SELECT * FROM accounts JOIN (private_accounts JOIN ledger_entries ON true) ON true",
+  ];
+
+  for (const sql of rejectedSql) {
+    assertFunctionCallRejected(sql);
+  }
+});
+
+test("validateExpenseSql allows comment and quote markers inside string literals", (): void => {
+  const acceptedSql: ReadonlyArray<string> = [
+    "SELECT '\"' AS marker FROM ledger_entries",
+    "SELECT '--' AS marker FROM ledger_entries",
+    "SELECT '/*' AS marker FROM ledger_entries",
+    "SELECT 'customer''s \" -- /*' AS marker FROM ledger_entries",
+    "SELECT 'E''value' AS marker FROM ledger_entries",
+    "SELECT '$5 and $tag$' AS marker FROM ledger_entries",
+  ];
+
+  for (const sql of acceptedSql) {
+    assert.equal(validateExpenseSql(sql).statements.length, 1);
+  }
+});
+
+test("validateExpenseSql rejects syntax markers outside string literals with specific errors", (): void => {
+  assertPolicyError("SELECT \"account_id\" FROM ledger_entries", "quoted_identifiers_not_allowed");
+  assertPolicyError("SELECT account_id FROM ledger_entries -- comment", "sql_comments_not_allowed");
+  assertPolicyError("SELECT /* comment */ account_id FROM ledger_entries", "sql_comments_not_allowed");
+  assertPolicyError("SELECT $tag$value$tag$ FROM ledger_entries", "dollar_quoted_strings_not_allowed");
+  assertPolicyError("SELECT 'unterminated FROM ledger_entries", "unterminated_string_literal");
+});
+
+test("validateExpenseSql rejects dollar signs in unquoted function identifiers", (): void => {
+  assertPolicyError("SELECT evil$and(1)", "dollar_quoted_strings_not_allowed");
+  assertPolicyError("SELECT public.evil$and(1)", "dollar_quoted_strings_not_allowed");
+});
+
+test("validateExpenseSql rejects escape strings before they can conceal restricted syntax", (): void => {
+  const rejectedSql: ReadonlyArray<string> = [
+    "SELECT E'a\\'b' FROM \"ledger_entries\" WHERE 'x' = E'c\\'d'",
+    "SELECT e'a\\'b' /* comment */ FROM ledger_entries WHERE 'x' = e'c\\'d'",
+    "SELECT E'a\\'b' FROM private_accounts WHERE 'x' = E'c\\'d'",
+    "SELECT e'a\\'b', pg_sleep(1), e'c\\'d'",
+  ];
+
+  for (const sql of rejectedSql) {
+    assertPolicyError(sql, "escape_string_literals_not_allowed");
+  }
+});
+
+test("validateExpenseSql allows typed literals with type names ending in e", (): void => {
+  const acceptedSql: ReadonlyArray<string> = [
+    "SELECT DATE'2026-08-09' AS report_date FROM ledger_entries",
+    "SELECT TIME'12:00:00' AS report_time FROM ledger_entries",
+  ];
+
+  for (const sql of acceptedSql) {
+    assert.equal(validateExpenseSql(sql).statements.length, 1);
+  }
 });
 
 test("restricted SQL policy does not expose internal or removed relations", (): void => {

--- a/packages/agent-shared/src/sql-policy.ts
+++ b/packages/agent-shared/src/sql-policy.ts
@@ -40,6 +40,26 @@ const SOURCE_CLAUSE_END: ReadonlySet<string> = new Set([
   "window",
 ]);
 
+const SQL_GRAMMAR_PAREN_KEYWORDS: ReadonlySet<string> = new Set([
+  "and",
+  "or",
+  "where",
+  "in",
+  "exists",
+  "values",
+]);
+
+const SQL_DERIVED_QUERY_PAREN_KEYWORDS: ReadonlySet<string> = new Set([
+  "from",
+  "join",
+]);
+
+const DERIVED_QUERY_FIRST_KEYWORDS: ReadonlySet<string> = new Set([
+  "select",
+  "with",
+  "values",
+]);
+
 const ALLOWED_RELATION_NAMES = [
   "ledger_entries",
   "accounts",
@@ -80,6 +100,7 @@ type SqlPolicyErrorCode =
   | "sql_comments_not_allowed"
   | "quoted_identifiers_not_allowed"
   | "dollar_quoted_strings_not_allowed"
+  | "escape_string_literals_not_allowed"
   | "unterminated_string_literal"
   | "invalid_relation_reference"
   | "relation_not_allowed";
@@ -313,31 +334,42 @@ const containsSetConfig = (sql: string): boolean => /\bset_config\b/iu.test(sql)
 
 const containsOnConflict = (sql: string): boolean => /\bon\s+conflict\b/iu.test(sql);
 
-const assertSupportedSqlSyntax = (sql: string): void => {
-  if (sql.includes("--") || sql.includes("/*")) {
-    fail("sql_comments_not_allowed", "SQL comments are not allowed");
-  }
-  if (sql.includes("\"")) {
-    fail("quoted_identifiers_not_allowed", "Quoted identifiers are not allowed");
-  }
-  if (/\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$/u.test(sql)) {
-    fail("dollar_quoted_strings_not_allowed", "Dollar-quoted strings are not allowed");
-  }
-};
-
-const stripSingleQuotedStrings = (sql: string): string => {
+const sanitizeSqlForTokenization = (sql: string): string => {
   let result = "";
   let inString = false;
 
   for (let i = 0; i < sql.length; i++) {
     const ch = sql[i];
     if (!inString) {
+      const previousCh = sql[i - 1];
+      if (
+        (ch === "E" || ch === "e")
+        && sql[i + 1] === "'"
+        && (previousCh === undefined || !isWordPart(previousCh))
+      ) {
+        fail(
+          "escape_string_literals_not_allowed",
+          "PostgreSQL escape string literals are not allowed",
+        );
+      }
       if (ch === "'") {
         inString = true;
         result += " ";
-      } else {
-        result += ch;
+        continue;
       }
+      if ((ch === "-" && sql[i + 1] === "-") || (ch === "/" && sql[i + 1] === "*")) {
+        fail("sql_comments_not_allowed", "SQL comments are not allowed");
+      }
+      if (ch === "\"") {
+        fail("quoted_identifiers_not_allowed", "Quoted identifiers are not allowed");
+      }
+      if (ch === "$") {
+        fail(
+          "dollar_quoted_strings_not_allowed",
+          "Dollar signs outside regular string literals are not allowed",
+        );
+      }
+      result += ch;
       continue;
     }
 
@@ -700,13 +732,6 @@ const assertOnlyAllowedFunctionCallsInSegment = (
       continue;
     }
 
-    if (token.lower === "in" || token.lower === "exists" || token.lower === "values") {
-      const closeIndex = findMatchingParen(tokens, index + 1, endIndex);
-      assertOnlyAllowedFunctionCallsInSegment(tokens, index + 2, closeIndex);
-      index = closeIndex;
-      continue;
-    }
-
     const previousIndex = findPreviousSignificantIndex(tokens, index - 1);
     const previousToken = previousIndex === null ? undefined : tokens[previousIndex];
     if (
@@ -721,6 +746,19 @@ const assertOnlyAllowedFunctionCallsInSegment = (
 
     if (previousToken?.value === ".") {
       failFunctionCallNotAllowed(token.value);
+    }
+
+    const derivedQueryFirstToken = tokens[index + 2];
+    const startsDerivedQuery = derivedQueryFirstToken !== undefined
+      && DERIVED_QUERY_FIRST_KEYWORDS.has(derivedQueryFirstToken.lower);
+    if (
+      SQL_GRAMMAR_PAREN_KEYWORDS.has(token.lower)
+      || (SQL_DERIVED_QUERY_PAREN_KEYWORDS.has(token.lower) && startsDerivedQuery)
+    ) {
+      const closeIndex = findMatchingParen(tokens, index + 1, endIndex);
+      assertOnlyAllowedFunctionCallsInSegment(tokens, index + 2, closeIndex);
+      index = closeIndex;
+      continue;
     }
 
     if (!ALLOWED_SQL_FUNCTIONS.has(token.lower)) {
@@ -771,8 +809,7 @@ const collectReferencedRelationsFromWithClause = (
 };
 
 const collectReferencedRelations = (sql: string): ReadonlyArray<AllowedRelationName> => {
-  assertSupportedSqlSyntax(sql);
-  const sanitizedSql = stripSingleQuotedStrings(sql);
+  const sanitizedSql = sanitizeSqlForTokenization(sql);
   if (containsOnConflict(sanitizedSql)) {
     fail("on_conflict_not_allowed", "ON CONFLICT is not supported in restricted SQL");
   }
@@ -845,8 +882,7 @@ const validateExpenseSqlStatement = (sql: string): ValidatedExpenseSqlStatement 
     fail("set_config_not_allowed", "set_config() calls are not allowed");
   }
 
-  assertSupportedSqlSyntax(sql);
-  const sanitizedSql = stripSingleQuotedStrings(sql);
+  const sanitizedSql = sanitizeSqlForTokenization(sql);
   if (containsOnConflict(sanitizedSql)) {
     fail("on_conflict_not_allowed", "ON CONFLICT is not supported in restricted SQL");
   }


### PR DESCRIPTION
## Summary
- distinguish grouping and derived-query parentheses from function calls
- make restricted SQL marker checks aware of ordinary string literals
- preserve function and relation restrictions across newly accepted contexts

## Validation
- not run locally per repository workflow