### PR TITLE
Enforce read-only SQL relation targets

### DIFF
--- a/apps/sql-api/src/machineApi/routeHandlers.test.ts
+++ b/apps/sql-api/src/machineApi/routeHandlers.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { handleMeRouteWithResolver } from "./routeHandlers.js";
+import { handleMeRouteWithResolver, handleSqlRouteWithWorkspaceResolver } from "./routeHandlers.js";
 import { createAuthenticatedEvent } from "../handlerTestUtils.js";
 import type { MachineApiDependencies, MachineRouteContext } from "./types.js";
 
@@ -44,4 +44,53 @@ test("handleMeRoute omits defaultWorkspaceId", async (): Promise<void> => {
   assert.equal(response.statusCode, 200);
   const payload = JSON.parse(response.body) as { data: Record<string, unknown> };
   assert.equal("defaultWorkspaceId" in payload.data, false);
+});
+
+test("handleSqlRoute rejects SELECT-only mutations before workspace resolution", async (): Promise<void> => {
+  let workspaceResolutionCount = 0;
+  let trustedQueryCount = 0;
+  let restrictedContextCount = 0;
+  const context: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({ sql: "DELETE FROM fx_rates_daily WHERE base_currency = 'EUR'" }),
+      headers: { Host: "api.example.com" },
+      httpMethod: "POST",
+      path: "/v1/sql",
+      resource: "/sql",
+    }),
+    dependencies: {
+      ...createDependencies(),
+      queryAsTrustedIdentity: async () => {
+        trustedQueryCount += 1;
+        throw new Error("queryAsTrustedIdentity should not be called");
+      },
+      withRestrictedTrustedIdentityContext: async () => {
+        restrictedContextCount += 1;
+        throw new Error("withRestrictedTrustedIdentityContext should not be called");
+      },
+    },
+  };
+
+  const response = await handleSqlRouteWithWorkspaceResolver(
+    context,
+    async (): Promise<string> => {
+      workspaceResolutionCount += 1;
+      return "workspace-1";
+    },
+  );
+  const payload = JSON.parse(response.body) as {
+    instructions: string;
+    error: Readonly<{ code: string }>;
+  };
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(payload.error.code, "read_only_relation_mutation_not_allowed");
+  assert.equal(
+    payload.instructions,
+    "Relation fx_rates_daily is SELECT-only and cannot be targeted by DELETE in restricted SQL. Use SELECT to read it; write only to ledger_entries, budget_lines, workspace_settings, or account_metadata.",
+  );
+  assert.equal(workspaceResolutionCount, 0);
+  assert.equal(trustedQueryCount, 0);
+  assert.equal(restrictedContextCount, 0);
 });

--- a/apps/sql-api/src/machineApi/routeHandlers.ts
+++ b/apps/sql-api/src/machineApi/routeHandlers.ts
@@ -9,7 +9,13 @@ import {
   buildSelectWorkspaceAction,
   buildSuccessEnvelope,
 } from "@expense-budget-tracker/agent-shared";
-import { MAX_SQL_ROWS, SQL_STATEMENT_TIMEOUT_MS, SqlPolicyError } from "@expense-budget-tracker/agent-shared/sql-policy";
+import {
+  MAX_SQL_ROWS,
+  SQL_STATEMENT_TIMEOUT_MS,
+  SqlPolicyError,
+  validateExpenseSql,
+  type ValidatedExpenseSql,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
 import { resolveOrCreateWorkspaceForTrustedIdentity } from "../db.js";
 import { buildDiscoveryEnvelope, readJsonBody } from "./request.js";
 import { buildRetryableErrorResponse, json } from "./responses.js";
@@ -247,8 +253,24 @@ export const handleSelectWorkspaceRoute = async (
   }
 };
 
