### PR TITLE
Protect filtered budget values

### DIFF
--- a/apps/web/src/lib/dataMask.ts
+++ b/apps/web/src/lib/dataMask.ts
@@ -1,5 +1,7 @@
 export type CellVisibility = Readonly<{ showData: boolean; maskClass: string }>;
 
+export const MASKED_CELL_PLACEHOLDER = "0";
+
 /**
  * Returns visibility for a cell given the current allowlist.
  * allowlist=null means "show all" (All mode).

--- a/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetPlanCell.tsx
@@ -11,6 +11,7 @@ import {
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/cn";
+import { MASKED_CELL_PLACEHOLDER } from "@/lib/dataMask";
 import type { NumberFormat } from "@/lib/locale";
 import type { BudgetAdjustmentDirection } from "@/server/budget/budgetAdjustments";
 import { useFilteredMode } from "@/ui/FilteredModeProvider";
@@ -1122,14 +1123,15 @@ export const BudgetPlanCell = (props: BudgetPlanCellProps): ReactElement => {
       ref={cellRef}
       className={cn(
         styles.cell,
-        styles.cellEditable,
+        showData ? styles.cellEditable : "",
         cmClass,
         maskClass,
-        taintedClass,
-        isPlanOver ? tableStateStyles.over : "",
+        showData ? taintedClass : "",
+        showData && isPlanOver ? tableStateStyles.over : "",
       )}
       data-testid={showData ? `budget-plan-cell-${editorId}` : undefined}
     >
+      {!showData && MASKED_CELL_PLACEHOLDER}
       {showData && (
         <button
           ref={triggerButtonRef}

--- a/apps/web/src/ui/tables/budget/model/blocks.test.ts
+++ b/apps/web/src/ui/tables/budget/model/blocks.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BudgetRow } from "@/server/budget/getBudgetGrid";
+import { buildBlocks } from "@/ui/tables/budget/model/blocks";
+
+const budgetRow = (
+  category: string,
+  planned: number,
+): BudgetRow => ({
+  month: "2026-02",
+  direction: "spend",
+  category,
+  plannedBase: planned,
+  plannedModifier: 0,
+  planned,
+  actual: 0,
+  hasUnconvertible: false,
+});
+
+const spendCategories = (
+  rows: ReadonlyArray<BudgetRow>,
+  allowlist: ReadonlySet<string> | null,
+): ReadonlyArray<string> => {
+  const blocks = buildBlocks(rows, ["2026-02"], "2026-02", allowlist);
+  const block = blocks[0];
+  assert.ok(block);
+  return block.categories;
+};
+
+test("puts every visible category before every masked category in filtered mode", (): void => {
+  const rows = [
+    budgetRow("masked-high", 1_000),
+    budgetRow("visible-low", 10),
+    budgetRow("masked-low", 1),
+    budgetRow("visible-high", 100),
+  ];
+
+  assert.deepEqual(
+    spendCategories(rows, new Set(["visible-low", "visible-high"])),
+    ["visible-high", "visible-low", "masked-high", "masked-low"],
+  );
+});
+
+test("sorts visible categories by effective value in filtered mode", (): void => {
+  const rows = [
+    budgetRow("visible-low", 10),
+    budgetRow("visible-high", 100),
+    budgetRow("visible-middle", 50),
+  ];
+
+  assert.deepEqual(
+    spendCategories(rows, new Set(["visible-low", "visible-high", "visible-middle"])),
+    ["visible-high", "visible-middle", "visible-low"],
+  );
+});
+
+test("keeps masked categories in source order when their amounts invert", (): void => {
+  const allowlist = new Set(["visible"]);
+  const highThenLow = [
+    budgetRow("masked-first", 100),
+    budgetRow("masked-second", 10),
+    budgetRow("visible", 50),
+  ];
+  const lowThenHigh = [
+    budgetRow("masked-first", 10),
+    budgetRow("masked-second", 100),
+    budgetRow("visible", 50),
+  ];
+
+  assert.deepEqual(
+    spendCategories(highThenLow, allowlist),
+    ["visible", "masked-first", "masked-second"],
+  );
+  assert.deepEqual(
+    spendCategories(lowThenHigh, allowlist),
+    ["visible", "masked-first", "masked-second"],
+  );
+});
+
+test("sorts every category by effective value in all mode", (): void => {
+  const rows = [
+    budgetRow("low", 10),
+    budgetRow("high", 100),
+    budgetRow("middle", 50),
+  ];
+
+  assert.deepEqual(
+    spendCategories(rows, null),
+    ["high", "middle", "low"],
+  );
+});

--- a/apps/web/src/ui/tables/budget/model/blocks.ts
+++ b/apps/web/src/ui/tables/budget/model/blocks.ts
@@ -39,9 +39,9 @@ export const computeEffectiveValue = (
 
 /**
  * Sorts categories by effective value for the current year, descending.
- * When maskedCategories is non-empty, visible categories come first,
- * then masked ones - each group sorted by effective value independently.
- * Stable sort preserves relative order for equal values.
+ * Visible categories come first and masked categories retain their source order.
+ * Effective values are not computed for masked categories.
+ * Stable sort preserves relative order for equal visible values.
  */
 export const sortCategoriesByEffectiveValue = (
   categories: ReadonlyArray<string>,
@@ -50,16 +50,16 @@ export const sortCategoriesByEffectiveValue = (
   currentMonth: string,
   maskedCategories: ReadonlySet<string>,
 ): ReadonlyArray<string> => {
-  const withValues = [...categories].map((category) => ({
-    category,
-    value: computeEffectiveValue(cells, category, currentYearMonths, currentMonth),
-    isMasked: maskedCategories.has(category),
-  }));
-  withValues.sort((a, b) => {
-    if (a.isMasked !== b.isMasked) return a.isMasked ? 1 : -1;
-    return b.value - a.value;
-  });
-  return withValues.map((entry) => entry.category);
+  const visibleWithValues = categories
+    .filter((category) => !maskedCategories.has(category))
+    .map((category) => ({
+      category,
+      value: computeEffectiveValue(cells, category, currentYearMonths, currentMonth),
+    }));
+  visibleWithValues.sort((a, b) => b.value - a.value);
+
+  const masked = categories.filter((category) => maskedCategories.has(category));
+  return [...visibleWithValues.map((entry) => entry.category), ...masked];
 };
 
 /**
@@ -67,7 +67,7 @@ export const sortCategoriesByEffectiveValue = (
  * Categories are sorted by effective value for the current year (descending):
  * past months use actual, current and future months use planned.
  * When an allowlist is active, visible (allowed) categories
- * are sorted first, then masked ones - each group by effective value.
+ * are sorted first, then masked ones in their original encounter order.
  */
 export const buildBlocks = (
   rows: ReadonlyArray<BudgetRow>,

--- a/apps/web/src/ui/tables/budget/table/sections/BudgetDerivedSection.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/BudgetDerivedSection.tsx
@@ -3,7 +3,7 @@
 import { Fragment, type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
-import { getCellVisibility } from "@/lib/dataMask";
+import { getCellVisibility, MASKED_CELL_PLACEHOLDER } from "@/lib/dataMask";
 import type { NumberFormat } from "@/lib/locale";
 import type { BusinessPersonalTransferCell } from "@/server/budget/getBudgetGrid";
 import {
@@ -88,6 +88,12 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
   const derivedVisibility = getCellVisibility(effectiveAllowlist, null);
   const derivedMaskClass = derivedVisibility.maskClass;
   const canOpenDerivedDrillDown = derivedVisibility.showData;
+  const renderDerivedValue = (formattedValue: string): string => (
+    derivedVisibility.showData ? formattedValue : MASKED_CELL_PLACEHOLDER
+  );
+  const renderDerivedStateClass = (stateClass: string): string => (
+    derivedVisibility.showData ? stateClass : ""
+  );
 
   return (
     <>
@@ -98,26 +104,32 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
         currentYear={currentYear}
         yearComputed={yearComputed}
         loadingKind="derived"
+        showData={derivedVisibility.showData}
+        maskClass={derivedMaskClass}
         rowClassName={styles.categoryRow}
         renderPastYear={(year, yearData) => (
           <td key={`total-${year}`} className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
-            {formatFxAmount(yearData.yearFxAdjust, numberFormat)}
+            {renderDerivedValue(formatFxAmount(yearData.yearFxAdjust, numberFormat))}
           </td>
         )}
         renderFutureYear={(year) => (
-          <td key={`total-${year}`} className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`} />
+          <td key={`total-${year}`} className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
+            {derivedVisibility.showData ? null : MASKED_CELL_PLACEHOLDER}
+          </td>
         )}
         renderCurrentYear={(year, yearData) => (
           <Fragment key={`total-${year}`}>
-            <td className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`} />
             <td className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
-              {formatFxAmount(yearData.yearFxAdjust, numberFormat)}
+              {derivedVisibility.showData ? null : MASKED_CELL_PLACEHOLDER}
+            </td>
+            <td className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
+              {renderDerivedValue(formatFxAmount(yearData.yearFxAdjust, numberFormat))}
             </td>
           </Fragment>
         )}
         renderPastMonth={(month) => {
           const fx = fxAdjustments.get(month);
-          const fxClickable = fx !== undefined;
+          const fxClickable = canOpenDerivedDrillDown && fx !== undefined;
           return renderValueCells({
             key: month,
             month,
@@ -155,7 +167,7 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
         })}
         renderCurrentMonth={(month) => {
           const fx = fxAdjustments.get(month);
-          const fxClickable = fx !== undefined;
+          const fxClickable = canOpenDerivedDrillDown && fx !== undefined;
           return renderValueCells({
             key: month,
             month,
@@ -183,20 +195,22 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
         currentYear={currentYear}
         yearComputed={yearComputed}
         loadingKind="subtotal"
+        showData={derivedVisibility.showData}
+        maskClass={derivedMaskClass}
         rowClassName={styles.directionRow}
         renderPastYear={(year, yearData) => {
           const yearTotalStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.actual));
           return (
-            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalStateClass} ${getRemainderValueClass(yearData.remainder.actual, yearData.anyTainted)}`}>
-              {formatSignedAmount(yearData.remainder.actual, numberFormat)}
+            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${renderDerivedStateClass(yearTotalStateClass)} ${renderDerivedStateClass(getRemainderValueClass(yearData.remainder.actual, yearData.anyTainted))}`}>
+              {renderDerivedValue(formatSignedAmount(yearData.remainder.actual, numberFormat))}
             </td>
           );
         }}
         renderFutureYear={(year, yearData) => {
           const yearTotalStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.planned));
           return (
-            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalStateClass} ${getRemainderValueClass(yearData.remainder.planned, yearData.anyTainted)}`}>
-              {formatSignedAmount(yearData.remainder.planned, numberFormat)}
+            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${renderDerivedStateClass(yearTotalStateClass)} ${renderDerivedStateClass(getRemainderValueClass(yearData.remainder.planned, yearData.anyTainted))}`}>
+              {renderDerivedValue(formatSignedAmount(yearData.remainder.planned, numberFormat))}
             </td>
           );
         }}
@@ -205,11 +219,11 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           const yearTotalActualStateClass = buildYearTotalStateClass(yearData.anyTainted, isNegativeValueOver(yearData.remainder.actual));
           return (
             <Fragment key={`total-${year}`}>
-              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalPlanStateClass} ${getRemainderValueClass(yearData.remainder.planned, yearData.anyTainted)}`}>
-                {formatSignedAmount(yearData.remainder.planned, numberFormat)}
+              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${renderDerivedStateClass(yearTotalPlanStateClass)} ${renderDerivedStateClass(getRemainderValueClass(yearData.remainder.planned, yearData.anyTainted))}`}>
+                {renderDerivedValue(formatSignedAmount(yearData.remainder.planned, numberFormat))}
               </td>
