### PR TITLE
Keep filtered category order data-independent

### DIFF
--- a/apps/web/src/ui/tables/budget/model/blocks.test.ts
+++ b/apps/web/src/ui/tables/budget/model/blocks.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BudgetRow } from "@/server/budget/getBudgetGrid";
+import { buildBlocks } from "@/ui/tables/budget/model/blocks";
+
+const budgetRow = (
+  category: string,
+  planned: number,
+): BudgetRow => ({
+  month: "2026-02",
+  direction: "spend",
+  category,
+  plannedBase: planned,
+  plannedModifier: 0,
+  planned,
+  actual: 0,
+  hasUnconvertible: false,
+});
+
+const spendCategories = (
+  rows: ReadonlyArray<BudgetRow>,
+  allowlist: ReadonlySet<string> | null,
+): ReadonlyArray<string> => {
+  const blocks = buildBlocks(rows, ["2026-02"], "2026-02", allowlist);
+  const block = blocks[0];
+  assert.ok(block);
+  return block.categories;
+};
+
+test("puts every visible category before every masked category in filtered mode", (): void => {
+  const rows = [
+    budgetRow("masked-high", 1_000),
+    budgetRow("visible-low", 10),
+    budgetRow("masked-low", 1),
+    budgetRow("visible-high", 100),
+  ];
+
+  assert.deepEqual(
+    spendCategories(rows, new Set(["visible-low", "visible-high"])),
+    ["visible-high", "visible-low", "masked-high", "masked-low"],
+  );
+});
+
+test("sorts visible categories by effective value in filtered mode", (): void => {
+  const rows = [
+    budgetRow("visible-low", 10),
+    budgetRow("visible-high", 100),
+    budgetRow("visible-middle", 50),
+  ];
+
+  assert.deepEqual(
+    spendCategories(rows, new Set(["visible-low", "visible-high", "visible-middle"])),
+    ["visible-high", "visible-middle", "visible-low"],
+  );
+});
+
+test("keeps masked categories in source order when their amounts invert", (): void => {
+  const allowlist = new Set(["visible"]);
+  const highThenLow = [
+    budgetRow("masked-first", 100),
+    budgetRow("masked-second", 10),
+    budgetRow("visible", 50),
+  ];
+  const lowThenHigh = [
+    budgetRow("masked-first", 10),
+    budgetRow("masked-second", 100),
+    budgetRow("visible", 50),
+  ];
+
+  assert.deepEqual(
+    spendCategories(highThenLow, allowlist),
+    ["visible", "masked-first", "masked-second"],
+  );
+  assert.deepEqual(
+    spendCategories(lowThenHigh, allowlist),
+    ["visible", "masked-first", "masked-second"],
+  );
+});
+
+test("sorts every category by effective value in all mode", (): void => {
+  const rows = [
+    budgetRow("low", 10),
+    budgetRow("high", 100),
+    budgetRow("middle", 50),
+  ];
+
+  assert.deepEqual(
+    spendCategories(rows, null),
+    ["high", "middle", "low"],
+  );
+});

--- a/apps/web/src/ui/tables/budget/model/blocks.ts
+++ b/apps/web/src/ui/tables/budget/model/blocks.ts
@@ -39,9 +39,9 @@ export const computeEffectiveValue = (
 
 /**
  * Sorts categories by effective value for the current year, descending.
- * When maskedCategories is non-empty, visible categories come first,
- * then masked ones - each group sorted by effective value independently.
- * Stable sort preserves relative order for equal values.
+ * Visible categories come first and masked categories retain their source order.
+ * Effective values are not computed for masked categories.
+ * Stable sort preserves relative order for equal visible values.
  */
 export const sortCategoriesByEffectiveValue = (
   categories: ReadonlyArray<string>,
@@ -50,16 +50,16 @@ export const sortCategoriesByEffectiveValue = (
   currentMonth: string,
   maskedCategories: ReadonlySet<string>,
 ): ReadonlyArray<string> => {
-  const withValues = [...categories].map((category) => ({
-    category,
-    value: computeEffectiveValue(cells, category, currentYearMonths, currentMonth),
-    isMasked: maskedCategories.has(category),
-  }));
-  withValues.sort((a, b) => {
-    if (a.isMasked !== b.isMasked) return a.isMasked ? 1 : -1;
-    return b.value - a.value;
-  });
-  return withValues.map((entry) => entry.category);
+  const visibleWithValues = categories
+    .filter((category) => !maskedCategories.has(category))
+    .map((category) => ({
+      category,
+      value: computeEffectiveValue(cells, category, currentYearMonths, currentMonth),
+    }));
+  visibleWithValues.sort((a, b) => b.value - a.value);
+
+  const masked = categories.filter((category) => maskedCategories.has(category));
+  return [...visibleWithValues.map((entry) => entry.category), ...masked];
 };
 
 /**
@@ -67,7 +67,7 @@ export const sortCategoriesByEffectiveValue = (
  * Categories are sorted by effective value for the current year (descending):
  * past months use actual, current and future months use planned.
  * When an allowlist is active, visible (allowed) categories
- * are sorted first, then masked ones - each group by effective value.
+ * are sorted first, then masked ones in their original encounter order.
  */
 export const buildBlocks = (
   rows: ReadonlyArray<BudgetRow>,


### PR DESCRIPTION
Summary:
- sort allowed categories by effective value before masked categories
- preserve masked category encounter order without computing hidden sort values
- add focused model coverage for filtered and all modes

Testing:
- not run locally, as required for integration PRs