-export const handleSqlRoute = async (
+const buildSqlPolicyErrorResponse = (
+  error: SqlPolicyError,
+  apiBaseUrl: string,
+): APIGatewayProxyResult =>
+  json(
+    400,
+    buildErrorEnvelope(
+      { allowedRelations: ALLOWED_RELATION_NAMES },
+      [],
+      getSqlPolicyInstructions(error, apiBaseUrl),
+      error.code,
+      error.message,
+    ),
+  );
+
+export const handleSqlRouteWithWorkspaceResolver = async (
   context: MachineRouteContext,
+  resolveWorkspaceId: typeof resolveSqlWorkspaceId,
 ): Promise<APIGatewayProxyResult> => {
   const body = readJsonBody(context.event);
   if (body === null) {
@@ -269,11 +291,27 @@ export const handleSqlRoute = async (
     );
   }
 
+  let validated: ValidatedExpenseSql;
+  try {
+    validated = validateExpenseSql(rawSql.trim());
+  } catch (error) {
+    if (error instanceof SqlPolicyError) {
+      return buildSqlPolicyErrorResponse(error, context.apiBaseUrl);
+    }
+
+    return buildRetryableErrorResponse(
+      "agent_sql_failed",
+      "Retry SQL in a moment.",
+      error,
+      { retryable: true },
+    );
+  }
+
   const headerWorkspaceId = (context.event.headers["X-Workspace-Id"] ?? context.event.headers["x-workspace-id"] ?? "").trim();
 
   let workspaceId: string | null;
   try {
-    workspaceId = await resolveSqlWorkspaceId(context.dependencies, context.authenticated, headerWorkspaceId);
+    workspaceId = await resolveWorkspaceId(context.dependencies, context.authenticated, headerWorkspaceId);
   } catch (error) {
     return buildRetryableErrorResponse(
       "agent_sql_failed",
@@ -297,7 +335,7 @@ export const handleSqlRoute = async (
   }
 
   try {
-    const response = await runSql(context.dependencies, context.authenticated, workspaceId, rawSql.trim());
+    const response = await runSql(context.dependencies, context.authenticated, workspaceId, validated);
     if (response === null) {
       return json(
         404,
@@ -314,19 +352,6 @@ export const handleSqlRoute = async (
       ),
     );
   } catch (error) {
-    if (error instanceof SqlPolicyError) {
-      return json(
-        400,
-        buildErrorEnvelope(
-          { allowedRelations: ALLOWED_RELATION_NAMES },
-          [],
-          getSqlPolicyInstructions(error, context.apiBaseUrl),
-          error.code,
-          error.message,
-        ),
-      );
-    }
-
     if (isUserSqlExecutionError(error)) {
       return json(
         400,
@@ -348,3 +373,8 @@ export const handleSqlRoute = async (
     );
   }
 };
+
+export const handleSqlRoute = async (
+  context: MachineRouteContext,
+): Promise<APIGatewayProxyResult> =>
+  handleSqlRouteWithWorkspaceResolver(context, resolveSqlWorkspaceId);

--- a/apps/sql-api/src/machineApi/sqlService.test.ts
+++ b/apps/sql-api/src/machineApi/sqlService.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import type { QueryResult } from "pg";
 import { SqlPolicyError } from "@expense-budget-tracker/agent-shared/sql-policy";
 import { createQueryResult } from "../handlerTestUtils.js";
-import { runSqlWithWorkspaceGetter } from "./sqlService.js";
+import { getSqlPolicyInstructions, runSqlWithWorkspaceGetter } from "./sqlService.js";
 import type {
   AuthenticatedContext,
   MachineApiDependencies,
@@ -72,6 +72,38 @@ test("runSql rejects function-only SQL before executing restricted queries", asy
     (error: unknown) => error instanceof SqlPolicyError && error.code === "function_calls_not_allowed",
   );
 
+  assert.equal(restrictedContextCalled, false);
+});
+
+test("runSql rejects SELECT-only mutation targets before workspace or restricted database access", async (): Promise<void> => {
+  let workspaceGetterCalled = false;
+  let restrictedContextCalled = false;
+  const dependencies = createDependencies({
+    withRestrictedTrustedIdentityContext: async () => {
+      restrictedContextCalled = true;
+      throw new Error("restricted context should not run");
+    },
+  });
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "WITH deleted_rates AS (DELETE FROM fx_rates_raw WHERE base_currency = 'EUR' RETURNING *) SELECT * FROM deleted_rates",
+      async (): Promise<WorkspaceSummary> => {
+        workspaceGetterCalled = true;
+        return workspaceGetter();
+      },
+    ),
+    (error: unknown) =>
+      error instanceof SqlPolicyError
+      && error.code === "read_only_relation_mutation_not_allowed"
+      && getSqlPolicyInstructions(error, "https://api.example.com/v1")
+        === "Relation fx_rates_raw is SELECT-only and cannot be targeted by DELETE in restricted SQL. Use SELECT to read it; write only to ledger_entries, budget_lines, workspace_settings, or account_metadata.",
+  );
+
+  assert.equal(workspaceGetterCalled, false);
   assert.equal(restrictedContextCalled, false);
 });
 

--- a/apps/sql-api/src/machineApi/sqlService.ts
+++ b/apps/sql-api/src/machineApi/sqlService.ts
@@ -1,9 +1,11 @@
 import {
-  executeExpenseSql,
+  executeValidatedExpenseSql,
   MAX_SQL_ROWS,
   SQL_STATEMENT_TIMEOUT_MS,
   SqlPolicyError,
+  validateExpenseSql,
   type AllowedRelationName,
+  type ValidatedExpenseSql,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
 import type { AuthenticatedContext, EntityHints, MachineApiDependencies, PgError, WorkspaceSummary } from "./types.js";
 import { getWorkspace } from "./workspaceService.js";
@@ -109,6 +111,14 @@ export const getSqlPolicyInstructions = (
     return `Relation is not exposed by policy. Use ${apiBaseUrl}/schema to see allowed relations, columns, and any agent hints, then retry. Workspace context must be set via /workspaces/{workspaceId}/select or X-Workspace-Id.`;
   }
 
+  if (error.code === "read_only_relation_mutation_not_allowed") {
+    return `${error.message}. Use SELECT to read it; write only to ledger_entries, budget_lines, workspace_settings, or account_metadata.`;
+  }
+
+  if (error.code === "recursive_cte_search_cycle_not_allowed") {
+    return "Recursive CTE SEARCH and CYCLE clauses are not supported in restricted SQL. Rewrite the CTE without those clauses.";
+  }
+
   if (error.code === "unsupported_statement") {
     return "Use one or more SQL statements of type SELECT, WITH, INSERT, UPDATE, or DELETE. BEGIN/COMMIT/ROLLBACK and DDL are not allowed.";
   }
@@ -140,11 +150,11 @@ export const getSqlPolicyInstructions = (
   return "Fix the SQL statement and retry. Use only supported relations.";
 };
 
-export const runSqlWithWorkspaceGetter = async (
+const executeSqlWithWorkspaceGetter = async (
   dependencies: MachineApiDependencies,
   authenticated: AuthenticatedContext,
   workspaceId: string,
-  sql: string,
+  validated: ValidatedExpenseSql,
   workspaceGetter: WorkspaceGetter,
 ): Promise<Readonly<Record<string, unknown>> | null> => {
   const workspace = await workspaceGetter(dependencies, authenticated.identity, workspaceId);
@@ -152,8 +162,8 @@ export const runSqlWithWorkspaceGetter = async (
     return null;
   }
 
-  const result = await executeExpenseSql(
-    sql,
+  const result = await executeValidatedExpenseSql(
+    validated,
     async (validatedSql) => dependencies.withRestrictedTrustedIdentityContext(
       authenticated.identity,
       workspaceId,
@@ -192,16 +202,31 @@ export const runSqlWithWorkspaceGetter = async (
   };
 };
 
-export const runSql = async (
+export const runSqlWithWorkspaceGetter = async (
   dependencies: MachineApiDependencies,
   authenticated: AuthenticatedContext,
   workspaceId: string,
   sql: string,
+  workspaceGetter: WorkspaceGetter,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
-  runSqlWithWorkspaceGetter(
+  executeSqlWithWorkspaceGetter(
     dependencies,
     authenticated,
     workspaceId,
-    sql,
+    validateExpenseSql(sql),
+    workspaceGetter,
+  );
+
+export const runSql = async (
+  dependencies: MachineApiDependencies,
+  authenticated: AuthenticatedContext,
+  workspaceId: string,
+  validated: ValidatedExpenseSql,
+): Promise<Readonly<Record<string, unknown>> | null> =>
+  executeSqlWithWorkspaceGetter(
+    dependencies,
+    authenticated,
+    workspaceId,
+    validated,
     getWorkspace,
   );

--- a/apps/web/src/app/api/agent/sql/route.test.ts
+++ b/apps/web/src/app/api/agent/sql/route.test.ts
@@ -62,3 +62,46 @@ test("postAgentSqlRouteWithDeps maps function-call policy failures to 400", asyn
     },
   });
 });
+
+test("postAgentSqlRouteWithDeps rejects SELECT-only mutations before workspace or database access", async (): Promise<void> => {
+  let workspaceResolutionCount = 0;
+  let executionCount = 0;
+
+  const response = await postAgentSqlRouteWithDeps(
+    new Request("http://localhost/api/agent/sql", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ sql: "UPDATE accounts SET account_id = 'a-renamed-usd'" }),
+    }),
+    {
+      authenticateAgentRequest: async () => createAuthenticatedRequest(),
+      resolveWorkspaceIdForSql: async () => {
+        workspaceResolutionCount += 1;
+        return "workspace-1";
+      },
+      executeAgentSql: async () => {
+        executionCount += 1;
+        throw new Error("executeAgentSql should not be called");
+      },
+    },
+  );
+
+  const payload = await response.json() as {
+    instructions: string;
+    error: Readonly<{ code: string; message: string }>;
+  };
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload.error, {
+    code: "read_only_relation_mutation_not_allowed",
+    message: "Relation accounts is SELECT-only and cannot be targeted by UPDATE in restricted SQL",
+  });
+  assert.equal(
+    payload.instructions,
+    "Relation accounts is SELECT-only and cannot be targeted by UPDATE in restricted SQL. Use SELECT to read it; write only to ledger_entries, budget_lines, workspace_settings, or account_metadata.",
+  );
+  assert.equal(workspaceResolutionCount, 0);
+  assert.equal(executionCount, 0);
+});

--- a/apps/web/src/app/api/agent/sql/route.ts
+++ b/apps/web/src/app/api/agent/sql/route.ts
@@ -4,7 +4,7 @@
  * Uses the same restricted SQL policy as the API Gateway SQL API, but returns
  * the stable agent envelope plus lightweight entity hints for known relations.
  */
-import { SqlPolicyError } from "@expense-budget-tracker/agent-shared/sql-policy";
+import { SqlPolicyError, validateExpenseSql } from "@expense-budget-tracker/agent-shared/sql-policy";
 import {
   authenticateAgentRequest,
   getAgentAuthError,
@@ -34,6 +34,14 @@ const getSqlPolicyInstructions = (error: SqlPolicyError): string => {
     }
 
     return "Relation is not exposed by policy. Use GET /api/agent/schema to see allowed relations, columns, and any agent hints, then retry.";
+  }
+
+  if (error.code === "read_only_relation_mutation_not_allowed") {
+    return `${error.message}. Use SELECT to read it; write only to ledger_entries, budget_lines, workspace_settings, or account_metadata.`;
+  }
+
+  if (error.code === "recursive_cte_search_cycle_not_allowed") {
+    return "Recursive CTE SEARCH and CYCLE clauses are not supported in restricted SQL. Rewrite the CTE without those clauses.";
   }
 
   if (error.code === "unsupported_statement") {
@@ -111,6 +119,7 @@ export const postAgentSqlRouteWithDeps = async (
 
   try {
     const authenticated = await dependencies.authenticateAgentRequest(request);
+    const validated = validateExpenseSql(sql);
     const headerWorkspaceId = getWorkspaceId(request);
     const workspaceId = await dependencies.resolveWorkspaceIdForSql(authenticated, headerWorkspaceId);
     if (workspaceId === null || workspaceId === "") {
@@ -124,7 +133,7 @@ export const postAgentSqlRouteWithDeps = async (
       );
     }
 
-    const result = await dependencies.executeAgentSql(authenticated, workspaceId, sql);
+    const result = await dependencies.executeAgentSql(authenticated, workspaceId, validated);
 
     if (result === null) {
       return jsonAgentError(

--- a/apps/web/src/server/agent/sql.ts
+++ b/apps/web/src/server/agent/sql.ts
@@ -2,11 +2,12 @@
  * Agent-facing SQL execution on app.* using the shared SQL policy.
  */
 import {
-  executeExpenseSql,
+  executeValidatedExpenseSql,
   getAllowedRelationNames,
   MAX_SQL_ROWS,
   SQL_STATEMENT_TIMEOUT_MS,
   type AllowedRelationName,
+  type ValidatedExpenseSql,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
 import { withRestrictedTrustedIdentityContext } from "@/server/db";
 import { type AgentAuthenticatedRequest } from "@/server/agent/apiKeyAuth";
@@ -140,15 +141,15 @@ export const getUserSqlExecutionMessage = (error: unknown): string => {
 export const executeAgentSql = async (
   authenticated: AgentAuthenticatedRequest,
   workspaceId: string,
-  sql: string,
+  validated: ValidatedExpenseSql,
 ): Promise<AgentSqlResult | null> => {
   const workspace = await getWorkspaceForTrustedIdentity(authenticated.identity, workspaceId);
   if (workspace === null) {
     return null;
   }
 
-  const result = await executeExpenseSql(
-    sql,
+  const result = await executeValidatedExpenseSql(
+    validated,
     async (validatedSql) => withRestrictedTrustedIdentityContext(
       authenticated.identity,
       workspaceId,

--- a/apps/web/src/server/chat/shared.test.ts
+++ b/apps/web/src/server/chat/shared.test.ts
@@ -44,6 +44,44 @@ test("execQuery rejects function calls before reaching the database", async (): 
   );
 });
 
+test("execQuery rejects SELECT-only mutation targets before database or mutation lock entry", async (): Promise<void> => {
+  let userContextCount = 0;
+  let restrictedContextCount = 0;
+  let mutationLockCount = 0;
+
+  await assert.rejects(
+    () => execQueryWithDependencies(
+      "WITH changed AS (UPDATE accounts SET account_id = 'a-renamed-usd' RETURNING *) SELECT * FROM changed",
+      {
+        userId: "user-1",
+        workspaceId: "workspace-1",
+        sessionId: "session-1",
+        turnId: "turn-1",
+      },
+      {
+        withUserContext: async (): Promise<never> => {
+          userContextCount += 1;
+          throw new Error("User context should not run");
+        },
+        withRestrictedUserContext: async (): Promise<never> => {
+          restrictedContextCount += 1;
+          throw new Error("Restricted context should not run");
+        },
+        lockUncancelledChatTurnForMutationWithQuery: async (): Promise<void> => {
+          mutationLockCount += 1;
+        },
+      },
+    ),
+    (error: unknown) =>
+      error instanceof Error
+      && error.message === "Relation accounts is SELECT-only and cannot be targeted by UPDATE in restricted SQL. Use SELECT to read it; write only to ledger_entries, budget_lines, workspace_settings, or account_metadata",
+  );
+
+  assert.equal(userContextCount, 0);
+  assert.equal(restrictedContextCount, 0);
+  assert.equal(mutationLockCount, 0);
+});
+
 test("cancel-first exact turn fencing rejects before mutating chat SQL", async (): Promise<void> => {
   let mutationCount = 0;
   const queryFn: QueryFn = async (sql): Promise<PgQueryResult> => {

--- a/apps/web/src/server/chat/shared.ts
+++ b/apps/web/src/server/chat/shared.ts
@@ -333,6 +333,12 @@ const toChatSqlError = (error: SqlPolicyError): Error => {
   if (error.code === "relation_not_allowed") {
     return new Error(`${error.message} in chat queries`);
   }
+  if (error.code === "recursive_cte_search_cycle_not_allowed") {
+    return new Error("Recursive CTE SEARCH and CYCLE clauses are not supported in chat queries. Rewrite the CTE without those clauses");
+  }
+  if (error.code === "read_only_relation_mutation_not_allowed") {
+    return new Error(`${error.message}. Use SELECT to read it; write only to ledger_entries, budget_lines, workspace_settings, or account_metadata`);
+  }
   return new Error(error.message);
 };
 

--- a/packages/agent-shared/src/sql-policy.test.ts
+++ b/packages/agent-shared/src/sql-policy.test.ts
@@ -68,6 +68,105 @@ test("validateExpenseSql still allows direct relation queries without function c
   assert.deepEqual(validated.statements[0]?.referencedRelations, ["ledger_entries"]);
 });
 
+test("validateExpenseSql allows reads from SELECT-only relations", (): void => {
+  const acceptedSql: ReadonlyArray<string> = [
+    "SELECT account_id FROM accounts",
+    "SELECT rate FROM fx_rates_raw",
+    "SELECT rate FROM fx_rates_daily",
+  ];
+
+  for (const sql of acceptedSql) {
+    assert.equal(validateExpenseSql(sql).statements.length, 1);
+  }
+});
+
+test("validateExpenseSql rejects INSERT, UPDATE, and DELETE targets that are SELECT-only", (): void => {
+  const rejectedSql: ReadonlyArray<string> = [
+    "INSERT INTO accounts (account_id) VALUES ('a-main-usd')",
+    "UPDATE accounts SET account_id = 'a-renamed-usd'",
+    "DELETE FROM accounts WHERE account_id = 'a-main-usd'",
+    "INSERT INTO fx_rates_raw (base_currency) VALUES ('EUR')",
+    "UPDATE fx_rates_raw SET rate = 1",
+    "DELETE FROM fx_rates_raw WHERE base_currency = 'EUR'",
+    "INSERT INTO fx_rates_daily (base_currency) VALUES ('EUR')",
+    "UPDATE fx_rates_daily SET rate = 1",
+    "DELETE FROM fx_rates_daily WHERE base_currency = 'EUR'",
+  ];
+
+  for (const sql of rejectedSql) {
+    assert.throws(
+      () => validateExpenseSql(sql),
+      (error: unknown) =>
+        error instanceof SqlPolicyError
+        && error.code === "read_only_relation_mutation_not_allowed"
+        && error.message.includes("is SELECT-only"),
+    );
+  }
+});
+
+test("validateExpenseSql rejects SELECT-only mutation targets in data-modifying CTEs", (): void => {
+  assert.throws(
+    () => validateExpenseSql(
+      "WITH deleted_rates AS (DELETE FROM public.fx_rates_daily WHERE base_currency = 'EUR' RETURNING *) SELECT * FROM deleted_rates",
+    ),
+    (error: unknown) =>
+      error instanceof SqlPolicyError
+      && error.code === "read_only_relation_mutation_not_allowed"
+      && error.message === "Relation fx_rates_daily is SELECT-only and cannot be targeted by DELETE in restricted SQL",
+  );
+});
+
+test("validateExpenseSql rejects recursive CTE SEARCH and CYCLE clauses before hidden mutations", (): void => {
+  const rejectedSql: ReadonlyArray<string> = [
+    "WITH RECURSIVE rows(n) AS (SELECT 1) SEARCH DEPTH FIRST BY n SET ordercol UPDATE accounts SET account_id = 'a-renamed-usd'",
+    "WITH RECURSIVE rows(n) AS (SELECT 1) SEARCH BREADTH FIRST BY n SET ordercol DELETE FROM fx_rates_raw WHERE base_currency = 'EUR'",
+    "WITH RECURSIVE rows(n) AS (SELECT 1) SEARCH DEPTH FIRST BY n SET ordercol INSERT INTO fx_rates_daily (base_currency) VALUES ('EUR')",
+    "WITH RECURSIVE rows(n) AS (SELECT 1) SEARCH DEPTH FIRST BY n SET ordercol, changed AS (UPDATE accounts SET account_id = 'a-renamed-usd' RETURNING *) SELECT * FROM changed",
+    "WITH RECURSIVE rows(n) AS (SELECT 1) CYCLE n SET is_cycle USING cycle_path, changed AS (DELETE FROM fx_rates_raw WHERE base_currency = 'EUR' RETURNING *) SELECT * FROM changed",
+  ];
+
+  for (const sql of rejectedSql) {
+    assert.throws(
+      () => validateExpenseSql(sql),
+      (error: unknown) =>
+        error instanceof SqlPolicyError
+        && error.code === "recursive_cte_search_cycle_not_allowed"
+        && error.message === "Recursive CTE SEARCH and CYCLE clauses are not supported in restricted SQL",
+    );
+  }
+});
+
+test("validateExpenseSql allows SEARCH and CYCLE text in regular string literals", (): void => {
+  const validated = validateExpenseSql(
+    "SELECT 'SEARCH DEPTH FIRST' AS search_text, 'CYCLE path' AS cycle_text FROM accounts",
+  );
+
+  assert.equal(validated.statements.length, 1);
+  assert.deepEqual(validated.statements[0]?.referencedRelations, ["accounts"]);
+});
+
+test("validateExpenseSql allows mutations of workspace-owned relations", (): void => {
+  const acceptedSql: ReadonlyArray<string> = [
+    "INSERT INTO ledger_entries (event_id, ts, account_id, amount, currency, kind, workspace_id) VALUES ('event-1', '2026-08-09', 'a-main-usd', 1, 'USD', 'income', 'workspace-1')",
+    "UPDATE budget_lines SET planned_value = 100 WHERE workspace_id = 'workspace-1'",
+    "DELETE FROM workspace_settings WHERE workspace_id = 'workspace-1'",
+    "WITH changed AS (UPDATE account_metadata SET liquidity = 'low' WHERE workspace_id = 'workspace-1' RETURNING *) SELECT * FROM changed",
+  ];
+
+  for (const sql of acceptedSql) {
+    assert.equal(validateExpenseSql(sql).statements.length, 1);
+  }
+});
+
+test("validateExpenseSql allows a mutable target to read from a SELECT-only source", (): void => {
+  const validated = validateExpenseSql(
+    "INSERT INTO ledger_entries (event_id, ts, account_id, amount, currency, kind, workspace_id) SELECT 'event-1', '2026-08-09', 'a-main-usd', rate, quote_currency, 'income', 'workspace-1' FROM fx_rates_daily WHERE base_currency = 'EUR'",
+  );
+
+  assert.equal(validated.statements[0]?.isMutating, true);
+  assert.deepEqual(validated.statements[0]?.referencedRelations, ["ledger_entries", "fx_rates_daily"]);
+});
+
 test("validateExpenseSql allows grouping and derived subqueries after SQL keywords", (): void => {
   const acceptedSql: ReadonlyArray<string> = [
     "SELECT account_id FROM ledger_entries WHERE account_id = 'a-main-usd' AND (kind = 'expense')",

--- a/packages/agent-shared/src/sql-policy.ts
+++ b/packages/agent-shared/src/sql-policy.ts
@@ -74,6 +74,16 @@ export type AllowedRelationName = typeof ALLOWED_RELATION_NAMES[number];
 
 const ALLOWED_RELATIONS: ReadonlySet<string> = new Set(ALLOWED_RELATION_NAMES);
 
+const READ_ONLY_RELATION_NAMES: ReadonlyArray<AllowedRelationName> = [
+  "accounts",
+  "fx_rates_raw",
+  "fx_rates_daily",
+] as const;
+
+const READ_ONLY_RELATIONS: ReadonlySet<AllowedRelationName> = new Set<AllowedRelationName>(
+  READ_ONLY_RELATION_NAMES,
+);
+
 type SqlToken = Readonly<{
   kind: "word" | "punct";
   value: string;
@@ -92,6 +102,13 @@ type CteDefinition = Readonly<{
   bodyEndIndex: number;
 }>;
 
+type MutationOperation = "INSERT" | "UPDATE" | "DELETE";
+
+type MutationTarget = Readonly<{
+  operation: MutationOperation;
+  relationName: AllowedRelationName;
+}>;
+
 type SqlPolicyErrorCode =
   | "unsupported_statement"
   | "on_conflict_not_allowed"
@@ -103,7 +120,9 @@ type SqlPolicyErrorCode =
   | "escape_string_literals_not_allowed"
   | "unterminated_string_literal"
   | "invalid_relation_reference"
-  | "relation_not_allowed";
+  | "relation_not_allowed"
+  | "recursive_cte_search_cycle_not_allowed"
+  | "read_only_relation_mutation_not_allowed";
 
 export class SqlPolicyError extends Error {
   readonly code: SqlPolicyErrorCode;
@@ -666,6 +685,15 @@ const parseCteDefinitions = (
     });
 
     index = bodyCloseIndex + 1;
+    if (
+      isRecursive
+      && (tokens[index]?.lower === "search" || tokens[index]?.lower === "cycle")
+    ) {
+      fail(
+        "recursive_cte_search_cycle_not_allowed",
+        "Recursive CTE SEARCH and CYCLE clauses are not supported in restricted SQL",
+      );
+    }
     if (tokens[index]?.value === ",") {
       index++;
       continue;
@@ -808,6 +836,77 @@ const collectReferencedRelationsFromWithClause = (
   return Array.from(relations);
 };
 
+const collectMutationTarget = (
+  tokens: ReadonlyArray<SqlToken>,
+  startIndex: number,
+  operation: MutationOperation,
+): MutationTarget => {
+  const targetStartIndex = tokens[startIndex]?.lower === "only" ? startIndex + 1 : startIndex;
+  const reference = parseRelationName(tokens, targetStartIndex);
+  if (!ALLOWED_RELATIONS.has(reference.relationName)) {
+    fail("relation_not_allowed", `Relation ${reference.relationName} is not allowed`);
+  }
+
+  return {
+    operation,
+    relationName: asAllowedRelationName(reference.relationName),
+  };
+};
+
+const collectMutationTargetsFromSegment = (
+  tokens: ReadonlyArray<SqlToken>,
+  startIndex: number,
+  endIndex: number,
+): ReadonlyArray<MutationTarget> => {
+  if (startIndex >= endIndex) {
+    return [];
+  }
+
+  const firstToken = tokens[startIndex];
+  if (firstToken === undefined || firstToken.kind !== "word") {
+    return [];
+  }
+
+  if (firstToken.lower === "insert" && tokens[startIndex + 1]?.lower === "into") {
+    return [collectMutationTarget(tokens, startIndex + 2, "INSERT")];
+  }
+
+  if (firstToken.lower === "update") {
+    return [collectMutationTarget(tokens, startIndex + 1, "UPDATE")];
+  }
+
+  if (firstToken.lower === "delete" && tokens[startIndex + 1]?.lower === "from") {
+    return [collectMutationTarget(tokens, startIndex + 2, "DELETE")];
+  }
+
+  if (firstToken.lower !== "with") {
+    return [];
+  }
+
+  const { ctes, mainQueryStartIndex } = parseCteDefinitions(tokens, startIndex, endIndex);
+  const targets: Array<MutationTarget> = [];
+  for (const cte of ctes) {
+    targets.push(...collectMutationTargetsFromSegment(tokens, cte.bodyStartIndex, cte.bodyEndIndex));
+  }
+  targets.push(...collectMutationTargetsFromSegment(tokens, mainQueryStartIndex, endIndex));
+  return targets;
+};
+
+const assertMutationTargetsAreWritable = (
+  tokens: ReadonlyArray<SqlToken>,
+  startIndex: number,
+  endIndex: number,
+): void => {
+  for (const target of collectMutationTargetsFromSegment(tokens, startIndex, endIndex)) {
+    if (READ_ONLY_RELATIONS.has(target.relationName)) {
+      fail(
+        "read_only_relation_mutation_not_allowed",
+        `Relation ${target.relationName} is SELECT-only and cannot be targeted by ${target.operation} in restricted SQL`,
+      );
+    }
+  }
+};
+
 const collectReferencedRelations = (sql: string): ReadonlyArray<AllowedRelationName> => {
   const sanitizedSql = sanitizeSqlForTokenization(sql);
   if (containsOnConflict(sanitizedSql)) {
@@ -887,6 +986,7 @@ const validateExpenseSqlStatement = (sql: string): ValidatedExpenseSqlStatement 
     fail("on_conflict_not_allowed", "ON CONFLICT is not supported in restricted SQL");
   }
   const tokens = tokenizeSql(sanitizedSql);
+  assertMutationTargetsAreWritable(tokens, 0, tokens.length);
   assertOnlyAllowedFunctionCallsInSegment(tokens, 0, tokens.length);
 
   return {
@@ -909,11 +1009,10 @@ export const validateExpenseSql = (sql: string): ValidatedExpenseSql => {
   };
 };
 
-export const executeExpenseSql = async (
-  sql: string,
+export const executeValidatedExpenseSql = async (
+  validated: ValidatedExpenseSql,
   execute: (validatedSql: string) => Promise<RestrictedSqlQueryResult>,
 ): Promise<ExecutedExpenseSql> => {
-  const validated = validateExpenseSql(sql);
   const statements: Array<ExecutedExpenseSqlStatement> = [];
 
   for (const statement of validated.statements) {
@@ -939,3 +1038,8 @@ export const executeExpenseSql = async (
     statements,
   };
 };
+
+export const executeExpenseSql = async (
+  sql: string,
+  execute: (validatedSql: string) => Promise<RestrictedSqlQueryResult>,
+): Promise<ExecutedExpenseSql> => executeValidatedExpenseSql(validateExpenseSql(sql), execute);


### PR DESCRIPTION
## Summary
- reject INSERT, UPDATE, and DELETE targets for SELECT-only accounts and FX relations
- detect mutation targets in data-modifying CTEs and reject unsupported recursive SEARCH/CYCLE clauses
- validate before workspace/database/lock entry across chat and agent SQL surfaces
- add focused shared-policy and endpoint coverage

## Checks
- Not run locally per repository delivery workflow; integration PRs require no CI.