### PR TITLE
Restore pinch zoom on budget table

### DIFF
--- a/apps/web/src/ui/tables/budget/BudgetTable.module.css
+++ b/apps/web/src/ui/tables/budget/BudgetTable.module.css
@@ -41,7 +41,6 @@
   overflow-x: auto;
   margin-top: 12px;
   overscroll-behavior-inline: contain;
-  touch-action: pan-x pan-y;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
## Summary
- remove the restrictive budget-table touch-action declaration
- preserve browser-default pinch zoom and native pan/scroll behavior

## Review
- zero P0-P4 findings

## Checks
- not run locally, per repository workflow