### PR TITLE
Stabilize budget table presentation

### DIFF
--- a/apps/web/src/ui/tables/budget/BudgetTable.module.css
+++ b/apps/web/src/ui/tables/budget/BudgetTable.module.css
@@ -33,10 +33,16 @@
 }
 
 .scroll {
+  --budget-category-column-width: 180px;
+
+  box-sizing: border-box;
+  inline-size: 100%;
+  max-inline-size: 100%;
   overflow-x: auto;
   margin-top: 12px;
-  display: flex;
-  align-items: flex-start;
+  overscroll-behavior-inline: contain;
+  touch-action: pan-x pan-y;
+  -webkit-overflow-scrolling: touch;
 }
 
 .scroll thead {
@@ -57,10 +63,22 @@
   font-size: 13px;
   line-height: 20px;
   white-space: nowrap;
-  min-width: 100%;
+  table-layout: fixed;
+  inline-size: calc(var(--budget-category-column-width) + var(--budget-values-inline-size));
+  min-inline-size: calc(var(--budget-category-column-width) + var(--budget-values-inline-size));
+}
+
+.categoryColumn {
+  inline-size: var(--budget-category-column-width);
+}
+
+.valueColumn {
+  inline-size: var(--budget-value-column-width);
 }
 
 .headCell {
+  box-sizing: border-box;
+  overflow: hidden;
   padding: 6px 10px;
   text-align: center;
   font-weight: 650;
@@ -68,6 +86,8 @@
 }
 
 .subHeadCell {
+  box-sizing: border-box;
+  overflow: hidden;
   padding: 2px 10px 6px;
   text-align: end;
   font-size: 11px;
@@ -79,6 +99,11 @@
 .stickyCol {
   position: sticky;
   inset-inline-start: 0;
+  box-sizing: border-box;
+  inline-size: var(--budget-category-column-width);
+  max-inline-size: var(--budget-category-column-width);
+  overflow: hidden;
+  text-overflow: ellipsis;
   background: var(--panel);
   z-index: 10;
 }
@@ -94,18 +119,10 @@
   content: "";
   position: absolute;
   top: 0;
-  inset-inline-end: -1px;
+  inset-inline-end: 0;
   bottom: 0;
   width: 1px;
   background: var(--panel-border);
-}
-
-.leftSpacer {
-  min-width: 150px;
-  font-size: 12px;
-  color: var(--muted);
-  text-align: center;
-  vertical-align: middle;
 }
 
 .directionRow {
@@ -131,10 +148,14 @@
 }
 
 .cell {
+  box-sizing: border-box;
+  inline-size: var(--budget-value-column-width);
+  max-inline-size: var(--budget-value-column-width);
+  overflow: hidden;
   padding: 4px 10px;
   text-align: end;
   font-variant-numeric: tabular-nums;
-  min-width: 90px;
+  text-overflow: clip;
 }
 
 .cellSubtotal {
@@ -223,6 +244,11 @@ tbody tr:last-child .currentMonthActual {
 .yearLoading {
   text-align: center;
   color: var(--muted);
+}
+
+.monthLoading {
+  color: var(--muted);
+  text-align: center;
 }
 
 .cellEditable:not(.data-masked),
@@ -663,7 +689,13 @@ tbody tr:last-child .currentMonthActual {
 
 @media (max-width: 768px) {
   .scroll {
-    padding-inline-start: 0;
+    --budget-category-column-width: 120px;
+  }
+
+  .directionLabel,
+  .categoryLabel,
+  .headCell {
+    padding-inline: 8px;
   }
 
   .popover {

--- a/apps/web/src/ui/tables/budget/BudgetTable.tsx
+++ b/apps/web/src/ui/tables/budget/BudgetTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, type ReactElement } from "react";
+import { Fragment, type CSSProperties, type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import alertStyles from "@/ui/Alert.module.css";
 import { useCopyToast } from "@/ui/hooks/useCopyToast";
@@ -16,8 +16,15 @@ import {
   type BudgetTableProps,
   useBudgetTableController,
 } from "@/ui/tables/budget/controller/useBudgetTableController";
-import tableStateStyles from "@/ui/tables/shared/TableStates.module.css";
+import { buildBudgetValueColumns } from "@/ui/tables/budget/budgetTableLogic";
 import styles from "@/ui/tables/budget/BudgetTable.module.css";
+
+const BUDGET_VALUE_COLUMN_WIDTH_PX = 90;
+
+type BudgetTableGeometryStyle = CSSProperties & Readonly<{
+  "--budget-value-column-width": string;
+  "--budget-values-inline-size": string;
+}>;
 
 export const BudgetTable = (props: BudgetTableProps): ReactElement => {
   const { conversionWarnings, reportingCurrency, hints, refreshToken } = props;
@@ -25,6 +32,14 @@ export const BudgetTable = (props: BudgetTableProps): ReactElement => {
   const { numberFormat } = useFormat();
   const { toastMessage, copyToClipboard } = useCopyToast();
   const controller = useBudgetTableController(props);
+  const valueColumns = buildBudgetValueColumns(
+    controller.columnSequence,
+    controller.currentMonth,
+  );
+  const tableGeometryStyle: BudgetTableGeometryStyle = {
+    "--budget-value-column-width": `${BUDGET_VALUE_COLUMN_WIDTH_PX}px`,
+    "--budget-values-inline-size": `${valueColumns.length * BUDGET_VALUE_COLUMN_WIDTH_PX}px`,
+  };
 
   if (controller.months.length === 0) {
     return <p className={styles.empty}>{t("budget.noData")}</p>;
@@ -61,12 +76,17 @@ export const BudgetTable = (props: BudgetTableProps): ReactElement => {
         data-testid="budget-table-scroll"
         ref={controller.scrollRef}
       >
-        <table className={styles.table}>
+        <table className={styles.table} style={tableGeometryStyle}>
+          <colgroup>
+            <col className={styles.categoryColumn} />
+            {valueColumns.map((column) => (
+              <col key={column.key} className={styles.valueColumn} />
+            ))}
+          </colgroup>
           <BudgetTableHeader
             columnSequence={controller.columnSequence}
             currentMonth={controller.currentMonth}
             currentYear={controller.currentYear}
-            isLoadingLeft={controller.isLoadingLeft}
           />
           <tbody>
             {controller.blocks.map((block) => (
@@ -80,6 +100,8 @@ export const BudgetTable = (props: BudgetTableProps): ReactElement => {
                   columnSequence={controller.columnSequence}
                   currentMonth={controller.currentMonth}
                   currentYear={controller.currentYear}
+                  loadedFrom={controller.loadedFrom}
+                  loadedTo={controller.loadedTo}
                   yearComputed={controller.yearComputed}
                   filteredSubtotalsMap={controller.filteredSubtotalsMap}
                   taintedDirectionMonths={controller.taintedDirectionMonths}
@@ -107,6 +129,8 @@ export const BudgetTable = (props: BudgetTableProps): ReactElement => {
               columnSequence={controller.columnSequence}
               currentMonth={controller.currentMonth}
               currentYear={controller.currentYear}
+              loadedFrom={controller.loadedFrom}
+              loadedTo={controller.loadedTo}
               yearComputed={controller.yearComputed}
               incomeSubtotals={controller.incomeSubtotals}
               spendSubtotals={controller.spendSubtotals}
@@ -126,7 +150,6 @@ export const BudgetTable = (props: BudgetTableProps): ReactElement => {
             />
           </tbody>
         </table>
-        <div className={tableStateStyles.loadingEdge}>{controller.isLoadingRight ? t("common.loading") : ""}</div>
       </div>
       {toastMessage !== null && <div className="copy-toast">{toastMessage}</div>}
       {controller.drillDownFilter !== null && (

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableController.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableController.ts
@@ -68,8 +68,6 @@ export type BudgetTableController = Readonly<{
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
   pendingSaves: number;
   budgetAdjustments: BudgetAdjustmentRowsController;
-  isLoadingLeft: boolean;
-  isLoadingRight: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
   drillDownFilter: DrillDownFilter | null;
   fxBreakdownMonth: string | null;
@@ -271,8 +269,6 @@ export const useBudgetTableController = (
     yearComputed,
     pendingSaves: rangeState.pendingSaves + budgetAdjustments.pendingMutationCount,
     budgetAdjustments,
-    isLoadingLeft: rangeState.isLoadingLeft,
-    isLoadingRight: rangeState.isLoadingRight,
     scrollRef: viewportState.scrollRef,
     drillDownFilter,
     fxBreakdownMonth,

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
@@ -57,8 +57,6 @@ export type BudgetTableRangeState = Readonly<{
   businessPersonalTransfers: Readonly<Record<string, BusinessPersonalTransferCell>>;
   hasBusinessAccount: boolean;
   pendingSaves: number;
-  isLoadingLeft: boolean;
-  isLoadingRight: boolean;
   onSyncStart: () => void;
   onSyncEnd: () => void;
   handlePlanSave: (
@@ -240,8 +238,6 @@ export const useBudgetTableRangeState = ({
   const [mebByLiq, setMebByLiq] = useState<Readonly<Record<string, Readonly<Record<string, number>>>>>(monthEndBalancesByLiquidity);
   const [businessPersonalTransfers, setBusinessPersonalTransfers] = useState<Readonly<Record<string, BusinessPersonalTransferCell>>>(initialBusinessPersonalTransfers);
   const [hasBusinessAccount, setHasBusinessAccount] = useState<boolean>(initialHasBusinessAccount);
-  const [isLoadingLeft, setIsLoadingLeft] = useState<boolean>(false);
-  const [isLoadingRight, setIsLoadingRight] = useState<boolean>(false);
   const [pendingSaves, setPendingSaves] = useState<number>(0);
 
   const isLoadingViewportRangeRef = useRef<boolean>(false);
@@ -496,8 +492,6 @@ export const useBudgetTableRangeState = ({
       }
 
       const isLeft = extension.direction === "left";
-      setIsLoadingLeft(isLeft);
-      setIsLoadingRight(!isLeft);
 
       try {
         const outcome = await loadGeneratedBudgetRange(
@@ -563,8 +557,6 @@ export const useBudgetTableRangeState = ({
           await loadRequestedViewportRange();
         } finally {
           isLoadingViewportRangeRef.current = false;
-          setIsLoadingLeft(false);
-          setIsLoadingRight(false);
         }
       },
       "viewport month range coordination",
@@ -582,8 +574,6 @@ export const useBudgetTableRangeState = ({
     businessPersonalTransfers,
     hasBusinessAccount,
     pendingSaves,
-    isLoadingLeft,
-    isLoadingRight,
     onSyncStart,
     onSyncEnd,
     handlePlanSave,

--- a/apps/web/src/ui/tables/budget/model/dateRanges.test.ts
+++ b/apps/web/src/ui/tables/budget/model/dateRanges.test.ts
@@ -3,9 +3,11 @@ import test from "node:test";
 
 import { generateMonthRange } from "@/lib/monthUtils";
 import {
+  buildBudgetValueColumns,
   buildColumnSequence,
   getBudgetDisplayRange,
   getBudgetRangeExtension,
+  isBudgetMonthLoaded,
 } from "@/ui/tables/budget/model/dateRanges";
 
 test("builds the fixed budget calendar from January ten years ago through December ten years ahead", (): void => {
@@ -57,4 +59,30 @@ test("caps viewport overscan at the fixed display boundary", (): void => {
     monthFrom: "2016-01",
     monthTo: "2026-01",
   });
+});
+
+test("flattens the fixed calendar into stable physical value columns", (): void => {
+  const displayRange = getBudgetDisplayRange("2026-08");
+  const months = generateMonthRange(displayRange.monthFrom, displayRange.monthTo);
+  const valueColumns = buildBudgetValueColumns(
+    buildColumnSequence(months),
+    "2026-08",
+  );
+
+  assert.equal(valueColumns.length, 21 * 13 + 2);
+  assert.deepEqual(
+    valueColumns.filter((column) => column.key.startsWith("2026-08")),
+    [{ key: "2026-08-plan" }, { key: "2026-08-actual" }],
+  );
+  assert.deepEqual(
+    valueColumns.filter((column) => column.key.startsWith("total-2026")),
+    [{ key: "total-2026-plan" }, { key: "total-2026-actual" }],
+  );
+});
+
+test("recognizes only months inside the contiguous loaded interval", (): void => {
+  assert.equal(isBudgetMonthLoaded("2026-01", "2026-02", "2027-08"), false);
+  assert.equal(isBudgetMonthLoaded("2026-02", "2026-02", "2027-08"), true);
+  assert.equal(isBudgetMonthLoaded("2027-08", "2026-02", "2027-08"), true);
+  assert.equal(isBudgetMonthLoaded("2027-09", "2026-02", "2027-08"), false);
 });

--- a/apps/web/src/ui/tables/budget/model/dateRanges.ts
+++ b/apps/web/src/ui/tables/budget/model/dateRanges.ts
@@ -16,6 +16,10 @@ export type BudgetRangeExtension = Readonly<{
   monthTo: string;
 }>;
 
+export type BudgetValueColumn = Readonly<{
+  key: string;
+}>;
+
 const DISPLAY_YEAR_RADIUS = 10;
 
 export const getBudgetDisplayRange = (currentMonth: string): BudgetDisplayRange => {
@@ -97,6 +101,45 @@ export const buildColumnSequence = (months: ReadonlyArray<string>): ReadonlyArra
   }
   return result;
 };
+
+export const buildBudgetValueColumns = (
+  columnSequence: ReadonlyArray<ColumnEntry>,
+  currentMonth: string,
+): ReadonlyArray<BudgetValueColumn> => {
+  const currentYear = getYear(currentMonth);
+  const result: Array<BudgetValueColumn> = [];
+
+  for (const column of columnSequence) {
+    if (column.kind === "month") {
+      if (column.month === currentMonth) {
+        result.push(
+          { key: `${column.month}-plan` },
+          { key: `${column.month}-actual` },
+        );
+      } else {
+        result.push({ key: column.month });
+      }
+      continue;
+    }
+
+    if (column.year === currentYear) {
+      result.push(
+        { key: `total-${column.year}-plan` },
+        { key: `total-${column.year}-actual` },
+      );
+    } else {
+      result.push({ key: `total-${column.year}` });
+    }
+  }
+
+  return result;
+};
+
+export const isBudgetMonthLoaded = (
+  month: string,
+  loadedFrom: string,
+  loadedTo: string,
+): boolean => month >= loadedFrom && month <= loadedTo;
 
 export const isPastMonth = (month: string, currentMonth: string): boolean => month < currentMonth;
 export const isFutureMonth = (month: string, currentMonth: string): boolean => month > currentMonth;

--- a/apps/web/src/ui/tables/budget/table/BudgetTableHeader.tsx
+++ b/apps/web/src/ui/tables/budget/table/BudgetTableHeader.tsx
@@ -11,18 +11,16 @@ export type BudgetTableHeaderProps = Readonly<{
   columnSequence: ReadonlyArray<ColumnEntry>;
   currentMonth: string;
   currentYear: string;
-  isLoadingLeft: boolean;
 }>;
 
 export const BudgetTableHeader = (props: BudgetTableHeaderProps): ReactElement => {
-  const { columnSequence, currentMonth, currentYear, isLoadingLeft } = props;
+  const { columnSequence, currentMonth, currentYear } = props;
   const { t } = useTranslation();
 
   return (
     <thead>
       <tr>
         <th className={`${styles.headCell} ${styles.stickyCol}`}>{t("budget.category")}</th>
-        <th className={styles.leftSpacer} rowSpan={2}>{isLoadingLeft ? t("common.loading") : ""}</th>
         {columnSequence.map((column) => {
           if (column.kind === "year-total") {
             return (

--- a/apps/web/src/ui/tables/budget/table/sections/BudgetDerivedSection.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/BudgetDerivedSection.tsx
@@ -38,11 +38,24 @@ const getRemainderValueClass = (value: number, isTainted: boolean): string => {
   return Math.round(value) < 0 ? styles.remainderNegative : styles.remainderPositive;
 };
 
+const getLoadedCumulativeBalance = (
+  cumulativeBalances: ReadonlyMap<string, CumulativeBalance>,
+  month: string,
+): CumulativeBalance => {
+  const balance = cumulativeBalances.get(month);
+  if (balance === undefined) {
+    throw new RangeError(`Loaded budget month "${month}" is missing its cumulative balance`);
+  }
+  return balance;
+};
+
 export type BudgetDerivedSectionProps = Readonly<{
   effectiveAllowlist: ReadonlySet<string> | null;
   columnSequence: ReadonlyArray<ColumnEntry>;
   currentMonth: string;
   currentYear: string;
+  loadedFrom: string;
+  loadedTo: string;
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
   incomeSubtotals: ReadonlyMap<string, CellValue> | undefined;
   spendSubtotals: ReadonlyMap<string, CellValue> | undefined;
@@ -67,6 +80,8 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
     columnSequence,
     currentMonth,
     currentYear,
+    loadedFrom,
+    loadedTo,
     yearComputed,
     incomeSubtotals,
     spendSubtotals,
@@ -102,6 +117,8 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
         columnSequence={columnSequence}
         currentMonth={currentMonth}
         currentYear={currentYear}
+        loadedFrom={loadedFrom}
+        loadedTo={loadedTo}
         yearComputed={yearComputed}
         loadingKind="derived"
         showData={derivedVisibility.showData}
@@ -193,6 +210,8 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
         columnSequence={columnSequence}
         currentMonth={currentMonth}
         currentYear={currentYear}
+        loadedFrom={loadedFrom}
+        loadedTo={loadedTo}
         yearComputed={yearComputed}
         loadingKind="subtotal"
         showData={derivedVisibility.showData}
@@ -310,6 +329,8 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
         columnSequence={columnSequence}
         currentMonth={currentMonth}
         currentYear={currentYear}
+        loadedFrom={loadedFrom}
+        loadedTo={loadedTo}
         yearComputed={yearComputed}
         loadingKind="subtotal"
         showData={derivedVisibility.showData}
@@ -346,7 +367,7 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           );
         }}
         renderPastMonth={(month) => {
-          const balance = cumulativeBalances.get(month) as CumulativeBalance;
+          const balance = getLoadedCumulativeBalance(cumulativeBalances, month);
           return renderValueCells({
             key: month,
             month,
@@ -366,7 +387,7 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           });
         }}
         renderFutureMonth={(month) => {
-          const balance = cumulativeBalances.get(month) as CumulativeBalance;
+          const balance = getLoadedCumulativeBalance(cumulativeBalances, month);
           return renderValueCells({
             key: month,
             month,
@@ -386,7 +407,7 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           });
         }}
         renderCurrentMonth={(month) => {
-          const balance = cumulativeBalances.get(month) as CumulativeBalance;
+          const balance = getLoadedCumulativeBalance(cumulativeBalances, month);
           return renderValueCells({
             key: month,
             month,
@@ -414,6 +435,8 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           columnSequence={columnSequence}
           currentMonth={currentMonth}
           currentYear={currentYear}
+          loadedFrom={loadedFrom}
+          loadedTo={loadedTo}
           yearComputed={yearComputed}
           numberFormat={numberFormat}
           showData={derivedVisibility.showData}
@@ -429,6 +452,8 @@ export const BudgetDerivedSection = (props: BudgetDerivedSectionProps): ReactEle
           columnSequence={columnSequence}
           currentMonth={currentMonth}
           currentYear={currentYear}
+          loadedFrom={loadedFrom}
+          loadedTo={loadedTo}
           yearComputed={yearComputed}
           loadingKind="derived"
           showData={derivedVisibility.showData}

--- a/apps/web/src/ui/tables/budget/table/sections/BudgetDirectionSection.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/BudgetDirectionSection.tsx
@@ -22,6 +22,8 @@ export type BudgetDirectionSectionProps = Readonly<{
   columnSequence: ReadonlyArray<ColumnEntry>;
   currentMonth: string;
   currentYear: string;
+  loadedFrom: string;
+  loadedTo: string;
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
   filteredSubtotalsMap: ReadonlyMap<string, ReadonlyMap<string, CellValue>>;
   taintedDirectionMonths: ReadonlySet<string>;
@@ -73,6 +75,8 @@ export const BudgetDirectionSection = (props: BudgetDirectionSectionProps): Reac
     columnSequence,
     currentMonth,
     currentYear,
+    loadedFrom,
+    loadedTo,
     yearComputed,
     filteredSubtotalsMap,
     taintedDirectionMonths,
@@ -100,6 +104,8 @@ export const BudgetDirectionSection = (props: BudgetDirectionSectionProps): Reac
         columnSequence={columnSequence}
         currentMonth={currentMonth}
         currentYear={currentYear}
+        loadedFrom={loadedFrom}
+        loadedTo={loadedTo}
         yearComputed={yearComputed}
         filteredSubtotalsMap={filteredSubtotalsMap}
         taintedDirectionMonths={taintedDirectionMonths}
@@ -122,6 +128,8 @@ export const BudgetDirectionSection = (props: BudgetDirectionSectionProps): Reac
             columnSequence={columnSequence}
             currentMonth={currentMonth}
             currentYear={currentYear}
+            loadedFrom={loadedFrom}
+            loadedTo={loadedTo}
             yearComputed={yearComputed}
             taintedCells={taintedCells}
             numberFormat={numberFormat}

--- a/apps/web/src/ui/tables/budget/table/sections/derived/LiquidityRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/derived/LiquidityRow.tsx
@@ -15,6 +15,7 @@ import {
   renderColumnCells,
   renderDerivedYearLoadingCells,
   renderMaskedYearCells,
+  renderUnloadedMonthCells,
 } from "../shared";
 
 type LiquidityRowProps = Readonly<{
@@ -22,6 +23,8 @@ type LiquidityRowProps = Readonly<{
   columnSequence: ReadonlyArray<ColumnEntry>;
   currentMonth: string;
   currentYear: string;
+  loadedFrom: string;
+  loadedTo: string;
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
   numberFormat: NumberFormat;
   showData: boolean;
@@ -36,6 +39,8 @@ export const LiquidityRow = (props: LiquidityRowProps): ReactElement => {
     columnSequence,
     currentMonth,
     currentYear,
+    loadedFrom,
+    loadedTo,
     yearComputed,
     numberFormat,
     showData,
@@ -60,16 +65,19 @@ export const LiquidityRow = (props: LiquidityRowProps): ReactElement => {
           ? t(`budget.liquidity${liquidity.charAt(0).toUpperCase()}${liquidity.slice(1)}`)
           : MASKED_CELL_PLACEHOLDER}
       </td>
-      <td className={styles.leftSpacer} />
       {columnSequence.map((column) => {
         const yearData = column.kind === "year-total" ? yearComputed.get(column.year) : undefined;
         return renderColumnCells({
           column,
           currentMonth,
           currentYear,
+          loadedFrom,
+          loadedTo,
           isYearLoading: column.kind === "year-total" && yearData === undefined,
           renderYearLoading: (isCurrentYearValue) =>
             renderYearLoading(column.kind === "year-total" ? column.year : "", isCurrentYearValue),
+          renderMonthLoading: (month) =>
+            renderUnloadedMonthCells(month, currentMonth, styles.cell),
           renderPastYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
               return renderYearLoading(column.kind === "year-total" ? column.year : "", false);

--- a/apps/web/src/ui/tables/budget/table/sections/derived/MetricRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/derived/MetricRow.tsx
@@ -12,6 +12,7 @@ import {
   renderDerivedYearLoadingCells,
   renderMaskedYearCells,
   renderSubtotalYearLoadingCells,
+  renderUnloadedMonthCells,
 } from "../shared";
 
 type MetricRowProps = Readonly<{
@@ -19,6 +20,8 @@ type MetricRowProps = Readonly<{
   columnSequence: ReadonlyArray<ColumnEntry>;
   currentMonth: string;
   currentYear: string;
+  loadedFrom: string;
+  loadedTo: string;
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
   renderPastYear: (year: string, yearData: YearTotalComputed) => ReactElement;
   renderFutureYear: (year: string, yearData: YearTotalComputed) => ReactElement;
@@ -38,6 +41,8 @@ export const MetricRow = (props: MetricRowProps): ReactElement => {
     columnSequence,
     currentMonth,
     currentYear,
+    loadedFrom,
+    loadedTo,
     yearComputed,
     rowClassName,
     renderPastYear,
@@ -62,16 +67,24 @@ export const MetricRow = (props: MetricRowProps): ReactElement => {
   return (
     <tr className={rowClassName}>
       <td className={`${rowClassName === styles.directionRow ? styles.directionLabel : styles.categoryLabel} ${styles.stickyCol}`}>{label}</td>
-      <td className={styles.leftSpacer} />
       {columnSequence.map((column) => {
         const yearData = column.kind === "year-total" ? yearComputed.get(column.year) : undefined;
         return renderColumnCells({
           column,
           currentMonth,
           currentYear,
+          loadedFrom,
+          loadedTo,
           isYearLoading: column.kind === "year-total" && yearData === undefined,
           renderYearLoading: (isCurrentYearValue) =>
             renderLoading(column.kind === "year-total" ? column.year : "", isCurrentYearValue),
+          renderMonthLoading: (month) => renderUnloadedMonthCells(
+            month,
+            currentMonth,
+            loadingKind === "subtotal"
+              ? `${styles.cell} ${styles.cellSubtotal}`
+              : styles.cell,
+          ),
           renderPastYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
               return renderLoading(column.kind === "year-total" ? column.year : "", false);

--- a/apps/web/src/ui/tables/budget/table/sections/direction/CategoryRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/direction/CategoryRow.tsx
@@ -29,6 +29,7 @@ import {
   renderColumnCells,
   renderDerivedYearLoadingCells,
   renderMaskedYearCells,
+  renderUnloadedMonthCells,
 } from "../shared";
 
 type CategoryRowProps = Readonly<{
@@ -39,6 +40,8 @@ type CategoryRowProps = Readonly<{
   columnSequence: ReadonlyArray<ColumnEntry>;
   currentMonth: string;
   currentYear: string;
+  loadedFrom: string;
+  loadedTo: string;
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
   taintedCells: ReadonlySet<string>;
   numberFormat: NumberFormat;
@@ -89,6 +92,8 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
     columnSequence,
     currentMonth,
     currentYear,
+    loadedFrom,
+    loadedTo,
     yearComputed,
     taintedCells,
     numberFormat,
@@ -118,16 +123,19 @@ export const CategoryRow = (props: CategoryRowProps): ReactElement => {
       >
         {categoryVisibility.showData ? category : MASKED_CELL_PLACEHOLDER}
       </td>
-      <td className={styles.leftSpacer} />
       {columnSequence.map((column) => {
         const yearData = column.kind === "year-total" ? yearComputed.get(column.year) : undefined;
         return renderColumnCells({
           column,
           currentMonth,
           currentYear,
+          loadedFrom,
+          loadedTo,
           isYearLoading: column.kind === "year-total" && yearData === undefined,
           renderYearLoading: (isCurrentYearValue) =>
             renderYearLoading(column.kind === "year-total" ? column.year : "", isCurrentYearValue),
+          renderMonthLoading: (month) =>
+            renderUnloadedMonthCells(month, currentMonth, styles.cell),
           renderPastYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
               return renderYearLoading(column.kind === "year-total" ? column.year : "", false);

--- a/apps/web/src/ui/tables/budget/table/sections/direction/DirectionSubtotalRow.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/direction/DirectionSubtotalRow.tsx
@@ -23,6 +23,7 @@ import {
   renderColumnCells,
   renderDerivedYearLoadingCells,
   renderSubtotalYearLoadingCells,
+  renderUnloadedMonthCells,
   renderValueCells,
 } from "../shared";
 
@@ -31,6 +32,8 @@ type DirectionSubtotalRowProps = Readonly<{
   columnSequence: ReadonlyArray<ColumnEntry>;
   currentMonth: string;
   currentYear: string;
+  loadedFrom: string;
+  loadedTo: string;
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
   filteredSubtotalsMap: ReadonlyMap<string, ReadonlyMap<string, CellValue>>;
   taintedDirectionMonths: ReadonlySet<string>;
@@ -46,6 +49,8 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
     columnSequence,
     currentMonth,
     currentYear,
+    loadedFrom,
+    loadedTo,
     yearComputed,
     filteredSubtotalsMap,
     taintedDirectionMonths,
@@ -66,16 +71,22 @@ export const DirectionSubtotalRow = (props: DirectionSubtotalRowProps): ReactEle
       <td className={`${labelClass} ${styles.stickyCol}`}>
         {t(`budget.direction${block.direction.charAt(0).toUpperCase()}${block.direction.slice(1)}`)}
       </td>
-      <td className={styles.leftSpacer} />
       {columnSequence.map((column) => {
         const yearData = column.kind === "year-total" ? yearComputed.get(column.year) : undefined;
         return renderColumnCells({
           column,
           currentMonth,
           currentYear,
+          loadedFrom,
+          loadedTo,
           isYearLoading: column.kind === "year-total" && yearData === undefined,
           renderYearLoading: (isCurrentYearValue) =>
             renderYearLoading(column.kind === "year-total" ? column.year : "", isCurrentYearValue),
+          renderMonthLoading: (month) => renderUnloadedMonthCells(
+            month,
+            currentMonth,
+            `${styles.cell}${subtotalClass}`,
+          ),
           renderPastYear: () => {
             if (column.kind !== "year-total" || yearData === undefined) {
               return renderYearLoading(column.kind === "year-total" ? column.year : "", false);

--- a/apps/web/src/ui/tables/budget/table/sections/shared.tsx
+++ b/apps/web/src/ui/tables/budget/table/sections/shared.tsx
@@ -4,6 +4,7 @@ import { MASKED_CELL_PLACEHOLDER } from "@/lib/dataMask";
 import type { NumberFormat } from "@/lib/locale";
 import {
   isFutureMonth,
+  isBudgetMonthLoaded,
   isPastMonth,
   type ColumnEntry,
 } from "@/ui/tables/budget/budgetTableLogic";
@@ -42,8 +43,11 @@ export type RenderColumnCellsParams = Readonly<{
   column: ColumnEntry;
   currentMonth: string;
   currentYear: string;
+  loadedFrom: string;
+  loadedTo: string;
   isYearLoading: boolean;
   renderYearLoading: (isCurrentYear: boolean) => ReactElement;
+  renderMonthLoading: (month: string) => ReactElement;
   renderPastYear: () => ReactElement;
   renderFutureYear: () => ReactElement;
   renderCurrentYear: () => ReactElement;
@@ -192,13 +196,41 @@ export const renderMaskedYearCells = (
   );
 };
 
+export const renderUnloadedMonthCells = (
+  month: string,
+  currentMonth: string,
+  cellClassName: string,
+): ReactElement => {
+  if (month !== currentMonth) {
+    return (
+      <td key={month} className={`${cellClassName} ${styles.monthLoading}`}>
+        &hellip;
+      </td>
+    );
+  }
+
+  return (
+    <Fragment key={month}>
+      <td className={`${cellClassName} ${styles.currentMonthPlan} ${styles.monthLoading}`}>
+        &hellip;
+      </td>
+      <td className={`${cellClassName} ${styles.currentMonthActual} ${styles.monthLoading}`}>
+        &hellip;
+      </td>
+    </Fragment>
+  );
+};
+
 export const renderColumnCells = (params: RenderColumnCellsParams): ReactElement => {
   const {
     column,
     currentMonth,
     currentYear,
+    loadedFrom,
+    loadedTo,
     isYearLoading,
     renderYearLoading,
+    renderMonthLoading,
     renderPastYear,
     renderFutureYear,
     renderCurrentYear,
@@ -218,6 +250,10 @@ export const renderColumnCells = (params: RenderColumnCellsParams): ReactElement
       return renderFutureYear();
     }
     return renderCurrentYear();
+  }
+
+  if (!isBudgetMonthLoaded(column.month, loadedFrom, loadedTo)) {
+    return renderMonthLoading(column.month);
   }
 
   if (isPastMonth(column.month, currentMonth)) {


### PR DESCRIPTION
## Summary
- render a fixed physical budget table column layout
- show non-interactive placeholders for unloaded months while preserving independent year totals
- keep the sticky category column usable with native mobile horizontal scrolling

## Validation
- static review completed with no P0-P4 findings
- project checks intentionally deferred to trunk CI