### PR TITLE
Fix Langfuse tool update callback returns

### DIFF
--- a/apps/web/src/server/chat/openai/tooling/toolExecutor.ts
+++ b/apps/web/src/server/chat/openai/tooling/toolExecutor.ts
@@ -145,10 +145,12 @@ export const runOneToolCallWithDependencies = async (
       runToolTelemetryOperation(
         params,
         "update",
-        (): void => toolObservation?.update({
-          level: "ERROR",
-          statusMessage: formatToolErrorStatusMessage(serializedError),
-        }),
+        (): void => {
+          toolObservation?.update({
+            level: "ERROR",
+            statusMessage: formatToolErrorStatusMessage(serializedError),
+          });
+        },
         dependencies.log,
       );
       throw error;
@@ -173,10 +175,12 @@ export const runOneToolCallWithDependencies = async (
       runToolTelemetryOperation(
         params,
         "update",
-        (): void => toolObservation?.update({
-          level: "ERROR",
-          statusMessage: formatToolErrorStatusMessage(output.error),
-        }),
+        (): void => {
+          toolObservation?.update({
+            level: "ERROR",
+            statusMessage: formatToolErrorStatusMessage(output.error),
+          });
+        },
         dependencies.log,
       );
     }


### PR DESCRIPTION
## Summary
- make Langfuse tool update telemetry callbacks return void explicitly
- preserve existing error telemetry behavior

## Validation
- not run locally; required CI owns executable validation