### PR TITLE
Fix budget background loading retries

### DIFF
--- a/apps/web/e2e-local/budget-adjustments.local-demo.spec.ts
+++ b/apps/web/e2e-local/budget-adjustments.local-demo.spec.ts
@@ -1,5 +1,12 @@
-import { expect, test, type Page, type Response } from "@playwright/test";
+import {
+  expect,
+  test,
+  type Page,
+  type Request,
+  type Response,
+} from "@playwright/test";
 
+import { getCurrentMonth } from "@/lib/monthUtils";
 import type { BudgetGridResult, BudgetRow } from "@/server/budget/getBudgetGrid";
 
 type CreatedAdjustment = Readonly<{
@@ -20,6 +27,20 @@ type ModeReloadCapture = Readonly<{
   started: Promise<void>;
   getRequestCount: () => number;
 }>;
+
+type BudgetTableGeometry = Readonly<{
+  monthHeaderCount: number;
+  yearHeaderCount: number;
+  scrollWidth: number;
+  tableWidth: number;
+}>;
+
+type BudgetYearTotalRequestCapture = Readonly<{
+  getRequests: () => ReadonlyArray<Request>;
+  stop: () => void;
+}>;
+
+const BUDGET_OBSERVER_HORIZONTAL_MARGIN_PX = 600;
 
 const createDeferred = (): Deferred => {
   let resolvePromise = (): void => {
@@ -112,6 +133,42 @@ const isBudgetGridResponse = (response: Response): boolean =>
   new URL(response.url()).pathname === "/api/budget-grid"
   && response.request().method() === "GET";
 
+const isBudgetYearRangeRequest = (
+  request: Request,
+  year: string,
+): boolean => {
+  const url = new URL(request.url());
+  return url.pathname === "/api/budget-grid"
+    && request.method() === "GET"
+    && url.searchParams.get("monthFrom") === `${year}-01`
+    && url.searchParams.get("monthTo") === `${year}-12`;
+};
+
+const isBudgetYearRangeResponse = (
+  response: Response,
+  year: string,
+): boolean => isBudgetYearRangeRequest(
+  response.request(),
+  year,
+);
+
+const captureBudgetYearTotalRequests = (
+  page: Page,
+  year: string,
+): BudgetYearTotalRequestCapture => {
+  const requests: Array<Request> = [];
+  const captureRequest = (request: Request): void => {
+    if (isBudgetYearRangeRequest(request, year)) {
+      requests.push(request);
+    }
+  };
+  page.on("request", captureRequest);
+  return {
+    getRequests: (): ReadonlyArray<Request> => [...requests],
+    stop: (): void => page.off("request", captureRequest),
+  };
+};
+
 const gotoBudgetAndWaitForGrid = async (page: Page): Promise<void> => {
   const initialBudgetGridResponse = page.waitForResponse(isBudgetGridResponse);
   await page.goto("/budget", { waitUntil: "domcontentloaded" });
@@ -124,32 +181,98 @@ const reloadBudgetAndWaitForGrid = async (page: Page): Promise<void> => {
   expect((await initialBudgetGridResponse).ok()).toBe(true);
 };
 
-const extendBudgetThroughMonth = async (
+const readBudgetTableGeometry = async (
+  page: Page,
+): Promise<BudgetTableGeometry> => page.getByTestId("budget-table-scroll")
+  .evaluate((element): BudgetTableGeometry => {
+    const table = element.querySelector("table");
+    if (!(table instanceof HTMLTableElement)) {
+      throw new Error("Budget table scroll container has no table");
+    }
+    return {
+      monthHeaderCount: table.querySelectorAll("[data-budget-month]").length,
+      yearHeaderCount: table.querySelectorAll("[data-budget-year-total]").length,
+      scrollWidth: element.scrollWidth,
+      tableWidth: table.offsetWidth,
+    };
+  });
+
+const loadBudgetMonthAndYearTotal = async (
   page: Page,
   targetMonth: string,
+  currentMonth: string,
+  direction: "income" | "spend",
+  category: string,
+  yearTotalRequestCapture: BudgetYearTotalRequestCapture,
 ): Promise<void> => {
-  const targetHeader = page.locator(`[data-month="${targetMonth}"]`);
-  while (await targetHeader.count() === 0) {
-    const loadedMonthHeaders = page.locator("[data-month]");
-    const loadedMonthCount = await loadedMonthHeaders.count();
-    if (loadedMonthCount === 0) {
-      throw new Error("Budget table has no rendered month headers");
-    }
-    const loadedTo = await loadedMonthHeaders.nth(loadedMonthCount - 1)
-      .getAttribute("data-month");
-    if (loadedTo === null) {
-      throw new Error("Last budget month header has no data-month");
-    }
-    const monthTo = offsetMonth(loadedTo, 6);
-    await page.getByTestId("budget-table-scroll").evaluate((element): void => {
-      element.scrollLeft = element.scrollWidth;
-      element.dispatchEvent(new Event("scroll"));
-    });
-    await expect(page.locator(`[data-month="${monthTo}"]`)).toHaveCount(
-      1,
-      { timeout: 15_000 },
-    );
-  }
+  const targetYear = targetMonth.slice(0, 4);
+  const targetHeader = page.locator(
+    `[data-budget-month="${targetMonth}"]`,
+  );
+  const targetYearHeader = page.locator(
+    `[data-budget-year-total="${targetYear}"]`,
+  );
+  const targetCell = page.getByTestId(
+    `budget-plan-open-budget-plan:${targetMonth}:${direction}:${category}`,
+  );
+  const targetYearTotal = page.getByTestId(
+    `budget-year-plan-${targetYear}:${direction}:${category}`,
+  );
+  await expect(targetHeader).toHaveCount(1);
+  await expect(targetYearHeader).toHaveCount(1);
+  await expect(targetCell).toHaveCount(0);
+  await expect(targetYearTotal).toHaveCount(0);
+  const geometryBeforeLoad = await readBudgetTableGeometry(page);
+  await targetHeader.evaluate((element): void => {
+    element.scrollIntoView({ block: "nearest", inline: "end" });
+  });
+
+  await expect(targetCell).toBeVisible({ timeout: 15_000 });
+  const isYearTotalOutsideObserverMargin = await targetYearHeader.evaluate(
+    (element, horizontalMarginPx): boolean => {
+      const scrollContainer = element.closest(
+        '[data-testid="budget-table-scroll"]',
+      );
+      if (!(scrollContainer instanceof HTMLElement)) {
+        throw new Error(
+          "Budget year total header has no scroll container",
+        );
+      }
+      const scrollRect = scrollContainer.getBoundingClientRect();
+      const headerRect = element.getBoundingClientRect();
+      return headerRect.right <= scrollRect.left - horizontalMarginPx
+        || headerRect.left >= scrollRect.right + horizontalMarginPx;
+    },
+    BUDGET_OBSERVER_HORIZONTAL_MARGIN_PX,
+  );
+  expect(isYearTotalOutsideObserverMargin).toBe(true);
+  await page.waitForTimeout(100);
+  expect(yearTotalRequestCapture.getRequests()).toHaveLength(0);
+  await expect(targetYearTotal).toHaveCount(0);
+
+  const yearTotalRequest = page.waitForRequest((request): boolean =>
+    isBudgetYearRangeRequest(request, targetYear));
+  const yearTotalResponse = page.waitForResponse((response): boolean =>
+    isBudgetYearRangeResponse(response, targetYear));
+  await targetYearHeader.evaluate((element): void => {
+    element.scrollIntoView({ block: "nearest", inline: "center" });
+  });
+  const [request, response] = await Promise.all([
+    yearTotalRequest,
+    yearTotalResponse,
+  ]);
+  const requestUrl = new URL(request.url());
+  expect(requestUrl.searchParams.get("planFrom")).toBe(`${targetYear}-01`);
+  expect(requestUrl.searchParams.get("actualTo")).toBe(currentMonth);
+  await expect(targetYearTotal).toBeVisible({ timeout: 15_000 });
+  await expect.poll(() => readBudgetTableGeometry(page)).toEqual(
+    geometryBeforeLoad,
+  );
+  const capturedRequests = yearTotalRequestCapture.getRequests();
+  expect(capturedRequests).toHaveLength(1);
+  expect(capturedRequests[0]).toBe(request);
+  expect(response.request()).toBe(request);
+  expect(response.ok()).toBe(true);
 };
 
 const readFormattedAmount = async (
@@ -547,20 +670,34 @@ test("keeps cross-year totals and Demo adjustment state coherent across reloads 
   test.slow();
   if (baseURL === undefined) throw new Error("Local Demo Playwright baseURL is required");
   await setDemoCookies(page, baseURL, "en");
-  await gotoBudgetAndWaitForGrid(page);
-
   const seasonalId = "demo-adjustment-groceries-seasonal";
   const deletedSeedId = "demo-adjustment-groceries-discount";
-  const currentEditorId = await getEditorId(page, "spend", "Groceries", 0);
-  const currentMonth = currentEditorId.split(":")[1];
-  if (currentMonth === undefined) {
-    throw new Error(`Cannot read month from editor ID "${currentEditorId}"`);
-  }
+  const currentMonth = getCurrentMonth();
   const currentYear = currentMonth.slice(0, 4);
-  const destinationYear = String(Number(currentYear) + 1);
+  const destinationYear = String(Number(currentYear) + 3);
   const destinationMonth = `${destinationYear}-01`;
-  const destinationYearEnd = `${destinationYear}-12`;
-  await extendBudgetThroughMonth(page, destinationYearEnd);
+  const currentEditorId =
+    `budget-plan:${currentMonth}:spend:Groceries`;
+  const initialYearTotalRequestCapture = captureBudgetYearTotalRequests(
+    page,
+    destinationYear,
+  );
+  try {
+    await gotoBudgetAndWaitForGrid(page);
+    await expect(
+      page.getByTestId(`budget-plan-open-${currentEditorId}`),
+    ).toBeVisible({ timeout: 15_000 });
+    await loadBudgetMonthAndYearTotal(
+      page,
+      destinationMonth,
+      currentMonth,
+      "spend",
+      "Groceries",
+      initialYearTotalRequestCapture,
+    );
+  } finally {
+    initialYearTotalRequestCapture.stop();
+  }
 
   const currentYearTestId =
     `budget-year-plan-${currentYear}:spend:Groceries`;
@@ -706,8 +843,23 @@ test("keeps cross-year totals and Demo adjustment state coherent across reloads 
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("budget-sync-status")).toHaveCount(0);
 
-  await reloadBudgetAndWaitForGrid(page);
-  await extendBudgetThroughMonth(page, destinationYearEnd);
+  const reloadYearTotalRequestCapture = captureBudgetYearTotalRequests(
+    page,
+    destinationYear,
+  );
+  try {
+    await reloadBudgetAndWaitForGrid(page);
+    await loadBudgetMonthAndYearTotal(
+      page,
+      destinationMonth,
+      currentMonth,
+      "spend",
+      "Groceries",
+      reloadYearTotalRequestCapture,
+    );
+  } finally {
+    reloadYearTotalRequestCapture.stop();
+  }
   await expectFormattedAmount(
     page,
     currentYearTestId,
@@ -764,7 +916,23 @@ test("keeps cross-year totals and Demo adjustment state coherent across reloads 
 
   await page.unroute("**/budget");
   await setDemoCookies(page, baseURL, "en");
-  await gotoBudgetAndWaitForGrid(page);
+  const modeReturnYearTotalRequestCapture = captureBudgetYearTotalRequests(
+    page,
+    destinationYear,
+  );
+  try {
+    await gotoBudgetAndWaitForGrid(page);
+    await loadBudgetMonthAndYearTotal(
+      page,
+      destinationMonth,
+      currentMonth,
+      "spend",
+      "Groceries",
+      modeReturnYearTotalRequestCapture,
+    );
+  } finally {
+    modeReturnYearTotalRequestCapture.stop();
+  }
   await page.getByTestId(`budget-plan-open-${destinationEditorId}`).click();
   await expect(
     page.getByTestId(`budget-adjustment-note-${seasonalId}`),

--- a/apps/web/src/ui/tables/budget/budgetTableApi.ts
+++ b/apps/web/src/ui/tables/budget/budgetTableApi.ts
@@ -167,6 +167,7 @@ export const fetchBudgetRange = async (
   planFrom: string,
   actualTo: string,
   refreshToken: string,
+  signal: AbortSignal,
 ): Promise<BudgetGridResult> => {
   const params = new URLSearchParams({
     monthFrom,
@@ -175,7 +176,7 @@ export const fetchBudgetRange = async (
     actualTo,
   });
   const url = buildLiveDataUrl("/api/budget-grid", params, refreshToken);
-  const response = await fetchLiveData(url);
+  const response = await fetchLiveData(url, { signal });
   if (!response.ok) {
     throw new Error(`Budget API error: ${response.status} ${await response.text()}`);
   }

--- a/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.test.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.test.ts
@@ -59,13 +59,18 @@ type ControllerHarness = Readonly<{
     handler: (adjustmentId: string) => Promise<DeleteBudgetAdjustmentOutcome>,
   ) => void;
   setRangeHandler: (
-    handler: (monthFrom: string, monthTo: string) => Promise<BudgetGridResult>,
+    handler: (
+      monthFrom: string,
+      monthTo: string,
+      signal: AbortSignal,
+    ) => Promise<BudgetGridResult>,
   ) => void;
 }>;
 
 const FIRST_ID = "00000000-0000-4000-8000-000000000001";
 const SECOND_ID = "00000000-0000-4000-8000-000000000002";
 const CREATED_ID = "00000000-0000-4000-8000-000000000003";
+const ACTIVE_ABORT_SIGNAL = new AbortController().signal;
 
 const createDeferred = <T,>(): Deferred<T> => {
   let resolvePromise: (value: T) => void = (): void => {
@@ -200,6 +205,7 @@ const createHarness = (
   let rangeHandler = async (
     _monthFrom: string,
     _monthTo: string,
+    _signal: AbortSignal,
   ): Promise<BudgetGridResult> => createGrid(initialAdjustments, []);
 
   const runtime = createBudgetAdjustmentRowsController({
@@ -218,9 +224,9 @@ const createHarness = (
       deleteCalls.push(adjustmentId);
       return deleteHandler(adjustmentId);
     },
-    fetchRange: async (monthFrom, monthTo): Promise<BudgetGridResult> => {
+    fetchRange: async (monthFrom, monthTo, signal): Promise<BudgetGridResult> => {
       rangeCalls.push({ monthFrom, monthTo });
-      return rangeHandler(monthFrom, monthTo);
+      return rangeHandler(monthFrom, monthTo, signal);
     },
     generateAdjustmentId: (): string => CREATED_ID,
     schedule: clock.schedule,
@@ -639,7 +645,11 @@ test("classifies definitive patch failures and reconciles ambiguous failures by 
   const rangeResult = createGrid([canonical], []);
   harness.setRangeHandler(async (): Promise<BudgetGridResult> => rangeResult);
   assert.deepEqual(
-    await harness.runtime.commands.loadRange("2026-12", "2027-01"),
+    await harness.runtime.commands.loadRange(
+      "2026-12",
+      "2027-01",
+      ACTIVE_ABORT_SIGNAL,
+    ),
     { status: "accepted", result: rangeResult },
   );
   assert.deepEqual(harness.rangeCalls, [{ monthFrom: "2026-12", monthTo: "2027-01" }]);
@@ -1346,7 +1356,11 @@ test("keeps a protected source cell projected through authoritative range absenc
   };
   const release = harness.runtime.commands.retainCell("source-editor", location);
 
-  const outcome = await harness.runtime.commands.loadRange("2026-07", "2026-07");
+  const outcome = await harness.runtime.commands.loadRange(
+    "2026-07",
+    "2026-07",
+    ACTIVE_ABORT_SIGNAL,
+  );
   assert.equal(outcome.status, "accepted");
   assert.equal(harness.runtime.commands.getRow(FIRST_ID, null), null);
   assert.equal(
@@ -1374,8 +1388,16 @@ test("accepts exact-overlap ranges in response order and supersedes stale result
     createDraft("9", "2026-07", "Food", "local"),
   );
 
-  const olderLoad = harness.runtime.commands.loadRange("2026-07", "2026-07");
-  const newerLoad = harness.runtime.commands.loadRange("2026-07", "2026-07");
+  const olderLoad = harness.runtime.commands.loadRange(
+    "2026-07",
+    "2026-07",
+    ACTIVE_ABORT_SIGNAL,
+  );
+  const newerLoad = harness.runtime.commands.loadRange(
+    "2026-07",
+    "2026-07",
+    ACTIVE_ABORT_SIGNAL,
+  );
   assert.equal(harness.runtime.getSnapshot().pendingRangeCount, 2);
   const newerGrid = createGrid([{ ...initial, amount: 3 }], []);
   newer.resolve(newerGrid);
@@ -1399,8 +1421,16 @@ test("accepts exact-overlap ranges when the older response settles first", async
   harness.setRangeHandler((_monthFrom, _monthTo) =>
     harness.rangeCalls.length === 1 ? older.promise : newer.promise);
 
-  const olderLoad = harness.runtime.commands.loadRange("2026-07", "2026-07");
-  const newerLoad = harness.runtime.commands.loadRange("2026-07", "2026-07");
+  const olderLoad = harness.runtime.commands.loadRange(
+    "2026-07",
+    "2026-07",
+    ACTIVE_ABORT_SIGNAL,
+  );
+  const newerLoad = harness.runtime.commands.loadRange(
+    "2026-07",
+    "2026-07",
+    ACTIVE_ABORT_SIGNAL,
+  );
   const olderGrid = createGrid([{ ...initial, amount: 2 }], []);
   older.resolve(olderGrid);
   assert.deepEqual(await olderLoad, { status: "accepted", result: olderGrid });
@@ -1418,7 +1448,11 @@ test("loads the maximum supported month without advancing beyond the range", asy
   harness.setRangeHandler(async (): Promise<BudgetGridResult> => grid);
 
   assert.deepEqual(
-    await harness.runtime.commands.loadRange("9999-12", "9999-12"),
+    await harness.runtime.commands.loadRange(
+      "9999-12",
+      "9999-12",
+      ACTIVE_ABORT_SIGNAL,
+    ),
     { status: "accepted", result: grid },
   );
   assert.deepEqual(harness.rangeCalls, [{ monthFrom: "9999-12", monthTo: "9999-12" }]);
@@ -1434,8 +1468,16 @@ test("reconciles safe months but withholds a partially superseded range result",
   harness.setRangeHandler((_monthFrom, _monthTo) =>
     harness.rangeCalls.length === 1 ? older.promise : newer.promise);
 
-  const olderLoad = harness.runtime.commands.loadRange("2026-07", "2026-08");
-  const newerLoad = harness.runtime.commands.loadRange("2026-08", "2026-09");
+  const olderLoad = harness.runtime.commands.loadRange(
+    "2026-07",
+    "2026-08",
+    ACTIVE_ABORT_SIGNAL,
+  );
+  const newerLoad = harness.runtime.commands.loadRange(
+    "2026-08",
+    "2026-09",
+    ACTIVE_ABORT_SIGNAL,
+  );
   const newerGrid = createGrid([{ ...august, amount: 30 }], []);
   newer.resolve(newerGrid);
   assert.deepEqual(await newerLoad, { status: "accepted", result: newerGrid });
@@ -1450,11 +1492,40 @@ test("reconciles safe months but withholds a partially superseded range result",
   assert.equal(rows.find((row) => row.adjustmentId === SECOND_ID)?.confirmed.amount, 30);
 });
 
+test("cancels a range load without publishing a range failure", async (): Promise<void> => {
+  const harness = createHarness([]);
+  const abortController = new AbortController();
+  harness.setRangeHandler((
+    _monthFrom,
+    _monthTo,
+    signal,
+  ): Promise<BudgetGridResult> => new Promise((_resolve, reject): void => {
+    signal.addEventListener("abort", (): void => reject(signal.reason), {
+      once: true,
+    });
+  }));
+
+  const rangeLoad = harness.runtime.commands.loadRange(
+    "2026-07",
+    "2026-08",
+    abortController.signal,
+  );
+  abortController.abort();
+
+  await assert.rejects(rangeLoad, { name: "AbortError" });
+  assert.equal(harness.runtime.getSnapshot().pendingRangeCount, 0);
+  assert.equal(harness.runtime.getSnapshot().rangeErrorByKey.size, 0);
+});
+
 test("rejects range failures and clears them after a broader accepted recovery", async (): Promise<void> => {
   const harness = createHarness([]);
   const network = createDeferred<BudgetGridResult>();
   harness.setRangeHandler((_monthFrom, _monthTo) => network.promise);
-  const networkLoad = harness.runtime.commands.loadRange("2026-07", "2026-08");
+  const networkLoad = harness.runtime.commands.loadRange(
+    "2026-07",
+    "2026-08",
+    ACTIVE_ABORT_SIGNAL,
+  );
   assert.equal(harness.runtime.getSnapshot().pendingRangeCount, 1);
   network.reject(new BudgetAdjustmentApiError(
     "Budget grid load",
@@ -1471,7 +1542,11 @@ test("rejects range failures and clears them after a broader accepted recovery",
 
   const broader = createDeferred<BudgetGridResult>();
   harness.setRangeHandler((_monthFrom, _monthTo) => broader.promise);
-  const recovery = harness.runtime.commands.loadRange("2026-06", "2026-09");
+  const recovery = harness.runtime.commands.loadRange(
+    "2026-06",
+    "2026-09",
+    ACTIVE_ABORT_SIGNAL,
+  );
   assert.equal(harness.runtime.getSnapshot().rangeErrorByKey.size, 1);
   const recoveredGrid = createGrid([], []);
   broader.resolve(recoveredGrid);
@@ -1482,7 +1557,11 @@ test("rejects range failures and clears them after a broader accepted recovery",
     createAdjustment(FIRST_ID, 1, "invalid-month", "Food", null),
   ], []));
   await assert.rejects(
-    harness.runtime.commands.loadRange("2026-09", "2026-09"),
+    harness.runtime.commands.loadRange(
+      "2026-09",
+      "2026-09",
+      ACTIVE_ABORT_SIGNAL,
+    ),
     /Budget adjustment range response row 0 is invalid/,
   );
   assert.equal(harness.runtime.getSnapshot().rangeErrorByKey.size, 1);
@@ -1495,8 +1574,16 @@ test("keeps the newest identical-range failure when responses settle in reverse"
   const harness = createHarness([]);
   harness.setRangeHandler((_monthFrom, _monthTo) =>
     harness.rangeCalls.length === 1 ? older.promise : newer.promise);
-  const olderLoad = harness.runtime.commands.loadRange("2026-07", "2026-08");
-  const newerLoad = harness.runtime.commands.loadRange("2026-07", "2026-08");
+  const olderLoad = harness.runtime.commands.loadRange(
+    "2026-07",
+    "2026-08",
+    ACTIVE_ABORT_SIGNAL,
+  );
+  const newerLoad = harness.runtime.commands.loadRange(
+    "2026-07",
+    "2026-08",
+    ACTIVE_ABORT_SIGNAL,
+  );
 
   newer.reject(new Error("newer range failure"));
   await assert.rejects(newerLoad, /newer range failure/);
@@ -1518,7 +1605,11 @@ test("keeps a failed range error until accepted partitions cover every month", a
     throw new Error("range offline");
   });
   await assert.rejects(
-    harness.runtime.commands.loadRange("2026-07", "2026-09"),
+    harness.runtime.commands.loadRange(
+      "2026-07",
+      "2026-09",
+      ACTIVE_ABORT_SIGNAL,
+    ),
     /range offline/,
   );
   assert.equal(harness.runtime.getSnapshot().rangeErrorByKey.size, 1);
@@ -1526,12 +1617,20 @@ test("keeps a failed range error until accepted partitions cover every month", a
   const partitionGrid = createGrid([], []);
   harness.setRangeHandler(async (): Promise<BudgetGridResult> => partitionGrid);
   assert.equal(
-    (await harness.runtime.commands.loadRange("2026-07", "2026-07")).status,
+    (await harness.runtime.commands.loadRange(
+      "2026-07",
+      "2026-07",
+      ACTIVE_ABORT_SIGNAL,
+    )).status,
     "accepted",
   );
   assert.equal(harness.runtime.getSnapshot().rangeErrorByKey.size, 1);
   assert.equal(
-    (await harness.runtime.commands.loadRange("2026-08", "2026-09")).status,
+    (await harness.runtime.commands.loadRange(
+      "2026-08",
+      "2026-09",
+      ACTIVE_ABORT_SIGNAL,
+    )).status,
     "accepted",
   );
   assert.equal(harness.runtime.getSnapshot().rangeErrorByKey.size, 0);

--- a/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetAdjustmentRowsController.ts
@@ -106,7 +106,11 @@ export type BudgetAdjustmentRowsControllerCommands = Readonly<{
   flushRow: (adjustmentId: string) => Promise<BudgetAdjustmentFlushOutcome>;
   recoverRow: (adjustmentId: string) => Promise<BudgetAdjustmentRecoveryOutcome>;
   requestDelete: (adjustmentId: string) => Promise<BudgetAdjustmentFlushOutcome>;
-  loadRange: (monthFrom: string, monthTo: string) => Promise<BudgetAdjustmentRangeLoadOutcome>;
+  loadRange: (
+    monthFrom: string,
+    monthTo: string,
+    signal: AbortSignal,
+  ) => Promise<BudgetAdjustmentRangeLoadOutcome>;
   refreshRow: (adjustmentId: string) => Promise<BudgetAdjustmentRangeLoadOutcome>;
   getRow: (
     adjustmentId: string,
@@ -151,7 +155,11 @@ export type BudgetAdjustmentRowsControllerDependencies = Readonly<{
     params: PatchBudgetAdjustmentParams,
   ) => Promise<BudgetAdjustment>;
   deleteAdjustment: (adjustmentId: string) => Promise<DeleteBudgetAdjustmentOutcome>;
-  fetchRange: (monthFrom: string, monthTo: string) => Promise<BudgetGridResult>;
+  fetchRange: (
+    monthFrom: string,
+    monthTo: string,
+    signal: AbortSignal,
+  ) => Promise<BudgetGridResult>;
   generateAdjustmentId: () => string;
   schedule: (callback: () => void, delayMs: number) => TimerHandle;
   cancelScheduled: (handle: TimerHandle) => void;
@@ -234,6 +242,7 @@ export const createBudgetAdjustmentRowsController = (
     dependencies.planFrom,
   );
   let disposed = false;
+  let lifecycleAbortController = new AbortController();
   let snapshot: BudgetAdjustmentRowsControllerState;
   const listeners = new Set<() => void>();
   const timers = new Map<string, TimerHandle>();
@@ -639,18 +648,21 @@ export const createBudgetAdjustmentRowsController = (
   const loadRange = async (
     monthFrom: string,
     monthTo: string,
+    signal: AbortSignal,
   ): Promise<BudgetAdjustmentRangeLoadOutcome> => {
     const disposedError = getDisposedError(
       `load budget adjustment range ${monthFrom}..${monthTo}`,
     );
     if (disposedError !== null) throw disposedError;
+    signal.throwIfAborted();
     const issued = issueBudgetAdjustmentRangeRequest(reconciliation, monthFrom, monthTo);
     reconciliation = issued.state;
     const rangeKey = getRangeKey(monthFrom, monthTo);
     pendingRangeCount += 1;
     publish();
     try {
-      const result = await dependencies.fetchRange(monthFrom, monthTo);
+      const result = await dependencies.fetchRange(monthFrom, monthTo, signal);
+      signal.throwIfAborted();
       const ambiguityRequirementsBeforeResponse =
         reconciliation.ambiguousRangeRequirementByAdjustmentId;
       const previousRows = reconciliation.rows;
@@ -705,6 +717,9 @@ export const createBudgetAdjustmentRowsController = (
       return accepted ? { status: "accepted", result } : { status: "superseded" };
     } catch (error: unknown) {
       reconciliation = reconcileBudgetAdjustmentRangeFailure(reconciliation, issued.request);
+      if (signal.aborted) {
+        throw error;
+      }
       if (!isRangeFailureSuperseded(
         reconciliation,
         issued.request.requestId,
@@ -747,6 +762,7 @@ export const createBudgetAdjustmentRowsController = (
         requirement.sourceMonth > requirement.targetMonth
           ? requirement.sourceMonth
           : requirement.targetMonth,
+        lifecycleAbortController.signal,
       );
     }
     const row = reconciliation.rows.find((candidate): boolean =>
@@ -764,7 +780,11 @@ export const createBudgetAdjustmentRowsController = (
     const monthTo = row.confirmed.month > draftMonth
       ? row.confirmed.month
       : draftMonth;
-    return loadRange(monthFrom, monthTo);
+    return loadRange(
+      monthFrom,
+      monthTo,
+      lifecycleAbortController.signal,
+    );
   };
 
   const recoverRow = (
@@ -960,6 +980,7 @@ export const createBudgetAdjustmentRowsController = (
     commands,
     activate: (): void => {
       if (!disposed) return;
+      lifecycleAbortController = new AbortController();
       if (suspendedInvalidationYears.size > 0) {
         dependencies.invalidateYears(new Set(suspendedInvalidationYears));
         suspendedInvalidationYears.clear();
@@ -976,6 +997,7 @@ export const createBudgetAdjustmentRowsController = (
     dispose: (): void => {
       if (disposed) return;
       disposed = true;
+      lifecycleAbortController.abort();
       for (const [adjustmentId, handle] of timers) {
         suspendedAutosaveIds.add(adjustmentId);
         dependencies.cancelScheduled(handle);

--- a/apps/web/src/ui/tables/budget/controller/budgetBackgroundRetry.test.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetBackgroundRetry.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createBudgetBackgroundRetryProgress,
+  finishBudgetBackgroundRetryCycle,
+  getBudgetBackgroundRetryCycleDelayMs,
+  getBudgetBackgroundRetryDelayMs,
+  resumeBudgetBackgroundRetryCycle,
+  startBudgetBackgroundRetryAttempt,
+  waitForBudgetBackgroundRetry,
+} from "@/ui/tables/budget/controller/budgetBackgroundRetry";
+
+test("bounds budget background retries with a small linear backoff", (): void => {
+  assert.equal(getBudgetBackgroundRetryDelayMs(1), 250);
+  assert.equal(getBudgetBackgroundRetryDelayMs(2), 500);
+  assert.equal(getBudgetBackgroundRetryDelayMs(3), null);
+});
+
+test("rejects invalid budget background retry attempt counts", (): void => {
+  assert.throws(
+    () => getBudgetBackgroundRetryDelayMs(0),
+    /positive safe integer/,
+  );
+});
+
+test("re-drives one bounded budget background request cycle", (): void => {
+  assert.equal(getBudgetBackgroundRetryCycleDelayMs(1), 1_000);
+  assert.equal(getBudgetBackgroundRetryCycleDelayMs(2), null);
+});
+
+test("rejects invalid budget background retry cycle counts", (): void => {
+  assert.throws(
+    () => getBudgetBackgroundRetryCycleDelayMs(0),
+    /positive safe integer/,
+  );
+});
+
+test("cancels a budget background backoff before scheduling it", async (): Promise<void> => {
+  const abortController = new AbortController();
+  abortController.abort();
+
+  assert.equal(
+    await waitForBudgetBackgroundRetry(250, abortController.signal),
+    "cancelled",
+  );
+});
+
+test("persists the complete retry bound across lifecycle replacements", (): void => {
+  let progress = createBudgetBackgroundRetryProgress();
+  progress = startBudgetBackgroundRetryAttempt(progress);
+  const inheritedProgress = progress;
+  progress = startBudgetBackgroundRetryAttempt(inheritedProgress);
+  assert.equal(progress.completedAttemptCount, 2);
+  progress = startBudgetBackgroundRetryAttempt(progress);
+
+  const firstCycle = finishBudgetBackgroundRetryCycle(progress);
+  assert.equal(firstCycle.retryDelayMs, 1_000);
+  progress = resumeBudgetBackgroundRetryCycle(firstCycle.progress);
+  progress = startBudgetBackgroundRetryAttempt(progress);
+  progress = startBudgetBackgroundRetryAttempt(progress);
+  progress = startBudgetBackgroundRetryAttempt(progress);
+
+  const finalCycle = finishBudgetBackgroundRetryCycle(progress);
+  assert.equal(finalCycle.retryDelayMs, null);
+  assert.deepEqual(finalCycle.progress, {
+    completedAttemptCount: 0,
+    completedCycleCount: 2,
+    status: "exhausted",
+  });
+});

--- a/apps/web/src/ui/tables/budget/controller/budgetBackgroundRetry.ts
+++ b/apps/web/src/ui/tables/budget/controller/budgetBackgroundRetry.ts
@@ -1,0 +1,129 @@
+const MAX_BACKGROUND_REQUEST_ATTEMPTS = 3;
+const BACKGROUND_REQUEST_RETRY_DELAY_MS = 250;
+const MAX_BACKGROUND_REQUEST_CYCLES = 2;
+const BACKGROUND_REQUEST_CYCLE_DELAY_MS = 1_000;
+
+export type BudgetBackgroundRetryProgress = Readonly<{
+  completedAttemptCount: number;
+  completedCycleCount: number;
+  status: "attempting" | "cycle-wait" | "exhausted";
+}>;
+
+export type BudgetBackgroundRetryCycleCompletion = Readonly<{
+  progress: BudgetBackgroundRetryProgress;
+  retryDelayMs: number | null;
+}>;
+
+export const createBudgetBackgroundRetryProgress = (): BudgetBackgroundRetryProgress => ({
+  completedAttemptCount: 0,
+  completedCycleCount: 0,
+  status: "attempting",
+});
+
+export const getBudgetBackgroundRetryDelayMs = (
+  completedAttemptCount: number,
+): number | null => {
+  if (!Number.isSafeInteger(completedAttemptCount) || completedAttemptCount < 1) {
+    throw new RangeError(
+      `Budget background retry completedAttemptCount must be a positive safe integer: ${completedAttemptCount}`,
+    );
+  }
+  if (completedAttemptCount >= MAX_BACKGROUND_REQUEST_ATTEMPTS) {
+    return null;
+  }
+  return completedAttemptCount * BACKGROUND_REQUEST_RETRY_DELAY_MS;
+};
+
+export const getBudgetBackgroundRetryCycleDelayMs = (
+  completedCycleCount: number,
+): number | null => {
+  if (!Number.isSafeInteger(completedCycleCount) || completedCycleCount < 1) {
+    throw new RangeError(
+      `Budget background retry completedCycleCount must be a positive safe integer: ${completedCycleCount}`,
+    );
+  }
+  return completedCycleCount >= MAX_BACKGROUND_REQUEST_CYCLES
+    ? null
+    : BACKGROUND_REQUEST_CYCLE_DELAY_MS;
+};
+
+export const startBudgetBackgroundRetryAttempt = (
+  progress: BudgetBackgroundRetryProgress,
+): BudgetBackgroundRetryProgress => {
+  if (progress.status !== "attempting") {
+    throw new Error(
+      `Cannot start a budget background retry attempt while status is "${progress.status}"`,
+    );
+  }
+  if (progress.completedAttemptCount >= MAX_BACKGROUND_REQUEST_ATTEMPTS) {
+    throw new RangeError(
+      `Budget background retry cycle already exhausted ${progress.completedAttemptCount} attempts`,
+    );
+  }
+  return {
+    ...progress,
+    completedAttemptCount: progress.completedAttemptCount + 1,
+  };
+};
+
+export const finishBudgetBackgroundRetryCycle = (
+  progress: BudgetBackgroundRetryProgress,
+): BudgetBackgroundRetryCycleCompletion => {
+  if (
+    progress.status !== "attempting"
+    || progress.completedAttemptCount !== MAX_BACKGROUND_REQUEST_ATTEMPTS
+  ) {
+    throw new Error(
+      `Cannot finish budget background retry cycle from status "${progress.status}" after ${progress.completedAttemptCount} attempts`,
+    );
+  }
+  const completedCycleCount = progress.completedCycleCount + 1;
+  const retryDelayMs = getBudgetBackgroundRetryCycleDelayMs(
+    completedCycleCount,
+  );
+  return {
+    progress: {
+      completedAttemptCount: 0,
+      completedCycleCount,
+      status: retryDelayMs === null ? "exhausted" : "cycle-wait",
+    },
+    retryDelayMs,
+  };
+};
+
+export const resumeBudgetBackgroundRetryCycle = (
+  progress: BudgetBackgroundRetryProgress,
+): BudgetBackgroundRetryProgress => {
+  if (progress.status !== "cycle-wait") {
+    throw new Error(
+      `Cannot resume budget background retry cycle while status is "${progress.status}"`,
+    );
+  }
+  return { ...progress, status: "attempting" };
+};
+
+export const waitForBudgetBackgroundRetry = (
+  delayMs: number,
+  signal: AbortSignal,
+): Promise<"cancelled" | "elapsed"> => {
+  if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
+    throw new RangeError(
+      `Budget background retry delayMs must be a non-negative safe integer: ${delayMs}`,
+    );
+  }
+  if (signal.aborted) {
+    return Promise.resolve("cancelled");
+  }
+
+  return new Promise((resolve): void => {
+    const handleAbort = (): void => {
+      window.clearTimeout(timeoutId);
+      resolve("cancelled");
+    };
+    const timeoutId = window.setTimeout((): void => {
+      signal.removeEventListener("abort", handleAbort);
+      resolve("elapsed");
+    }, delayMs);
+    signal.addEventListener("abort", handleAbort, { once: true });
+  });
+};

--- a/apps/web/src/ui/tables/budget/controller/useBudgetAdjustmentRowsController.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetAdjustmentRowsController.ts
@@ -54,7 +54,7 @@ export const useBudgetAdjustmentRowsController = ({
       patchAdjustment: (adjustmentId, params) =>
         patchBudgetAdjustment(adjustmentId, params),
       deleteAdjustment: (adjustmentId) => deleteBudgetAdjustment(adjustmentId),
-      fetchRange: (monthFrom, monthTo) => {
+      fetchRange: (monthFrom, monthTo, signal) => {
         const current = currentRequestRef.current;
         return fetchBudgetRange(
           monthFrom,
@@ -62,6 +62,7 @@ export const useBudgetAdjustmentRowsController = ({
           current.planFrom,
           current.actualTo,
           current.refreshToken,
+          signal,
         );
       },
       generateAdjustmentId: (): string => crypto.randomUUID(),

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.test.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BudgetRangeExtension } from "@/ui/tables/budget/budgetTableLogic";
+import {
+  buildBudgetViewportRetryKey,
+  retainPendingBudgetViewportRetryProgress,
+  selectBudgetViewportRangeExtension,
+} from "@/ui/tables/budget/controller/useBudgetTableRangeState";
+
+const exhaustedProgress = {
+  completedAttemptCount: 0,
+  completedCycleCount: 2,
+  status: "exhausted" as const,
+};
+
+test("selects another pending viewport side after one exact key exhausts", (): void => {
+  const left: BudgetRangeExtension = {
+    direction: "left",
+    monthFrom: "2025-01",
+    monthTo: "2025-06",
+  };
+  const right: BudgetRangeExtension = {
+    direction: "right",
+    monthFrom: "2026-07",
+    monthTo: "2026-12",
+  };
+  const progressByKey = new Map([
+    [
+      buildBudgetViewportRetryKey(
+        left.direction,
+        left.monthFrom,
+        left.monthTo,
+      ),
+      exhaustedProgress,
+    ],
+  ]);
+
+  assert.deepEqual(
+    selectBudgetViewportRangeExtension([left, right], progressByKey),
+    right,
+  );
+  progressByKey.set(
+    buildBudgetViewportRetryKey(
+      right.direction,
+      right.monthFrom,
+      right.monthTo,
+    ),
+    exhaustedProgress,
+  );
+  assert.equal(
+    selectBudgetViewportRangeExtension([left, right], progressByKey),
+    null,
+  );
+});
+
+test("gives a genuinely expanded viewport extension a fresh budget", (): void => {
+  const exhaustedLeft: BudgetRangeExtension = {
+    direction: "left",
+    monthFrom: "2025-01",
+    monthTo: "2025-06",
+  };
+  const expandedLeft: BudgetRangeExtension = {
+    direction: "left",
+    monthFrom: "2024-07",
+    monthTo: "2025-06",
+  };
+  const progressByKey = new Map([
+    [
+      buildBudgetViewportRetryKey(
+        exhaustedLeft.direction,
+        exhaustedLeft.monthFrom,
+        exhaustedLeft.monthTo,
+      ),
+      exhaustedProgress,
+    ],
+  ]);
+
+  assert.deepEqual(
+    selectBudgetViewportRangeExtension([expandedLeft], progressByKey),
+    expandedLeft,
+  );
+});
+
+test("retains only retry progress for exact keys that remain pending", (): void => {
+  const pendingKey = buildBudgetViewportRetryKey(
+    "right",
+    "2026-07",
+    "2026-12",
+  );
+  const obsoleteKey = buildBudgetViewportRetryKey(
+    "left",
+    "2025-01",
+    "2025-06",
+  );
+  const progressByKey = new Map([
+    [pendingKey, exhaustedProgress],
+    [obsoleteKey, exhaustedProgress],
+  ]);
+
+  const retained = retainPendingBudgetViewportRetryProgress(
+    progressByKey,
+    new Set([pendingKey]),
+  );
+
+  assert.deepEqual([...retained.keys()], [pendingKey]);
+  assert.deepEqual([...progressByKey.keys()], [pendingKey, obsoleteKey]);
+});

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
@@ -7,6 +7,7 @@ import {
   adjustCumulativeBeforeForPrependedRows,
   getBudgetRangeExtension,
   getTargetFillMonths,
+  type BudgetRangeExtension,
 } from "@/ui/tables/budget/budgetTableLogic";
 import {
   applyBudgetBaseToRows,
@@ -23,7 +24,19 @@ import {
   type BudgetBaseRangeRequest,
 } from "@/ui/tables/budget/budgetBaseRangeReconciliation";
 import type { BudgetAdjustmentRangeLoadOutcome } from "@/ui/tables/budget/controller/budgetAdjustmentRowsController";
-import { logBudgetTableError } from "@/ui/tables/budget/table/logBudgetTableError";
+import {
+  createBudgetBackgroundRetryProgress,
+  finishBudgetBackgroundRetryCycle,
+  getBudgetBackgroundRetryDelayMs,
+  resumeBudgetBackgroundRetryCycle,
+  startBudgetBackgroundRetryAttempt,
+  waitForBudgetBackgroundRetry,
+  type BudgetBackgroundRetryProgress,
+} from "@/ui/tables/budget/controller/budgetBackgroundRetry";
+import {
+  logBudgetTableError,
+  logBudgetTableWarning,
+} from "@/ui/tables/budget/table/logBudgetTableError";
 
 const BATCH_SIZE = 6;
 
@@ -43,6 +56,7 @@ type UseBudgetTableRangeStateParams = Readonly<{
   loadBudgetRange: (
     monthFrom: string,
     monthTo: string,
+    signal: AbortSignal,
   ) => Promise<BudgetAdjustmentRangeLoadOutcome>;
 }>;
 
@@ -122,6 +136,83 @@ type GeneratedBudgetRangeLoadOutcome =
     status: "superseded";
     request: BudgetBaseRangeRequest;
   }>;
+
+type AcceptedGeneratedBudgetRange = Readonly<{
+  result: BudgetGridResult;
+  request: BudgetBaseRangeRequest;
+}>;
+
+export type BudgetViewportRetryKey =
+  `${"left" | "right"}:${string}:${string}`;
+
+export const buildBudgetViewportRetryKey = (
+  direction: "left" | "right",
+  monthFrom: string,
+  monthTo: string,
+): BudgetViewportRetryKey => `${direction}:${monthFrom}:${monthTo}`;
+
+export const selectBudgetViewportRangeExtension = (
+  extensions: ReadonlyArray<BudgetRangeExtension>,
+  progressByKey: ReadonlyMap<BudgetViewportRetryKey, BudgetBackgroundRetryProgress>,
+): BudgetRangeExtension | null => extensions.find((extension): boolean => {
+  const progress = progressByKey.get(buildBudgetViewportRetryKey(
+    extension.direction,
+    extension.monthFrom,
+    extension.monthTo,
+  ));
+  return progress === undefined || progress.status === "attempting";
+}) ?? null;
+
+export const retainPendingBudgetViewportRetryProgress = (
+  progressByKey: ReadonlyMap<BudgetViewportRetryKey, BudgetBackgroundRetryProgress>,
+  pendingKeys: ReadonlySet<BudgetViewportRetryKey>,
+): Map<BudgetViewportRetryKey, BudgetBackgroundRetryProgress> => new Map(
+  [...progressByKey].filter(([requestKey]): boolean => (
+    pendingKeys.has(requestKey)
+  )),
+);
+
+const getPendingBudgetViewportRangeExtensions = (
+  displayMonthFrom: string,
+  displayMonthTo: string,
+  loadedFrom: string,
+  loadedTo: string,
+  requestedVisibleFrom: string,
+  requestedVisibleTo: string,
+): ReadonlyArray<BudgetRangeExtension> => {
+  const extensions: Array<BudgetRangeExtension> = [];
+  if (requestedVisibleFrom < loadedFrom) {
+    const leftExtension = getBudgetRangeExtension(
+      displayMonthFrom,
+      displayMonthTo,
+      loadedFrom,
+      loadedTo,
+      requestedVisibleFrom,
+      loadedTo,
+      BATCH_SIZE,
+    );
+    if (leftExtension === null || leftExtension.direction !== "left") {
+      throw new Error("Cannot build pending left budget viewport extension");
+    }
+    extensions.push(leftExtension);
+  }
+  if (requestedVisibleTo > loadedTo) {
+    const rightExtension = getBudgetRangeExtension(
+      displayMonthFrom,
+      displayMonthTo,
+      loadedFrom,
+      loadedTo,
+      loadedFrom,
+      requestedVisibleTo,
+      BATCH_SIZE,
+    );
+    if (rightExtension === null || rightExtension.direction !== "right") {
+      throw new Error("Cannot build pending right budget viewport extension");
+    }
+    extensions.push(rightExtension);
+  }
+  return extensions;
+};
 
 const enumerateRangeMonths = (
   monthFrom: string,
@@ -241,6 +332,18 @@ export const useBudgetTableRangeState = ({
   const [pendingSaves, setPendingSaves] = useState<number>(0);
 
   const isLoadingViewportRangeRef = useRef<boolean>(false);
+  const viewportRetryTimerRef = useRef<number | null>(null);
+  const viewportRetryProgressByKeyRef = useRef<
+    Map<BudgetViewportRetryKey, BudgetBackgroundRetryProgress>
+  >(new Map());
+  const activeViewportRetryKeyRef =
+    useRef<BudgetViewportRetryKey | null>(null);
+  const enqueueViewportRangeLoadRef = useRef<(() => void) | null>(null);
+  const lifecycleAbortControllerRef = useRef<AbortController | null>(null);
+  if (lifecycleAbortControllerRef.current === null) {
+    lifecycleAbortControllerRef.current = new AbortController();
+  }
+  const isMountedRef = useRef<boolean>(true);
   const rangeRequestQueueRef = useRef<Promise<void>>(Promise.resolve());
   const loadedFromRef = useRef<string>(initialMonthFrom);
   const loadedToRef = useRef<string>(initialMonthTo);
@@ -256,10 +359,47 @@ export const useBudgetTableRangeState = ({
   const baseMutationGenerationByCellRef =
     useRef<BudgetBaseMutationGenerationByCell>(new Map());
 
+  useEffect(() => {
+    const abortController = lifecycleAbortControllerRef.current;
+    const isLifecycleReplay = abortController?.signal.aborted === true;
+    if (abortController === null || isLifecycleReplay) {
+      lifecycleAbortControllerRef.current = new AbortController();
+    }
+    isMountedRef.current = true;
+    const activeRetryKey = activeViewportRetryKeyRef.current;
+    const activeRetryProgress = activeRetryKey === null
+      ? undefined
+      : viewportRetryProgressByKeyRef.current.get(activeRetryKey);
+    if (isLifecycleReplay && activeRetryProgress?.status === "cycle-wait") {
+      viewportRetryProgressByKeyRef.current.set(
+        activeRetryKey,
+        resumeBudgetBackgroundRetryCycle(activeRetryProgress),
+      );
+      const enqueueViewportRangeLoadCurrent =
+        enqueueViewportRangeLoadRef.current;
+      if (enqueueViewportRangeLoadCurrent === null) {
+        throw new Error(
+          "Cannot resume viewport month range after lifecycle replay: queue callback is unavailable",
+        );
+      }
+      enqueueViewportRangeLoadCurrent();
+    }
+    return (): void => {
+      isMountedRef.current = false;
+      lifecycleAbortControllerRef.current?.abort();
+      if (viewportRetryTimerRef.current !== null) {
+        window.clearTimeout(viewportRetryTimerRef.current);
+        viewportRetryTimerRef.current = null;
+      }
+    };
+  }, []);
+
   const loadGeneratedBudgetRange = useCallback(async (
     monthFrom: string,
     monthTo: string,
+    signal: AbortSignal,
   ): Promise<GeneratedBudgetRangeLoadOutcome> => {
+    signal.throwIfAborted();
     if (latestRangeRequestGenerationRef.current === Number.MAX_SAFE_INTEGER) {
       throw new RangeError("Cannot issue another budget range request: generation limit reached");
     }
@@ -274,7 +414,7 @@ export const useBudgetTableRangeState = ({
       latestRangeRequestGenerationByMonthRef.current.set(month, generation);
     }
 
-    const outcome = await loadBudgetRange(monthFrom, monthTo);
+    const outcome = await loadBudgetRange(monthFrom, monthTo, signal);
     return outcome.status === "accepted"
       ? { status: "accepted", result: outcome.result, request }
       : { status: "superseded", request };
@@ -321,18 +461,25 @@ export const useBudgetTableRangeState = ({
   }, []);
 
   const runVisibleRangeRefresh = useCallback(async (): Promise<void> => {
+    const lifecycleSignal = lifecycleAbortControllerRef.current?.signal;
+    if (lifecycleSignal === undefined || lifecycleSignal.aborted) {
+      return;
+    }
     onVisibleRangeRefreshStart();
 
     try {
       const outcome = await loadGeneratedBudgetRange(
         loadedFromRef.current,
         loadedToRef.current,
+        lifecycleSignal,
       );
+      if (lifecycleSignal.aborted) return;
       if (outcome.status === "superseded") return;
       const result = outcome.result;
       const reconciledRows = reconcileAcceptedBaseRange(result, outcome.request);
       applyFetchedBudgetResult(setAllRows, setCumBefore, setMeb, setMebByLiq, setBusinessPersonalTransfers, setHasBusinessAccount, result, reconciledRows);
     } catch (error) {
+      if (lifecycleSignal.aborted) return;
       logBudgetTableError("visible range refresh", error);
     }
   }, [loadGeneratedBudgetRange, onVisibleRangeRefreshStart, reconcileAcceptedBaseRange]);
@@ -476,65 +623,309 @@ export const useBudgetTableRangeState = ({
     enqueueRangeRequest(runVisibleRangeRefresh, "visible range refresh coordination");
   }, [enqueueRangeRequest, runVisibleRangeRefresh]);
 
-  const loadRequestedViewportRange = useCallback(async (): Promise<void> => {
+  const loadViewportRangeWithRetry = useCallback(async (
+    monthFrom: string,
+    monthTo: string,
+    direction: "left" | "right",
+    lifecycleSignal: AbortSignal,
+  ): Promise<AcceptedGeneratedBudgetRange> => {
+    const operation = `load ${direction} viewport month range ${monthFrom}..${monthTo}`;
+    const requestKey = buildBudgetViewportRetryKey(
+      direction,
+      monthFrom,
+      monthTo,
+    );
+
     while (true) {
-      const extension = getBudgetRangeExtension(
+      if (lifecycleSignal.aborted) {
+        throw new Error(`Cancelled ${operation}: budget table unmounted`);
+      }
+      const currentProgress =
+        viewportRetryProgressByKeyRef.current.get(requestKey)
+        ?? createBudgetBackgroundRetryProgress();
+      const progress = startBudgetBackgroundRetryAttempt(currentProgress);
+      viewportRetryProgressByKeyRef.current.set(requestKey, progress);
+      const completedAttemptCount = progress.completedAttemptCount;
+      let failure: unknown;
+      try {
+        const outcome = await loadGeneratedBudgetRange(
+          monthFrom,
+          monthTo,
+          lifecycleSignal,
+        );
+        if (lifecycleSignal.aborted) {
+          throw new Error(`Cancelled ${operation}: budget table unmounted`);
+        }
+        if (outcome.status === "accepted") {
+          viewportRetryProgressByKeyRef.current.delete(requestKey);
+          if (activeViewportRetryKeyRef.current === requestKey) {
+            activeViewportRetryKeyRef.current = null;
+          }
+          return { result: outcome.result, request: outcome.request };
+        }
+        failure = new Error(
+          `Budget viewport range ${monthFrom}..${monthTo} was superseded on attempt ${completedAttemptCount}`,
+        );
+      } catch (error) {
+        if (lifecycleSignal.aborted) {
+          throw error;
+        }
+        failure = error;
+      }
+
+      const retryDelayMs = getBudgetBackgroundRetryDelayMs(
+        completedAttemptCount,
+      );
+      if (retryDelayMs === null) {
+        const reason = failure instanceof Error
+          ? failure.message
+          : String(failure);
+        throw new Error(
+          `${operation} exhausted ${completedAttemptCount} attempts: ${reason}`,
+          { cause: failure },
+        );
+      }
+      logBudgetTableWarning(
+        `${operation} retrying in ${retryDelayMs}ms after attempt ${completedAttemptCount}`,
+        failure,
+      );
+      const waitOutcome = await waitForBudgetBackgroundRetry(
+        retryDelayMs,
+        lifecycleSignal,
+      );
+      if (waitOutcome === "cancelled") {
+        throw new Error(`Cancelled ${operation}: budget table unmounted`);
+      }
+    }
+  }, [loadGeneratedBudgetRange]);
+
+  const loadRequestedViewportRange = useCallback(async (
+    lifecycleSignal: AbortSignal,
+  ): Promise<void> => {
+    while (true) {
+      if (lifecycleSignal.aborted) {
+        return;
+      }
+      const pendingExtensions = getPendingBudgetViewportRangeExtensions(
         displayMonthFrom,
         displayMonthTo,
         loadedFromRef.current,
         loadedToRef.current,
         requestedVisibleFromRef.current,
         requestedVisibleToRef.current,
-        BATCH_SIZE,
       );
+      const pendingExtensionByKey = new Map(
+        pendingExtensions.map((extension): readonly [
+          BudgetViewportRetryKey,
+          BudgetRangeExtension,
+        ] => [
+          buildBudgetViewportRetryKey(
+            extension.direction,
+            extension.monthFrom,
+            extension.monthTo,
+          ),
+          extension,
+        ]),
+      );
+      viewportRetryProgressByKeyRef.current =
+        retainPendingBudgetViewportRetryProgress(
+          viewportRetryProgressByKeyRef.current,
+          new Set(pendingExtensionByKey.keys()),
+        );
+      if (
+        activeViewportRetryKeyRef.current !== null
+        && !viewportRetryProgressByKeyRef.current.has(
+          activeViewportRetryKeyRef.current,
+        )
+      ) {
+        activeViewportRetryKeyRef.current = null;
+      }
+      const activeRequestKey = activeViewportRetryKeyRef.current;
+      const activeExtension = activeRequestKey === null
+        ? undefined
+        : pendingExtensionByKey.get(activeRequestKey);
+      const activeProgress = activeRequestKey === null
+        ? undefined
+        : viewportRetryProgressByKeyRef.current.get(activeRequestKey);
+      const extension = activeExtension !== undefined
+        && (activeProgress === undefined || activeProgress.status === "attempting")
+        ? activeExtension
+        : selectBudgetViewportRangeExtension(
+          pendingExtensions,
+          viewportRetryProgressByKeyRef.current,
+        );
       if (extension === null) {
+        if (activeProgress?.status !== "cycle-wait") {
+          activeViewportRetryKeyRef.current = null;
+        }
         return;
       }
+      activeViewportRetryKeyRef.current = buildBudgetViewportRetryKey(
+        extension.direction,
+        extension.monthFrom,
+        extension.monthTo,
+      );
 
       const isLeft = extension.direction === "left";
 
-      try {
-        const outcome = await loadGeneratedBudgetRange(
-          extension.monthFrom,
-          extension.monthTo,
+      const outcome = await loadViewportRangeWithRetry(
+        extension.monthFrom,
+        extension.monthTo,
+        extension.direction,
+        lifecycleSignal,
+      );
+      if (lifecycleSignal.aborted) {
+        return;
+      }
+      const result = outcome.result;
+      const reconciledRows = reconcileAcceptedBaseRange(result, outcome.request);
+      if (isLeft) {
+        setAllRows((previous) => [...reconciledRows, ...previous]);
+        setCumBefore((previous) => (
+          adjustCumulativeBeforeForPrependedRows(previous, reconciledRows)
+        ));
+        loadedFromRef.current = extension.monthFrom;
+        setLoadedFrom(extension.monthFrom);
+      } else {
+        setAllRows((previous) => [...previous, ...reconciledRows]);
+        loadedToRef.current = extension.monthTo;
+        setLoadedTo(extension.monthTo);
+      }
+      setMeb((previous) => ({ ...previous, ...result.monthEndBalances }));
+      setMebByLiq((previous) => ({
+        ...previous,
+        ...result.monthEndBalancesByLiquidity,
+      }));
+      setBusinessPersonalTransfers((previous) => ({
+        ...previous,
+        ...result.businessPersonalTransfers,
+      }));
+      setHasBusinessAccount(result.hasBusinessAccount);
+    }
+  }, [displayMonthFrom, displayMonthTo, loadViewportRangeWithRetry, reconcileAcceptedBaseRange]);
+
+  const enqueueViewportRangeLoad = useCallback((): void => {
+    if (
+      isLoadingViewportRangeRef.current
+      || viewportRetryTimerRef.current !== null
+    ) {
+      return;
+    }
+
+    isLoadingViewportRangeRef.current = true;
+    enqueueRangeRequest(
+      async (): Promise<void> => {
+        const lifecycleSignal = lifecycleAbortControllerRef.current?.signal;
+        if (lifecycleSignal === undefined || lifecycleSignal.aborted) {
+          isLoadingViewportRangeRef.current = false;
+          return;
+        }
+        let failed = false;
+        let failure: unknown;
+        try {
+          await loadRequestedViewportRange(lifecycleSignal);
+        } catch (error) {
+          failed = true;
+          failure = error;
+        } finally {
+          isLoadingViewportRangeRef.current = false;
+        }
+
+        if (lifecycleSignal.aborted) {
+          const activeLifecycleSignal =
+            lifecycleAbortControllerRef.current?.signal;
+          if (
+            isMountedRef.current
+            && activeLifecycleSignal !== undefined
+            && activeLifecycleSignal !== lifecycleSignal
+            && !activeLifecycleSignal.aborted
+          ) {
+            const enqueueViewportRangeLoadCurrent =
+              enqueueViewportRangeLoadRef.current;
+            if (enqueueViewportRangeLoadCurrent === null) {
+              throw new Error(
+                "Cannot resume viewport month range: queue callback is unavailable",
+              );
+            }
+            enqueueViewportRangeLoadCurrent();
+          }
+          return;
+        }
+        if (!isMountedRef.current) {
+          return;
+        }
+        if (!failed) {
+          return;
+        }
+        const activeRequestKey = activeViewportRetryKeyRef.current;
+        const activeRetryProgress = activeRequestKey === null
+          ? undefined
+          : viewportRetryProgressByKeyRef.current.get(activeRequestKey);
+        if (activeRequestKey === null || activeRetryProgress === undefined) {
+          throw new Error(
+            "Cannot finish viewport month range retry cycle: progress is unavailable",
+          );
+        }
+        const cycleCompletion = finishBudgetBackgroundRetryCycle(
+          activeRetryProgress,
         );
-        if (outcome.status === "superseded") {
+        viewportRetryProgressByKeyRef.current.set(
+          activeRequestKey,
+          cycleCompletion.progress,
+        );
+        if (cycleCompletion.retryDelayMs === null) {
+          activeViewportRetryKeyRef.current = null;
+          logBudgetTableError(
+            `viewport month range background load after ${cycleCompletion.progress.completedCycleCount} cycles`,
+            failure,
+          );
+          const enqueueViewportRangeLoadCurrent =
+            enqueueViewportRangeLoadRef.current;
+          if (enqueueViewportRangeLoadCurrent === null) {
+            throw new Error(
+              "Cannot continue viewport month ranges after exhaustion: queue callback is unavailable",
+            );
+          }
+          enqueueViewportRangeLoadCurrent();
           return;
         }
 
-        const result = outcome.result;
-        const reconciledRows = reconcileAcceptedBaseRange(result, outcome.request);
-        if (isLeft) {
-          setAllRows((previous) => [...reconciledRows, ...previous]);
-          setCumBefore((previous) => (
-            adjustCumulativeBeforeForPrependedRows(previous, reconciledRows)
-          ));
-          loadedFromRef.current = extension.monthFrom;
-          setLoadedFrom(extension.monthFrom);
-        } else {
-          setAllRows((previous) => [...previous, ...reconciledRows]);
-          loadedToRef.current = extension.monthTo;
-          setLoadedTo(extension.monthTo);
-        }
-        setMeb((previous) => ({ ...previous, ...result.monthEndBalances }));
-        setMebByLiq((previous) => ({
-          ...previous,
-          ...result.monthEndBalancesByLiquidity,
-        }));
-        setBusinessPersonalTransfers((previous) => ({
-          ...previous,
-          ...result.businessPersonalTransfers,
-        }));
-        setHasBusinessAccount(result.hasBusinessAccount);
-      } catch (error) {
-        logBudgetTableError(
-          `load ${extension.direction} viewport month range ${extension.monthFrom}..${extension.monthTo}`,
-          error,
+        logBudgetTableWarning(
+          `viewport month range background load retrying cycle ${cycleCompletion.progress.completedCycleCount + 1} in ${cycleCompletion.retryDelayMs}ms`,
+          failure,
         );
-        return;
-      }
-    }
-  }, [displayMonthFrom, displayMonthTo, loadGeneratedBudgetRange, reconcileAcceptedBaseRange]);
+        const scheduledRequestKey = activeRequestKey;
+        viewportRetryTimerRef.current = window.setTimeout((): void => {
+          viewportRetryTimerRef.current = null;
+          if (lifecycleSignal.aborted || !isMountedRef.current) {
+            return;
+          }
+          const scheduledRetryProgress =
+            viewportRetryProgressByKeyRef.current.get(scheduledRequestKey);
+          if (
+            activeViewportRetryKeyRef.current !== scheduledRequestKey
+            || scheduledRetryProgress?.status !== "cycle-wait"
+          ) {
+            return;
+          }
+          viewportRetryProgressByKeyRef.current.set(
+            scheduledRequestKey,
+            resumeBudgetBackgroundRetryCycle(scheduledRetryProgress),
+          );
+          const enqueueViewportRangeLoadCurrent =
+            enqueueViewportRangeLoadRef.current;
+          if (enqueueViewportRangeLoadCurrent === null) {
+            throw new Error(
+              "Cannot retry viewport month range: queue callback is unavailable",
+            );
+          }
+          enqueueViewportRangeLoadCurrent();
+        }, cycleCompletion.retryDelayMs);
+      },
+      "viewport month range coordination",
+    );
+  }, [enqueueRangeRequest, loadRequestedViewportRange]);
+  enqueueViewportRangeLoadRef.current = enqueueViewportRangeLoad;
 
   const requestVisibleMonths = useCallback((
     monthFrom: string,
@@ -546,22 +937,14 @@ export const useBudgetTableRangeState = ({
     if (monthTo > requestedVisibleToRef.current) {
       requestedVisibleToRef.current = monthTo;
     }
-    if (isLoadingViewportRangeRef.current) {
+    if (
+      isLoadingViewportRangeRef.current
+      || viewportRetryTimerRef.current !== null
+    ) {
       return;
     }
-
-    isLoadingViewportRangeRef.current = true;
-    enqueueRangeRequest(
-      async (): Promise<void> => {
-        try {
-          await loadRequestedViewportRange();
-        } finally {
-          isLoadingViewportRangeRef.current = false;
-        }
-      },
-      "viewport month range coordination",
-    );
-  }, [enqueueRangeRequest, loadRequestedViewportRange]);
+    enqueueViewportRangeLoad();
+  }, [enqueueViewportRangeLoad]);
 
   return {
     allRows,

--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableYearTotals.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableYearTotals.ts
@@ -4,7 +4,19 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { YearFetchResult, YearTotalComputed } from "@/ui/tables/budget/budgetTableLogic";
 import { computeYearTotal } from "@/ui/tables/budget/budgetTableLogic";
 import { fetchBudgetRange } from "@/ui/tables/budget/budgetTableApi";
-import { logBudgetTableError } from "@/ui/tables/budget/table/logBudgetTableError";
+import {
+  createBudgetBackgroundRetryProgress,
+  finishBudgetBackgroundRetryCycle,
+  getBudgetBackgroundRetryDelayMs,
+  resumeBudgetBackgroundRetryCycle,
+  startBudgetBackgroundRetryAttempt,
+  waitForBudgetBackgroundRetry,
+  type BudgetBackgroundRetryProgress,
+} from "@/ui/tables/budget/controller/budgetBackgroundRetry";
+import {
+  logBudgetTableError,
+  logBudgetTableWarning,
+} from "@/ui/tables/budget/table/logBudgetTableError";
 
 export type BudgetTableYearTotalsState = Readonly<{
   yearComputed: ReadonlyMap<string, YearTotalComputed>;
@@ -24,6 +36,16 @@ export type YearTotalRequest = Readonly<{
   monthTo: string;
   planFrom: string;
   actualTo: string;
+}>;
+
+type ScheduledYearTotalRetry = Readonly<{
+  revision: number;
+  timeoutId: number;
+}>;
+
+type YearRetryProgressRecord = Readonly<{
+  revision: number;
+  progress: BudgetBackgroundRetryProgress;
 }>;
 
 export const buildYearTotalRequest = (
@@ -78,54 +100,265 @@ export const useBudgetTableYearTotals = ({
   refreshToken,
 }: UseBudgetTableYearTotalsParams): BudgetTableYearTotalsState => {
   const [yearFetchResults, setYearFetchResults] = useState<ReadonlyMap<string, YearFetchResult>>(new Map());
+  const [yearRetryTrigger, setYearRetryTrigger] = useState<number>(0);
   const yearFetchingRef = useRef<Map<string, number>>(new Map());
   const yearRevisionRef = useRef<Map<string, number>>(new Map());
+  const yearRetryProgressRef =
+    useRef<Map<string, YearRetryProgressRecord>>(new Map());
+  const yearRetryTimerRef = useRef<Map<string, ScheduledYearTotalRetry>>(new Map());
+  const lifecycleAbortControllerRef = useRef<AbortController | null>(null);
+  if (lifecycleAbortControllerRef.current === null) {
+    lifecycleAbortControllerRef.current = new AbortController();
+  }
+  const isMountedRef = useRef<boolean>(true);
+  const advanceYearRetryTrigger = useCallback((): void => {
+    setYearRetryTrigger((value): number => {
+      if (value === Number.MAX_SAFE_INTEGER) {
+        throw new RangeError(
+          "Cannot retry another year total: trigger limit reached",
+        );
+      }
+      return value + 1;
+    });
+  }, []);
 
   useEffect(() => {
+    const abortController = lifecycleAbortControllerRef.current;
+    const isLifecycleReplay = abortController?.signal.aborted === true;
+    if (abortController === null || isLifecycleReplay) {
+      lifecycleAbortControllerRef.current = new AbortController();
+    }
+    isMountedRef.current = true;
+    let resumedRetryCycle = false;
+    if (isLifecycleReplay) {
+      for (const [year, retryRecord] of yearRetryProgressRef.current) {
+        if (retryRecord.progress.status !== "cycle-wait") {
+          continue;
+        }
+        yearRetryProgressRef.current.set(year, {
+          ...retryRecord,
+          progress: resumeBudgetBackgroundRetryCycle(retryRecord.progress),
+        });
+        resumedRetryCycle = true;
+      }
+    }
+    if (resumedRetryCycle) {
+      advanceYearRetryTrigger();
+    }
+    return (): void => {
+      isMountedRef.current = false;
+      lifecycleAbortControllerRef.current?.abort();
+      for (const { timeoutId } of yearRetryTimerRef.current.values()) {
+        window.clearTimeout(timeoutId);
+      }
+      yearRetryTimerRef.current.clear();
+    };
+  }, [advanceYearRetryTrigger]);
+
+  useEffect(() => {
+    const unavailableRevisionByYear = new Map(yearFetchingRef.current);
+    for (const [year, scheduledRetry] of yearRetryTimerRef.current) {
+      unavailableRevisionByYear.set(year, scheduledRetry.revision);
+    }
+    for (const [year, retryRecord] of yearRetryProgressRef.current) {
+      if (retryRecord.progress.status !== "attempting") {
+        unavailableRevisionByYear.set(year, retryRecord.revision);
+      }
+    }
     const yearsToFetch = getObservedYearsToFetch(
       observedYears,
       new Set(yearFetchResults.keys()),
-      yearFetchingRef.current,
+      unavailableRevisionByYear,
       yearRevisionRef.current,
     );
     for (const { year, revision } of yearsToFetch) {
+      const lifecycleSignal = lifecycleAbortControllerRef.current?.signal;
+      if (lifecycleSignal === undefined || lifecycleSignal.aborted) {
+        continue;
+      }
       yearFetchingRef.current.set(year, revision);
       const request = buildYearTotalRequest(year, currentMonth);
-      fetchBudgetRange(
-        request.monthFrom,
-        request.monthTo,
-        request.planFrom,
-        request.actualTo,
-        refreshToken,
-      )
-        .then((result) => {
-          if ((yearRevisionRef.current.get(year) ?? 0) !== revision) {
+      const fetchObservedYear = async (): Promise<void> => {
+        const operation = `year total background fetch for ${year}`;
+
+        while (true) {
+          if (
+            lifecycleSignal.aborted
+            || !isMountedRef.current
+            || (yearRevisionRef.current.get(year) ?? 0) !== revision
+          ) {
             return;
           }
-          setYearFetchResults((previous) => new Map([
-            ...previous,
-            [
-              year,
-              {
-                rows: result.rows,
-                cumulativeBefore: result.cumulativeBefore,
-                monthEndBalances: result.monthEndBalances,
-                monthEndBalancesByLiquidity: result.monthEndBalancesByLiquidity,
-                businessPersonalTransfers: result.businessPersonalTransfers,
-              },
-            ],
-          ]));
-        })
-        .catch((error) => {
-          logBudgetTableError(`year total background fetch for ${year}`, error);
-        })
-        .finally(() => {
+          const currentRetryRecord = yearRetryProgressRef.current.get(year);
+          const currentProgress = currentRetryRecord?.revision === revision
+            ? currentRetryRecord.progress
+            : createBudgetBackgroundRetryProgress();
+          const progress = startBudgetBackgroundRetryAttempt(currentProgress);
+          yearRetryProgressRef.current.set(year, { revision, progress });
+          const completedAttemptCount = progress.completedAttemptCount;
+          try {
+            const result = await fetchBudgetRange(
+              request.monthFrom,
+              request.monthTo,
+              request.planFrom,
+              request.actualTo,
+              refreshToken,
+              lifecycleSignal,
+            );
+            if (
+              lifecycleSignal.aborted
+              || !isMountedRef.current
+              || (yearRevisionRef.current.get(year) ?? 0) !== revision
+            ) {
+              return;
+            }
+            const acceptedRetryRecord = yearRetryProgressRef.current.get(year);
+            if (acceptedRetryRecord?.revision === revision) {
+              yearRetryProgressRef.current.delete(year);
+            }
+            setYearFetchResults((previous) => new Map([
+              ...previous,
+              [
+                year,
+                {
+                  rows: result.rows,
+                  cumulativeBefore: result.cumulativeBefore,
+                  monthEndBalances: result.monthEndBalances,
+                  monthEndBalancesByLiquidity: result.monthEndBalancesByLiquidity,
+                  businessPersonalTransfers: result.businessPersonalTransfers,
+                },
+              ],
+            ]));
+            return;
+          } catch (error) {
+            if (
+              lifecycleSignal.aborted
+              || !isMountedRef.current
+              || (yearRevisionRef.current.get(year) ?? 0) !== revision
+            ) {
+              return;
+            }
+            const retryDelayMs = getBudgetBackgroundRetryDelayMs(
+              completedAttemptCount,
+            );
+            if (retryDelayMs === null) {
+              throw error;
+            }
+            logBudgetTableWarning(
+              `${operation} retrying in ${retryDelayMs}ms after attempt ${completedAttemptCount}`,
+              error,
+            );
+            const waitOutcome = await waitForBudgetBackgroundRetry(
+              retryDelayMs,
+              lifecycleSignal,
+            );
+            if (waitOutcome === "cancelled") {
+              return;
+            }
+          }
+        }
+      };
+      const runYearFetchCycle = async (): Promise<void> => {
+        let failed = false;
+        let failure: unknown;
+        try {
+          await fetchObservedYear();
+        } catch (error) {
+          failed = true;
+          failure = error;
+        } finally {
           if (yearFetchingRef.current.get(year) === revision) {
             yearFetchingRef.current.delete(year);
           }
+        }
+
+        if (lifecycleSignal.aborted) {
+          const activeLifecycleSignal =
+            lifecycleAbortControllerRef.current?.signal;
+          if (
+            isMountedRef.current
+            && activeLifecycleSignal !== undefined
+            && activeLifecycleSignal !== lifecycleSignal
+            && !activeLifecycleSignal.aborted
+          ) {
+            advanceYearRetryTrigger();
+          }
+          return;
+        }
+        if (!isMountedRef.current) {
+          return;
+        }
+        if (!failed) {
+          return;
+        }
+        if (
+          !isMountedRef.current
+          || (yearRevisionRef.current.get(year) ?? 0) !== revision
+        ) {
+          return;
+        }
+
+        const retryRecord = yearRetryProgressRef.current.get(year);
+        if (retryRecord?.revision !== revision) {
+          throw new Error(
+            `Cannot finish year total retry cycle for ${year}: revision ${revision} progress is unavailable`,
+          );
+        }
+        const cycleCompletion = finishBudgetBackgroundRetryCycle(
+          retryRecord.progress,
+        );
+        yearRetryProgressRef.current.set(year, {
+          revision,
+          progress: cycleCompletion.progress,
         });
+        if (cycleCompletion.retryDelayMs === null) {
+          logBudgetTableError(
+            `year total background fetch for ${year} after ${cycleCompletion.progress.completedCycleCount} cycles`,
+            failure,
+          );
+          return;
+        }
+
+        logBudgetTableWarning(
+          `year total background fetch for ${year} retrying cycle ${cycleCompletion.progress.completedCycleCount + 1} in ${cycleCompletion.retryDelayMs}ms`,
+          failure,
+        );
+        const timeoutId = window.setTimeout((): void => {
+          const scheduledRetry = yearRetryTimerRef.current.get(year);
+          if (
+            scheduledRetry?.revision !== revision
+            || scheduledRetry.timeoutId !== timeoutId
+          ) {
+            return;
+          }
+          if (
+            lifecycleSignal.aborted
+            || !isMountedRef.current
+            || (yearRevisionRef.current.get(year) ?? 0) !== revision
+          ) {
+            return;
+          }
+          const scheduledRetryRecord = yearRetryProgressRef.current.get(year);
+          if (
+            scheduledRetryRecord?.revision !== revision
+            || scheduledRetryRecord.progress.status !== "cycle-wait"
+          ) {
+            return;
+          }
+          yearRetryProgressRef.current.set(year, {
+            revision,
+            progress: resumeBudgetBackgroundRetryCycle(
+              scheduledRetryRecord.progress,
+            ),
+          });
+          yearRetryTimerRef.current.delete(year);
+          advanceYearRetryTrigger();
+        }, cycleCompletion.retryDelayMs);
+        yearRetryTimerRef.current.set(year, { revision, timeoutId });
+      };
+      void runYearFetchCycle();
     }
-  }, [currentMonth, observedYears, refreshToken, yearFetchResults]);
+  }, [advanceYearRetryTrigger, currentMonth, observedYears, refreshToken, yearFetchResults, yearRetryTrigger]);
 
   const yearComputed = useMemo<ReadonlyMap<string, YearTotalComputed>>(() => {
     const result = new Map<string, YearTotalComputed>();
@@ -152,6 +385,12 @@ export const useBudgetTableYearTotals = ({
     for (const year of invalidatedYears) {
       yearRevisionRef.current.set(year, (yearRevisionRef.current.get(year) ?? 0) + 1);
       yearFetchingRef.current.delete(year);
+      yearRetryProgressRef.current.delete(year);
+      const scheduledRetry = yearRetryTimerRef.current.get(year);
+      if (scheduledRetry !== undefined) {
+        window.clearTimeout(scheduledRetry.timeoutId);
+        yearRetryTimerRef.current.delete(year);
+      }
     }
     setYearFetchResults((previous) => removeInvalidatedYearFetchResults(previous, invalidatedYears));
   }, []);
@@ -160,6 +399,8 @@ export const useBudgetTableYearTotals = ({
     const years = new Set<string>([
       ...yearFetchResults.keys(),
       ...yearFetchingRef.current.keys(),
+      ...yearRetryProgressRef.current.keys(),
+      ...yearRetryTimerRef.current.keys(),
       ...observedYears,
     ]);
     invalidateYearTotals(years);

--- a/apps/web/src/ui/tables/budget/table/logBudgetTableError.ts
+++ b/apps/web/src/ui/tables/budget/table/logBudgetTableError.ts
@@ -6,3 +6,10 @@ export const logBudgetTableError = (
 ): void => {
   console.error(`Budget table ${operation} failed:`, error);
 };
+
+export const logBudgetTableWarning = (
+  operation: string,
+  error: unknown,
+): void => {
+  console.warn(`Budget table ${operation}:`, error);
+};


### PR DESCRIPTION
## Summary
- bound and persist viewport and annual background-load retry progress across lifecycle replay
- propagate cancellation through budget range requests and preserve fixed calendar geometry
- update lazy-loading e2e coverage to causally verify month cells and exact-year totals

## Validation
- Not run locally per repository workflow; final static review reported zero P0-P4 findings.