### PR TITLE
Fix reporting currency balance footer totals

### DIFF
--- a/apps/web/src/ui/tables/balances/BalanceSummaryTables.tsx
+++ b/apps/web/src/ui/tables/balances/BalanceSummaryTables.tsx
@@ -16,6 +16,7 @@ import type { ColumnDef, SortState } from "@/ui/tables/shared/data-table/types";
 import { formatAmount } from "@/ui/tables/shared/format";
 import tableStyles from "@/ui/tables/shared/TableUi.module.css";
 import balancesStyles from "./BalancesTable.module.css";
+import type { ReportingCurrencyTotals } from "./balancesTableModel";
 
 export type LiquidityTotal = Readonly<{
   liquidity: AccountMetadataLiquidity;
@@ -46,9 +47,7 @@ type BalanceSummaryTablesProps = Readonly<{
   reportingCurrency: string;
   numberFormat: NumberFormat;
   maskClass: string;
-  totalUsd: number | null;
-  totalPositiveUsd: number;
-  totalNegativeUsd: number;
+  reportingCurrencyTotals: ReportingCurrencyTotals;
 }>;
 
 export const BalanceSummaryTables = (props: BalanceSummaryTablesProps): ReactElement => {
@@ -65,9 +64,7 @@ export const BalanceSummaryTables = (props: BalanceSummaryTablesProps): ReactEle
     reportingCurrency,
     numberFormat,
     maskClass,
-    totalUsd,
-    totalPositiveUsd,
-    totalNegativeUsd,
+    reportingCurrencyTotals,
   } = props;
   const { t } = useTranslation();
   const getAccountGroupLabel = (accountGroup: AccountMetadataGroup): string =>
@@ -126,11 +123,15 @@ export const BalanceSummaryTables = (props: BalanceSummaryTablesProps): ReactEle
   const totalsFooterRows: ReadonlyArray<ReactElement> = [
     <tr key="total" className={cn(tableStyles.row, tableStyles.rowTotal)}>
       <td className={cn(tableStyles.cell, tableStyles.cellBold)}>{t("balances.total", { currency: reportingCurrency })}</td>
-      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>{formatAmount(totalPositiveUsd, numberFormat)}</td>
-      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>{formatAmount(totalNegativeUsd, numberFormat)}</td>
+      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>
+        {reportingCurrencyTotals.balancePositive !== null ? formatAmount(reportingCurrencyTotals.balancePositive, numberFormat) : "\u2014"}
+      </td>
+      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>
+        {reportingCurrencyTotals.balanceNegative !== null ? formatAmount(reportingCurrencyTotals.balanceNegative, numberFormat) : "\u2014"}
+      </td>
       <td className={tableStyles.cell} />
       <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>
-        {totalUsd !== null ? formatAmount(totalUsd, numberFormat) : "\u2014"}
+        {reportingCurrencyTotals.balance !== null ? formatAmount(reportingCurrencyTotals.balance, numberFormat) : "\u2014"}
       </td>
     </tr>,
   ];
@@ -186,10 +187,14 @@ export const BalanceSummaryTables = (props: BalanceSummaryTablesProps): ReactEle
   const liquidityFooterRows: ReadonlyArray<ReactElement> = [
     <tr key="total" className={cn(tableStyles.row, tableStyles.rowTotal)}>
       <td className={cn(tableStyles.cell, tableStyles.cellBold)}>{t("balances.total", { currency: reportingCurrency })}</td>
-      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>{formatAmount(totalPositiveUsd, numberFormat)}</td>
-      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>{formatAmount(totalNegativeUsd, numberFormat)}</td>
       <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>
-        {totalUsd !== null ? formatAmount(totalUsd, numberFormat) : "\u2014"}
+        {reportingCurrencyTotals.balancePositive !== null ? formatAmount(reportingCurrencyTotals.balancePositive, numberFormat) : "\u2014"}
+      </td>
+      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>
+        {reportingCurrencyTotals.balanceNegative !== null ? formatAmount(reportingCurrencyTotals.balanceNegative, numberFormat) : "\u2014"}
+      </td>
+      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>
+        {reportingCurrencyTotals.balance !== null ? formatAmount(reportingCurrencyTotals.balance, numberFormat) : "\u2014"}
       </td>
       <td className={tableStyles.cell} />
     </tr>,
@@ -246,10 +251,14 @@ export const BalanceSummaryTables = (props: BalanceSummaryTablesProps): ReactEle
   const accountGroupFooterRows: ReadonlyArray<ReactElement> = [
     <tr key="total" className={cn(tableStyles.row, tableStyles.rowTotal)}>
       <td className={cn(tableStyles.cell, tableStyles.cellBold)}>{t("balances.total", { currency: reportingCurrency })}</td>
-      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>{formatAmount(totalPositiveUsd, numberFormat)}</td>
-      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>{formatAmount(totalNegativeUsd, numberFormat)}</td>
       <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>
-        {totalUsd !== null ? formatAmount(totalUsd, numberFormat) : "\u2014"}
+        {reportingCurrencyTotals.balancePositive !== null ? formatAmount(reportingCurrencyTotals.balancePositive, numberFormat) : "\u2014"}
+      </td>
+      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>
+        {reportingCurrencyTotals.balanceNegative !== null ? formatAmount(reportingCurrencyTotals.balanceNegative, numberFormat) : "\u2014"}
+      </td>
+      <td className={cn(tableStyles.cell, tableStyles.cellRight, tableStyles.cellBold, maskClass)}>
+        {reportingCurrencyTotals.balance !== null ? formatAmount(reportingCurrencyTotals.balance, numberFormat) : "\u2014"}
       </td>
       <td className={tableStyles.cell} />
     </tr>,

--- a/apps/web/src/ui/tables/balances/BalancesTable.tsx
+++ b/apps/web/src/ui/tables/balances/BalancesTable.tsx
@@ -24,13 +24,12 @@ import {
   TOTALS_SORT_DEFAULTS,
   buildSortedAccountGroupTotals,
   buildSortedLiquidityTotals,
+  calculateReportingCurrencyTotals,
   filterAndSortAccounts,
   sortCurrencyTotals,
-  sumConvertedBalance,
-  sumNegativeConvertedBalance,
-  sumPositiveConvertedBalance,
   type AccountGroupTotal,
   type LiquidityTotal,
+  type ReportingCurrencyTotals,
 } from "./balancesTableModel";
 
 type Props = Readonly<{
@@ -126,9 +125,10 @@ export const BalancesTable = (props: Props): ReactElement => {
     [localAccounts, accountsSort.sort, showInactive],
   );
 
-  const totalUsd = useMemo<number | null>(() => sumConvertedBalance(localTotals), [localTotals]);
-  const totalPositiveUsd = useMemo<number>(() => sumPositiveConvertedBalance(localTotals), [localTotals]);
-  const totalNegativeUsd = useMemo<number>(() => sumNegativeConvertedBalance(localTotals), [localTotals]);
+  const reportingCurrencyTotals = useMemo<ReportingCurrencyTotals>(
+    () => calculateReportingCurrencyTotals(localAccounts),
+    [localAccounts],
+  );
 
   if (localAccounts.length === 0) {
     return (
@@ -185,9 +185,7 @@ export const BalancesTable = (props: Props): ReactElement => {
         reportingCurrency={reportingCurrency}
         numberFormat={numberFormat}
         maskClass={maskClass}
-        totalUsd={totalUsd}
-        totalPositiveUsd={totalPositiveUsd}
-        totalNegativeUsd={totalNegativeUsd}
+        reportingCurrencyTotals={reportingCurrencyTotals}
       />
 
       <BalanceAccountsTable

--- a/apps/web/src/ui/tables/balances/balancesTableModel.test.ts
+++ b/apps/web/src/ui/tables/balances/balancesTableModel.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { AccountRow } from "@/server/balances/getBalancesSummary";
+import { calculateReportingCurrencyTotals } from "@/ui/tables/balances/balancesTableModel";
+
+const account = (
+  accountId: string,
+  balance: number,
+  balanceReport: number | null,
+): AccountRow => ({
+  accountId,
+  currency: "EUR",
+  liquidity: "high",
+  accountType: "personal",
+  accountGroup: "regular",
+  status: "active",
+  balance,
+  balanceReport,
+  lastTransactionTs: null,
+  overdue: false,
+});
+
+test("calculateReportingCurrencyTotals preserves gross account balances with mixed signs in one currency", (): void => {
+  const totals = calculateReportingCurrencyTotals([
+    account("positive", 100, 110),
+    account("negative", -40, -44),
+  ]);
+
+  assert.deepEqual(totals, {
+    balance: 66,
+    balancePositive: 110,
+    balanceNegative: -44,
+  });
+  assert.equal(totals.balancePositive! + totals.balanceNegative!, totals.balance);
+});
+
+test("calculateReportingCurrencyTotals makes affected totals unavailable when a non-zero balance lacks conversion", (): void => {
+  assert.deepEqual(
+    calculateReportingCurrencyTotals([
+      account("missing-positive", 100, null),
+      account("converted-negative", -40, -44),
+    ]),
+    {
+      balance: null,
+      balancePositive: null,
+      balanceNegative: -44,
+    },
+  );
+
+  assert.deepEqual(
+    calculateReportingCurrencyTotals([
+      account("converted-positive", 100, 110),
+      account("missing-negative", -40, null),
+    ]),
+    {
+      balance: null,
+      balancePositive: 110,
+      balanceNegative: null,
+    },
+  );
+});
+
+test("calculateReportingCurrencyTotals ignores missing conversion for a zero balance", (): void => {
+  assert.deepEqual(
+    calculateReportingCurrencyTotals([
+      account("zero", 0, null),
+      account("converted", 100, 110),
+    ]),
+    {
+      balance: 110,
+      balancePositive: 110,
+      balanceNegative: 0,
+    },
+  );
+});

--- a/apps/web/src/ui/tables/balances/balancesTableModel.ts
+++ b/apps/web/src/ui/tables/balances/balancesTableModel.ts
@@ -41,6 +41,12 @@ type AccountTotalAccumulator = Readonly<{
   accountCount: number;
 }>;
 
+export type ReportingCurrencyTotals = Readonly<{
+  balance: number | null;
+  balancePositive: number | null;
+  balanceNegative: number | null;
+}>;
+
 export const LIQUIDITY_ORDER: Readonly<Record<AccountMetadataLiquidity, number>> = { high: 0, medium: 1, low: 2 };
 export const ACCOUNT_TYPE_ORDER: Readonly<Record<AccountMetadataAccountType, number>> = { personal: 0, business: 1 };
 export const ACCOUNT_GROUP_ORDER: Readonly<Record<AccountMetadataGroup, number>> = { regular: 0, investment: 1 };
@@ -304,34 +310,30 @@ export const filterAndSortAccounts = (
   });
 };
 
-export const sumConvertedBalance = (totals: ReadonlyArray<CurrencyTotal>): number | null => {
-  let sum = 0;
-  let hasNull = false;
-  for (const total of totals) {
-    if (total.balanceReport === null) {
-      hasNull = true;
-    } else {
-      sum += total.balanceReport;
+export const calculateReportingCurrencyTotals = (
+  accounts: ReadonlyArray<AccountRow>,
+): ReportingCurrencyTotals => {
+  let balance = 0;
+  let balancePositive = 0;
+  let balanceNegative = 0;
+  let hasMissingPositiveConversion = false;
+  let hasMissingNegativeConversion = false;
+
+  for (const account of accounts) {
+    if (account.balanceReport === null) {
+      if (account.balance > 0) hasMissingPositiveConversion = true;
+      if (account.balance < 0) hasMissingNegativeConversion = true;
+      continue;
     }
-  }
-  if (hasNull) return null;
-  return sum;
-};
 
-export const sumPositiveConvertedBalance = (totals: ReadonlyArray<CurrencyTotal>): number => {
-  let sum = 0;
-  for (const total of totals) {
-    if (total.balanceReport !== null && total.balanceReport > 0) sum += total.balanceReport;
-    else if (total.balanceReport === null && total.balance > 0) sum += total.balancePositive;
+    balance += account.balanceReport;
+    if (account.balanceReport > 0) balancePositive += account.balanceReport;
+    if (account.balanceReport < 0) balanceNegative += account.balanceReport;
   }
-  return sum;
-};
 
-export const sumNegativeConvertedBalance = (totals: ReadonlyArray<CurrencyTotal>): number => {
-  let sum = 0;
-  for (const total of totals) {
-    if (total.balanceReport !== null && total.balanceReport < 0) sum += total.balanceReport;
-    else if (total.balanceReport === null && total.balance < 0) sum += total.balanceNegative;
-  }
-  return sum;
+  return {
+    balance: hasMissingPositiveConversion || hasMissingNegativeConversion ? null : balance,
+    balancePositive: hasMissingPositiveConversion ? null : balancePositive,
+    balanceNegative: hasMissingNegativeConversion ? null : balanceNegative,
+  };
 };


### PR DESCRIPTION
## Summary
- calculate footer gross totals from converted account-level balances
- keep affected totals unavailable when a non-zero account lacks conversion
- use reporting-currency-neutral naming across all three shared footers
- cover mixed signs, gross-to-net identity, and missing conversion in the pure model

## Validation
- Required CI owns executable validation; no project checks were run locally.