### PR TITLE
Fix budget retry key narrowing during lifecycle replay

### DIFF
--- a/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
+++ b/apps/web/src/ui/tables/budget/controller/useBudgetTableRangeState.ts
@@ -370,7 +370,11 @@ export const useBudgetTableRangeState = ({
     const activeRetryProgress = activeRetryKey === null
       ? undefined
       : viewportRetryProgressByKeyRef.current.get(activeRetryKey);
-    if (isLifecycleReplay && activeRetryProgress?.status === "cycle-wait") {
+    if (
+      isLifecycleReplay
+      && activeRetryKey !== null
+      && activeRetryProgress?.status === "cycle-wait"
+    ) {
       viewportRetryProgressByKeyRef.current.set(
         activeRetryKey,
         resumeBudgetBackgroundRetryCycle(activeRetryProgress),


### PR DESCRIPTION
## Summary
- require a non-null active retry key before resuming a lifecycle-replayed retry cycle
- preserve existing runtime branching while allowing TypeScript to narrow the Map key

## Validation
- fresh static review: zero P0-P4 findings
- local checks not run per repository workflow