### PR TITLE
Add fixed budget calendar viewport loading

### DIFF
--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableController.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableController.ts
@@ -22,6 +22,7 @@ import { useBudgetTableYearTotals } from "@/ui/tables/budget/controller/useBudge
 import { useBudgetAdjustmentRowsController } from "@/ui/tables/budget/controller/useBudgetAdjustmentRowsController";
 import type { BudgetAdjustmentRowsController } from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
 import type { BudgetBaseLocalAcknowledgementByCell } from "@/ui/tables/budget/budgetBaseRangeReconciliation";
+import { getBudgetDisplayRange } from "@/ui/tables/budget/budgetTableLogic";
 
 export type BudgetTableProps = Readonly<{
   rows: ReadonlyArray<BudgetRow>;
@@ -44,6 +45,8 @@ export type BudgetTableController = Readonly<{
   localBaseAcknowledgementByCell: BudgetBaseLocalAcknowledgementByCell;
   currentMonth: string;
   currentYear: string;
+  loadedFrom: string;
+  loadedTo: string;
   months: ReadonlyArray<string>;
   blocks: ReadonlyArray<DirectionBlock>;
   columnSequence: ReadonlyArray<ColumnEntry>;
@@ -122,6 +125,8 @@ export const useBudgetTableController = (
 
   const currentMonth = useMemo(() => getCurrentMonth(), []);
   const currentYear = useMemo(() => getYear(currentMonth), [currentMonth]);
+  const displayRange = useMemo(() => getBudgetDisplayRange(currentMonth), [currentMonth]);
+  const [observedYearTotals, setObservedYearTotals] = useState<ReadonlySet<string>>(new Set());
   const resetYearTotalsRef = useRef<() => void>(() => undefined);
   const invalidateYearTotalsRef = useRef<(years: ReadonlySet<string>) => void>(
     () => undefined,
@@ -144,6 +149,8 @@ export const useBudgetTableController = (
 
   const rangeState = useBudgetTableRangeState({
     rows: props.rows,
+    displayMonthFrom: displayRange.monthFrom,
+    displayMonthTo: displayRange.monthTo,
     initialMonthFrom: props.initialMonthFrom,
     initialMonthTo: props.initialMonthTo,
     cumulativeBefore: props.cumulativeBefore,
@@ -151,13 +158,13 @@ export const useBudgetTableController = (
     monthEndBalancesByLiquidity: props.monthEndBalancesByLiquidity,
     businessPersonalTransfers: props.businessPersonalTransfers,
     hasBusinessAccount: props.hasBusinessAccount,
+    refreshToken: props.refreshToken,
     onVisibleRangeRefreshStart: handleVisibleRangeRefreshStart,
     loadBudgetRange: budgetAdjustments.loadRange,
   });
 
   const { yearComputed, invalidateYearTotals, resetYearTotals } = useBudgetTableYearTotals({
-    loadedFrom: rangeState.loadedFrom,
-    loadedTo: rangeState.loadedTo,
+    observedYears: observedYearTotals,
     currentMonth,
     effectiveAllowlist,
     refreshToken: props.refreshToken,
@@ -181,15 +188,27 @@ export const useBudgetTableController = (
     ],
   );
 
+  const handleYearTotalsObserved = useCallback((years: ReadonlySet<string>): void => {
+    setObservedYearTotals((previous) => {
+      const next = new Set(previous);
+      for (const year of years) {
+        next.add(year);
+      }
+      return next.size === previous.size ? previous : next;
+    });
+  }, []);
+
   const viewportState = useBudgetTableViewport({
     currentMonth,
     pendingSaves: rangeState.pendingSaves + budgetAdjustments.pendingMutationCount,
-    onReachLeft: rangeState.loadLeft,
-    onReachRight: rangeState.loadRight,
+    onMonthsObserved: rangeState.requestVisibleMonths,
+    onYearTotalsObserved: handleYearTotalsObserved,
   });
 
   const derivedState = useBudgetTableDerivedState({
     allRows: rowsWithAdjustments,
+    displayFrom: displayRange.monthFrom,
+    displayTo: displayRange.monthTo,
     loadedFrom: rangeState.loadedFrom,
     loadedTo: rangeState.loadedTo,
     cumBefore: rangeState.cumBefore,
@@ -229,6 +248,8 @@ export const useBudgetTableController = (
       rangeState.localBaseAcknowledgementByCell,
     currentMonth,
     currentYear,
+    loadedFrom: rangeState.loadedFrom,
+    loadedTo: rangeState.loadedTo,
     months: derivedState.months,
     blocks: derivedState.blocks,
     columnSequence: derivedState.columnSequence,

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableDerivedState.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableDerivedState.ts
@@ -41,6 +41,8 @@ export type BudgetTableDerivedState = Readonly<{
 
 type UseBudgetTableDerivedStateParams = Readonly<{
   allRows: ReadonlyArray<BudgetRow>;
+  displayFrom: string;
+  displayTo: string;
   loadedFrom: string;
   loadedTo: string;
   cumBefore: CumulativeBefore;
@@ -52,6 +54,8 @@ type UseBudgetTableDerivedStateParams = Readonly<{
 
 export const useBudgetTableDerivedState = ({
   allRows,
+  displayFrom,
+  displayTo,
   loadedFrom,
   loadedTo,
   cumBefore,
@@ -61,6 +65,11 @@ export const useBudgetTableDerivedState = ({
   effectiveAllowlist,
 }: UseBudgetTableDerivedStateParams): BudgetTableDerivedState => {
   const months = useMemo<ReadonlyArray<string>>(
+    () => generateMonthRange(displayFrom, displayTo),
+    [displayFrom, displayTo],
+  );
+
+  const loadedMonths = useMemo<ReadonlyArray<string>>(
     () => generateMonthRange(loadedFrom, loadedTo),
     [loadedFrom, loadedTo],
   );
@@ -107,7 +116,7 @@ export const useBudgetTableDerivedState = ({
   const cumulativeBalances = useMemo<ReadonlyMap<string, CumulativeBalance>>(
     () =>
       computeCumulativeBalances(
-        months,
+        loadedMonths,
         incomeSubtotals,
         spendSubtotals,
         transferSubtotals,
@@ -116,12 +125,12 @@ export const useBudgetTableDerivedState = ({
         currentMonth,
         meb,
       ),
-    [months, incomeSubtotals, spendSubtotals, transferSubtotals, cumBefore, taintedMonths, currentMonth, meb],
+    [loadedMonths, incomeSubtotals, spendSubtotals, transferSubtotals, cumBefore, taintedMonths, currentMonth, meb],
   );
 
   const fxAdjustments = useMemo<ReadonlyMap<string, number>>(
-    () => computeFxAdjustments(months, incomeSubtotals, spendSubtotals, transferSubtotals, meb, currentMonth),
-    [months, incomeSubtotals, spendSubtotals, transferSubtotals, meb, currentMonth],
+    () => computeFxAdjustments(loadedMonths, incomeSubtotals, spendSubtotals, transferSubtotals, meb, currentMonth),
+    [loadedMonths, incomeSubtotals, spendSubtotals, transferSubtotals, meb, currentMonth],
   );
 
   const liquidityTiers = useMemo<ReadonlyArray<string>>(() => {
@@ -144,14 +153,14 @@ export const useBudgetTableDerivedState = ({
   const projectedLiqBalances = useMemo<ReadonlyMap<string, Readonly<Record<string, number>>>>(
     () =>
       computeCumulativeBalancesByLiquidity(
-        months,
+        loadedMonths,
         incomeSubtotals,
         spendSubtotals,
         transferSubtotals,
         currentMonth,
         mebByLiq,
       ),
-    [months, incomeSubtotals, spendSubtotals, transferSubtotals, currentMonth, mebByLiq],
+    [loadedMonths, incomeSubtotals, spendSubtotals, transferSubtotals, currentMonth, mebByLiq],
   );
 
   return {

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
@@ -5,6 +5,7 @@ import type { BudgetGridResult, BudgetRow, BusinessPersonalTransferCell, Cumulat
 import { offsetMonth } from "@/lib/monthUtils";
 import {
   adjustCumulativeBeforeForPrependedRows,
+  getBudgetRangeExtension,
   getTargetFillMonths,
 } from "@/ui/tables/budget/budgetTableLogic";
 import {
@@ -28,6 +29,8 @@ const BATCH_SIZE = 6;
 
 type UseBudgetTableRangeStateParams = Readonly<{
   rows: ReadonlyArray<BudgetRow>;
+  displayMonthFrom: string;
+  displayMonthTo: string;
   initialMonthFrom: string;
   initialMonthTo: string;
   cumulativeBefore: CumulativeBefore;
@@ -35,6 +38,7 @@ type UseBudgetTableRangeStateParams = Readonly<{
   monthEndBalancesByLiquidity: Readonly<Record<string, Readonly<Record<string, number>>>>;
   businessPersonalTransfers: Readonly<Record<string, BusinessPersonalTransferCell>>;
   hasBusinessAccount: boolean;
+  refreshToken: string;
   onVisibleRangeRefreshStart: () => void;
   loadBudgetRange: (
     monthFrom: string,
@@ -89,8 +93,7 @@ export type BudgetTableRangeState = Readonly<{
     mutationGeneration: number,
   ) => void;
   refreshLoadedRange: () => void;
-  loadLeft: () => Promise<void>;
-  loadRight: () => Promise<void>;
+  requestVisibleMonths: (monthFrom: string, monthTo: string) => void;
 }>;
 
 const applyFetchedBudgetResult = (
@@ -212,6 +215,8 @@ const applyFillMonthsToRows = (
 
 export const useBudgetTableRangeState = ({
   rows,
+  displayMonthFrom,
+  displayMonthTo,
   initialMonthFrom,
   initialMonthTo,
   cumulativeBefore,
@@ -219,6 +224,7 @@ export const useBudgetTableRangeState = ({
   monthEndBalancesByLiquidity,
   businessPersonalTransfers: initialBusinessPersonalTransfers,
   hasBusinessAccount: initialHasBusinessAccount,
+  refreshToken,
   onVisibleRangeRefreshStart,
   loadBudgetRange,
 }: UseBudgetTableRangeStateParams): BudgetTableRangeState => {
@@ -238,8 +244,12 @@ export const useBudgetTableRangeState = ({
   const [isLoadingRight, setIsLoadingRight] = useState<boolean>(false);
   const [pendingSaves, setPendingSaves] = useState<number>(0);
 
-  const isLoadingLeftRef = useRef<boolean>(false);
-  const isLoadingRightRef = useRef<boolean>(false);
+  const isLoadingViewportRangeRef = useRef<boolean>(false);
+  const rangeRequestQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const loadedFromRef = useRef<string>(initialMonthFrom);
+  const loadedToRef = useRef<string>(initialMonthTo);
+  const requestedVisibleFromRef = useRef<string>(initialMonthFrom);
+  const requestedVisibleToRef = useRef<string>(initialMonthTo);
   const initialRefreshHandledRef = useRef<boolean>(false);
   const latestRangeRequestGenerationRef = useRef<number>(0);
   const latestRangeRequestGenerationByMonthRef = useRef<Map<string, number>>(
@@ -303,11 +313,25 @@ export const useBudgetTableRangeState = ({
     setPendingSaves((count) => Math.max(0, count - 1));
   }, []);
 
+  const enqueueRangeRequest = useCallback((
+    request: () => Promise<void>,
+    operation: string,
+  ): void => {
+    rangeRequestQueueRef.current = rangeRequestQueueRef.current
+      .then(request)
+      .catch((error: unknown): void => {
+        logBudgetTableError(operation, error);
+      });
+  }, []);
+
   const runVisibleRangeRefresh = useCallback(async (): Promise<void> => {
     onVisibleRangeRefreshStart();
 
     try {
-      const outcome = await loadGeneratedBudgetRange(loadedFrom, loadedTo);
+      const outcome = await loadGeneratedBudgetRange(
+        loadedFromRef.current,
+        loadedToRef.current,
+      );
       if (outcome.status === "superseded") return;
       const result = outcome.result;
       const reconciledRows = reconcileAcceptedBaseRange(result, outcome.request);
@@ -315,7 +339,7 @@ export const useBudgetTableRangeState = ({
     } catch (error) {
       logBudgetTableError("visible range refresh", error);
     }
-  }, [loadGeneratedBudgetRange, loadedFrom, loadedTo, onVisibleRangeRefreshStart, reconcileAcceptedBaseRange]);
+  }, [loadGeneratedBudgetRange, onVisibleRangeRefreshStart, reconcileAcceptedBaseRange]);
 
   useEffect(() => {
     if (!initialRefreshHandledRef.current) {
@@ -323,8 +347,8 @@ export const useBudgetTableRangeState = ({
       return;
     }
 
-    void runVisibleRangeRefresh();
-  }, [runVisibleRangeRefresh]);
+    enqueueRangeRequest(runVisibleRangeRefresh, "visible range refresh coordination");
+  }, [enqueueRangeRequest, refreshToken, runVisibleRangeRefresh]);
 
   const handlePlanSave = useCallback((
     month: string,
@@ -453,69 +477,99 @@ export const useBudgetTableRangeState = ({
   }, [publishBaseAcknowledgements]);
 
   const refreshLoadedRange = useCallback((): void => {
-    void runVisibleRangeRefresh();
-  }, [runVisibleRangeRefresh]);
+    enqueueRangeRequest(runVisibleRangeRefresh, "visible range refresh coordination");
+  }, [enqueueRangeRequest, runVisibleRangeRefresh]);
 
-  const loadLeft = useCallback(async (): Promise<void> => {
-    if (isLoadingLeftRef.current) {
+  const loadRequestedViewportRange = useCallback(async (): Promise<void> => {
+    while (true) {
+      const extension = getBudgetRangeExtension(
+        displayMonthFrom,
+        displayMonthTo,
+        loadedFromRef.current,
+        loadedToRef.current,
+        requestedVisibleFromRef.current,
+        requestedVisibleToRef.current,
+        BATCH_SIZE,
+      );
+      if (extension === null) {
+        return;
+      }
+
+      const isLeft = extension.direction === "left";
+      setIsLoadingLeft(isLeft);
+      setIsLoadingRight(!isLeft);
+
+      try {
+        const outcome = await loadGeneratedBudgetRange(
+          extension.monthFrom,
+          extension.monthTo,
+        );
+        if (outcome.status === "superseded") {
+          return;
+        }
+
+        const result = outcome.result;
+        const reconciledRows = reconcileAcceptedBaseRange(result, outcome.request);
+        if (isLeft) {
+          setAllRows((previous) => [...reconciledRows, ...previous]);
+          setCumBefore((previous) => (
+            adjustCumulativeBeforeForPrependedRows(previous, reconciledRows)
+          ));
+          loadedFromRef.current = extension.monthFrom;
+          setLoadedFrom(extension.monthFrom);
+        } else {
+          setAllRows((previous) => [...previous, ...reconciledRows]);
+          loadedToRef.current = extension.monthTo;
+          setLoadedTo(extension.monthTo);
+        }
+        setMeb((previous) => ({ ...previous, ...result.monthEndBalances }));
+        setMebByLiq((previous) => ({
+          ...previous,
+          ...result.monthEndBalancesByLiquidity,
+        }));
+        setBusinessPersonalTransfers((previous) => ({
+          ...previous,
+          ...result.businessPersonalTransfers,
+        }));
+        setHasBusinessAccount(result.hasBusinessAccount);
+      } catch (error) {
+        logBudgetTableError(
+          `load ${extension.direction} viewport month range ${extension.monthFrom}..${extension.monthTo}`,
+          error,
+        );
+        return;
+      }
+    }
+  }, [displayMonthFrom, displayMonthTo, loadGeneratedBudgetRange, reconcileAcceptedBaseRange]);
+
+  const requestVisibleMonths = useCallback((
+    monthFrom: string,
+    monthTo: string,
+  ): void => {
+    if (monthFrom < requestedVisibleFromRef.current) {
+      requestedVisibleFromRef.current = monthFrom;
+    }
+    if (monthTo > requestedVisibleToRef.current) {
+      requestedVisibleToRef.current = monthTo;
+    }
+    if (isLoadingViewportRangeRef.current) {
       return;
     }
 
-    isLoadingLeftRef.current = true;
-    setIsLoadingLeft(true);
-
-    const newTo = offsetMonth(loadedFrom, -1);
-    const newFrom = offsetMonth(loadedFrom, -BATCH_SIZE);
-
-    try {
-      const outcome = await loadGeneratedBudgetRange(newFrom, newTo);
-      if (outcome.status === "superseded") return;
-      const result = outcome.result;
-      const prependedRows = reconcileAcceptedBaseRange(result, outcome.request);
-      setAllRows((previous) => [...prependedRows, ...previous]);
-      setCumBefore((previous) => adjustCumulativeBeforeForPrependedRows(previous, prependedRows));
-      setLoadedFrom(newFrom);
-      setMeb((previous) => ({ ...previous, ...result.monthEndBalances }));
-      setMebByLiq((previous) => ({ ...previous, ...result.monthEndBalancesByLiquidity }));
-      setBusinessPersonalTransfers((previous) => ({ ...previous, ...result.businessPersonalTransfers }));
-      setHasBusinessAccount(result.hasBusinessAccount);
-    } catch (error) {
-      logBudgetTableError("load previous month range", error);
-    } finally {
-      isLoadingLeftRef.current = false;
-      setIsLoadingLeft(false);
-    }
-  }, [loadGeneratedBudgetRange, loadedFrom, reconcileAcceptedBaseRange]);
-
-  const loadRight = useCallback(async (): Promise<void> => {
-    if (isLoadingRightRef.current) {
-      return;
-    }
-
-    isLoadingRightRef.current = true;
-    setIsLoadingRight(true);
-
-    const newFrom = offsetMonth(loadedTo, 1);
-    const newTo = offsetMonth(loadedTo, BATCH_SIZE);
-
-    try {
-      const outcome = await loadGeneratedBudgetRange(newFrom, newTo);
-      if (outcome.status === "superseded") return;
-      const result = outcome.result;
-      const appendedRows = reconcileAcceptedBaseRange(result, outcome.request);
-      setAllRows((previous) => [...previous, ...appendedRows]);
-      setLoadedTo(newTo);
-      setMeb((previous) => ({ ...previous, ...result.monthEndBalances }));
-      setMebByLiq((previous) => ({ ...previous, ...result.monthEndBalancesByLiquidity }));
-      setBusinessPersonalTransfers((previous) => ({ ...previous, ...result.businessPersonalTransfers }));
-      setHasBusinessAccount(result.hasBusinessAccount);
-    } catch (error) {
-      logBudgetTableError("load next month range", error);
-    } finally {
-      isLoadingRightRef.current = false;
-      setIsLoadingRight(false);
-    }
-  }, [loadGeneratedBudgetRange, loadedTo, reconcileAcceptedBaseRange]);
+    isLoadingViewportRangeRef.current = true;
+    enqueueRangeRequest(
+      async (): Promise<void> => {
+        try {
+          await loadRequestedViewportRange();
+        } finally {
+          isLoadingViewportRangeRef.current = false;
+          setIsLoadingLeft(false);
+          setIsLoadingRight(false);
+        }
+      },
+      "viewport month range coordination",
+    );
+  }, [enqueueRangeRequest, loadRequestedViewportRange]);
 
   return {
     allRows,
@@ -538,7 +592,6 @@ export const useBudgetTableRangeState = ({
     handleBaseAcknowledged,
     handleFillMonthsAcknowledged,
     refreshLoadedRange,
-    loadLeft,
-    loadRight,
+    requestVisibleMonths,
   };
 };

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableViewport.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableViewport.ts
@@ -4,13 +4,15 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import type { RefObject } from "react";
 import styles from "@/ui/tables/budget/BudgetTable.module.css";
 
-const SCROLL_THRESHOLD = 200;
+const HORIZONTAL_PREFETCH_MARGIN = "0px 600px 0px 600px";
+const MONTH_OBSERVATION_ATTRIBUTE = "data-budget-month";
+const YEAR_OBSERVATION_ATTRIBUTE = "data-budget-year-total";
 
 type UseBudgetTableViewportParams = Readonly<{
   currentMonth: string;
   pendingSaves: number;
-  onReachLeft: () => Promise<void>;
-  onReachRight: () => Promise<void>;
+  onMonthsObserved: (monthFrom: string, monthTo: string) => void;
+  onYearTotalsObserved: (years: ReadonlySet<string>) => void;
 }>;
 
 export type BudgetTableViewportState = Readonly<{
@@ -21,43 +23,11 @@ export type BudgetTableViewportState = Readonly<{
 export const useBudgetTableViewport = ({
   currentMonth,
   pendingSaves,
-  onReachLeft,
-  onReachRight,
+  onMonthsObserved,
+  onYearTotalsObserved,
 }: UseBudgetTableViewportParams): BudgetTableViewportState => {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const prevScrollWidthRef = useRef<number>(0);
-  const isPrependingRef = useRef<boolean>(false);
   const isRtl = typeof document !== "undefined" && document.documentElement.dir === "rtl";
-
-  const markPrependPending = useCallback((): void => {
-    if (isPrependingRef.current) {
-      return;
-    }
-
-    const scrollElement = scrollRef.current;
-    if (scrollElement === null) {
-      return;
-    }
-
-    prevScrollWidthRef.current = scrollElement.scrollWidth;
-    isPrependingRef.current = true;
-  }, []);
-
-  useLayoutEffect(() => {
-    if (!isPrependingRef.current) {
-      return;
-    }
-
-    isPrependingRef.current = false;
-
-    const scrollElement = scrollRef.current;
-    if (scrollElement === null) {
-      return;
-    }
-
-    const scrollDelta = scrollElement.scrollWidth - prevScrollWidthRef.current;
-    scrollElement.scrollLeft += isRtl ? -scrollDelta : scrollDelta;
-  });
 
   const scrollToCurrentMonth = useCallback((): void => {
     const scrollElement = scrollRef.current;
@@ -107,36 +77,53 @@ export const useBudgetTableViewport = ({
       return;
     }
 
-    let rafId = 0;
-    const handleScroll = (): void => {
-      if (rafId !== 0) {
-        return;
-      }
+    const intersectingMonths = new Set<string>();
+    const intersectingYears = new Set<string>();
+    const observer = new IntersectionObserver(
+      (entries): void => {
+        for (const entry of entries) {
+          const target = entry.target as HTMLElement;
+          const month = target.getAttribute(MONTH_OBSERVATION_ATTRIBUTE);
+          const year = target.getAttribute(YEAR_OBSERVATION_ATTRIBUTE);
 
-      rafId = requestAnimationFrame(() => {
-        rafId = 0;
-        const scrollStart = isRtl ? -scrollElement.scrollLeft : scrollElement.scrollLeft;
-        const scrollEnd =
-          scrollElement.scrollWidth - Math.abs(scrollElement.scrollLeft) - scrollElement.clientWidth;
-
-        if (scrollStart < SCROLL_THRESHOLD) {
-          markPrependPending();
-          void onReachLeft();
+          if (month !== null) {
+            if (entry.isIntersecting) {
+              intersectingMonths.add(month);
+            } else {
+              intersectingMonths.delete(month);
+            }
+          }
+          if (year !== null) {
+            if (entry.isIntersecting) {
+              intersectingYears.add(year);
+            } else {
+              intersectingYears.delete(year);
+            }
+          }
         }
-        if (scrollEnd < SCROLL_THRESHOLD) {
-          void onReachRight();
-        }
-      });
-    };
 
-    scrollElement.addEventListener("scroll", handleScroll, { passive: true });
-    return () => {
-      scrollElement.removeEventListener("scroll", handleScroll);
-      if (rafId !== 0) {
-        cancelAnimationFrame(rafId);
-      }
-    };
-  }, [isRtl, markPrependPending, onReachLeft, onReachRight]);
+        if (intersectingMonths.size > 0) {
+          const visibleMonths = [...intersectingMonths].sort();
+          onMonthsObserved(visibleMonths[0], visibleMonths[visibleMonths.length - 1]);
+        }
+        if (intersectingYears.size > 0) {
+          onYearTotalsObserved(new Set(intersectingYears));
+        }
+      },
+      {
+        root: scrollElement,
+        rootMargin: HORIZONTAL_PREFETCH_MARGIN,
+      },
+    );
+
+    for (const target of scrollElement.querySelectorAll<HTMLElement>(
+      `[${MONTH_OBSERVATION_ATTRIBUTE}], [${YEAR_OBSERVATION_ATTRIBUTE}]`,
+    )) {
+      observer.observe(target);
+    }
+
+    return () => observer.disconnect();
+  }, [onMonthsObserved, onYearTotalsObserved]);
 
   useEffect(() => {
     const scrollElement = scrollRef.current;

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableYearTotals.test.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableYearTotals.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 
 import type { YearFetchResult } from "@/ui/tables/budget/budgetTableLogic";
 import {
+  buildYearTotalRequest,
+  getObservedYearsToFetch,
   removeInvalidatedYearFetchResults,
   snapshotYearTotalInvalidation,
 } from "@/ui/tables/budget/controller/useBudgetTableYearTotals";
@@ -41,4 +43,24 @@ test("keeps invalidation stable after the caller mutates its set", (): void => {
   const invalidated = removeInvalidatedYearFetchResults(cached, invalidatedYears);
 
   assert.deepEqual([...invalidated.keys()], ["2025"]);
+});
+
+test("deduplicates fetched and current-revision annual requests", (): void => {
+  const years = getObservedYearsToFetch(
+    new Set(["2025", "2026", "2027"]),
+    new Set(["2025"]),
+    new Map([["2026", 0]]),
+    new Map([["2026", 0], ["2027", 2]]),
+  );
+
+  assert.deepEqual(years, [{ year: "2027", revision: 2 }]);
+});
+
+test("builds an exact January-through-December annual request", (): void => {
+  assert.deepEqual(buildYearTotalRequest("2031", "2026-08"), {
+    monthFrom: "2031-01",
+    monthTo: "2031-12",
+    planFrom: "2031-01",
+    actualTo: "2026-08",
+  });
 });

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableYearTotals.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableYearTotals.ts
@@ -1,9 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ColumnEntry, YearFetchResult, YearTotalComputed } from "@/ui/tables/budget/budgetTableLogic";
-import { buildColumnSequence, computeYearTotal } from "@/ui/tables/budget/budgetTableLogic";
-import { generateMonthRange } from "@/lib/monthUtils";
+import type { YearFetchResult, YearTotalComputed } from "@/ui/tables/budget/budgetTableLogic";
+import { computeYearTotal } from "@/ui/tables/budget/budgetTableLogic";
 import { fetchBudgetRange } from "@/ui/tables/budget/budgetTableApi";
 import { logBudgetTableError } from "@/ui/tables/budget/table/logBudgetTableError";
 
@@ -14,18 +13,48 @@ export type BudgetTableYearTotalsState = Readonly<{
 }>;
 
 type UseBudgetTableYearTotalsParams = Readonly<{
-  loadedFrom: string;
-  loadedTo: string;
+  observedYears: ReadonlySet<string>;
   currentMonth: string;
   effectiveAllowlist: ReadonlySet<string> | null;
   refreshToken: string;
 }>;
 
-const getVisibleYearColumns = (
-  loadedFrom: string,
-  loadedTo: string,
-): ReadonlyArray<ColumnEntry> =>
-  buildColumnSequence(generateMonthRange(loadedFrom, loadedTo)).filter((column) => column.kind === "year-total");
+export type YearTotalRequest = Readonly<{
+  monthFrom: string;
+  monthTo: string;
+  planFrom: string;
+  actualTo: string;
+}>;
+
+export const buildYearTotalRequest = (
+  year: string,
+  currentMonth: string,
+): YearTotalRequest => ({
+  monthFrom: `${year}-01`,
+  monthTo: `${year}-12`,
+  planFrom: `${year}-01`,
+  actualTo: currentMonth,
+});
+
+export const getObservedYearsToFetch = (
+  observedYears: ReadonlySet<string>,
+  fetchedYears: ReadonlySet<string>,
+  fetchingRevisionByYear: ReadonlyMap<string, number>,
+  revisionByYear: ReadonlyMap<string, number>,
+): ReadonlyArray<Readonly<{ year: string; revision: number }>> => (
+  [...observedYears]
+    .sort()
+    .flatMap((year): ReadonlyArray<Readonly<{ year: string; revision: number }>> => {
+      const revision = revisionByYear.get(year) ?? 0;
+      if (
+        fetchedYears.has(year)
+        || fetchingRevisionByYear.get(year) === revision
+      ) {
+        return [];
+      }
+      return [{ year, revision }];
+    })
+);
 
 export const removeInvalidatedYearFetchResults = (
   previous: ReadonlyMap<string, YearFetchResult>,
@@ -43,8 +72,7 @@ export const snapshotYearTotalInvalidation = (
 ): ReadonlySet<string> => new Set(years);
 
 export const useBudgetTableYearTotals = ({
-  loadedFrom,
-  loadedTo,
+  observedYears,
   currentMonth,
   effectiveAllowlist,
   refreshToken,
@@ -52,25 +80,24 @@ export const useBudgetTableYearTotals = ({
   const [yearFetchResults, setYearFetchResults] = useState<ReadonlyMap<string, YearFetchResult>>(new Map());
   const yearFetchingRef = useRef<Map<string, number>>(new Map());
   const yearRevisionRef = useRef<Map<string, number>>(new Map());
-  const visibleYearColumns = useMemo<ReadonlyArray<ColumnEntry>>(
-    () => getVisibleYearColumns(loadedFrom, loadedTo),
-    [loadedFrom, loadedTo],
-  );
 
   useEffect(() => {
-    for (const column of visibleYearColumns) {
-      if (column.kind !== "year-total") {
-        continue;
-      }
-
-      const { year } = column;
-      const revision = yearRevisionRef.current.get(year) ?? 0;
-      if (yearFetchResults.has(year) || yearFetchingRef.current.get(year) === revision) {
-        continue;
-      }
-
+    const yearsToFetch = getObservedYearsToFetch(
+      observedYears,
+      new Set(yearFetchResults.keys()),
+      yearFetchingRef.current,
+      yearRevisionRef.current,
+    );
+    for (const { year, revision } of yearsToFetch) {
       yearFetchingRef.current.set(year, revision);
-      fetchBudgetRange(`${year}-01`, `${year}-12`, `${year}-01`, currentMonth, refreshToken)
+      const request = buildYearTotalRequest(year, currentMonth);
+      fetchBudgetRange(
+        request.monthFrom,
+        request.monthTo,
+        request.planFrom,
+        request.actualTo,
+        refreshToken,
+      )
         .then((result) => {
           if ((yearRevisionRef.current.get(year) ?? 0) !== revision) {
             return;
@@ -98,7 +125,7 @@ export const useBudgetTableYearTotals = ({
           }
         });
     }
-  }, [currentMonth, refreshToken, visibleYearColumns, yearFetchResults]);
+  }, [currentMonth, observedYears, refreshToken, yearFetchResults]);
 
   const yearComputed = useMemo<ReadonlyMap<string, YearTotalComputed>>(() => {
     const result = new Map<string, YearTotalComputed>();
@@ -133,12 +160,10 @@ export const useBudgetTableYearTotals = ({
     const years = new Set<string>([
       ...yearFetchResults.keys(),
       ...yearFetchingRef.current.keys(),
-      ...visibleYearColumns
-        .filter((column) => column.kind === "year-total")
-        .map((column) => column.kind === "year-total" ? column.year : ""),
+      ...observedYears,
     ]);
     invalidateYearTotals(years);
-  }, [invalidateYearTotals, visibleYearColumns, yearFetchResults]);
+  }, [invalidateYearTotals, observedYears, yearFetchResults]);
 
   return {
     yearComputed,

--- a/apps/web/src/ui/tables/budget/model/dateRanges.test.ts
+++ b/apps/web/src/ui/tables/budget/model/dateRanges.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { generateMonthRange } from "@/lib/monthUtils";
+import {
+  buildColumnSequence,
+  getBudgetDisplayRange,
+  getBudgetRangeExtension,
+} from "@/ui/tables/budget/model/dateRanges";
+
+test("builds the fixed budget calendar from January ten years ago through December ten years ahead", (): void => {
+  const displayRange = getBudgetDisplayRange("2026-08");
+  const months = generateMonthRange(displayRange.monthFrom, displayRange.monthTo);
+  const columns = buildColumnSequence(months);
+
+  assert.deepEqual(displayRange, {
+    monthFrom: "2016-01",
+    monthTo: "2036-12",
+  });
+  assert.equal(months.length, 21 * 12);
+  assert.equal(columns.length, 21 * 13);
+  assert.deepEqual(columns[0], { kind: "month", month: "2016-01" });
+  assert.deepEqual(columns.at(-1), { kind: "year-total", year: "2036" });
+});
+
+test("loads one contiguous extension across a far scrollbar jump", (): void => {
+  const extension = getBudgetRangeExtension(
+    "2016-01",
+    "2036-12",
+    "2026-02",
+    "2027-08",
+    "2033-04",
+    "2033-10",
+    6,
+  );
+
+  assert.deepEqual(extension, {
+    direction: "right",
+    monthFrom: "2027-09",
+    monthTo: "2034-03",
+  });
+});
+
+test("caps viewport overscan at the fixed display boundary", (): void => {
+  const extension = getBudgetRangeExtension(
+    "2016-01",
+    "2036-12",
+    "2026-02",
+    "2027-08",
+    "2016-01",
+    "2016-03",
+    6,
+  );
+
+  assert.deepEqual(extension, {
+    direction: "left",
+    monthFrom: "2016-01",
+    monthTo: "2026-01",
+  });
+});

--- a/apps/web/src/ui/tables/budget/model/dateRanges.ts
+++ b/apps/web/src/ui/tables/budget/model/dateRanges.ts
@@ -1,9 +1,87 @@
-import { getYear } from "@/lib/monthUtils";
+import { getYear, offsetMonth } from "@/lib/monthUtils";
 
 export type ColumnEntry = Readonly<
   | { kind: "month"; month: string }
   | { kind: "year-total"; year: string }
 >;
+
+export type BudgetDisplayRange = Readonly<{
+  monthFrom: string;
+  monthTo: string;
+}>;
+
+export type BudgetRangeExtension = Readonly<{
+  direction: "left" | "right";
+  monthFrom: string;
+  monthTo: string;
+}>;
+
+const DISPLAY_YEAR_RADIUS = 10;
+
+export const getBudgetDisplayRange = (currentMonth: string): BudgetDisplayRange => {
+  if (!/^\d{4}-(?:0[1-9]|1[0-2])$/.test(currentMonth)) {
+    throw new RangeError(`Current budget month "${currentMonth}" must use YYYY-MM format`);
+  }
+  const currentYear = Number(getYear(currentMonth));
+
+  return {
+    monthFrom: `${currentYear - DISPLAY_YEAR_RADIUS}-01`,
+    monthTo: `${currentYear + DISPLAY_YEAR_RADIUS}-12`,
+  };
+};
+
+/**
+ * Returns the next missing range needed to keep loaded months contiguous while
+ * extending toward the observed fixed-calendar columns.
+ */
+export const getBudgetRangeExtension = (
+  displayFrom: string,
+  displayTo: string,
+  loadedFrom: string,
+  loadedTo: string,
+  observedFrom: string,
+  observedTo: string,
+  batchSize: number,
+): BudgetRangeExtension | null => {
+  if (displayFrom > loadedFrom || loadedFrom > loadedTo || loadedTo > displayTo) {
+    throw new RangeError(
+      `Loaded budget range ${loadedFrom}..${loadedTo} must be inside display range ${displayFrom}..${displayTo}`,
+    );
+  }
+  if (observedFrom > observedTo) {
+    throw new RangeError(
+      `Observed budget month ${observedFrom} must not be after ${observedTo}`,
+    );
+  }
+  if (observedFrom < displayFrom || observedTo > displayTo) {
+    throw new RangeError(
+      `Observed budget range ${observedFrom}..${observedTo} must be inside display range ${displayFrom}..${displayTo}`,
+    );
+  }
+  if (!Number.isInteger(batchSize) || batchSize < 1) {
+    throw new RangeError(`Budget range batch size must be a positive integer, received ${batchSize}`);
+  }
+
+  if (observedFrom < loadedFrom) {
+    const overscannedFrom = offsetMonth(observedFrom, -(batchSize - 1));
+    return {
+      direction: "left",
+      monthFrom: overscannedFrom < displayFrom ? displayFrom : overscannedFrom,
+      monthTo: offsetMonth(loadedFrom, -1),
+    };
+  }
+
+  if (observedTo > loadedTo) {
+    const overscannedTo = offsetMonth(observedTo, batchSize - 1);
+    return {
+      direction: "right",
+      monthFrom: offsetMonth(loadedTo, 1),
+      monthTo: overscannedTo > displayTo ? displayTo : overscannedTo,
+    };
+  }
+
+  return null;
+};
 
 /**
  * Builds an ordered column sequence from a month range, inserting a

--- a/apps/web/src/ui/tables/budget/table/BudgetTableHeader.tsx
+++ b/apps/web/src/ui/tables/budget/table/BudgetTableHeader.tsx
@@ -30,6 +30,7 @@ export const BudgetTableHeader = (props: BudgetTableHeaderProps): ReactElement =
                 key={`total-${column.year}`}
                 className={`${styles.headCell} ${styles.yearTotal}`}
                 colSpan={column.year === currentYear ? 2 : 1}
+                data-budget-year-total={column.year}
               >
                 {t("budget.total")} {column.year}
               </th>
@@ -42,6 +43,7 @@ export const BudgetTableHeader = (props: BudgetTableHeaderProps): ReactElement =
               className={`${styles.headCell}${column.month === currentMonth ? ` ${styles.currentMonth}` : ""}`}
               colSpan={column.month === currentMonth ? 2 : 1}
               data-month={column.month}
+              data-budget-month={column.month}
             >
               {column.month}
             </th>


### PR DESCRIPTION
Implements item 01 of the fixed budget calendar work. Adds a stable 21-calendar-year axis, contiguous viewport-driven monthly loading, and independent exact-year annual totals. Promotion remains deferred; item 02 will add unloaded placeholders, fixed widths, spacer cleanup, and mobile presentation.