-              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalActualStateClass} ${getRemainderValueClass(yearData.remainder.actual, yearData.anyTainted)}`}>
-                {formatSignedAmount(yearData.remainder.actual, numberFormat)}
+              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${renderDerivedStateClass(yearTotalActualStateClass)} ${renderDerivedStateClass(getRemainderValueClass(yearData.remainder.actual, yearData.anyTainted))}`}>
+                {renderDerivedValue(formatSignedAmount(yearData.remainder.actual, numberFormat))}
               </td>
             </Fragment>
           );
@@ -298,20 +312,22 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
         currentYear={currentYear}
         yearComputed={yearComputed}
         loadingKind="subtotal"
+        showData={derivedVisibility.showData}
+        maskClass={derivedMaskClass}
         rowClassName={styles.directionRow}
         renderPastYear={(year, yearData) => {
           const yearTotalStateClass = buildYearTotalStateClass(yearData.decemberBalance.isTainted, isNegativeValueOver(yearData.decemberBalance.actual));
           return (
-            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalStateClass}`}>
-              {formatAmount(yearData.decemberBalance.actual, numberFormat)}
+            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${renderDerivedStateClass(yearTotalStateClass)}`}>
+              {renderDerivedValue(formatAmount(yearData.decemberBalance.actual, numberFormat))}
             </td>
           );
         }}
         renderFutureYear={(year, yearData) => {
           const yearTotalStateClass = buildYearTotalStateClass(yearData.decemberBalance.isTainted, isNegativeValueOver(yearData.decemberBalance.plan));
           return (
-            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalStateClass}`}>
-              {formatAmount(yearData.decemberBalance.plan, numberFormat)}
+            <td key={`total-${year}`} className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${renderDerivedStateClass(yearTotalStateClass)}`}>
+              {renderDerivedValue(formatAmount(yearData.decemberBalance.plan, numberFormat))}
             </td>
           );
         }}
