### PR TITLE
Use effective plan for current-year totals

### DIFF
--- a/apps/web/src/ui/tables/budget/model/yearTotals.test.ts
+++ b/apps/web/src/ui/tables/budget/model/yearTotals.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BudgetRow } from "@/server/budget/getBudgetGrid";
+import { computeYearTotal } from "@/ui/tables/budget/model/yearTotals";
+
+const budgetRow = (
+  month: string,
+  direction: string,
+  category: string,
+  planned: number,
+  actual: number,
+): BudgetRow => ({
+  month,
+  direction,
+  category,
+  plannedBase: planned,
+  plannedModifier: 0,
+  planned,
+  actual,
+  hasUnconvertible: false,
+});
+
+test("computeYearTotal uses actuals from completed months in the current-year plan", (): void => {
+  const rows: ReadonlyArray<BudgetRow> = [
+    budgetRow("2026-01", "income", "Included", 100, 10),
+    budgetRow("2026-05", "income", "Included", 50, 5),
+    budgetRow("2026-12", "income", "Included", 30, 99),
+    budgetRow("2026-01", "income", "Excluded", 200, 20),
+    budgetRow("2026-05", "income", "Excluded", 40, 4),
+    budgetRow("2026-12", "income", "Excluded", 10, 1),
+    budgetRow("2026-01", "spend", "Cost", 100, 5),
+    budgetRow("2026-05", "spend", "Cost", 20, 2),
+    budgetRow("2026-12", "spend", "Cost", 15, 3),
+    budgetRow("2026-01", "transfer", "Move", 9, 2),
+    budgetRow("2026-05", "transfer", "Move", 5, 1),
+    budgetRow("2026-12", "transfer", "Move", 3, 4),
+  ];
+
+  const total = computeYearTotal(
+    rows,
+    { incomeActual: 0, spendActual: 0, transferActual: 0 },
+    {},
+    {},
+    {},
+    "2026",
+    "2026-05",
+    new Set(["Included"]),
+  );
+
+  assert.deepEqual(total.directionCategoryTotals.get("income")?.get("Included"), {
+    plannedBase: 180,
+    plannedModifier: 0,
+    planned: 90,
+    actual: 114,
+  });
+  assert.deepEqual(total.directionCategoryTotals.get("income")?.get("Excluded"), {
+    plannedBase: 250,
+    plannedModifier: 0,
+    planned: 70,
+    actual: 25,
+  });
+  assert.equal(total.directionSubtotals.get("income")?.planned, 160);
+  assert.equal(total.directionSubtotals.get("income")?.actual, 139);
+  assert.equal(total.filteredSubtotals.get("income")?.planned, 90);
+  assert.equal(total.filteredSubtotals.get("income")?.actual, 114);
+  assert.equal(total.remainder.planned, 130);
+  assert.equal(total.remainder.actual, 136);
+});
+
+test("computeYearTotal keeps full-year plans for past and future years", (): void => {
+  for (const year of ["2025", "2027"]) {
+    const rows: ReadonlyArray<BudgetRow> = [
+      budgetRow(`${year}-01`, "income", "Salary", 100, 10),
+      budgetRow(`${year}-05`, "income", "Salary", 50, 5),
+      budgetRow(`${year}-12`, "income", "Salary", 30, 99),
+    ];
+
+    const total = computeYearTotal(
+      rows,
+      { incomeActual: 0, spendActual: 0, transferActual: 0 },
+      {},
+      {},
+      {},
+      year,
+      "2026-05",
+      null,
+    );
+
+    assert.equal(total.directionCategoryTotals.get("income")?.get("Salary")?.planned, 180);
+    assert.equal(total.directionCategoryTotals.get("income")?.get("Salary")?.actual, 114);
+  }
+});

--- a/apps/web/src/ui/tables/budget/model/yearTotals.ts
+++ b/apps/web/src/ui/tables/budget/model/yearTotals.ts
@@ -1,4 +1,4 @@
-import { getYearMonths } from "@/lib/monthUtils";
+import { getYear, getYearMonths } from "@/lib/monthUtils";
 import type { BudgetRow, BusinessPersonalTransferCell, CumulativeBefore } from "@/server/budget/getBudgetGrid";
 import { computeCumulativeBalances, computeCumulativeBalancesByLiquidity, computeFxAdjustments } from "@/ui/tables/budget/model/balances";
 import type { CumulativeBalance } from "@/ui/tables/budget/model/balances";
@@ -40,6 +40,25 @@ export type YearTotalComputed = Readonly<{
   anyTainted: boolean;
 }>;
 
+const sumCellValuesForYear = (
+  months: ReadonlyArray<string>,
+  getValue: (month: string) => CellValue,
+  year: string,
+  currentMonth: string,
+): CellValue => {
+  const total = sumCellValuesOverMonths(months, getValue);
+  if (year !== getYear(currentMonth)) {
+    return total;
+  }
+
+  let planned = 0;
+  for (const month of months) {
+    const cell = getValue(month);
+    planned += month < currentMonth ? cell.actual : cell.planned;
+  }
+  return { ...total, planned };
+};
+
 /**
  * Computes all yearly totals from a full year of BudgetRows fetched from the server.
  * Returns pre-aggregated data for every year-total cell in the table:
@@ -65,11 +84,11 @@ export const computeYearTotal = (
   for (const block of blocks) {
     directionSubtotals.set(
       block.direction,
-      sumCellValuesOverMonths(yearMonths, (m) => block.subtotals.get(m) ?? zeroCellValue),
+      sumCellValuesForYear(yearMonths, (m) => block.subtotals.get(m) ?? zeroCellValue, year, currentMonth),
     );
     const catTotals = new Map<string, CellValue>();
     for (const cat of block.categories) {
-      catTotals.set(cat, sumCellValuesOverMonths(yearMonths, (m) => lookupCell(block.cells, m, cat)));
+      catTotals.set(cat, sumCellValuesForYear(yearMonths, (m) => lookupCell(block.cells, m, cat), year, currentMonth));
     }
     directionCategoryTotals.set(block.direction, catTotals);
   }
@@ -80,7 +99,7 @@ export const computeYearTotal = (
       const filtered = computeAllowedSubtotals(block, yearMonths, allowlist);
       filteredSubtotals.set(
         block.direction,
-        sumCellValuesOverMonths(yearMonths, (m) => filtered.get(m) ?? zeroCellValue),
+        sumCellValuesForYear(yearMonths, (m) => filtered.get(m) ?? zeroCellValue, year, currentMonth),
       );
     }
   }


### PR DESCRIPTION
## Summary
- use actual values for completed months in current-year annual plan totals
- preserve full-year plan behavior for past and future years
- cover category, direction, filtered subtotal, remainder, and annual actual behavior

## Validation
- not run locally; required trunk CI owns executable validation