### PR TITLE
Explain restricted SQL escape string remediation

### DIFF
--- a/apps/sql-api/src/machineApi/routeHandlers.test.ts
+++ b/apps/sql-api/src/machineApi/routeHandlers.test.ts
@@ -94,3 +94,40 @@ test("handleSqlRoute rejects SELECT-only mutations before workspace resolution",
   assert.equal(trustedQueryCount, 0);
   assert.equal(restrictedContextCount, 0);
 });
+
+test("handleSqlRoute explains how to replace PostgreSQL escape strings", async (): Promise<void> => {
+  let workspaceResolutionCount = 0;
+  const context: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({ sql: "SELECT E'value' FROM ledger_entries" }),
+      headers: { Host: "api.example.com" },
+      httpMethod: "POST",
+      path: "/v1/sql",
+      resource: "/sql",
+    }),
+  };
+
+  const response = await handleSqlRouteWithWorkspaceResolver(
+    context,
+    async (): Promise<string> => {
+      workspaceResolutionCount += 1;
+      return "workspace-1";
+    },
+  );
+  const payload = JSON.parse(response.body) as {
+    instructions: string;
+    error: Readonly<{ code: string; message: string }>;
+  };
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(payload.error, {
+    code: "escape_string_literals_not_allowed",
+    message: "PostgreSQL escape string literals are not allowed",
+  });
+  assert.equal(
+    payload.instructions,
+    "PostgreSQL E'...' escape strings are unsupported in restricted SQL. Use ordinary single-quoted literals and represent embedded apostrophes by doubling them, for example 'customer''s'.",
+  );
+  assert.equal(workspaceResolutionCount, 0);
+});

--- a/apps/sql-api/src/machineApi/sqlService.ts
+++ b/apps/sql-api/src/machineApi/sqlService.ts
@@ -147,6 +147,10 @@ export const getSqlPolicyInstructions = (
     return "Dollar-quoted strings are not allowed. Use regular single-quoted literals.";
   }
 
+  if (error.code === "escape_string_literals_not_allowed") {
+    return "PostgreSQL E'...' escape strings are unsupported in restricted SQL. Use ordinary single-quoted literals and represent embedded apostrophes by doubling them, for example 'customer''s'.";
+  }
+
   return "Fix the SQL statement and retry. Use only supported relations.";
 };
 

--- a/apps/web/src/app/api/agent/sql/route.test.ts
+++ b/apps/web/src/app/api/agent/sql/route.test.ts
@@ -63,6 +63,48 @@ test("postAgentSqlRouteWithDeps maps function-call policy failures to 400", asyn
   });
 });
 
+test("postAgentSqlRouteWithDeps explains how to replace PostgreSQL escape strings", async (): Promise<void> => {
+  let workspaceResolutionCount = 0;
+  let executionCount = 0;
+  const response = await postAgentSqlRouteWithDeps(
+    new Request("http://localhost/api/agent/sql", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT E'value' FROM ledger_entries" }),
+    }),
+    {
+      authenticateAgentRequest: async () => createAuthenticatedRequest(),
+      resolveWorkspaceIdForSql: async () => {
+        workspaceResolutionCount += 1;
+        return "workspace-1";
+      },
+      executeAgentSql: async () => {
+        executionCount += 1;
+        throw new Error("executeAgentSql should not be called");
+      },
+    },
+  );
+
+  const payload = await response.json() as {
+    instructions: string;
+    error: Readonly<{ code: string; message: string }>;
+  };
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload.error, {
+    code: "escape_string_literals_not_allowed",
+    message: "PostgreSQL escape string literals are not allowed",
+  });
+  assert.equal(
+    payload.instructions,
+    "PostgreSQL E'...' escape strings are unsupported in restricted SQL. Use ordinary single-quoted literals and represent embedded apostrophes by doubling them, for example 'customer''s'.",
+  );
+  assert.equal(workspaceResolutionCount, 0);
+  assert.equal(executionCount, 0);
+});
+
 test("postAgentSqlRouteWithDeps rejects SELECT-only mutations before workspace or database access", async (): Promise<void> => {
   let workspaceResolutionCount = 0;
   let executionCount = 0;

--- a/apps/web/src/app/api/agent/sql/route.ts
+++ b/apps/web/src/app/api/agent/sql/route.ts
@@ -72,6 +72,10 @@ const getSqlPolicyInstructions = (error: SqlPolicyError): string => {
     return "Dollar-quoted strings are not allowed. Use regular single-quoted literals.";
   }
 
+  if (error.code === "escape_string_literals_not_allowed") {
+    return "PostgreSQL E'...' escape strings are unsupported in restricted SQL. Use ordinary single-quoted literals and represent embedded apostrophes by doubling them, for example 'customer''s'.";
+  }
+
   return "Fix the SQL statement and retry. Use only supported relations.";
 };
 

--- a/apps/web/src/server/chat/shared.test.ts
+++ b/apps/web/src/server/chat/shared.test.ts
@@ -44,6 +44,20 @@ test("execQuery rejects function calls before reaching the database", async (): 
   );
 });
 
+test("execQuery explains how to replace PostgreSQL escape strings", async (): Promise<void> => {
+  await assert.rejects(
+    () => execQuery("SELECT E'value' FROM ledger_entries", {
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+    }),
+    (error: unknown) =>
+      error instanceof Error
+      && error.message === "PostgreSQL E'...' escape strings are unsupported in restricted SQL. Use ordinary single-quoted literals and represent embedded apostrophes by doubling them, for example 'customer''s'.",
+  );
+});
+
 test("execQuery rejects SELECT-only mutation targets before database or mutation lock entry", async (): Promise<void> => {
   let userContextCount = 0;
   let restrictedContextCount = 0;

--- a/apps/web/src/server/chat/shared.ts
+++ b/apps/web/src/server/chat/shared.ts
@@ -324,6 +324,9 @@ const toChatSqlError = (error: SqlPolicyError): Error => {
   if (error.code === "dollar_quoted_strings_not_allowed") {
     return new Error("Dollar-quoted strings are not allowed in chat queries");
   }
+  if (error.code === "escape_string_literals_not_allowed") {
+    return new Error("PostgreSQL E'...' escape strings are unsupported in restricted SQL. Use ordinary single-quoted literals and represent embedded apostrophes by doubling them, for example 'customer''s'.");
+  }
   if (error.code === "unterminated_string_literal") {
     return new Error("Unterminated SQL string literal");
   }


### PR DESCRIPTION
## Summary
- add actionable remediation for unsupported PostgreSQL escape strings across chat and agent APIs
- preserve specific policy codes and existing response envelopes
- cover browser chat, machine API, and web agent endpoint behavior

## Checks
- Not run locally per repository delivery workflow; integration PRs require no CI.