### PR TITLE
Add Langfuse error levels for failed chat operations

### DIFF
--- a/apps/web/src/server/chat/openai/langfuse.test.ts
+++ b/apps/web/src/server/chat/openai/langfuse.test.ts
@@ -16,6 +16,13 @@ const TRACE_ID = "0123456789abcdef0123456789abcdef";
 
 type StartObservationDependencies = Parameters<typeof startChatTurnObservationWithDeps>[2];
 type ObservationUpdate = Parameters<LangfuseObservation["updateOtelSpanAttributes"]>[0];
+type LangfuseLogEvent = Parameters<StartObservationDependencies["log"]>[0];
+type RootTelemetryOperation = "success update" | "error update" | "end";
+
+type ObservationErrors = Readonly<{
+  update: Error | null;
+  end: Error | null;
+}>;
 
 type RecordingObservation = Readonly<{
   observation: LangfuseObservation;
@@ -23,15 +30,23 @@ type RecordingObservation = Readonly<{
   getEndCount: () => number;
 }>;
 
-const createRecordingObservation = (): RecordingObservation => {
+const createObservation = (
+  errors: ObservationErrors,
+): RecordingObservation => {
   const updates: Array<ObservationUpdate> = [];
   let endCount = 0;
   const observation = {
     updateOtelSpanAttributes: (attributes: ObservationUpdate): void => {
       updates.push(attributes);
+      if (errors.update !== null) {
+        throw errors.update;
+      }
     },
     end: (): void => {
       endCount += 1;
+      if (errors.end !== null) {
+        throw errors.end;
+      }
     },
   } as LangfuseObservation;
 
@@ -42,13 +57,52 @@ const createRecordingObservation = (): RecordingObservation => {
   };
 };
 
+const createRecordingObservation = (): RecordingObservation =>
+  createObservation({
+    update: null,
+    end: null,
+  });
+
+const ignoreLog: StartObservationDependencies["log"] = (): void => {};
+
+const createExpectedChatTurnTelemetryLog = (
+  operation: RootTelemetryOperation,
+  error: Error,
+): LangfuseLogEvent => ({
+  domain: "chat",
+  action: "error",
+  vendor: "openai",
+  stage: "agent",
+  error: `Langfuse chat turn ${operation} failed: ${error.message}`,
+  requestId: "request-1",
+  userId: "user-1",
+  workspaceId: "workspace-1",
+  sessionId: "session-1",
+});
+
+const createExpectedTranscriptionTelemetryLog = (
+  operation: RootTelemetryOperation,
+  error: Error,
+): LangfuseLogEvent => ({
+  domain: "chat",
+  action: "error",
+  vendor: "openai",
+  stage: "agent",
+  error: `Langfuse chat transcription ${operation} failed: ${error.message}`,
+  requestId: "request-1",
+  userId: "user-1",
+  workspaceId: "workspace-1",
+});
+
 const createObservationDependencies = (
   observation: LangfuseObservation,
+  logger: StartObservationDependencies["log"],
 ): StartObservationDependencies => ({
   createTraceId: (() => TRACE_ID) as StartObservationDependencies["createTraceId"],
   propagateAttributes: (async (_attributes, callback): Promise<unknown> =>
     await callback()) as StartObservationDependencies["propagateAttributes"],
   startObservation: (() => observation) as StartObservationDependencies["startObservation"],
+  log: logger,
 });
 
 const CHAT_TURN_PARAMS: Parameters<typeof startChatTurnObservationWithDeps>[0] = {
@@ -80,7 +134,7 @@ test("startChatTurnObservationWithDeps leaves successful roots at the default le
     async (rootObservation): Promise<void> => {
       assert.equal(rootObservation, recording.observation);
     },
-    createObservationDependencies(recording.observation),
+    createObservationDependencies(recording.observation, ignoreLog),
   );
 
   assert.deepEqual(recording.updates, [{
@@ -91,15 +145,63 @@ test("startChatTurnObservationWithDeps leaves successful roots at the default le
   assert.equal(recording.getEndCount(), 1);
 });
 
+test("startChatTurnObservationWithDeps preserves success when the success telemetry update throws", async (): Promise<void> => {
+  const updateError = new Error("Langfuse success update failed");
+  const endError = new Error("Langfuse end failed");
+  const recording = createObservation({
+    update: updateError,
+    end: endError,
+  });
+  const logEvents: Array<LangfuseLogEvent> = [];
+  let callbackCount = 0;
+
+  await startChatTurnObservationWithDeps(
+    CHAT_TURN_PARAMS,
+    async (rootObservation): Promise<void> => {
+      callbackCount += 1;
+      assert.equal(rootObservation, recording.observation);
+    },
+    createObservationDependencies(
+      recording.observation,
+      (event): void => {
+        logEvents.push(event);
+      },
+    ),
+  );
+
+  assert.equal(callbackCount, 1);
+  assert.deepEqual(recording.updates, [{
+    output: {
+      result: "success",
+    },
+  }]);
+  assert.equal(recording.getEndCount(), 1);
+  assert.deepEqual(logEvents, [
+    createExpectedChatTurnTelemetryLog("success update", updateError),
+    createExpectedChatTurnTelemetryLog("end", endError),
+  ]);
+});
+
 test("startChatTurnObservationWithDeps marks failed roots as errors and rethrows", async (): Promise<void> => {
-  const recording = createRecordingObservation();
+  const updateError = new Error("Langfuse error update failed");
+  const endError = new Error("Langfuse end failed");
+  const recording = createObservation({
+    update: updateError,
+    end: endError,
+  });
+  const logEvents: Array<LangfuseLogEvent> = [];
   const callbackError = new Error("Chat turn failed");
   const propagatedError = await startChatTurnObservationWithDeps(
     CHAT_TURN_PARAMS,
     async (): Promise<void> => {
       throw callbackError;
     },
-    createObservationDependencies(recording.observation),
+    createObservationDependencies(
+      recording.observation,
+      (event): void => {
+        logEvents.push(event);
+      },
+    ),
   ).then(
     (): null => null,
     (error: unknown): unknown => error,
@@ -115,6 +217,10 @@ test("startChatTurnObservationWithDeps marks failed roots as errors and rethrows
     },
   }]);
   assert.equal(recording.getEndCount(), 1);
+  assert.deepEqual(logEvents, [
+    createExpectedChatTurnTelemetryLog("error update", updateError),
+    createExpectedChatTurnTelemetryLog("end", endError),
+  ]);
 });
 
 test("startChatTranscriptionObservationWithDeps leaves successful roots at the default level", async (): Promise<void> => {
@@ -126,7 +232,7 @@ test("startChatTranscriptionObservationWithDeps leaves successful roots at the d
       assert.equal(rootObservation, recording.observation);
       return "transcript";
     },
-    createObservationDependencies(recording.observation),
+    createObservationDependencies(recording.observation, ignoreLog),
   );
 
   assert.equal(result, "transcript");
@@ -138,15 +244,65 @@ test("startChatTranscriptionObservationWithDeps leaves successful roots at the d
   assert.equal(recording.getEndCount(), 1);
 });
 
+test("startChatTranscriptionObservationWithDeps preserves success when the success telemetry update throws", async (): Promise<void> => {
+  const updateError = new Error("Langfuse transcription success update failed");
+  const endError = new Error("Langfuse transcription end failed");
+  const recording = createObservation({
+    update: updateError,
+    end: endError,
+  });
+  const logEvents: Array<LangfuseLogEvent> = [];
+  let callbackCount = 0;
+
+  const result = await startChatTranscriptionObservationWithDeps(
+    CHAT_TRANSCRIPTION_PARAMS,
+    async (rootObservation): Promise<string> => {
+      callbackCount += 1;
+      assert.equal(rootObservation, recording.observation);
+      return "transcript";
+    },
+    createObservationDependencies(
+      recording.observation,
+      (event): void => {
+        logEvents.push(event);
+      },
+    ),
+  );
+
+  assert.equal(result, "transcript");
+  assert.equal(callbackCount, 1);
+  assert.deepEqual(recording.updates, [{
+    output: {
+      result: "success",
+    },
+  }]);
+  assert.equal(recording.getEndCount(), 1);
+  assert.deepEqual(logEvents, [
+    createExpectedTranscriptionTelemetryLog("success update", updateError),
+    createExpectedTranscriptionTelemetryLog("end", endError),
+  ]);
+});
+
 test("startChatTranscriptionObservationWithDeps marks failed roots as errors and rethrows", async (): Promise<void> => {
-  const recording = createRecordingObservation();
+  const updateError = new Error("Langfuse transcription error update failed");
+  const endError = new Error("Langfuse transcription end failed");
+  const recording = createObservation({
+    update: updateError,
+    end: endError,
+  });
+  const logEvents: Array<LangfuseLogEvent> = [];
   const callbackError = new Error("Transcription failed");
   const propagatedError = await startChatTranscriptionObservationWithDeps(
     CHAT_TRANSCRIPTION_PARAMS,
     async (): Promise<string> => {
       throw callbackError;
     },
-    createObservationDependencies(recording.observation),
+    createObservationDependencies(
+      recording.observation,
+      (event): void => {
+        logEvents.push(event);
+      },
+    ),
   ).then(
     (): null => null,
     (error: unknown): unknown => error,
@@ -162,6 +318,10 @@ test("startChatTranscriptionObservationWithDeps marks failed roots as errors and
     },
   }]);
   assert.equal(recording.getEndCount(), 1);
+  assert.deepEqual(logEvents, [
+    createExpectedTranscriptionTelemetryLog("error update", updateError),
+    createExpectedTranscriptionTelemetryLog("end", endError),
+  ]);
 });
 
 test("sanitizeLangfuseSerializedTelemetry masks nested text while preserving media", (): void => {

--- a/apps/web/src/server/chat/openai/langfuse.test.ts
+++ b/apps/web/src/server/chat/openai/langfuse.test.ts
@@ -1,12 +1,168 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { sanitizeLangfuseSerializedTelemetry } from "@/server/chat/openai/langfuse";
+import type { LangfuseObservation } from "@langfuse/tracing";
+import {
+  sanitizeLangfuseSerializedTelemetry,
+  startChatTranscriptionObservationWithDeps,
+  startChatTurnObservationWithDeps,
+} from "@/server/chat/openai/langfuse";
 
 const MEDIA_DATA_URI = "data:image/png;base64,1234567890123456";
 const UNPADDED_MEDIA_DATA_URI_MOD_2 = "data:application/octet-stream;base64,12345678901234";
 const UNPADDED_MEDIA_DATA_URI_MOD_3 = "data:application/octet-stream;base64,123456789012345";
 const PADDED_MEDIA_DATA_URI_ONE = "data:application/octet-stream;base64,123456789012345=";
 const PADDED_MEDIA_DATA_URI_TWO = "data:application/octet-stream;base64,12345678901234==";
+const TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+type StartObservationDependencies = Parameters<typeof startChatTurnObservationWithDeps>[2];
+type ObservationUpdate = Parameters<LangfuseObservation["updateOtelSpanAttributes"]>[0];
+
+type RecordingObservation = Readonly<{
+  observation: LangfuseObservation;
+  updates: Array<ObservationUpdate>;
+  getEndCount: () => number;
+}>;
+
+const createRecordingObservation = (): RecordingObservation => {
+  const updates: Array<ObservationUpdate> = [];
+  let endCount = 0;
+  const observation = {
+    updateOtelSpanAttributes: (attributes: ObservationUpdate): void => {
+      updates.push(attributes);
+    },
+    end: (): void => {
+      endCount += 1;
+    },
+  } as LangfuseObservation;
+
+  return {
+    observation,
+    updates,
+    getEndCount: (): number => endCount,
+  };
+};
+
+const createObservationDependencies = (
+  observation: LangfuseObservation,
+): StartObservationDependencies => ({
+  createTraceId: (() => TRACE_ID) as StartObservationDependencies["createTraceId"],
+  propagateAttributes: (async (_attributes, callback): Promise<unknown> =>
+    await callback()) as StartObservationDependencies["propagateAttributes"],
+  startObservation: (() => observation) as StartObservationDependencies["startObservation"],
+});
+
+const CHAT_TURN_PARAMS: Parameters<typeof startChatTurnObservationWithDeps>[0] = {
+  requestId: "request-1",
+  userId: "user-1",
+  workspaceId: "workspace-1",
+  sessionId: "session-1",
+  model: "gpt-5",
+  turnIndex: 1,
+  runState: "running",
+  turnInput: [{ type: "text", text: "Hello" }],
+};
+
+const CHAT_TRANSCRIPTION_PARAMS: Parameters<typeof startChatTranscriptionObservationWithDeps>[0] = {
+  requestId: "request-1",
+  userId: "user-1",
+  workspaceId: "workspace-1",
+  source: "web",
+  fileName: "recording.webm",
+  mediaType: "audio/webm",
+  fileSize: 1024,
+};
+
+test("startChatTurnObservationWithDeps leaves successful roots at the default level", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+
+  await startChatTurnObservationWithDeps(
+    CHAT_TURN_PARAMS,
+    async (rootObservation): Promise<void> => {
+      assert.equal(rootObservation, recording.observation);
+    },
+    createObservationDependencies(recording.observation),
+  );
+
+  assert.deepEqual(recording.updates, [{
+    output: {
+      result: "success",
+    },
+  }]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
+test("startChatTurnObservationWithDeps marks failed roots as errors and rethrows", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const callbackError = new Error("Chat turn failed");
+  const propagatedError = await startChatTurnObservationWithDeps(
+    CHAT_TURN_PARAMS,
+    async (): Promise<void> => {
+      throw callbackError;
+    },
+    createObservationDependencies(recording.observation),
+  ).then(
+    (): null => null,
+    (error: unknown): unknown => error,
+  );
+
+  assert.equal(propagatedError, callbackError);
+  assert.deepEqual(recording.updates, [{
+    level: "ERROR",
+    statusMessage: "Chat turn failed",
+    output: {
+      result: "error",
+      message: "Chat turn failed",
+    },
+  }]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
+test("startChatTranscriptionObservationWithDeps leaves successful roots at the default level", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+
+  const result = await startChatTranscriptionObservationWithDeps(
+    CHAT_TRANSCRIPTION_PARAMS,
+    async (rootObservation): Promise<string> => {
+      assert.equal(rootObservation, recording.observation);
+      return "transcript";
+    },
+    createObservationDependencies(recording.observation),
+  );
+
+  assert.equal(result, "transcript");
+  assert.deepEqual(recording.updates, [{
+    output: {
+      result: "success",
+    },
+  }]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
+test("startChatTranscriptionObservationWithDeps marks failed roots as errors and rethrows", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const callbackError = new Error("Transcription failed");
+  const propagatedError = await startChatTranscriptionObservationWithDeps(
+    CHAT_TRANSCRIPTION_PARAMS,
+    async (): Promise<string> => {
+      throw callbackError;
+    },
+    createObservationDependencies(recording.observation),
+  ).then(
+    (): null => null,
+    (error: unknown): unknown => error,
+  );
+
+  assert.equal(propagatedError, callbackError);
+  assert.deepEqual(recording.updates, [{
+    level: "ERROR",
+    statusMessage: "Transcription failed",
+    output: {
+      result: "error",
+      message: "Transcription failed",
+    },
+  }]);
+  assert.equal(recording.getEndCount(), 1);
+});
 
 test("sanitizeLangfuseSerializedTelemetry masks nested text while preserving media", (): void => {
   const telemetry = {

--- a/apps/web/src/server/chat/openai/langfuse.ts
+++ b/apps/web/src/server/chat/openai/langfuse.ts
@@ -45,7 +45,25 @@ type StartObservationDependencies = Readonly<{
   createTraceId: typeof createTraceId;
   propagateAttributes: typeof propagateAttributes;
   startObservation: typeof startObservation;
+  log: typeof log;
 }>;
+
+type RootObservationTelemetryOperation = "success update" | "error update" | "end";
+
+type RootObservationTelemetryContext =
+  | Readonly<{
+    observationName: "chat turn";
+    requestId: string;
+    userId: string;
+    workspaceId: string;
+    sessionId: string;
+  }>
+  | Readonly<{
+    observationName: "chat transcription";
+    requestId: string;
+    userId: string;
+    workspaceId: string;
+  }>;
 
 const MASK_PATTERNS: ReadonlyArray<Readonly<{
   pattern: RegExp;
@@ -242,6 +260,30 @@ const DEFAULT_START_OBSERVATION_DEPENDENCIES: StartObservationDependencies = {
   createTraceId,
   propagateAttributes,
   startObservation,
+  log,
+};
+
+const runRootObservationTelemetryOperation = (
+  context: RootObservationTelemetryContext,
+  operation: RootObservationTelemetryOperation,
+  telemetryOperation: () => void,
+  logger: typeof log,
+): void => {
+  try {
+    telemetryOperation();
+  } catch (error) {
+    logger({
+      domain: "chat",
+      action: "error",
+      vendor: "openai",
+      stage: "agent",
+      error: `Langfuse ${context.observationName} ${operation} failed: ${error instanceof Error ? error.message : String(error)}`,
+      requestId: context.requestId,
+      userId: context.userId,
+      workspaceId: context.workspaceId,
+      ...("sessionId" in context ? { sessionId: context.sessionId } : {}),
+    });
+  }
 };
 
 export const sanitizeChatTranscriptionForTelemetry = (
@@ -275,6 +317,13 @@ export const startChatTurnObservationWithDeps = async (
     spanId: traceId.slice(0, 16),
     traceFlags: 1,
   };
+  const telemetryContext: RootObservationTelemetryContext = {
+    observationName: "chat turn",
+    requestId: params.requestId,
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    sessionId: params.sessionId,
+  };
   let callbackStarted = false;
   let callbackError: unknown | null = null;
 
@@ -304,25 +353,42 @@ export const startChatTurnObservationWithDeps = async (
         );
 
         try {
-          await fn(rootObservation);
-          rootObservation.updateOtelSpanAttributes({
-            output: {
-              result: "success",
-            },
-          });
-        } catch (error) {
-          callbackError = error;
-          rootObservation.updateOtelSpanAttributes({
-            level: "ERROR",
-            statusMessage: error instanceof Error ? error.message : String(error),
-            output: {
-              result: "error",
-              message: error instanceof Error ? error.message : String(error),
-            },
-          });
-          throw error;
+          try {
+            await fn(rootObservation);
+          } catch (error) {
+            callbackError = error;
+            runRootObservationTelemetryOperation(
+              telemetryContext,
+              "error update",
+              (): void => rootObservation.updateOtelSpanAttributes({
+                level: "ERROR",
+                statusMessage: error instanceof Error ? error.message : String(error),
+                output: {
+                  result: "error",
+                  message: error instanceof Error ? error.message : String(error),
+                },
+              }),
+              dependencies.log,
+            );
+            throw error;
+          }
+          runRootObservationTelemetryOperation(
+            telemetryContext,
+            "success update",
+            (): void => rootObservation.updateOtelSpanAttributes({
+              output: {
+                result: "success",
+              },
+            }),
+            dependencies.log,
+          );
         } finally {
-          rootObservation.end();
+          runRootObservationTelemetryOperation(
+            telemetryContext,
+            "end",
+            (): void => rootObservation.end(),
+            dependencies.log,
+          );
         }
       },
     );
@@ -332,22 +398,30 @@ export const startChatTurnObservationWithDeps = async (
     }
 
     if (callbackStarted) {
-      log({
+      dependencies.log({
         domain: "chat",
         action: "error",
         vendor: "openai",
         stage: "agent",
         error: `Langfuse telemetry failed after the chat turn finished: ${error instanceof Error ? error.message : String(error)}`,
+        requestId: params.requestId,
+        userId: params.userId,
+        workspaceId: params.workspaceId,
+        sessionId: params.sessionId,
       });
       return;
     }
 
-    log({
+    dependencies.log({
       domain: "chat",
       action: "error",
       vendor: "openai",
       stage: "agent",
       error: `Langfuse telemetry failed: ${error instanceof Error ? error.message : String(error)}`,
+      requestId: params.requestId,
+      userId: params.userId,
+      workspaceId: params.workspaceId,
+      sessionId: params.sessionId,
     });
     await fn(null);
   }
@@ -373,6 +447,12 @@ export const startChatTranscriptionObservationWithDeps = async <TResult>(
     traceId,
     spanId: traceId.slice(0, 16),
     traceFlags: 1,
+  };
+  const telemetryContext: RootObservationTelemetryContext = {
+    observationName: "chat transcription",
+    requestId: params.requestId,
+    userId: params.userId,
+    workspaceId: params.workspaceId,
   };
   let callbackStarted = false;
   let callbackCompleted = false;
@@ -402,27 +482,44 @@ export const startChatTranscriptionObservationWithDeps = async <TResult>(
         );
 
         try {
-          callbackResult = await fn(rootObservation);
-          callbackCompleted = true;
-          rootObservation.updateOtelSpanAttributes({
-            output: {
-              result: "success",
-            },
-          });
+          try {
+            callbackResult = await fn(rootObservation);
+            callbackCompleted = true;
+          } catch (error) {
+            callbackError = error;
+            runRootObservationTelemetryOperation(
+              telemetryContext,
+              "error update",
+              (): void => rootObservation.updateOtelSpanAttributes({
+                level: "ERROR",
+                statusMessage: error instanceof Error ? error.message : String(error),
+                output: {
+                  result: "error",
+                  message: error instanceof Error ? error.message : String(error),
+                },
+              }),
+              dependencies.log,
+            );
+            throw error;
+          }
+          runRootObservationTelemetryOperation(
+            telemetryContext,
+            "success update",
+            (): void => rootObservation.updateOtelSpanAttributes({
+              output: {
+                result: "success",
+              },
+            }),
+            dependencies.log,
+          );
           return callbackResult;
-        } catch (error) {
-          callbackError = error;
-          rootObservation.updateOtelSpanAttributes({
-            level: "ERROR",
-            statusMessage: error instanceof Error ? error.message : String(error),
-            output: {
-              result: "error",
-              message: error instanceof Error ? error.message : String(error),
-            },
-          });
-          throw error;
         } finally {
-          rootObservation.end();
+          runRootObservationTelemetryOperation(
+            telemetryContext,
+            "end",
+            (): void => rootObservation.end(),
+            dependencies.log,
+          );
         }
       },
     );
@@ -436,12 +533,14 @@ export const startChatTranscriptionObservationWithDeps = async <TResult>(
     }
 
     if (callbackStarted && callbackCompleted) {
-      log({
+      dependencies.log({
         domain: "chat",
         action: "error",
         vendor: "openai",
         stage: "agent",
         requestId: params.requestId,
+        userId: params.userId,
+        workspaceId: params.workspaceId,
         error: `Langfuse telemetry failed after the chat transcription finished: ${error instanceof Error ? error.message : String(error)}`,
       });
       if (!callbackCompleted) {
@@ -450,12 +549,14 @@ export const startChatTranscriptionObservationWithDeps = async <TResult>(
       return callbackResult as TResult;
     }
 
-    log({
+    dependencies.log({
       domain: "chat",
       action: "error",
       vendor: "openai",
       stage: "agent",
       requestId: params.requestId,
+      userId: params.userId,
+      workspaceId: params.workspaceId,
       error: `Langfuse telemetry failed: ${error instanceof Error ? error.message : String(error)}`,
     });
     return await fn(null);

--- a/apps/web/src/server/chat/openai/langfuse.ts
+++ b/apps/web/src/server/chat/openai/langfuse.ts
@@ -313,6 +313,8 @@ export const startChatTurnObservationWithDeps = async (
         } catch (error) {
           callbackError = error;
           rootObservation.updateOtelSpanAttributes({
+            level: "ERROR",
+            statusMessage: error instanceof Error ? error.message : String(error),
             output: {
               result: "error",
               message: error instanceof Error ? error.message : String(error),
@@ -411,6 +413,8 @@ export const startChatTranscriptionObservationWithDeps = async <TResult>(
         } catch (error) {
           callbackError = error;
           rootObservation.updateOtelSpanAttributes({
+            level: "ERROR",
+            statusMessage: error instanceof Error ? error.message : String(error),
             output: {
               result: "error",
               message: error instanceof Error ? error.message : String(error),

--- a/apps/web/src/server/chat/openai/loop.test.ts
+++ b/apps/web/src/server/chat/openai/loop.test.ts
@@ -264,7 +264,8 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
       runOneToolCall: async (toolParams): Promise<Readonly<{
         output: string;
         isMutating: boolean;
-        succeeded: boolean;
+        succeeded: true;
+        error: null;
       }>> => {
         executedToolScope = {
           sessionId: toolParams.sessionId,
@@ -274,6 +275,7 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
           output: toolOutput,
           isMutating: false,
           succeeded: true,
+          error: null,
         };
       },
     }),
@@ -362,11 +364,13 @@ test("runOpenAILoop emits a synthetic final delta and returns the summary replay
       runOneToolCall: async ({ item }): Promise<Readonly<{
         output: string;
         isMutating: boolean;
-        succeeded: boolean;
+        succeeded: true;
+        error: null;
       }>> => ({
         output: `{\"tool\":\"${item.call_id}\"}`,
         isMutating: false,
         succeeded: true,
+        error: null,
       }),
     }),
   );

--- a/apps/web/src/server/chat/openai/loop.test.ts
+++ b/apps/web/src/server/chat/openai/loop.test.ts
@@ -225,6 +225,7 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
   let modelCallCount = 0;
   const openAIRequests: Array<OpenAIResponsesRequest> = [];
   let executedToolScope: Readonly<{
+    requestId: string;
     sessionId: string;
     turnId: string;
   }> | null = null;
@@ -268,6 +269,7 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
         error: null;
       }>> => {
         executedToolScope = {
+          requestId: toolParams.requestId,
           sessionId: toolParams.sessionId,
           turnId: toolParams.turnId,
         };
@@ -283,6 +285,7 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
 
   assert.equal(modelCallCount, 2);
   assert.deepEqual(executedToolScope, {
+    requestId: params.requestId,
     sessionId: params.sessionId,
     turnId: params.turnId,
   });

--- a/apps/web/src/server/chat/openai/loop.ts
+++ b/apps/web/src/server/chat/openai/loop.ts
@@ -412,6 +412,7 @@ const runLoopWithDeps = async (
     for (const functionCall of modelCall.functionCalls) {
       const output = await dependencies.runOneToolCall({
         item: functionCall,
+        requestId: params.requestId,
         userId: params.userId,
         workspaceId: params.workspaceId,
         sessionId: params.sessionId,

--- a/apps/web/src/server/chat/openai/tooling/toolExecutor.test.ts
+++ b/apps/web/src/server/chat/openai/tooling/toolExecutor.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { LangfuseObservation } from "@langfuse/tracing";
+import { runOneToolCallWithDependencies } from "./toolExecutor";
+import type { ExecutedChatToolCall } from "./tools";
+
+type ToolExecutorParams = Parameters<typeof runOneToolCallWithDependencies>[0];
+type ToolExecutorDependencies = Parameters<typeof runOneToolCallWithDependencies>[1];
+type ObservationUpdate = Parameters<LangfuseObservation["update"]>[0];
+type ObservationOtelUpdate = Parameters<LangfuseObservation["updateOtelSpanAttributes"]>[0];
+type ObservationLifecycleEvent = "attributes" | "update" | "end";
+
+type RecordingObservation = Readonly<{
+  rootObservation: LangfuseObservation;
+  updates: ReadonlyArray<ObservationUpdate>;
+  otelUpdates: ReadonlyArray<ObservationOtelUpdate>;
+  lifecycle: ReadonlyArray<ObservationLifecycleEvent>;
+  getEndCount: () => number;
+}>;
+
+const createRecordingObservation = (): RecordingObservation => {
+  const updates: Array<ObservationUpdate> = [];
+  const otelUpdates: Array<ObservationOtelUpdate> = [];
+  const lifecycle: Array<ObservationLifecycleEvent> = [];
+  let endCount = 0;
+
+  const toolObservation = {
+    update: (attributes: ObservationUpdate): void => {
+      updates.push(attributes);
+      lifecycle.push("update");
+    },
+    updateOtelSpanAttributes: (attributes: ObservationOtelUpdate): void => {
+      otelUpdates.push(attributes);
+      lifecycle.push("attributes");
+    },
+    end: (): void => {
+      endCount += 1;
+      lifecycle.push("end");
+    },
+  } as unknown as LangfuseObservation;
+
+  const rootObservation = {
+    startObservation: (): LangfuseObservation => toolObservation,
+  } as unknown as LangfuseObservation;
+
+  return {
+    rootObservation,
+    updates,
+    otelUpdates,
+    lifecycle,
+    getEndCount: (): number => endCount,
+  };
+};
+
+const createToolExecutorParams = (
+  rootObservation: LangfuseObservation,
+): ToolExecutorParams => ({
+  item: {
+    type: "function_call",
+    id: "tool-item-1",
+    call_id: "tool-call-1",
+    name: "query_database",
+    arguments: JSON.stringify({ sql: "SELECT 1" }),
+    status: "completed",
+  },
+  userId: "user-1",
+  workspaceId: "workspace-1",
+  sessionId: "session-1",
+  turnId: "turn-1",
+  rootObservation,
+});
+
+test("successful tools keep the default observation level and end once", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const toolOutput = "x".repeat(4_001);
+  const expectedResult: ExecutedChatToolCall = {
+    output: toolOutput,
+    isMutating: false,
+    succeeded: true,
+    error: null,
+  };
+  const dependencies: ToolExecutorDependencies = {
+    executeChatToolCall: async (): Promise<ExecutedChatToolCall> => expectedResult,
+  };
+
+  const result = await runOneToolCallWithDependencies(
+    createToolExecutorParams(recording.rootObservation),
+    dependencies,
+  );
+
+  assert.equal(result, expectedResult);
+  assert.deepEqual(recording.updates, []);
+  assert.deepEqual(recording.otelUpdates[0]?.output, {
+    output: `${"x".repeat(4_000)}...`,
+  });
+  assert.deepEqual(recording.lifecycle, ["attributes", "end"]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
+test("returned tool failures set the observation error level and end once", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const error = {
+    name: "DatabaseError",
+    message: "relation accounts does not exist",
+  };
+  const expectedResult: ExecutedChatToolCall = {
+    output: JSON.stringify({
+      ok: false,
+      tool: "query_database",
+      sql: "SELECT 1",
+      error,
+    }),
+    isMutating: false,
+    succeeded: false,
+    error,
+  };
+  const dependencies: ToolExecutorDependencies = {
+    executeChatToolCall: async (): Promise<ExecutedChatToolCall> => expectedResult,
+  };
+
+  const result = await runOneToolCallWithDependencies(
+    createToolExecutorParams(recording.rootObservation),
+    dependencies,
+  );
+
+  assert.equal(result, expectedResult);
+  assert.deepEqual(recording.otelUpdates[0]?.output, {
+    output: expectedResult.output,
+  });
+  assert.deepEqual(recording.updates, [{
+    level: "ERROR",
+    statusMessage: "DatabaseError: relation accounts does not exist",
+  }]);
+  assert.deepEqual(recording.lifecycle, ["attributes", "update", "end"]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
+test("thrown tool failures set the observation error level and rethrow", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const expectedError = new TypeError("database connection closed");
+  const dependencies: ToolExecutorDependencies = {
+    executeChatToolCall: async (): Promise<never> => {
+      throw expectedError;
+    },
+  };
+
+  await assert.rejects(
+    runOneToolCallWithDependencies(
+      createToolExecutorParams(recording.rootObservation),
+      dependencies,
+    ),
+    (error: unknown): boolean => error === expectedError,
+  );
+
+  assert.deepEqual(recording.otelUpdates[0]?.output, {
+    error: "database connection closed",
+  });
+  assert.deepEqual(recording.updates, [{
+    level: "ERROR",
+    statusMessage: "TypeError: database connection closed",
+  }]);
+  assert.deepEqual(recording.lifecycle, ["attributes", "update", "end"]);
+  assert.equal(recording.getEndCount(), 1);
+});

--- a/apps/web/src/server/chat/openai/tooling/toolExecutor.test.ts
+++ b/apps/web/src/server/chat/openai/tooling/toolExecutor.test.ts
@@ -9,6 +9,13 @@ type ToolExecutorDependencies = Parameters<typeof runOneToolCallWithDependencies
 type ObservationUpdate = Parameters<LangfuseObservation["update"]>[0];
 type ObservationOtelUpdate = Parameters<LangfuseObservation["updateOtelSpanAttributes"]>[0];
 type ObservationLifecycleEvent = "attributes" | "update" | "end";
+type ToolExecutorLogEvent = Parameters<ToolExecutorDependencies["log"]>[0];
+
+type ObservationErrors = Readonly<{
+  update: Error | null;
+  updateOtelSpanAttributes: Error | null;
+  end: Error | null;
+}>;
 
 type RecordingObservation = Readonly<{
   rootObservation: LangfuseObservation;
@@ -18,7 +25,9 @@ type RecordingObservation = Readonly<{
   getEndCount: () => number;
 }>;
 
-const createRecordingObservation = (): RecordingObservation => {
+const createObservation = (
+  errors: ObservationErrors,
+): RecordingObservation => {
   const updates: Array<ObservationUpdate> = [];
   const otelUpdates: Array<ObservationOtelUpdate> = [];
   const lifecycle: Array<ObservationLifecycleEvent> = [];
@@ -28,14 +37,23 @@ const createRecordingObservation = (): RecordingObservation => {
     update: (attributes: ObservationUpdate): void => {
       updates.push(attributes);
       lifecycle.push("update");
+      if (errors.update !== null) {
+        throw errors.update;
+      }
     },
     updateOtelSpanAttributes: (attributes: ObservationOtelUpdate): void => {
       otelUpdates.push(attributes);
       lifecycle.push("attributes");
+      if (errors.updateOtelSpanAttributes !== null) {
+        throw errors.updateOtelSpanAttributes;
+      }
     },
     end: (): void => {
       endCount += 1;
       lifecycle.push("end");
+      if (errors.end !== null) {
+        throw errors.end;
+      }
     },
   } as unknown as LangfuseObservation;
 
@@ -52,6 +70,15 @@ const createRecordingObservation = (): RecordingObservation => {
   };
 };
 
+const createRecordingObservation = (): RecordingObservation =>
+  createObservation({
+    update: null,
+    updateOtelSpanAttributes: null,
+    end: null,
+  });
+
+const ignoreLog: ToolExecutorDependencies["log"] = (): void => {};
+
 const createToolExecutorParams = (
   rootObservation: LangfuseObservation,
 ): ToolExecutorParams => ({
@@ -63,6 +90,7 @@ const createToolExecutorParams = (
     arguments: JSON.stringify({ sql: "SELECT 1" }),
     status: "completed",
   },
+  requestId: "request-1",
   userId: "user-1",
   workspaceId: "workspace-1",
   sessionId: "session-1",
@@ -81,6 +109,7 @@ test("successful tools keep the default observation level and end once", async (
   };
   const dependencies: ToolExecutorDependencies = {
     executeChatToolCall: async (): Promise<ExecutedChatToolCall> => expectedResult,
+    log: ignoreLog,
   };
 
   const result = await runOneToolCallWithDependencies(
@@ -116,6 +145,7 @@ test("returned tool failures set the observation error level and end once", asyn
   };
   const dependencies: ToolExecutorDependencies = {
     executeChatToolCall: async (): Promise<ExecutedChatToolCall> => expectedResult,
+    log: ignoreLog,
   };
 
   const result = await runOneToolCallWithDependencies(
@@ -142,6 +172,7 @@ test("thrown tool failures set the observation error level and rethrow", async (
     executeChatToolCall: async (): Promise<never> => {
       throw expectedError;
     },
+    log: ignoreLog,
   };
 
   await assert.rejects(
@@ -161,4 +192,117 @@ test("thrown tool failures set the observation error level and rethrow", async (
   }]);
   assert.deepEqual(recording.lifecycle, ["attributes", "update", "end"]);
   assert.equal(recording.getEndCount(), 1);
+});
+
+test("returned tool failures survive all observation update and end failures", async (): Promise<void> => {
+  const attributesError = new Error("Langfuse attributes failed");
+  const updateError = new Error("Langfuse update failed");
+  const endError = new Error("Langfuse end failed");
+  const recording = createObservation({
+    update: updateError,
+    updateOtelSpanAttributes: attributesError,
+    end: endError,
+  });
+  const expectedResult: ExecutedChatToolCall = {
+    output: JSON.stringify({ ok: false }),
+    isMutating: false,
+    succeeded: false,
+    error: {
+      name: "DatabaseError",
+      message: "query failed",
+    },
+  };
+  const logEvents: Array<ToolExecutorLogEvent> = [];
+  const dependencies: ToolExecutorDependencies = {
+    executeChatToolCall: async (): Promise<ExecutedChatToolCall> => expectedResult,
+    log: (event): void => {
+      logEvents.push(event);
+    },
+  };
+
+  const result = await runOneToolCallWithDependencies(
+    createToolExecutorParams(recording.rootObservation),
+    dependencies,
+  );
+
+  assert.equal(result, expectedResult);
+  assert.deepEqual(recording.lifecycle, ["attributes", "update", "end"]);
+  assert.deepEqual(logEvents, [
+    {
+      domain: "chat",
+      action: "error",
+      vendor: "openai",
+      stage: "agent",
+      error: `Langfuse tool observation update_attributes failed for query_database (tool-call-1): ${attributesError.message}`,
+      requestId: "request-1",
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+    },
+    {
+      domain: "chat",
+      action: "error",
+      vendor: "openai",
+      stage: "agent",
+      error: `Langfuse tool observation update failed for query_database (tool-call-1): ${updateError.message}`,
+      requestId: "request-1",
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+    },
+    {
+      domain: "chat",
+      action: "error",
+      vendor: "openai",
+      stage: "agent",
+      error: `Langfuse tool observation end failed for query_database (tool-call-1): ${endError.message}`,
+      requestId: "request-1",
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+    },
+  ]);
+});
+
+test("thrown tool failures survive all observation update and end failures", async (): Promise<void> => {
+  const attributesError = new Error("Langfuse attributes failed");
+  const updateError = new Error("Langfuse update failed");
+  const endError = new Error("Langfuse end failed");
+  const recording = createObservation({
+    update: updateError,
+    updateOtelSpanAttributes: attributesError,
+    end: endError,
+  });
+  const expectedError = new TypeError("database connection closed");
+  const logEvents: Array<ToolExecutorLogEvent> = [];
+  const dependencies: ToolExecutorDependencies = {
+    executeChatToolCall: async (): Promise<never> => {
+      throw expectedError;
+    },
+    log: (event): void => {
+      logEvents.push(event);
+    },
+  };
+
+  await assert.rejects(
+    runOneToolCallWithDependencies(
+      createToolExecutorParams(recording.rootObservation),
+      dependencies,
+    ),
+    (error: unknown): boolean => error === expectedError,
+  );
+
+  assert.deepEqual(recording.lifecycle, ["attributes", "update", "end"]);
+  assert.deepEqual(
+    logEvents.map((event): string | null => "requestId" in event ? event.requestId ?? null : null),
+    ["request-1", "request-1", "request-1"],
+  );
+  assert.deepEqual(
+    logEvents.map((event): string | null => "error" in event ? event.error : null),
+    [
+      `Langfuse tool observation update_attributes failed for query_database (tool-call-1): ${attributesError.message}`,
+      `Langfuse tool observation update failed for query_database (tool-call-1): ${updateError.message}`,
+      `Langfuse tool observation end failed for query_database (tool-call-1): ${endError.message}`,
+    ],
+  );
 });

--- a/apps/web/src/server/chat/openai/tooling/toolExecutor.ts
+++ b/apps/web/src/server/chat/openai/tooling/toolExecutor.ts
@@ -2,8 +2,17 @@ import type OpenAI from "openai";
 import type { LangfuseObservation } from "@langfuse/tracing";
 import {
   executeChatToolCall,
+  type ChatToolExecutionError,
   type ExecutedChatToolCall,
 } from "@/server/chat/openai/tooling/tools";
+
+type ToolExecutorDependencies = Readonly<{
+  executeChatToolCall: typeof executeChatToolCall;
+}>;
+
+const DEFAULT_TOOL_EXECUTOR_DEPENDENCIES: ToolExecutorDependencies = {
+  executeChatToolCall,
+};
 
 const sanitizeToolOutputForTelemetry = (
   output: string,
@@ -12,6 +21,22 @@ const sanitizeToolOutputForTelemetry = (
     ? output
     : `${output.slice(0, 4_000)}...`;
 
+const formatToolErrorStatusMessage = (
+  error: ChatToolExecutionError,
+): string => `${error.name}: ${error.message}`;
+
+const serializeThrownToolError = (
+  error: unknown,
+): ChatToolExecutionError => error instanceof Error
+  ? {
+    name: error.name,
+    message: error.message,
+  }
+  : {
+    name: "Error",
+    message: String(error),
+  };
+
 /**
  * Executes a single local tool call and returns both the serialized tool
  * output and the canonical metadata later used for route invalidation.
@@ -19,7 +44,7 @@ const sanitizeToolOutputForTelemetry = (
  * This keeps the refresh contract grounded in the executed SQL/result pair
  * instead of in earlier streamed tool-call snapshots.
  */
-export const runOneToolCall = async (
+export const runOneToolCallWithDependencies = async (
   params: Readonly<{
     item: OpenAI.Responses.ResponseFunctionToolCall;
     userId: string;
@@ -28,6 +53,7 @@ export const runOneToolCall = async (
     turnId: string;
     rootObservation: LangfuseObservation | null;
   }>,
+  dependencies: ToolExecutorDependencies,
 ): Promise<ExecutedChatToolCall> => {
   const toolObservation = params.rootObservation?.startObservation(
     params.item.name,
@@ -47,16 +73,37 @@ export const runOneToolCall = async (
 
   const startedAt = Date.now();
   try {
-    const output = await executeChatToolCall(
-      params.item.name,
-      params.item.arguments,
-      {
-        userId: params.userId,
-        workspaceId: params.workspaceId,
-        sessionId: params.sessionId,
-        turnId: params.turnId,
-      },
-    );
+    let output: ExecutedChatToolCall;
+    try {
+      output = await dependencies.executeChatToolCall(
+        params.item.name,
+        params.item.arguments,
+        {
+          userId: params.userId,
+          workspaceId: params.workspaceId,
+          sessionId: params.sessionId,
+          turnId: params.turnId,
+        },
+      );
+    } catch (error) {
+      const serializedError = serializeThrownToolError(error);
+      toolObservation?.updateOtelSpanAttributes({
+        output: {
+          error: serializedError.message,
+        },
+        metadata: {
+          toolName: params.item.name,
+          toolCallId: params.item.call_id,
+          durationMs: String(Date.now() - startedAt),
+        },
+      });
+      toolObservation?.update({
+        level: "ERROR",
+        statusMessage: formatToolErrorStatusMessage(serializedError),
+      });
+      throw error;
+    }
+
     toolObservation?.updateOtelSpanAttributes({
       output: {
         output: sanitizeToolOutputForTelemetry(output.output),
@@ -67,20 +114,22 @@ export const runOneToolCall = async (
         durationMs: String(Date.now() - startedAt),
       },
     });
-    toolObservation?.end();
+    if (!output.succeeded) {
+      toolObservation?.update({
+        level: "ERROR",
+        statusMessage: formatToolErrorStatusMessage(output.error),
+      });
+    }
     return output;
-  } catch (error) {
-    toolObservation?.updateOtelSpanAttributes({
-      output: {
-        error: error instanceof Error ? error.message : String(error),
-      },
-      metadata: {
-        toolName: params.item.name,
-        toolCallId: params.item.call_id,
-        durationMs: String(Date.now() - startedAt),
-      },
-    });
+  } finally {
     toolObservation?.end();
-    throw error;
   }
 };
+
+export const runOneToolCall = async (
+  params: Parameters<typeof runOneToolCallWithDependencies>[0],
+): Promise<ExecutedChatToolCall> =>
+  runOneToolCallWithDependencies(
+    params,
+    DEFAULT_TOOL_EXECUTOR_DEPENDENCIES,
+  );

--- a/apps/web/src/server/chat/openai/tooling/toolExecutor.ts
+++ b/apps/web/src/server/chat/openai/tooling/toolExecutor.ts
@@ -5,13 +5,28 @@ import {
   type ChatToolExecutionError,
   type ExecutedChatToolCall,
 } from "@/server/chat/openai/tooling/tools";
+import { log } from "@/server/logger";
+
+type ToolExecutorParams = Readonly<{
+  item: OpenAI.Responses.ResponseFunctionToolCall;
+  requestId: string;
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+  turnId: string;
+  rootObservation: LangfuseObservation | null;
+}>;
+
+type ToolTelemetryOperation = "update_attributes" | "update" | "end";
 
 type ToolExecutorDependencies = Readonly<{
   executeChatToolCall: typeof executeChatToolCall;
+  log: typeof log;
 }>;
 
 const DEFAULT_TOOL_EXECUTOR_DEPENDENCIES: ToolExecutorDependencies = {
   executeChatToolCall,
+  log,
 };
 
 const sanitizeToolOutputForTelemetry = (
@@ -37,6 +52,38 @@ const serializeThrownToolError = (
     message: String(error),
   };
 
+const logToolTelemetryError = (
+  params: ToolExecutorParams,
+  operation: ToolTelemetryOperation,
+  error: unknown,
+  logger: typeof log,
+): void => {
+  logger({
+    domain: "chat",
+    action: "error",
+    vendor: "openai",
+    stage: "agent",
+    error: `Langfuse tool observation ${operation} failed for ${params.item.name} (${params.item.call_id}): ${error instanceof Error ? error.message : String(error)}`,
+    requestId: params.requestId,
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    sessionId: params.sessionId,
+  });
+};
+
+const runToolTelemetryOperation = (
+  params: ToolExecutorParams,
+  operation: ToolTelemetryOperation,
+  telemetryOperation: () => void,
+  logger: typeof log,
+): void => {
+  try {
+    telemetryOperation();
+  } catch (error) {
+    logToolTelemetryError(params, operation, error, logger);
+  }
+};
+
 /**
  * Executes a single local tool call and returns both the serialized tool
  * output and the canonical metadata later used for route invalidation.
@@ -45,14 +92,7 @@ const serializeThrownToolError = (
  * instead of in earlier streamed tool-call snapshots.
  */
 export const runOneToolCallWithDependencies = async (
-  params: Readonly<{
-    item: OpenAI.Responses.ResponseFunctionToolCall;
-    userId: string;
-    workspaceId: string;
-    sessionId: string;
-    turnId: string;
-    rootObservation: LangfuseObservation | null;
-  }>,
+  params: ToolExecutorParams,
   dependencies: ToolExecutorDependencies,
 ): Promise<ExecutedChatToolCall> => {
   const toolObservation = params.rootObservation?.startObservation(
@@ -87,42 +127,67 @@ export const runOneToolCallWithDependencies = async (
       );
     } catch (error) {
       const serializedError = serializeThrownToolError(error);
-      toolObservation?.updateOtelSpanAttributes({
+      runToolTelemetryOperation(
+        params,
+        "update_attributes",
+        (): void => toolObservation?.updateOtelSpanAttributes({
+          output: {
+            error: serializedError.message,
+          },
+          metadata: {
+            toolName: params.item.name,
+            toolCallId: params.item.call_id,
+            durationMs: String(Date.now() - startedAt),
+          },
+        }),
+        dependencies.log,
+      );
+      runToolTelemetryOperation(
+        params,
+        "update",
+        (): void => toolObservation?.update({
+          level: "ERROR",
+          statusMessage: formatToolErrorStatusMessage(serializedError),
+        }),
+        dependencies.log,
+      );
+      throw error;
+    }
+
+    runToolTelemetryOperation(
+      params,
+      "update_attributes",
+      (): void => toolObservation?.updateOtelSpanAttributes({
         output: {
-          error: serializedError.message,
+          output: sanitizeToolOutputForTelemetry(output.output),
         },
         metadata: {
           toolName: params.item.name,
           toolCallId: params.item.call_id,
           durationMs: String(Date.now() - startedAt),
         },
-      });
-      toolObservation?.update({
-        level: "ERROR",
-        statusMessage: formatToolErrorStatusMessage(serializedError),
-      });
-      throw error;
-    }
-
-    toolObservation?.updateOtelSpanAttributes({
-      output: {
-        output: sanitizeToolOutputForTelemetry(output.output),
-      },
-      metadata: {
-        toolName: params.item.name,
-        toolCallId: params.item.call_id,
-        durationMs: String(Date.now() - startedAt),
-      },
-    });
+      }),
+      dependencies.log,
+    );
     if (!output.succeeded) {
-      toolObservation?.update({
-        level: "ERROR",
-        statusMessage: formatToolErrorStatusMessage(output.error),
-      });
+      runToolTelemetryOperation(
+        params,
+        "update",
+        (): void => toolObservation?.update({
+          level: "ERROR",
+          statusMessage: formatToolErrorStatusMessage(output.error),
+        }),
+        dependencies.log,
+      );
     }
     return output;
   } finally {
-    toolObservation?.end();
+    runToolTelemetryOperation(
+      params,
+      "end",
+      (): void => toolObservation?.end(),
+      dependencies.log,
+    );
   }
 };
 

--- a/apps/web/src/server/chat/openai/tooling/tools.test.ts
+++ b/apps/web/src/server/chat/openai/tooling/tools.test.ts
@@ -29,6 +29,39 @@ test("query_database forwards the exact session and turn scope to SQL execution"
   );
 
   assert.equal(result.succeeded, true);
+  assert.equal(result.error, null);
   assert.equal(result.isMutating, false);
   assert.deepEqual(receivedContext, context);
+});
+
+test("query_database exposes the same structured error returned to OpenAI", async (): Promise<void> => {
+  const sql = "SELECT account_id FROM missing_accounts";
+  const result = await executeChatToolCallWithDependencies(
+    "query_database",
+    JSON.stringify({ sql }),
+    {
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+    },
+    {
+      execQuery: async (): Promise<never> => {
+        throw new RangeError("relation missing_accounts does not exist");
+      },
+    },
+  );
+
+  assert.equal(result.succeeded, false);
+  assert.equal(result.isMutating, false);
+  assert.deepEqual(result.error, {
+    name: "RangeError",
+    message: "relation missing_accounts does not exist",
+  });
+  assert.deepEqual(JSON.parse(result.output), {
+    ok: false,
+    tool: "query_database",
+    sql,
+    error: result.error,
+  });
 });

--- a/apps/web/src/server/chat/openai/tooling/tools.ts
+++ b/apps/web/src/server/chat/openai/tooling/tools.ts
@@ -20,13 +20,30 @@ const DEFAULT_CHAT_TOOL_DEPENDENCIES: ChatToolDependencies = {
 
 type ToolSuccessPayload = Readonly<Record<string, unknown>>;
 
+export type ChatToolExecutionError = Readonly<{
+  name: string;
+  message: string;
+}>;
+
 type ToolErrorPayload = Readonly<{
   sql: string | null;
-  error: Readonly<{
-    name: string;
-    message: string;
-  }>;
+  error: ChatToolExecutionError;
 }>;
+
+/**
+ * A completed transcript item refreshes route-backed content only when the
+ * execution succeeded and mutated data. Failed executions retain their
+ * structured error separately from the serialized model-facing output.
+ */
+type ExecutedChatToolCallResult =
+  | Readonly<{
+    succeeded: true;
+    error: null;
+  }>
+  | Readonly<{
+    succeeded: false;
+    error: ChatToolExecutionError;
+  }>;
 
 export type ExecutedChatToolCall = Readonly<{
   /**
@@ -40,13 +57,7 @@ export type ExecutedChatToolCall = Readonly<{
    * inferring mutability from earlier streamed tool snapshots.
    */
   isMutating: boolean;
-  /**
-   * Whether the tool execution itself succeeded. A completed transcript item is
-   * not enough to refresh route-backed content; the runtime only invalidates
-   * main content when a completed tool call both succeeded and mutated data.
-   */
-  succeeded: boolean;
-}>;
+}> & ExecutedChatToolCallResult;
 
 type QueryDatabaseToolInput = Readonly<{
   sql?: unknown;
@@ -78,10 +89,7 @@ const createToolErrorResult = (
 
 const serializeToolError = (
   error: unknown,
-): Readonly<{
-  name: string;
-  message: string;
-}> => {
+): ChatToolExecutionError => {
   if (error instanceof Error) {
     return {
       name: error.name,
@@ -177,16 +185,19 @@ export const executeChatToolCallWithDependencies = async (
       }),
       isMutating,
       succeeded: true,
+      error: null,
     };
   } catch (error) {
+    const serializedError = serializeToolError(error);
     const payload: ToolErrorPayload = {
       sql,
-      error: serializeToolError(error),
+      error: serializedError,
     };
     return {
       output: createToolErrorResult("query_database", payload),
       isMutating,
       succeeded: false,
+      error: serializedError,
     };
   }
 };


### PR DESCRIPTION
## Summary
- classify failed database tool results and unexpected tool exceptions as Langfuse errors
- classify failed chat-turn and transcription roots while preserving successful outcomes
- isolate and correlate telemetry lifecycle failures without changing callback or tool results

## Review
- cumulative promotion review passed with no P0-P4 findings
- integration state is green

## Validation
- project checks were not run locally; repository workflows have no pull_request trigger