@@ -320,11 +336,11 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           const yearTotalActualStateClass = buildYearTotalStateClass(yearData.decemberBalance.isTainted, isNegativeValueOver(yearData.decemberBalance.actual));
           return (
             <Fragment key={`total-${year}`}>
-              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalPlanStateClass}`}>
-                {formatAmount(yearData.decemberBalance.plan, numberFormat)}
+              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${renderDerivedStateClass(yearTotalPlanStateClass)}`}>
+                {renderDerivedValue(formatAmount(yearData.decemberBalance.plan, numberFormat))}
               </td>
-              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${yearTotalActualStateClass}`}>
-                {formatAmount(yearData.decemberBalance.actual, numberFormat)}
+              <td className={`${styles.cell} ${styles.cellSubtotal} ${styles.yearTotal}${derivedMaskClass}${renderDerivedStateClass(yearTotalActualStateClass)}`}>
+                {renderDerivedValue(formatAmount(yearData.decemberBalance.actual, numberFormat))}
               </td>
             </Fragment>
           );
@@ -400,6 +416,7 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           currentYear={currentYear}
           yearComputed={yearComputed}
           numberFormat={numberFormat}
+          showData={derivedVisibility.showData}
           derivedMaskClass={derivedMaskClass}
           mebByLiq={mebByLiq}
           projectedLiqBalances={projectedLiqBalances}
@@ -414,6 +431,8 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           currentYear={currentYear}
           yearComputed={yearComputed}
           loadingKind="derived"
+          showData={derivedVisibility.showData}
+          maskClass={derivedMaskClass}
           rowClassName={`${styles.categoryRow} ${styles.businessPersonalDivider}`}
           renderPastYear={(year, yearData) => {
             const cell = yearData.businessPersonalTransfer;
@@ -421,27 +440,31 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
             return (
               <td
                 key={`total-${year}`}
-                className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}${stateClass}${canOpenDerivedDrillDown ? ` ${styles.cellClickable}` : ""}`}
+                className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}${renderDerivedStateClass(stateClass)}${canOpenDerivedDrillDown ? ` ${styles.cellClickable}` : ""}`}
                 onClick={canOpenDerivedDrillDown ? () => openDrillDown(buildBusinessPersonalTransferYearDrillDownFilter(year)) : undefined}
               >
-                {formatAmount(cell.actual, numberFormat)}
+                {renderDerivedValue(formatAmount(cell.actual, numberFormat))}
               </td>
             );
           }}
           renderFutureYear={(year) => (
-            <td key={`total-${year}`} className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`} />
+            <td key={`total-${year}`} className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
+              {derivedVisibility.showData ? null : MASKED_CELL_PLACEHOLDER}
+            </td>
           )}
           renderCurrentYear={(year, yearData) => {
             const cell = yearData.businessPersonalTransfer;
             const stateClass = buildYearTotalStateClass(cell.hasUnconvertible, false);
             return (
               <Fragment key={`total-${year}`}>
-                <td className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`} />
+                <td className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
+                  {derivedVisibility.showData ? null : MASKED_CELL_PLACEHOLDER}
+                </td>
                 <td
-                  className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}${stateClass}${canOpenDerivedDrillDown ? ` ${styles.cellClickable}` : ""}`}
+                  className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}${renderDerivedStateClass(stateClass)}${canOpenDerivedDrillDown ? ` ${styles.cellClickable}` : ""}`}
                   onClick={canOpenDerivedDrillDown ? () => openDrillDown(buildBusinessPersonalTransferYearDrillDownFilter(year)) : undefined}
                 >
-                  {formatAmount(cell.actual, numberFormat)}
+                  {renderDerivedValue(formatAmount(cell.actual, numberFormat))}
                 </td>
               </Fragment>
             );

--- a/apps/web/src/ui/tables/budget/table/sections/derived/LiquidityRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/derived/LiquidityRow.tsx
@@ -3,6 +3,7 @@
 import { Fragment, type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
+import { MASKED_CELL_PLACEHOLDER } from "@/lib/dataMask";
 import type { NumberFormat } from "@/lib/locale";
 import {
   formatAmount,
@@ -13,6 +14,7 @@ import styles from "@/ui/tables/budget/BudgetTable.module.css";
 import {
   renderColumnCells,
   renderDerivedYearLoadingCells,
+  renderMaskedYearCells,
 } from "../shared";
 
 type LiquidityRowProps = Readonly<{
@@ -22,6 +24,7 @@ type LiquidityRowProps = Readonly<{
   currentYear: string;
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
   numberFormat: NumberFormat;
+  showData: boolean;
   derivedMaskClass: string;
   mebByLiq: Readonly<Record<string, Readonly<Record<string, number>>>>;
   projectedLiqBalances: ReadonlyMap<string, Readonly<Record<string, number>>>;
@@ -35,16 +38,27 @@ export const LiquidityRow = (props: LiquidityRowProps): ReactElement => {
     currentYear,
     yearComputed,
     numberFormat,
+    showData,
     derivedMaskClass,
     mebByLiq,
     projectedLiqBalances,
   } = props;
   const { t } = useTranslation();
+  const renderValue = (value: number): string => (
+    showData ? formatAmount(value, numberFormat) : MASKED_CELL_PLACEHOLDER
+  );
+  const renderYearLoading = (year: string, isCurrentYearValue: boolean): ReactElement => (
+    showData
+      ? renderDerivedYearLoadingCells(year, isCurrentYearValue)
+      : renderMaskedYearCells(year, isCurrentYearValue, derivedMaskClass)
+  );
 
   return (
     <tr key={`bal-${liquidity}`} className={styles.categoryRow}>
       <td className={`${styles.categoryLabel} ${styles.stickyCol}${derivedMaskClass}`}>
-        {t(`budget.liquidity${liquidity.charAt(0).toUpperCase()}${liquidity.slice(1)}`)}
+        {showData
+          ? t(`budget.liquidity${liquidity.charAt(0).toUpperCase()}${liquidity.slice(1)}`)
+          : MASKED_CELL_PLACEHOLDER}
       </td>
       <td className={styles.leftSpacer} />
       {columnSequence.map((column) => {
@@ -55,73 +69,73 @@ export const LiquidityRow = (props: LiquidityRowProps): ReactElement => {
           currentYear,
           isYearLoading: column.kind === "year-total" && yearData === undefined,
           renderYearLoading: (isCurrentYearValue) =>
-            renderDerivedYearLoadingCells(column.kind === "year-total" ? column.year : "", isCurrentYearValue),
+            renderYearLoading(column.kind === "year-total" ? column.year : "", isCurrentYearValue),
           renderPastYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
-              return renderDerivedYearLoadingCells(column.kind === "year-total" ? column.year : "", false);
+              return renderYearLoading(column.kind === "year-total" ? column.year : "", false);
             }
             return (
               <td key={`total-${column.year}`} className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
-                {formatAmount(yearData.decemberBalancesByLiquidity[liquidity] ?? 0, numberFormat)}
+                {renderValue(yearData.decemberBalancesByLiquidity[liquidity] ?? 0)}
               </td>
             );
           },
           renderFutureYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
-              return renderDerivedYearLoadingCells(column.kind === "year-total" ? column.year : "", false);
+              return renderYearLoading(column.kind === "year-total" ? column.year : "", false);
             }
             return (
               <td key={`total-${column.year}`} className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
-                {formatAmount(yearData.decemberBalancesByLiquidityPlan[liquidity] ?? 0, numberFormat)}
+                {renderValue(yearData.decemberBalancesByLiquidityPlan[liquidity] ?? 0)}
               </td>
             );
           },
           renderCurrentYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
-              return renderDerivedYearLoadingCells(column.kind === "year-total" ? column.year : "", true);
+              return renderYearLoading(column.kind === "year-total" ? column.year : "", true);
             }
             return (
               <Fragment key={`total-${column.year}`}>
                 <td className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
-                  {formatAmount(yearData.decemberBalancesByLiquidityPlan[liquidity] ?? 0, numberFormat)}
+                  {renderValue(yearData.decemberBalancesByLiquidityPlan[liquidity] ?? 0)}
                 </td>
                 <td className={`${styles.cell} ${styles.yearTotal}${derivedMaskClass}`}>
-                  {formatAmount(yearData.decemberBalancesByLiquidity[liquidity] ?? 0, numberFormat)}
+                  {renderValue(yearData.decemberBalancesByLiquidity[liquidity] ?? 0)}
                 </td>
               </Fragment>
             );
           },
           renderPastMonth: () => {
             if (column.kind !== "month") {
-              return renderDerivedYearLoadingCells("invalid", false);
+              return renderYearLoading("invalid", false);
             }
             return (
               <td key={column.month} className={`${styles.cell}${derivedMaskClass}`}>
-                {formatAmount(mebByLiq[column.month]?.[liquidity] ?? 0, numberFormat)}
+                {renderValue(mebByLiq[column.month]?.[liquidity] ?? 0)}
               </td>
             );
           },
           renderFutureMonth: () => {
             if (column.kind !== "month") {
-              return renderDerivedYearLoadingCells("invalid", false);
+              return renderYearLoading("invalid", false);
             }
             return (
               <td key={column.month} className={`${styles.cell}${derivedMaskClass}`}>
-                {formatAmount(projectedLiqBalances.get(column.month)?.[liquidity] ?? 0, numberFormat)}
+                {renderValue(projectedLiqBalances.get(column.month)?.[liquidity] ?? 0)}
               </td>
             );
           },
           renderCurrentMonth: () => {
             if (column.kind !== "month") {
-              return renderDerivedYearLoadingCells("invalid", false);
+              return renderYearLoading("invalid", false);
             }
             return (
               <Fragment key={column.month}>
                 <td className={`${styles.cell} ${styles.currentMonthPlan}${derivedMaskClass}`}>
-                  {formatAmount(projectedLiqBalances.get(column.month)?.[liquidity] ?? 0, numberFormat)}
+                  {renderValue(projectedLiqBalances.get(column.month)?.[liquidity] ?? 0)}
                 </td>
                 <td className={`${styles.cell} ${styles.currentMonthActual}${derivedMaskClass}`}>
-                  {formatAmount(mebByLiq[column.month]?.[liquidity] ?? 0, numberFormat)}
+                  {renderValue(mebByLiq[column.month]?.[liquidity] ?? 0)}
                 </td>
               </Fragment>
             );

--- a/apps/web/src/ui/tables/budget/table/sections/derived/MetricRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/derived/MetricRow.tsx
@@ -10,6 +10,7 @@ import styles from "@/ui/tables/budget/BudgetTable.module.css";
 import {
   renderColumnCells,
   renderDerivedYearLoadingCells,
+  renderMaskedYearCells,
   renderSubtotalYearLoadingCells,
 } from "../shared";
 
@@ -26,6 +27,8 @@ type MetricRowProps = Readonly<{
   renderFutureMonth: (month: string) => ReactElement;
   renderCurrentMonth: (month: string) => ReactElement;
   loadingKind: "subtotal" | "derived";
+  showData: boolean;
+  maskClass: string;
   rowClassName: string;
 }>;
 
@@ -44,8 +47,17 @@ export const MetricRow = (props: MetricRowProps): ReactElement => {
     renderFutureMonth,
     renderCurrentMonth,
     loadingKind,
+    showData,
+    maskClass,
   } = props;
-  const renderLoading = loadingKind === "subtotal" ? renderSubtotalYearLoadingCells : renderDerivedYearLoadingCells;
+  const renderVisibleLoading = loadingKind === "subtotal"
+    ? renderSubtotalYearLoadingCells
+    : renderDerivedYearLoadingCells;
+  const renderLoading = (year: string, isCurrentYear: boolean): ReactElement => (
+    showData
+      ? renderVisibleLoading(year, isCurrentYear)
+      : renderMaskedYearCells(year, isCurrentYear, maskClass)
+  );
 
   return (
     <tr className={rowClassName}>

--- a/apps/web/src/ui/tables/budget/table/sections/direction/CategoryRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/direction/CategoryRow.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, type ReactElement } from "react";
 
-import { getCellVisibility } from "@/lib/dataMask";
+import { getCellVisibility, MASKED_CELL_PLACEHOLDER } from "@/lib/dataMask";
 import type { NumberFormat } from "@/lib/locale";
 import { BudgetPlanCell } from "@/ui/tables/budget/BudgetPlanCell";
 import {
@@ -28,6 +28,7 @@ import {
   isDirectionActualOverPlanned,
   renderColumnCells,
   renderDerivedYearLoadingCells,
+  renderMaskedYearCells,
 } from "../shared";
 
 type CategoryRowProps = Readonly<{
@@ -103,14 +104,19 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
     onSyncEnd,
   } = props;
   const categoryVisibility = getCellVisibility(effectiveAllowlist, category);
+  const renderYearLoading = (year: string, isCurrentYearValue: boolean): ReactElement => (
+    categoryVisibility.showData
+      ? renderDerivedYearLoadingCells(year, isCurrentYearValue)
+      : renderMaskedYearCells(year, isCurrentYearValue, categoryVisibility.maskClass)
+  );
 
   return (
     <tr key={category} className={styles.categoryRow}>
       <td
-        className={`${styles.categoryLabel} ${styles.stickyCol} copyable-cell${categoryVisibility.maskClass}`}
+        className={`${styles.categoryLabel} ${styles.stickyCol}${categoryVisibility.showData ? " copyable-cell" : ""}${categoryVisibility.maskClass}`}
         onClick={categoryVisibility.showData ? () => copyToClipboard(category) : undefined}
       >
-        {categoryVisibility.showData ? category : ""}
+        {categoryVisibility.showData ? category : MASKED_CELL_PLACEHOLDER}
       </td>
       <td className={styles.leftSpacer} />
       {columnSequence.map((column) => {
@@ -121,14 +127,16 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
           currentYear,
           isYearLoading: column.kind === "year-total" && yearData === undefined,
           renderYearLoading: (isCurrentYearValue) =>
-            renderDerivedYearLoadingCells(column.kind === "year-total" ? column.year : "", isCurrentYearValue),
+            renderYearLoading(column.kind === "year-total" ? column.year : "", isCurrentYearValue),
           renderPastYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
-              return renderDerivedYearLoadingCells(column.kind === "year-total" ? column.year : "", false);
+              return renderYearLoading(column.kind === "year-total" ? column.year : "", false);
             }
             const yearCell =
               yearData.directionCategoryTotals.get(block.direction)?.get(category) ?? zeroCellValue;
-            const yearTotalStateClass = buildYearTotalStateClass(yearData.taintedCategories.has(`${block.direction}::${category}`), false);
+            const yearTotalStateClass = categoryVisibility.showData
+              ? buildYearTotalStateClass(yearData.taintedCategories.has(`${block.direction}::${category}`), false)
+              : "";
             return (
               <td
                 key={`total-${column.year}`}
@@ -140,17 +148,19 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                   ? () => openDrillDown(buildCategoryYearDrillDownFilter(column.year, block.direction, category))
                   : undefined}
               >
-                {categoryVisibility.showData ? formatAmount(yearCell.actual, numberFormat) : ""}
+                {categoryVisibility.showData ? formatAmount(yearCell.actual, numberFormat) : MASKED_CELL_PLACEHOLDER}
               </td>
             );
           },
           renderFutureYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
-              return renderDerivedYearLoadingCells(column.kind === "year-total" ? column.year : "", false);
+              return renderYearLoading(column.kind === "year-total" ? column.year : "", false);
             }
             const yearCell =
               yearData.directionCategoryTotals.get(block.direction)?.get(category) ?? zeroCellValue;
-            const yearTotalStateClass = buildYearTotalStateClass(yearData.taintedCategories.has(`${block.direction}::${category}`), false);
+            const yearTotalStateClass = categoryVisibility.showData
+              ? buildYearTotalStateClass(yearData.taintedCategories.has(`${block.direction}::${category}`), false)
+              : "";
             return (
               <td
                 key={`total-${column.year}`}
@@ -159,19 +169,23 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                   ? `budget-year-plan-${column.year}:${block.direction}:${category}`
                   : undefined}
               >
-                {categoryVisibility.showData ? formatAmount(yearCell.planned, numberFormat) : ""}
+                {categoryVisibility.showData ? formatAmount(yearCell.planned, numberFormat) : MASKED_CELL_PLACEHOLDER}
               </td>
             );
           },
           renderCurrentYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
-              return renderDerivedYearLoadingCells(column.kind === "year-total" ? column.year : "", true);
+              return renderYearLoading(column.kind === "year-total" ? column.year : "", true);
             }
             const yearCell =
               yearData.directionCategoryTotals.get(block.direction)?.get(category) ?? zeroCellValue;
             const isActualOver = isDirectionActualOverPlanned(block.direction, yearCell.planned, yearCell.actual);
-            const yearTotalPlanStateClass = buildYearTotalStateClass(yearData.taintedCategories.has(`${block.direction}::${category}`), false);
-            const yearTotalActualStateClass = buildYearTotalStateClass(yearData.taintedCategories.has(`${block.direction}::${category}`), isActualOver);
+            const yearTotalPlanStateClass = categoryVisibility.showData
+              ? buildYearTotalStateClass(yearData.taintedCategories.has(`${block.direction}::${category}`), false)
+              : "";
+            const yearTotalActualStateClass = categoryVisibility.showData
+              ? buildYearTotalStateClass(yearData.taintedCategories.has(`${block.direction}::${category}`), isActualOver)
+              : "";
             return (
               <Fragment key={`total-${column.year}`}>
                 <td
@@ -180,7 +194,7 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                     ? `budget-year-plan-${column.year}:${block.direction}:${category}`
                     : undefined}
                 >
-                  {categoryVisibility.showData ? formatAmount(yearCell.planned, numberFormat) : ""}
+                  {categoryVisibility.showData ? formatAmount(yearCell.planned, numberFormat) : MASKED_CELL_PLACEHOLDER}
                 </td>
                 <td
                   className={`${styles.cell} ${styles.yearTotal}${categoryVisibility.maskClass}${yearTotalActualStateClass}${categoryVisibility.showData ? ` ${styles.cellClickable}` : ""}`}
@@ -191,17 +205,17 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                     ? () => openDrillDown(buildCategoryYearDrillDownFilter(column.year, block.direction, category))
                     : undefined}
                 >
-                  {categoryVisibility.showData ? formatAmount(yearCell.actual, numberFormat) : ""}
+                  {categoryVisibility.showData ? formatAmount(yearCell.actual, numberFormat) : MASKED_CELL_PLACEHOLDER}
                 </td>
               </Fragment>
             );
           },
           renderPastMonth: () => {
             if (column.kind !== "month") {
-              return renderDerivedYearLoadingCells("invalid", false);
+              return renderYearLoading("invalid", false);
             }
             const cell = lookupCell(block.cells, column.month, category);
-            const taintedClass = taintedCells.has(`${block.direction}::${column.month}::${category}`)
+            const taintedClass = categoryVisibility.showData && taintedCells.has(`${block.direction}::${column.month}::${category}`)
               ? ` ${tableStateStyles.error}`
               : "";
             return (
@@ -212,13 +226,13 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                   ? () => openDrillDown(buildCategoryMonthDrillDownFilter(column.month, block.direction, category))
                   : undefined}
               >
-                {categoryVisibility.showData ? formatAmount(cell.actual, numberFormat) : ""}
+                {categoryVisibility.showData ? formatAmount(cell.actual, numberFormat) : MASKED_CELL_PLACEHOLDER}
               </td>
             );
           },
           renderFutureMonth: () => {
             if (column.kind !== "month") {
-              return renderDerivedYearLoadingCells("invalid", false);
+              return renderYearLoading("invalid", false);
             }
             const cell = lookupCell(block.cells, column.month, category);
             const taintedClass = taintedCells.has(`${block.direction}::${column.month}::${category}`)
@@ -261,7 +275,7 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
           },
           renderCurrentMonth: () => {
             if (column.kind !== "month") {
-              return renderDerivedYearLoadingCells("invalid", false);
+              return renderYearLoading("invalid", false);
             }
             const cell = lookupCell(block.cells, column.month, category);
             const taintedClass = taintedCells.has(`${block.direction}::${column.month}::${category}`)
@@ -302,7 +316,7 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                   onSyncEnd={onSyncEnd}
                 />
                 <td
-                  className={`${styles.cell} ${styles.currentMonthActual}${categoryVisibility.maskClass}${taintedClass}${isActualOver ? ` ${tableStateStyles.over}` : ""}${categoryVisibility.showData ? ` ${styles.cellClickable}` : ""}`}
+                  className={`${styles.cell} ${styles.currentMonthActual}${categoryVisibility.maskClass}${categoryVisibility.showData ? taintedClass : ""}${categoryVisibility.showData && isActualOver ? ` ${tableStateStyles.over}` : ""}${categoryVisibility.showData ? ` ${styles.cellClickable}` : ""}`}
                   data-testid={categoryVisibility.showData
                     ? `budget-actual-${column.month}:${block.direction}:${category}`
                     : undefined}
@@ -310,7 +324,7 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
                     ? () => openDrillDown(buildCategoryMonthDrillDownFilter(column.month, block.direction, category))
                     : undefined}
                 >
-                  {categoryVisibility.showData ? formatAmount(cell.actual, numberFormat) : ""}
+                  {categoryVisibility.showData ? formatAmount(cell.actual, numberFormat) : MASKED_CELL_PLACEHOLDER}
                 </td>
               </Fragment>
             );

--- a/apps/web/src/ui/tables/budget/table/sections/shared.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/shared.tsx
@@ -1,5 +1,6 @@
 import { Fragment, type ReactElement } from "react";
 
+import { MASKED_CELL_PLACEHOLDER } from "@/lib/dataMask";
 import type { NumberFormat } from "@/lib/locale";
 import {
   isFutureMonth,
@@ -87,18 +88,22 @@ export const renderValueCells = (params: RenderValueCellsParams): ReactElement =
     formatter,
     onActualClick,
   } = params;
+  const isMasked = maskClass.includes("data-masked");
   const subtotalClass = isSubtotal ? ` ${styles.cellSubtotal}` : "";
-  const taintedClass = isTainted ? ` ${tableStateStyles.error}` : "";
+  const taintedClass = !isMasked && isTainted ? ` ${tableStateStyles.error}` : "";
+  const visiblePlannedValueClass = isMasked ? "" : plannedValueClass;
+  const visibleActualValueClass = isMasked ? "" : actualValueClass;
+  const visibleActualClick = isMasked ? null : onActualClick;
 
   if (isPastMonth(month, currentMonth)) {
-    const clickableClass = onActualClick !== null ? ` ${styles.cellClickable}` : "";
+    const clickableClass = visibleActualClick !== null ? ` ${styles.cellClickable}` : "";
     return (
       <td
         key={key}
-        className={`${styles.cell}${subtotalClass}${maskClass}${taintedClass}${clickableClass} ${actualValueClass}`}
-        onClick={onActualClick ?? undefined}
+        className={`${styles.cell}${subtotalClass}${maskClass}${taintedClass}${clickableClass} ${visibleActualValueClass}`}
+        onClick={visibleActualClick ?? undefined}
       >
-        {formatter(actual, numberFormat)}
+        {isMasked ? MASKED_CELL_PLACEHOLDER : formatter(actual, numberFormat)}
       </td>
     );
   }
@@ -107,26 +112,26 @@ export const renderValueCells = (params: RenderValueCellsParams): ReactElement =
     return (
       <td
         key={key}
-        className={`${styles.cell}${subtotalClass}${maskClass}${taintedClass}${isPlanOver ? ` ${tableStateStyles.over}` : ""} ${plannedValueClass}`}
+        className={`${styles.cell}${subtotalClass}${maskClass}${taintedClass}${!isMasked && isPlanOver ? ` ${tableStateStyles.over}` : ""} ${visiblePlannedValueClass}`}
       >
-        {formatter(planned, numberFormat)}
+        {isMasked ? MASKED_CELL_PLACEHOLDER : formatter(planned, numberFormat)}
       </td>
     );
   }
 
-  const clickableClass = onActualClick !== null ? ` ${styles.cellClickable}` : "";
+  const clickableClass = visibleActualClick !== null ? ` ${styles.cellClickable}` : "";
   return (
     <Fragment key={key}>
       <td
-        className={`${styles.cell} ${styles.currentMonthPlan}${subtotalClass}${maskClass}${taintedClass}${isPlanOver ? ` ${tableStateStyles.over}` : ""} ${plannedValueClass}`}
+        className={`${styles.cell} ${styles.currentMonthPlan}${subtotalClass}${maskClass}${taintedClass}${!isMasked && isPlanOver ? ` ${tableStateStyles.over}` : ""} ${visiblePlannedValueClass}`}
       >
-        {formatter(planned, numberFormat)}
+        {isMasked ? MASKED_CELL_PLACEHOLDER : formatter(planned, numberFormat)}
       </td>
       <td
-        className={`${styles.cell} ${styles.currentMonthActual}${subtotalClass}${maskClass}${taintedClass}${isActualOver ? ` ${tableStateStyles.over}` : ""}${clickableClass} ${actualValueClass}`}
-        onClick={onActualClick ?? undefined}
+        className={`${styles.cell} ${styles.currentMonthActual}${subtotalClass}${maskClass}${taintedClass}${!isMasked && isActualOver ? ` ${tableStateStyles.over}` : ""}${clickableClass} ${visibleActualValueClass}`}
+        onClick={visibleActualClick ?? undefined}
       >
-        {formatter(actual, numberFormat)}
+        {isMasked ? MASKED_CELL_PLACEHOLDER : formatter(actual, numberFormat)}
       </td>
     </Fragment>
   );
@@ -162,6 +167,27 @@ export const renderDerivedYearLoadingCells = (year: string, isCurrentYear: boole
   return (
     <td key={`total-${year}`} className={`${styles.cell} ${styles.yearTotal} ${styles.yearLoading}`}>
       &hellip;
+    </td>
+  );
+};
+
+export const renderMaskedYearCells = (
+  year: string,
+  isCurrentYear: boolean,
+  maskClass: string,
+): ReactElement => {
+  if (isCurrentYear) {
+    return (
+      <Fragment key={`total-${year}`}>
+        <td className={`${styles.cell} ${styles.yearTotal}${maskClass}`}>{MASKED_CELL_PLACEHOLDER}</td>
+        <td className={`${styles.cell} ${styles.yearTotal}${maskClass}`}>{MASKED_CELL_PLACEHOLDER}</td>
+      </Fragment>
+    );
+  }
+
+  return (
+    <td key={`total-${year}`} className={`${styles.cell} ${styles.yearTotal}${maskClass}`}>
+      {MASKED_CELL_PLACEHOLDER}
     </td>
   );
 };


### PR DESCRIPTION
## Summary
- keep allowed budget categories above masked categories while preserving stable masked order
- render a constant protected budget placeholder under the checkerboard mask
- prevent protected budget cells from exposing real content or interactive metadata

## Validation
- fresh independent cumulative static review: no P0-P4 issues found
- required trunk CI owns executable validation