### PR TITLE
Use GPT-5.6 Sol for chat

### DIFF
--- a/apps/web/src/lib/chatModels.ts
+++ b/apps/web/src/lib/chatModels.ts
@@ -1,8 +1,8 @@
 export const CHAT_VENDOR = "openai" as const;
-export const CHAT_MODEL_ID = "gpt-5.4" as const;
-export const CHAT_MODEL_REASONING_EFFORT = "high" as const;
+export const CHAT_MODEL_ID = "gpt-5.6-sol" as const;
+export const CHAT_MODEL_REASONING_EFFORT = "medium" as const;
 export const CHAT_MODEL_REASONING_SUMMARY = "auto" as const;
-export const CHAT_MODEL_LABEL = "GPT-5.4" as const;
+export const CHAT_MODEL_LABEL = "GPT-5.6 Sol" as const;
 export const CHAT_PROVIDER_LABEL = "OpenAI" as const;
 export const CHAT_MODEL_REASONING_LABEL = `${CHAT_MODEL_REASONING_EFFORT.slice(0, 1).toUpperCase()}${CHAT_MODEL_REASONING_EFFORT.slice(1)}` as const;
 export const CHAT_MODEL_BADGE_LABEL = `${CHAT_MODEL_LABEL} · ${CHAT_MODEL_REASONING_LABEL}` as const;


### PR DESCRIPTION
## Summary
- switch the built-in chat from GPT-5.4 to GPT-5.6 Sol
- change reasoning effort from high to medium
- update the displayed model label

## Testing
- not run locally per repository workflow