### PR TITLE
Split read-only and executable SQL paths

### DIFF
--- a/apps/sql-api/src/db.ts
+++ b/apps/sql-api/src/db.ts
@@ -238,3 +238,34 @@ export const withRestrictedTrustedIdentityContext = async <T>(
     client.release();
   }
 };
+
+/**
+ * Execute read-only user SQL in one stable-snapshot transaction under the
+ * least-privilege reader role.
+ */
+export const withReadOnlyRestrictedTrustedIdentityContext = async <T>(
+  identity: UserIdentity,
+  workspaceId: string,
+  statementTimeoutMs: number,
+  callback: (queryFn: QueryFn) => Promise<T>,
+): Promise<T> => {
+  await ensureTrustedIdentityProvisioned(identity, workspaceId);
+  const client = await (await getPool()).connect();
+
+  try {
+    await client.query("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY");
+    await client.query("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+    await client.query("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
+    await client.query("SELECT set_config('statement_timeout', $1, true)", [String(statementTimeoutMs)]);
+    await client.query("SET LOCAL ROLE api_sql_reader");
+    const boundQuery: QueryFn = (text, params) => client.query(text, params as Array<unknown>);
+    const result = await callback(boundQuery);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+};

--- a/apps/sql-api/src/machineApi.ts
+++ b/apps/sql-api/src/machineApi.ts
@@ -1,6 +1,11 @@
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { AGENT_API_KEY_ENV_VAR_NAME, buildErrorEnvelope } from "@expense-budget-tracker/agent-shared";
-import { ensureTrustedIdentityProvisioned, queryAsTrustedIdentity, withRestrictedTrustedIdentityContext } from "./db.js";
+import {
+  ensureTrustedIdentityProvisioned,
+  queryAsTrustedIdentity,
+  withReadOnlyRestrictedTrustedIdentityContext,
+  withRestrictedTrustedIdentityContext,
+} from "./db.js";
 import {
   handleCreateWorkspaceRoute,
   handleDiscoveryRoute,
@@ -9,6 +14,8 @@ import {
   handleSchemaRoute,
   handleSelectWorkspaceRoute,
   handleSourceDiscoveryRoute,
+  handleSqlExecuteRoute,
+  handleSqlQueryRoute,
   handleSqlRoute,
 } from "./machineApi/routeHandlers.js";
 import { createMachineRouteContext, getAuthenticatedContext, normalizePath } from "./machineApi/request.js";
@@ -21,6 +28,7 @@ export const createMachineApiHandler = (
   const dependencies: MachineApiDependencies = {
     ensureTrustedIdentityProvisioned,
     queryAsTrustedIdentity,
+    withReadOnlyRestrictedTrustedIdentityContext,
     withRestrictedTrustedIdentityContext,
     ...overrides,
   };
@@ -74,6 +82,14 @@ export const createMachineApiHandler = (
 
     if (event.httpMethod === "POST" && path === "/sql") {
       return handleSqlRoute(context);
+    }
+
+    if (event.httpMethod === "POST" && path === "/sql/query") {
+      return handleSqlQueryRoute(context);
+    }
+
+    if (event.httpMethod === "POST" && path === "/sql/execute") {
+      return handleSqlExecuteRoute(context);
     }
 
     return json(404, { error: "Not found" });

--- a/apps/sql-api/src/machineApi/routeHandlers.test.ts
+++ b/apps/sql-api/src/machineApi/routeHandlers.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createMachineApiHandler } from "../machineApi.js";
-import { handleMeRouteWithResolver, handleSqlRouteWithWorkspaceResolver } from "./routeHandlers.js";
+import {
+  handleMeRouteWithResolver,
+  handleSqlExecuteRouteWithWorkspaceResolver,
+  handleSqlQueryRouteWithWorkspaceResolver,
+  handleSqlRouteWithWorkspaceResolver,
+} from "./routeHandlers.js";
 import { createAuthenticatedEvent, createEvent } from "../handlerTestUtils.js";
 import type { MachineApiDependencies, MachineRouteContext } from "./types.js";
 
@@ -9,6 +14,9 @@ const createDependencies = (): MachineApiDependencies => ({
   ensureTrustedIdentityProvisioned: async () => undefined,
   queryAsTrustedIdentity: async () => {
     throw new Error("queryAsTrustedIdentity should not be called");
+  },
+  withReadOnlyRestrictedTrustedIdentityContext: async () => {
+    throw new Error("withReadOnlyRestrictedTrustedIdentityContext should not be called");
   },
   withRestrictedTrustedIdentityContext: async () => {
     throw new Error("withRestrictedTrustedIdentityContext should not be called");
@@ -153,5 +161,165 @@ test("handleSqlRoute explains how to replace PostgreSQL escape strings", async (
     payload.instructions,
     "PostgreSQL E'...' escape strings are unsupported in restricted SQL. Use ordinary single-quoted literals and represent embedded apostrophes by doubling them, for example 'customer''s'.",
   );
+  assert.equal(workspaceResolutionCount, 0);
+});
+
+test("SQL query, execute, and legacy routes reject data-modifying CTEs before workspace resolution", async (): Promise<void> => {
+  let workspaceResolutionCount = 0;
+  const context: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({
+        sql: "WITH changed AS (UPDATE account_metadata SET liquidity = 'low' RETURNING *) SELECT * FROM changed",
+      }),
+      httpMethod: "POST",
+      path: "/v1/sql/query",
+      resource: "/sql/query",
+    }),
+  };
+
+  const resolveWorkspaceId = async (): Promise<string> => {
+    workspaceResolutionCount += 1;
+    return "workspace-1";
+  };
+  const handlers = [
+    handleSqlQueryRouteWithWorkspaceResolver,
+    handleSqlExecuteRouteWithWorkspaceResolver,
+    handleSqlRouteWithWorkspaceResolver,
+  ] as const;
+
+  for (const handleRoute of handlers) {
+    const response = await handleRoute(context, resolveWorkspaceId);
+    const payload = JSON.parse(response.body) as {
+      error: Readonly<{ code: string; message: string }>;
+    };
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(payload.error, {
+      code: "unsupported_statement",
+      message: "Data-modifying CTE bodies are not supported; use SELECT, WITH, or VALUES in CTE bodies and move INSERT, UPDATE, or DELETE to the top-level statement. MERGE is not supported",
+    });
+  }
+  assert.equal(workspaceResolutionCount, 0);
+});
+
+test("handleSqlExecuteRoute and legacy route accept writes before workspace resolution", async (): Promise<void> => {
+  let workspaceResolutionCount = 0;
+  const context: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({
+        sql: "UPDATE account_metadata SET liquidity = 'low' WHERE workspace_id = 'workspace-1'",
+      }),
+      httpMethod: "POST",
+      path: "/v1/sql/execute",
+      resource: "/sql/execute",
+    }),
+  };
+
+  const resolveWorkspaceId = async (): Promise<null> => {
+    workspaceResolutionCount += 1;
+    return null;
+  };
+  const executeResponse = await handleSqlExecuteRouteWithWorkspaceResolver(
+    context,
+    resolveWorkspaceId,
+  );
+  const legacyResponse = await handleSqlRouteWithWorkspaceResolver(
+    context,
+    resolveWorkspaceId,
+  );
+  const executePayload = JSON.parse(executeResponse.body) as { error: Readonly<{ code: string }> };
+  const legacyPayload = JSON.parse(legacyResponse.body) as { error: Readonly<{ code: string }> };
+
+  assert.equal(executeResponse.statusCode, 400);
+  assert.equal(executePayload.error.code, "missing_workspace_id");
+  assert.equal(legacyResponse.statusCode, 400);
+  assert.equal(legacyPayload.error.code, "missing_workspace_id");
+  assert.equal(workspaceResolutionCount, 2);
+});
+
+test("new SQL routes reject batches while legacy SQL retains atomic script validation", async (): Promise<void> => {
+  let workspaceResolutionCount = 0;
+  const resolveWorkspaceId = async (): Promise<null> => {
+    workspaceResolutionCount += 1;
+    return null;
+  };
+  const queryContext: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({
+        sql: "SELECT account_id FROM accounts; SELECT rate FROM fx_rates_daily",
+      }),
+      httpMethod: "POST",
+      path: "/v1/sql/query",
+      resource: "/sql/query",
+    }),
+  };
+  const executeContext: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({
+        sql: "UPDATE account_metadata SET liquidity = 'low'; DELETE FROM budget_lines",
+      }),
+      httpMethod: "POST",
+      path: "/v1/sql/execute",
+      resource: "/sql/execute",
+    }),
+  };
+
+  const queryResponse = await handleSqlQueryRouteWithWorkspaceResolver(
+    queryContext,
+    resolveWorkspaceId,
+  );
+  const executeResponse = await handleSqlExecuteRouteWithWorkspaceResolver(
+    executeContext,
+    resolveWorkspaceId,
+  );
+  const legacyResponse = await handleSqlRouteWithWorkspaceResolver(
+    executeContext,
+    resolveWorkspaceId,
+  );
+  const queryPayload = JSON.parse(queryResponse.body) as { error: Readonly<{ code: string }> };
+  const executePayload = JSON.parse(executeResponse.body) as { error: Readonly<{ code: string }> };
+  const legacyPayload = JSON.parse(legacyResponse.body) as { error: Readonly<{ code: string }> };
+
+  assert.equal(queryResponse.statusCode, 400);
+  assert.equal(queryPayload.error.code, "single_statement_required");
+  assert.equal(executeResponse.statusCode, 400);
+  assert.equal(executePayload.error.code, "single_statement_required");
+  assert.equal(legacyResponse.statusCode, 400);
+  assert.equal(legacyPayload.error.code, "missing_workspace_id");
+  assert.equal(workspaceResolutionCount, 1);
+});
+
+test("SQL query, execute, and legacy routes reject nested WITH MERGE before workspace resolution", async (): Promise<void> => {
+  let workspaceResolutionCount = 0;
+  const context: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({
+        sql: "WITH outer_rows AS (WITH source AS (SELECT account_id FROM accounts) MERGE INTO account_metadata AS target USING source ON target.account_id = source.account_id WHEN MATCHED THEN UPDATE SET liquidity = 'low') SELECT * FROM outer_rows",
+      }),
+      httpMethod: "POST",
+      path: "/v1/sql/query",
+      resource: "/sql/query",
+    }),
+  };
+  const resolveWorkspaceId = async (): Promise<string> => {
+    workspaceResolutionCount += 1;
+    return "workspace-1";
+  };
+  const handlers = [
+    handleSqlQueryRouteWithWorkspaceResolver,
+    handleSqlExecuteRouteWithWorkspaceResolver,
+    handleSqlRouteWithWorkspaceResolver,
+  ] as const;
+
+  for (const handleRoute of handlers) {
+    const response = await handleRoute(context, resolveWorkspaceId);
+    const payload = JSON.parse(response.body) as { error: Readonly<{ code: string }> };
+    assert.equal(response.statusCode, 400);
+    assert.equal(payload.error.code, "unsupported_statement");
+  }
   assert.equal(workspaceResolutionCount, 0);
 });

--- a/apps/sql-api/src/machineApi/routeHandlers.ts
+++ b/apps/sql-api/src/machineApi/routeHandlers.ts
@@ -11,18 +11,22 @@ import {
   buildSuccessEnvelope,
 } from "@expense-budget-tracker/agent-shared";
 import {
+  MAX_SQL_MUTATION_ROWS,
   MAX_SQL_ROWS,
   SQL_STATEMENT_TIMEOUT_MS,
   SqlPolicyError,
   validateExpenseSql,
+  validateSingleExpenseSql,
+  validateSingleReadOnlyExpenseSql,
   type ValidatedExpenseSql,
+  type ValidatedReadOnlyExpenseSql,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
 import { resolveOrCreateWorkspaceForTrustedIdentity } from "../db.js";
 import { buildDiscoveryEnvelope, getApiBaseUrl, readJsonBody } from "./request.js";
 import { buildRetryableErrorResponse, json } from "./responses.js";
 import { ALLOWED_RELATION_NAMES, loadAllowedSchema } from "./schemaService.js";
-import { getSqlPolicyInstructions, getUserSqlExecutionMessage, isUserSqlExecutionError, runSql } from "./sqlService.js";
-import type { MachineApiDependencies, MachineRouteContext } from "./types.js";
+import { getSqlPolicyInstructions, getUserSqlExecutionMessage, isUserSqlExecutionError, runReadOnlySql, runSql } from "./sqlService.js";
+import type { AuthenticatedContext, MachineApiDependencies, MachineRouteContext } from "./types.js";
 import { createWorkspace, getWorkspace, listWorkspaces, persistSelectedWorkspace, resolveSqlWorkspaceId } from "./workspaceService.js";
 
 export const handleDiscoveryRoute = (
@@ -269,9 +273,24 @@ const buildSqlPolicyErrorResponse = (
     ),
   );
 
-export const handleSqlRouteWithWorkspaceResolver = async (
+type SqlValidator<TValidated extends ValidatedExpenseSql> = (sql: string) => TValidated;
+type SqlRunner<TValidated extends ValidatedExpenseSql> = (
+  dependencies: MachineApiDependencies,
+  authenticated: AuthenticatedContext,
+  workspaceId: string,
+  validated: TValidated,
+) => ReturnType<typeof runSql>;
+type SqlRouteText = Readonly<{
+  missingSql: string;
+  success: string;
+}>;
+
+const handleValidatedSqlRouteWithWorkspaceResolver = async <TValidated extends ValidatedExpenseSql>(
   context: MachineRouteContext,
   resolveWorkspaceId: typeof resolveSqlWorkspaceId,
+  validateSql: SqlValidator<TValidated>,
+  runValidatedSql: SqlRunner<TValidated>,
+  routeText: SqlRouteText,
 ): Promise<APIGatewayProxyResult> => {
   const body = readJsonBody(context.event);
   if (body === null) {
@@ -285,16 +304,16 @@ export const handleSqlRouteWithWorkspaceResolver = async (
       buildErrorEnvelope(
         { field: "sql", expected: "non-empty string" },
         [],
-        "Send a non-empty sql string. Semicolon-separated statements are allowed.",
+        routeText.missingSql,
         "missing_sql",
         "SQL is required",
       ),
     );
   }
 
-  let validated: ValidatedExpenseSql;
+  let validated: TValidated;
   try {
-    validated = validateExpenseSql(rawSql.trim());
+    validated = validateSql(rawSql);
   } catch (error) {
     if (error instanceof SqlPolicyError) {
       return buildSqlPolicyErrorResponse(error, context.apiBaseUrl);
@@ -336,7 +355,12 @@ export const handleSqlRouteWithWorkspaceResolver = async (
   }
 
   try {
-    const response = await runSql(context.dependencies, context.authenticated, workspaceId, validated);
+    const response = await runValidatedSql(
+      context.dependencies,
+      context.authenticated,
+      workspaceId,
+      validated,
+    );
     if (response === null) {
       return json(
         404,
@@ -349,10 +373,14 @@ export const handleSqlRouteWithWorkspaceResolver = async (
       buildSuccessEnvelope(
         response,
         [],
-        "Workspace context is required for SQL. Use X-Workspace-Id to override the saved workspace for this API key. Prefer SELECT first, semicolon-separated statements are allowed, only supported relations may be queried, only SUM, COUNT, MIN, MAX, AVG, and COALESCE functions are allowed, and results are capped per statement with returnedRowCount, totalRowCount, and truncated metadata.",
+        routeText.success,
       ),
     );
   } catch (error) {
+    if (error instanceof SqlPolicyError) {
+      return buildSqlPolicyErrorResponse(error, context.apiBaseUrl);
+    }
+
     if (isUserSqlExecutionError(error)) {
       return json(
         400,
@@ -374,6 +402,61 @@ export const handleSqlRouteWithWorkspaceResolver = async (
     );
   }
 };
+
+export const handleSqlQueryRouteWithWorkspaceResolver = async (
+  context: MachineRouteContext,
+  resolveWorkspaceId: typeof resolveSqlWorkspaceId,
+): Promise<APIGatewayProxyResult> =>
+  handleValidatedSqlRouteWithWorkspaceResolver<ValidatedReadOnlyExpenseSql>(
+    context,
+    resolveWorkspaceId,
+    validateSingleReadOnlyExpenseSql,
+    runReadOnlySql,
+    {
+      missingSql: "Send exactly one non-empty SELECT or WITH...SELECT sql statement.",
+      success: `Workspace context is required for SQL. Use X-Workspace-Id to override the saved workspace for this API key. This endpoint accepts exactly one read-only SELECT or WITH...SELECT statement. Only supported relations may be queried, only SUM, COUNT, MIN, MAX, AVG, and COALESCE functions are allowed, and returned rows are capped at ${MAX_SQL_ROWS} per request with returnedRowCount, totalRowCount, and truncated metadata.`,
+    },
+  );
+
+export const handleSqlExecuteRouteWithWorkspaceResolver = async (
+  context: MachineRouteContext,
+  resolveWorkspaceId: typeof resolveSqlWorkspaceId,
+): Promise<APIGatewayProxyResult> =>
+  handleValidatedSqlRouteWithWorkspaceResolver(
+    context,
+    resolveWorkspaceId,
+    validateSingleExpenseSql,
+    runSql,
+    {
+      missingSql: "Send exactly one non-empty SELECT, WITH, INSERT, UPDATE, or DELETE sql statement.",
+      success: `Workspace context is required for SQL. Use X-Workspace-Id to override the saved workspace for this API key. This endpoint accepts exactly one supported statement. Returned rows are capped at ${MAX_SQL_ROWS} per request with returnedRowCount, totalRowCount, and truncated metadata; mutations are limited to ${MAX_SQL_MUTATION_ROWS} affected rows.`,
+    },
+  );
+
+export const handleSqlRouteWithWorkspaceResolver = async (
+  context: MachineRouteContext,
+  resolveWorkspaceId: typeof resolveSqlWorkspaceId,
+): Promise<APIGatewayProxyResult> =>
+  handleValidatedSqlRouteWithWorkspaceResolver(
+    context,
+    resolveWorkspaceId,
+    validateExpenseSql,
+    runSql,
+    {
+      missingSql: "Send a non-empty sql string. Semicolon-separated statements are allowed.",
+      success: `Workspace context is required for SQL. Use X-Workspace-Id to override the saved workspace for this API key. Prefer SELECT first, semicolon-separated statements are allowed, only supported relations may be queried, only SUM, COUNT, MIN, MAX, AVG, and COALESCE functions are allowed, returned rows are capped at ${MAX_SQL_ROWS} per statement and request with returnedRowCount, totalRowCount, and truncated metadata, and mutations are limited to ${MAX_SQL_MUTATION_ROWS} affected rows per request.`,
+    },
+  );
+
+export const handleSqlQueryRoute = async (
+  context: MachineRouteContext,
+): Promise<APIGatewayProxyResult> =>
+  handleSqlQueryRouteWithWorkspaceResolver(context, resolveSqlWorkspaceId);
+
+export const handleSqlExecuteRoute = async (
+  context: MachineRouteContext,
+): Promise<APIGatewayProxyResult> =>
+  handleSqlExecuteRouteWithWorkspaceResolver(context, resolveSqlWorkspaceId);
 
 export const handleSqlRoute = async (
   context: MachineRouteContext,

--- a/apps/sql-api/src/machineApi/schemaService.test.ts
+++ b/apps/sql-api/src/machineApi/schemaService.test.ts
@@ -30,6 +30,9 @@ test("loadAllowedSchema resolves a real workspace context before querying", asyn
       queryWorkspaceId = workspaceId;
       return createQueryResult([]);
     },
+    withReadOnlyRestrictedTrustedIdentityContext: async () => {
+      throw new Error("withReadOnlyRestrictedTrustedIdentityContext should not be called");
+    },
     withRestrictedTrustedIdentityContext: async () => {
       throw new Error("withRestrictedTrustedIdentityContext should not be called");
     },

--- a/apps/sql-api/src/machineApi/sqlService.test.ts
+++ b/apps/sql-api/src/machineApi/sqlService.test.ts
@@ -3,7 +3,10 @@ import test from "node:test";
 import type { QueryResult } from "pg";
 import { SqlPolicyError } from "@expense-budget-tracker/agent-shared/sql-policy";
 import { createQueryResult } from "../handlerTestUtils.js";
-import { getSqlPolicyInstructions, runSqlWithWorkspaceGetter } from "./sqlService.js";
+import {
+  runReadOnlySqlWithWorkspaceGetter,
+  runSqlWithWorkspaceGetter,
+} from "./sqlService.js";
 import type {
   AuthenticatedContext,
   MachineApiDependencies,
@@ -30,6 +33,21 @@ const createDependencies = (
   ensureTrustedIdentityProvisioned: overrides.ensureTrustedIdentityProvisioned ?? (async () => undefined),
   queryAsTrustedIdentity: overrides.queryAsTrustedIdentity ?? (async () =>
     createQueryResult([{ workspace_id: "user-1", name: "Personal" }])),
+  withReadOnlyRestrictedTrustedIdentityContext:
+    overrides.withReadOnlyRestrictedTrustedIdentityContext ?? (async <T>(
+      _identity: AuthenticatedContext["identity"],
+      _workspaceId: string,
+      _statementTimeoutMs: number,
+      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+    ): Promise<T> =>
+      callback(async () =>
+        ({
+          command: "SELECT",
+          rowCount: 0,
+          oid: 0,
+          fields: [],
+          rows: [],
+        }) as QueryResult)),
   withRestrictedTrustedIdentityContext: overrides.withRestrictedTrustedIdentityContext ?? (async <T>(
     _identity: AuthenticatedContext["identity"],
     _workspaceId: string,
@@ -74,7 +92,7 @@ test("runSql rejects function-only SQL before executing restricted queries", asy
   assert.equal(restrictedContextCalled, false);
 });
 
-test("runSql rejects SELECT-only mutation targets before workspace or restricted database access", async (): Promise<void> => {
+test("runSql rejects data-modifying CTEs before workspace or restricted database access", async (): Promise<void> => {
   let workspaceGetterCalled = false;
   let restrictedContextCalled = false;
   const dependencies = createDependencies({
@@ -97,9 +115,8 @@ test("runSql rejects SELECT-only mutation targets before workspace or restricted
     ),
     (error: unknown) =>
       error instanceof SqlPolicyError
-      && error.code === "read_only_relation_mutation_not_allowed"
-      && getSqlPolicyInstructions(error, "https://api.example.com/v1")
-        === "Relation fx_rates_raw is SELECT-only and cannot be targeted by DELETE in restricted SQL. Use SELECT to read it; write only to ledger_entries, budget_lines, workspace_settings, or account_metadata.",
+      && error.code === "unsupported_statement"
+      && error.message === "Data-modifying CTE bodies are not supported; use SELECT, WITH, or VALUES in CTE bodies and move INSERT, UPDATE, or DELETE to the top-level statement. MERGE is not supported",
   );
 
   assert.equal(workspaceGetterCalled, false);
@@ -140,8 +157,10 @@ test("runSql rejects community public share relations before executing restricte
   assert.equal(restrictedContextCalled, false);
 });
 
-test("runSql executes allowed aggregate relation queries with row metadata", async (): Promise<void> => {
-  let restrictedContextCalled = false;
+test("runSql executes every statement in one restricted transaction", async (): Promise<void> => {
+  let restrictedContextCount = 0;
+  const executedSql: Array<string> = [];
+  const executedParams: Array<ReadonlyArray<unknown>> = [];
   const dependencies = createDependencies({
     withRestrictedTrustedIdentityContext: async <T>(
       _identity: AuthenticatedContext["identity"],
@@ -149,15 +168,36 @@ test("runSql executes allowed aggregate relation queries with row metadata", asy
       _statementTimeoutMs: number,
       callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
     ): Promise<T> => {
-      restrictedContextCalled = true;
-      return callback(async () =>
-        ({
-          command: "SELECT",
+      restrictedContextCount += 1;
+      return callback(async (sql, params) => {
+        executedSql.push(sql);
+        executedParams.push(params);
+        if (sql.startsWith("DECLARE ") || sql.startsWith("CLOSE ")) {
+          return ({
+            command: sql.startsWith("DECLARE ") ? "DECLARE" : "CLOSE",
+            rowCount: null,
+            oid: 0,
+            fields: [],
+            rows: [],
+          }) as QueryResult;
+        }
+        if (sql.startsWith("MOVE ")) {
+          return ({
+            command: "MOVE",
+            rowCount: 0,
+            oid: 0,
+            fields: [],
+            rows: [],
+          }) as QueryResult;
+        }
+        return ({
+          command: "FETCH",
           rowCount: 1,
           oid: 0,
           fields: [],
           rows: [{ balance: "123.45" }],
-        }) as QueryResult);
+        }) as QueryResult;
+      });
     },
   });
 
@@ -165,17 +205,161 @@ test("runSql executes allowed aggregate relation queries with row metadata", asy
     dependencies,
     createAuthenticatedContext(),
     "user-1",
-    "SELECT SUM(amount) AS balance FROM ledger_entries WHERE account_id = 'a-main-usd'",
+    "SELECT SUM(amount) AS balance FROM ledger_entries WHERE account_id = 'a-main-usd'; SELECT COUNT(*) FROM accounts",
     workspaceGetter,
   );
   const workspace = (result?.workspace ?? null) as WorkspaceSummary | null;
   const statements = (result?.statements ?? []) as ReadonlyArray<Readonly<Record<string, unknown>>>;
   const statement = statements[0];
 
-  assert.equal(restrictedContextCalled, true);
+  assert.equal(restrictedContextCount, 1);
+  assert.deepEqual(executedSql, [
+    "DECLARE api_sql_read_cursor_1 NO SCROLL CURSOR FOR SELECT SUM(amount) AS balance FROM ledger_entries WHERE account_id = 'a-main-usd'",
+    "FETCH FORWARD 101 FROM api_sql_read_cursor_1",
+    "MOVE FORWARD ALL FROM api_sql_read_cursor_1",
+    "CLOSE api_sql_read_cursor_1",
+    "DECLARE api_sql_read_cursor_2 NO SCROLL CURSOR FOR SELECT COUNT(*) FROM accounts",
+    "FETCH FORWARD 100 FROM api_sql_read_cursor_2",
+    "MOVE FORWARD ALL FROM api_sql_read_cursor_2",
+    "CLOSE api_sql_read_cursor_2",
+  ]);
+  assert.deepEqual(executedParams, [[], [], [], [], [], [], [], []]);
   assert.equal(workspace?.workspaceId, "user-1");
+  assert.equal(statements.length, 2);
   assert.equal(statement?.rowCount, 1);
   assert.equal(statement?.returnedRowCount, 1);
   assert.equal(statement?.totalRowCount, 1);
   assert.equal(statement?.truncated, false);
+});
+
+test("runReadOnlySql bounds composed reads in PostgreSQL and preserves accurate truncation metadata", async (): Promise<void> => {
+  const executedSql: Array<string> = [];
+  const executedParams: Array<ReadonlyArray<unknown>> = [];
+  const dependencies = createDependencies({
+    withReadOnlyRestrictedTrustedIdentityContext: async <T>(
+      _identity: AuthenticatedContext["identity"],
+      _workspaceId: string,
+      _statementTimeoutMs: number,
+      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+    ): Promise<T> => callback(async (querySql, params) => {
+      executedSql.push(querySql);
+      executedParams.push(params);
+      if (querySql.startsWith("FETCH ")) {
+        return createQueryResult([{ account_id: "a-main-usd" }]);
+      }
+      if (querySql.startsWith("MOVE ")) {
+        return ({
+          command: "MOVE",
+          rowCount: 249,
+          oid: 0,
+          fields: [],
+          rows: [],
+        }) as QueryResult;
+      }
+      return ({
+        command: querySql.startsWith("DECLARE ") ? "DECLARE" : "CLOSE",
+        rowCount: null,
+        oid: 0,
+        fields: [],
+        rows: [],
+      }) as QueryResult;
+    }),
+  });
+  const sql = "WITH account_rows AS (SELECT account_id FROM accounts) SELECT account_id FROM account_rows UNION SELECT account_id FROM accounts ORDER BY account_id OFFSET 1;";
+
+  const result = await runReadOnlySqlWithWorkspaceGetter(
+    dependencies,
+    createAuthenticatedContext(),
+    "user-1",
+    sql,
+    workspaceGetter,
+  );
+  const statements = (result?.statements ?? []) as ReadonlyArray<Readonly<Record<string, unknown>>>;
+  const statement = statements[0];
+  const rows = (statement?.rows ?? []) as ReadonlyArray<Readonly<Record<string, unknown>>>;
+
+  assert.deepEqual(executedSql, [
+    "DECLARE api_sql_read_cursor_1 NO SCROLL CURSOR FOR WITH account_rows AS (SELECT account_id FROM accounts) SELECT account_id FROM account_rows UNION SELECT account_id FROM accounts ORDER BY account_id OFFSET 1",
+    "FETCH FORWARD 101 FROM api_sql_read_cursor_1",
+    "MOVE FORWARD ALL FROM api_sql_read_cursor_1",
+    "CLOSE api_sql_read_cursor_1",
+  ]);
+  assert.equal(executedSql[0]?.endsWith("ORDER BY account_id OFFSET 1"), true);
+  assert.deepEqual(executedParams, [[], [], [], []]);
+  assert.deepEqual(rows, [{ account_id: "a-main-usd" }]);
+  assert.equal(statement?.returnedRowCount, 1);
+  assert.equal(statement?.totalRowCount, 250);
+  assert.equal(statement?.truncated, true);
+});
+
+test("runReadOnlySql uses only the read-only restricted transaction", async (): Promise<void> => {
+  let readOnlyContextCount = 0;
+  let writeContextCount = 0;
+  const dependencies = createDependencies({
+    withReadOnlyRestrictedTrustedIdentityContext: async <T>(
+      _identity: AuthenticatedContext["identity"],
+      _workspaceId: string,
+      _statementTimeoutMs: number,
+      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+    ): Promise<T> => {
+      readOnlyContextCount += 1;
+      return callback(async () => createQueryResult([{ account_id: "a-main-usd" }]));
+    },
+    withRestrictedTrustedIdentityContext: async () => {
+      writeContextCount += 1;
+      throw new Error("write context should not run");
+    },
+  });
+
+  await runReadOnlySqlWithWorkspaceGetter(
+    dependencies,
+    createAuthenticatedContext(),
+    "user-1",
+    "SELECT account_id FROM accounts",
+    workspaceGetter,
+  );
+
+  assert.equal(readOnlyContextCount, 1);
+  assert.equal(writeContextCount, 0);
+});
+
+test("runSql raises mutation batch overflow from inside the single transaction callback", async (): Promise<void> => {
+  let restrictedContextCount = 0;
+  let statementCount = 0;
+  const dependencies = createDependencies({
+    withRestrictedTrustedIdentityContext: async <T>(
+      _identity: AuthenticatedContext["identity"],
+      _workspaceId: string,
+      _statementTimeoutMs: number,
+      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+    ): Promise<T> => {
+      restrictedContextCount += 1;
+      return callback(async () => {
+        statementCount += 1;
+        return ({
+          command: "UPDATE",
+          rowCount: 60,
+          oid: 0,
+          fields: [],
+          rows: [],
+        }) as QueryResult;
+      });
+    },
+  });
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "UPDATE account_metadata SET liquidity = 'low'; DELETE FROM budget_lines",
+      workspaceGetter,
+    ),
+    (error: unknown) =>
+      error instanceof SqlPolicyError
+      && error.code === "mutation_request_row_limit_exceeded",
+  );
+
+  assert.equal(restrictedContextCount, 1);
+  assert.equal(statementCount, 2);
 });

--- a/apps/sql-api/src/machineApi/sqlService.ts
+++ b/apps/sql-api/src/machineApi/sqlService.ts
@@ -1,11 +1,14 @@
 import {
   executeValidatedExpenseSql,
+  MAX_SQL_MUTATION_ROWS,
   MAX_SQL_ROWS,
   SQL_STATEMENT_TIMEOUT_MS,
   SqlPolicyError,
   validateExpenseSql,
+  validateReadOnlyExpenseSql,
   type AllowedRelationName,
   type ValidatedExpenseSql,
+  type ValidatedReadOnlyExpenseSql,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
 import type { AuthenticatedContext, EntityHints, MachineApiDependencies, PgError, WorkspaceSummary } from "./types.js";
 import { getWorkspace } from "./workspaceService.js";
@@ -120,7 +123,26 @@ export const getSqlPolicyInstructions = (
   }
 
   if (error.code === "unsupported_statement") {
-    return "Use one or more SQL statements of type SELECT, WITH, INSERT, UPDATE, or DELETE. BEGIN/COMMIT/ROLLBACK and DDL are not allowed.";
+    return "Use only SELECT, WITH, INSERT, UPDATE, or DELETE. /sql/query and /sql/execute accept exactly one statement; legacy /sql accepts atomic multi-statement scripts. BEGIN/COMMIT/ROLLBACK and DDL are not allowed.";
+  }
+
+  if (error.code === "single_statement_required") {
+    return "Send exactly one SQL statement to /sql/query or /sql/execute. Use legacy /sql only when an atomic multi-statement script is required.";
+  }
+
+  if (error.code === "sql_script_too_long" || error.code === "too_many_sql_statements") {
+    return error.message;
+  }
+
+  if (
+    error.code === "mutation_statement_row_limit_exceeded"
+    || error.code === "mutation_request_row_limit_exceeded"
+  ) {
+    return `${error.message}. Narrow the mutation or split it into sequential requests of at most ${MAX_SQL_MUTATION_ROWS} affected rows each.`;
+  }
+
+  if (error.code === "read_only_sql_required") {
+    return "Use /sql/query for exactly one SELECT or WITH...SELECT statement without data-modifying CTEs. Send one approved write statement to /sql/execute.";
   }
 
   if (error.code === "on_conflict_not_allowed") {
@@ -160,20 +182,21 @@ const executeSqlWithWorkspaceGetter = async (
   workspaceId: string,
   validated: ValidatedExpenseSql,
   workspaceGetter: WorkspaceGetter,
+  runInRestrictedContext: MachineApiDependencies["withRestrictedTrustedIdentityContext"],
 ): Promise<Readonly<Record<string, unknown>> | null> => {
   const workspace = await workspaceGetter(dependencies, authenticated.identity, workspaceId);
   if (workspace === null) {
     return null;
   }
 
-  const result = await executeValidatedExpenseSql(
-    validated,
-    async (validatedSql) => dependencies.withRestrictedTrustedIdentityContext(
-      authenticated.identity,
-      workspaceId,
-      SQL_STATEMENT_TIMEOUT_MS,
-      async (queryFn) => {
-        const queryResult = await queryFn(validatedSql, []);
+  const result = await runInRestrictedContext(
+    authenticated.identity,
+    workspaceId,
+    SQL_STATEMENT_TIMEOUT_MS,
+    async (queryFn) => executeValidatedExpenseSql(
+      validated,
+      async (request) => {
+        const queryResult = await queryFn(request.sql, request.params);
         return {
           command: queryResult.command,
           rows: queryResult.rows as ReadonlyArray<Readonly<Record<string, unknown>>>,
@@ -219,6 +242,23 @@ export const runSqlWithWorkspaceGetter = async (
     workspaceId,
     validateExpenseSql(sql),
     workspaceGetter,
+    dependencies.withRestrictedTrustedIdentityContext,
+  );
+
+export const runReadOnlySqlWithWorkspaceGetter = async (
+  dependencies: MachineApiDependencies,
+  authenticated: AuthenticatedContext,
+  workspaceId: string,
+  sql: string,
+  workspaceGetter: WorkspaceGetter,
+): Promise<Readonly<Record<string, unknown>> | null> =>
+  executeSqlWithWorkspaceGetter(
+    dependencies,
+    authenticated,
+    workspaceId,
+    validateReadOnlyExpenseSql(sql),
+    workspaceGetter,
+    dependencies.withReadOnlyRestrictedTrustedIdentityContext,
   );
 
 export const runSql = async (
@@ -233,4 +273,20 @@ export const runSql = async (
     workspaceId,
     validated,
     getWorkspace,
+    dependencies.withRestrictedTrustedIdentityContext,
+  );
+
+export const runReadOnlySql = async (
+  dependencies: MachineApiDependencies,
+  authenticated: AuthenticatedContext,
+  workspaceId: string,
+  validated: ValidatedReadOnlyExpenseSql,
+): Promise<Readonly<Record<string, unknown>> | null> =>
+  executeSqlWithWorkspaceGetter(
+    dependencies,
+    authenticated,
+    workspaceId,
+    validated,
+    getWorkspace,
+    dependencies.withReadOnlyRestrictedTrustedIdentityContext,
   );

--- a/apps/sql-api/src/machineApi/types.ts
+++ b/apps/sql-api/src/machineApi/types.ts
@@ -1,7 +1,13 @@
 import type { AgentSchemaHints } from "@expense-budget-tracker/agent-shared";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import type { AllowedRelationName } from "@expense-budget-tracker/agent-shared/sql-policy";
-import { ensureTrustedIdentityProvisioned, queryAsTrustedIdentity, type UserIdentity, withRestrictedTrustedIdentityContext } from "../db.js";
+import {
+  ensureTrustedIdentityProvisioned,
+  queryAsTrustedIdentity,
+  type UserIdentity,
+  withReadOnlyRestrictedTrustedIdentityContext,
+  withRestrictedTrustedIdentityContext,
+} from "../db.js";
 
 export type AuthenticatedContext = Readonly<{
   identity: UserIdentity;
@@ -14,6 +20,7 @@ export type AuthenticatedContext = Readonly<{
 export type MachineApiDependencies = Readonly<{
   ensureTrustedIdentityProvisioned: typeof ensureTrustedIdentityProvisioned;
   queryAsTrustedIdentity: typeof queryAsTrustedIdentity;
+  withReadOnlyRestrictedTrustedIdentityContext: typeof withReadOnlyRestrictedTrustedIdentityContext;
   withRestrictedTrustedIdentityContext: typeof withRestrictedTrustedIdentityContext;
 }>;
 

--- a/apps/web/src/app/api/agent/sql/route.test.ts
+++ b/apps/web/src/app/api/agent/sql/route.test.ts
@@ -19,6 +19,50 @@ const createAuthenticatedRequest = (): AgentAuthenticatedRequest => ({
   lastUsedAt: null,
 });
 
+test("postAgentSqlRouteWithDeps describes per-statement and request-wide row limits from the result", async (): Promise<void> => {
+  const response = await postAgentSqlRouteWithDeps(
+    new Request("http://localhost/api/agent/sql", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT account_id FROM accounts" }),
+    }),
+    {
+      authenticateAgentRequest: async () => createAuthenticatedRequest(),
+      resolveWorkspaceIdForSql: async () => "workspace-1",
+      executeAgentSql: async () => ({
+        statements: [],
+        workspace: {
+          workspaceId: "workspace-1",
+          name: "Personal",
+        },
+        limits: {
+          maxRows: 37,
+          statementTimeoutMs: 30_000,
+        },
+      }),
+    },
+  );
+
+  const payload = await response.json() as {
+    data: Readonly<{
+      limits: Readonly<{ maxRows: number; statementTimeoutMs: number }>;
+    }>;
+    instructions: string;
+  };
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(payload.data.limits, {
+    maxRows: 37,
+    statementTimeoutMs: 30_000,
+  });
+  assert.equal(
+    payload.instructions,
+    "Access is limited to the selected workspace and this user's memberships. Prefer SELECT first. Only supported relations are available, multiple statements are allowed, only SUM, COUNT, MIN, MAX, AVG, and COALESCE functions are allowed, and returned rows are capped at 37 per statement and across the whole request, with returnedRowCount, totalRowCount, and truncated metadata.",
+  );
+});
+
 test("postAgentSqlRouteWithDeps maps function-call policy failures to 400", async (): Promise<void> => {
   const response = await postAgentSqlRouteWithDeps(
     new Request("http://localhost/api/agent/sql", {

--- a/apps/web/src/app/api/agent/sql/route.ts
+++ b/apps/web/src/app/api/agent/sql/route.ts
@@ -158,7 +158,7 @@ export const postAgentSqlRouteWithDeps = async (
           limits: result.limits,
         },
         [],
-        "Access is limited to the selected workspace and this user's memberships. Prefer SELECT first. Only supported relations are available, multiple statements are allowed, only SUM, COUNT, MIN, MAX, AVG, and COALESCE functions are allowed, and results are capped per statement with returnedRowCount, totalRowCount, and truncated metadata.",
+        `Access is limited to the selected workspace and this user's memberships. Prefer SELECT first. Only supported relations are available, multiple statements are allowed, only SUM, COUNT, MIN, MAX, AVG, and COALESCE functions are allowed, and returned rows are capped at ${String(result.limits.maxRows)} per statement and across the whole request, with returnedRowCount, totalRowCount, and truncated metadata.`,
       ),
     );
   } catch (error) {

--- a/apps/web/src/server/agent/sql.ts
+++ b/apps/web/src/server/agent/sql.ts
@@ -148,13 +148,13 @@ export const executeAgentSql = async (
     return null;
   }
 
-  const result = await executeValidatedExpenseSql(
-    validated,
-    async (validatedSql) => withRestrictedTrustedIdentityContext(
-      authenticated.identity,
-      workspaceId,
-      SQL_STATEMENT_TIMEOUT_MS,
-      async (queryFn) => queryFn(validatedSql, []),
+  const result = await withRestrictedTrustedIdentityContext(
+    authenticated.identity,
+    workspaceId,
+    SQL_STATEMENT_TIMEOUT_MS,
+    async (queryFn) => executeValidatedExpenseSql(
+      validated,
+      async (request) => queryFn(request.sql, request.params),
     ),
   );
 

--- a/apps/web/src/server/chat/shared.test.ts
+++ b/apps/web/src/server/chat/shared.test.ts
@@ -58,14 +58,14 @@ test("execQuery explains how to replace PostgreSQL escape strings", async (): Pr
   );
 });
 
-test("execQuery rejects SELECT-only mutation targets before database or mutation lock entry", async (): Promise<void> => {
+test("execQuery rejects data-modifying CTEs before database or mutation lock entry", async (): Promise<void> => {
   let userContextCount = 0;
   let restrictedContextCount = 0;
   let mutationLockCount = 0;
 
   await assert.rejects(
     () => execQueryWithDependencies(
-      "WITH changed AS (UPDATE accounts SET account_id = 'a-renamed-usd' RETURNING *) SELECT * FROM changed",
+      "WITH changed AS (UPDATE account_metadata SET liquidity = 'low' RETURNING *) SELECT * FROM changed",
       {
         userId: "user-1",
         workspaceId: "workspace-1",
@@ -88,7 +88,7 @@ test("execQuery rejects SELECT-only mutation targets before database or mutation
     ),
     (error: unknown) =>
       error instanceof Error
-      && error.message === "Relation accounts is SELECT-only and cannot be targeted by UPDATE in restricted SQL. Use SELECT to read it; write only to ledger_entries, budget_lines, workspace_settings, or account_metadata",
+      && error.message === "Data-modifying CTE bodies are not supported; use SELECT, WITH, or VALUES in CTE bodies and move INSERT, UPDATE, or DELETE to the top-level statement. MERGE is not supported",
   );
 
   assert.equal(userContextCount, 0);

--- a/apps/web/src/server/chat/shared.ts
+++ b/apps/web/src/server/chat/shared.ts
@@ -305,7 +305,7 @@ The result is returned as JSON in the shape { "ok": boolean, "tool": "query_data
 
 const toChatSqlError = (error: SqlPolicyError): Error => {
   if (error.code === "unsupported_statement") {
-    return new Error("Only SELECT, WITH, INSERT, UPDATE, and DELETE statements are allowed");
+    return new Error(error.message);
   }
   if (error.code === "on_conflict_not_allowed") {
     return new Error("ON CONFLICT is not supported in chat queries");

--- a/db/migrations/0066_api_sql_reader.sql
+++ b/db/migrations/0066_api_sql_reader.sql
@@ -1,0 +1,31 @@
+-- Create a least-privilege role for the read-only machine SQL endpoint.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'api_sql_reader') THEN
+    CREATE ROLE api_sql_reader WITH
+      NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOLOGIN NOREPLICATION NOBYPASSRLS;
+  END IF;
+END
+$$;
+
+ALTER ROLE api_sql_reader WITH
+  NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOLOGIN NOREPLICATION NOBYPASSRLS;
+GRANT api_sql_reader TO app;
+
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM api_sql_reader;
+REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM api_sql_reader;
+REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM api_sql_reader;
+
+GRANT USAGE ON SCHEMA public TO api_sql_reader;
+GRANT SELECT ON TABLE
+  ledger_entries,
+  budget_lines,
+  workspace_settings,
+  account_metadata,
+  fx_rates_raw,
+  fx_rates_daily
+TO api_sql_reader;
+
+GRANT EXECUTE ON FUNCTION current_app_user_has_selected_workspace_access()
+TO api_sql_reader;

--- a/db/views/accounts.sql
+++ b/db/views/accounts.sql
@@ -16,11 +16,14 @@ GROUP BY account_id;
 -- Grant after view creation (can't live in migrations — view doesn't exist yet).
 GRANT SELECT ON accounts TO app;
 
--- Grant to api_sql_executor if the role exists (created by migration 0012).
+-- Grant to restricted SQL roles if they exist.
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'api_sql_executor') THEN
     EXECUTE 'GRANT SELECT ON accounts TO api_sql_executor';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'api_sql_reader') THEN
+    EXECUTE 'GRANT SELECT ON accounts TO api_sql_reader';
   END IF;
 END
 $$;

--- a/infra/aws/lib/api-gateway.ts
+++ b/infra/aws/lib/api-gateway.ts
@@ -156,6 +156,14 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     authorizer,
     authorizationType: apigw.AuthorizationType.CUSTOM,
   });
+  sqlResource.addResource("query").addMethod("POST", new apigw.LambdaIntegration(sqlApiFn), {
+    authorizer,
+    authorizationType: apigw.AuthorizationType.CUSTOM,
+  });
+  sqlResource.addResource("execute").addMethod("POST", new apigw.LambdaIntegration(sqlApiFn), {
+    authorizer,
+    authorizationType: apigw.AuthorizationType.CUSTOM,
+  });
 
   // --- Usage Plan (per-key throttling via usageIdentifierKey) ---
   restApi.addUsagePlan("SqlApiUsagePlan", {

--- a/packages/agent-shared/src/sql-policy.test.ts
+++ b/packages/agent-shared/src/sql-policy.test.ts
@@ -3,9 +3,19 @@ import test from "node:test";
 import {
   executeExpenseSql,
   getAllowedRelationNames,
+  MAX_SQL_MUTATION_ROWS,
+  MAX_SQL_RETURNED_ROWS,
   MAX_SQL_ROWS,
+  MAX_SQL_SCRIPT_LENGTH,
+  MAX_SQL_STATEMENTS,
   SqlPolicyError,
   validateExpenseSql,
+  validateReadOnlyExpenseSql,
+  validateSingleExpenseSql,
+  validateSingleReadOnlyExpenseSql,
+  type RestrictedSqlExecutionRequest,
+  type RestrictedSqlQueryResult,
+  type RestrictedSqlResultRow,
 } from "./sql-policy.js";
 
 const assertFunctionCallRejected = (sql: string): void => {
@@ -25,6 +35,60 @@ const assertPolicyError = (sql: string, expectedCode: SqlPolicyError["code"]): v
   );
 };
 
+const createCursorExecutor = (
+  rowsByCursor: Readonly<Record<string, ReadonlyArray<RestrictedSqlResultRow>>>,
+  requests: Array<RestrictedSqlExecutionRequest>,
+): ((request: RestrictedSqlExecutionRequest) => Promise<RestrictedSqlQueryResult>) => {
+  const positions = new Map<string, number>();
+
+  return async (request): Promise<RestrictedSqlQueryResult> => {
+    requests.push(request);
+    assert.deepEqual(request.params, []);
+
+    const declareMatch = /^DECLARE (api_sql_read_cursor_\d+) NO SCROLL CURSOR FOR /u.exec(request.sql);
+    if (declareMatch !== null) {
+      const cursorName = declareMatch[1];
+      if (cursorName === undefined) {
+        throw new TypeError("Expected an internal cursor name");
+      }
+      positions.set(cursorName, 0);
+      return { command: "DECLARE", rows: [], rowCount: null };
+    }
+
+    const fetchMatch = /^FETCH FORWARD (\d+) FROM (api_sql_read_cursor_\d+)$/u.exec(request.sql);
+    if (fetchMatch !== null) {
+      const count = Number(fetchMatch[1]);
+      const cursorName = fetchMatch[2];
+      if (!Number.isSafeInteger(count) || cursorName === undefined) {
+        throw new TypeError("Expected a valid cursor FETCH request");
+      }
+      const sourceRows = rowsByCursor[cursorName] ?? [];
+      const position = positions.get(cursorName) ?? 0;
+      const rows = sourceRows.slice(position, position + count);
+      positions.set(cursorName, position + rows.length);
+      return { command: "FETCH", rows, rowCount: rows.length };
+    }
+
+    const moveMatch = /^MOVE FORWARD ALL FROM (api_sql_read_cursor_\d+)$/u.exec(request.sql);
+    if (moveMatch !== null) {
+      const cursorName = moveMatch[1];
+      if (cursorName === undefined) {
+        throw new TypeError("Expected an internal cursor name");
+      }
+      const sourceRows = rowsByCursor[cursorName] ?? [];
+      const position = positions.get(cursorName) ?? 0;
+      positions.set(cursorName, sourceRows.length);
+      return { command: "MOVE", rows: [], rowCount: sourceRows.length - position };
+    }
+
+    if (/^CLOSE api_sql_read_cursor_\d+$/u.test(request.sql)) {
+      return { command: "CLOSE", rows: [], rowCount: null };
+    }
+
+    throw new TypeError(`Unexpected restricted SQL request: ${request.sql}`);
+  };
+};
+
 test("validateExpenseSql allows allowlisted aggregate functions", (): void => {
   const acceptedSql: ReadonlyArray<string> = [
     "SELECT SUM(amount) AS balance FROM ledger_entries WHERE account_id = 'a-main-usd'",
@@ -40,6 +104,133 @@ test("validateExpenseSql allows allowlisted aggregate functions", (): void => {
     assert.equal(validated.statements.length, 1);
     assert.deepEqual(validated.statements[0]?.referencedRelations, ["ledger_entries"]);
   }
+});
+
+test("validateExpenseSql bounds script length and statement count", (): void => {
+  assert.throws(
+    () => validateExpenseSql(`SELECT '${"x".repeat(MAX_SQL_SCRIPT_LENGTH)}'`),
+    (error: unknown) => error instanceof SqlPolicyError && error.code === "sql_script_too_long",
+  );
+
+  const sql = Array.from(
+    { length: MAX_SQL_STATEMENTS + 1 },
+    () => "SELECT account_id FROM accounts",
+  ).join(";");
+  assert.throws(
+    () => validateExpenseSql(sql),
+    (error: unknown) => error instanceof SqlPolicyError && error.code === "too_many_sql_statements",
+  );
+});
+
+test("validateReadOnlyExpenseSql rejects direct writes", (): void => {
+  const rejectedSql: ReadonlyArray<string> = [
+    "UPDATE account_metadata SET liquidity = 'low' WHERE workspace_id = 'workspace-1'",
+    "SELECT account_id FROM accounts; INSERT INTO workspace_settings (workspace_id, reporting_currency) VALUES ('workspace-1', 'USD')",
+  ];
+
+  for (const sql of rejectedSql) {
+    assert.throws(
+      () => validateReadOnlyExpenseSql(sql),
+      (error: unknown) => error instanceof SqlPolicyError && error.code === "read_only_sql_required",
+    );
+  }
+});
+
+test("public validators reject data-modifying CTE bodies at every nesting depth", (): void => {
+  const rejectedSql: ReadonlyArray<string> = [
+    "WITH changed AS (INSERT INTO budget_lines (workspace_id) VALUES ('workspace-1') RETURNING *) SELECT * FROM changed",
+    "WITH outer_rows AS (WITH changed AS (UPDATE account_metadata SET liquidity = 'low' RETURNING *) SELECT * FROM changed) SELECT * FROM outer_rows",
+    "WITH outer_rows AS (WITH middle_rows AS (WITH changed AS (DELETE FROM ledger_entries RETURNING *) SELECT * FROM changed) SELECT * FROM middle_rows) SELECT * FROM outer_rows",
+  ];
+  const validators = [
+    validateExpenseSql,
+    validateReadOnlyExpenseSql,
+    validateSingleExpenseSql,
+    validateSingleReadOnlyExpenseSql,
+  ] as const;
+
+  for (const sql of rejectedSql) {
+    for (const validate of validators) {
+      assert.throws(
+        () => validate(sql),
+        (error: unknown) =>
+          error instanceof SqlPolicyError
+          && error.code === "unsupported_statement"
+          && error.message === "Data-modifying CTE bodies are not supported; use SELECT, WITH, or VALUES in CTE bodies and move INSERT, UPDATE, or DELETE to the top-level statement. MERGE is not supported",
+      );
+    }
+  }
+});
+
+test("public validators allow nested read-only SELECT and VALUES CTE bodies", (): void => {
+  const acceptedSql: ReadonlyArray<string> = [
+    "WITH outer_rows AS (WITH inner_rows AS (SELECT account_id FROM accounts) SELECT account_id FROM inner_rows) SELECT account_id FROM outer_rows",
+    "WITH outer_rows AS (WITH middle_rows AS (WITH inner_rows(value) AS (VALUES (1), (2)) SELECT value FROM inner_rows) SELECT value FROM middle_rows) SELECT value FROM outer_rows",
+  ];
+
+  for (const sql of acceptedSql) {
+    assert.equal(validateExpenseSql(sql).statements.length, 1);
+    assert.equal(validateReadOnlyExpenseSql(sql).statements.length, 1);
+    assert.equal(validateSingleExpenseSql(sql).statements.length, 1);
+    assert.equal(validateSingleReadOnlyExpenseSql(sql).statements.length, 1);
+  }
+});
+
+test("validateReadOnlyExpenseSql allows multi-statement read-only CTEs", (): void => {
+  const validated = validateReadOnlyExpenseSql(
+    "WITH totals AS (SELECT account_id, SUM(amount) AS balance FROM ledger_entries GROUP BY account_id) SELECT * FROM totals; WITH rows(value) AS (VALUES (1), (2)) SELECT value FROM rows",
+  );
+
+  assert.equal(validated.isReadOnly, true);
+  assert.equal(validated.statements.length, 2);
+  assert.equal(validated.statements.every((statement) => !statement.isMutating), true);
+});
+
+test("single-statement validators reject scripts without changing shared multi-statement validation", (): void => {
+  const readScript = "SELECT account_id FROM accounts; SELECT rate FROM fx_rates_daily";
+  const writeScript = "UPDATE account_metadata SET liquidity = 'low'; DELETE FROM budget_lines";
+
+  assert.equal(validateReadOnlyExpenseSql(readScript).statements.length, 2);
+  assert.equal(validateExpenseSql(writeScript).statements.length, 2);
+  for (const validate of [validateSingleExpenseSql, validateSingleReadOnlyExpenseSql]) {
+    assert.throws(
+      () => validate(readScript),
+      (error: unknown) => error instanceof SqlPolicyError && error.code === "single_statement_required",
+    );
+  }
+  assert.throws(
+    () => validateSingleExpenseSql(writeScript),
+    (error: unknown) => error instanceof SqlPolicyError && error.code === "single_statement_required",
+  );
+});
+
+test("restricted SQL rejects MERGE as the effective statement after WITH", (): void => {
+  const sql = "WITH source AS (SELECT account_id FROM accounts) MERGE INTO account_metadata AS target USING source ON target.account_id = source.account_id WHEN MATCHED THEN UPDATE SET liquidity = 'low'";
+
+  assertPolicyError(sql, "unsupported_statement");
+  assert.throws(
+    () => validateReadOnlyExpenseSql(sql),
+    (error: unknown) => error instanceof SqlPolicyError && error.code === "unsupported_statement",
+  );
+});
+
+test("restricted SQL rejects MERGE as an effective statement in nested CTE bodies", (): void => {
+  const sql = "WITH outer_rows AS (WITH source AS (SELECT account_id FROM accounts) MERGE INTO account_metadata AS target USING source ON target.account_id = source.account_id WHEN MATCHED THEN UPDATE SET liquidity = 'low') SELECT * FROM outer_rows";
+
+  assertPolicyError(sql, "unsupported_statement");
+  assert.throws(
+    () => validateReadOnlyExpenseSql(sql),
+    (error: unknown) => error instanceof SqlPolicyError && error.code === "unsupported_statement",
+  );
+});
+
+test("restricted SQL allows merge identifiers and string literals", (): void => {
+  const validated = validateReadOnlyExpenseSql(
+    "WITH merge AS (SELECT 'merge' AS merge FROM accounts) SELECT merge FROM merge",
+  );
+
+  assert.equal(validated.statements.length, 1);
+  assert.equal(validated.statements[0]?.isMutating, false);
 });
 
 test("validateExpenseSql rejects non-allowlisted function calls in restricted SQL", (): void => {
@@ -76,7 +267,9 @@ test("validateExpenseSql allows reads from SELECT-only relations", (): void => {
   ];
 
   for (const sql of acceptedSql) {
-    assert.equal(validateExpenseSql(sql).statements.length, 1);
+    const validated = validateExpenseSql(sql);
+    assert.equal(validated.statements.length, 1);
+    assert.equal(validated.statements[0]?.isMutating, false);
   }
 });
 
@@ -104,15 +297,15 @@ test("validateExpenseSql rejects INSERT, UPDATE, and DELETE targets that are SEL
   }
 });
 
-test("validateExpenseSql rejects SELECT-only mutation targets in data-modifying CTEs", (): void => {
+test("validateExpenseSql rejects data-modifying CTEs before relation-specific mutation checks", (): void => {
   assert.throws(
     () => validateExpenseSql(
       "WITH deleted_rates AS (DELETE FROM public.fx_rates_daily WHERE base_currency = 'EUR' RETURNING *) SELECT * FROM deleted_rates",
     ),
     (error: unknown) =>
       error instanceof SqlPolicyError
-      && error.code === "read_only_relation_mutation_not_allowed"
-      && error.message === "Relation fx_rates_daily is SELECT-only and cannot be targeted by DELETE in restricted SQL",
+      && error.code === "unsupported_statement"
+      && error.message === "Data-modifying CTE bodies are not supported; use SELECT, WITH, or VALUES in CTE bodies and move INSERT, UPDATE, or DELETE to the top-level statement. MERGE is not supported",
   );
 });
 
@@ -150,11 +343,13 @@ test("validateExpenseSql allows mutations of workspace-owned relations", (): voi
     "INSERT INTO ledger_entries (event_id, ts, account_id, amount, currency, kind, workspace_id) VALUES ('event-1', '2026-08-09', 'a-main-usd', 1, 'USD', 'income', 'workspace-1')",
     "UPDATE budget_lines SET planned_value = 100 WHERE workspace_id = 'workspace-1'",
     "DELETE FROM workspace_settings WHERE workspace_id = 'workspace-1'",
-    "WITH changed AS (UPDATE account_metadata SET liquidity = 'low' WHERE workspace_id = 'workspace-1' RETURNING *) SELECT * FROM changed",
+    "WITH source AS (SELECT account_id FROM accounts) UPDATE account_metadata SET liquidity = 'low' FROM source WHERE account_metadata.account_id = source.account_id",
   ];
 
   for (const sql of acceptedSql) {
-    assert.equal(validateExpenseSql(sql).statements.length, 1);
+    const validated = validateExpenseSql(sql);
+    assert.equal(validated.statements.length, 1);
+    assert.equal(validated.statements[0]?.isMutating, true);
   }
 });
 
@@ -319,18 +514,116 @@ test("executeExpenseSql reports truncation metadata without removing rowCount", 
     (_value, index) => ({ account_id: `account-${String(index)}` }),
   );
 
-  const executed = await executeExpenseSql(
-    "SELECT account_id FROM ledger_entries ORDER BY account_id",
-    async () => ({
-      command: "SELECT",
-      rows: sourceRows,
-      rowCount: sourceRows.length,
-    }),
-  );
+  const requests: Array<RestrictedSqlExecutionRequest> = [];
+  const sql = "SELECT account_id FROM ledger_entries ORDER BY account_id";
+  const executed = await executeExpenseSql(sql, createCursorExecutor({
+    api_sql_read_cursor_1: sourceRows,
+  }, requests));
 
   const statement = executed.statements[0];
   assert.equal(statement?.rowCount, MAX_SQL_ROWS);
   assert.equal(statement?.returnedRowCount, MAX_SQL_ROWS);
   assert.equal(statement?.totalRowCount, MAX_SQL_ROWS + 1);
   assert.equal(statement?.truncated, true);
+  assert.deepEqual(requests.map((request) => request.sql), [
+    `DECLARE api_sql_read_cursor_1 NO SCROLL CURSOR FOR ${sql}`,
+    `FETCH FORWARD ${String(MAX_SQL_ROWS + 1)} FROM api_sql_read_cursor_1`,
+    "MOVE FORWARD ALL FROM api_sql_read_cursor_1",
+    "CLOSE api_sql_read_cursor_1",
+  ]);
+  assert.equal(requests[0]?.sql.endsWith("ORDER BY account_id"), true);
+});
+
+test("executeExpenseSql bounds reads before execution and across the whole request", async (): Promise<void> => {
+  const requestedLimits: Array<number> = [];
+  const requests: Array<RestrictedSqlExecutionRequest> = [];
+  const firstRows = Array.from({ length: 80 }, (_value, index) => ({ value: index }));
+  const secondRows = Array.from({ length: 75 }, (_value, index) => ({ value: index }));
+  const cursorExecutor = createCursorExecutor({
+    api_sql_read_cursor_1: firstRows,
+    api_sql_read_cursor_2: secondRows,
+  }, requests);
+  const executed = await executeExpenseSql(
+    "SELECT account_id FROM accounts; SELECT rate FROM fx_rates_daily",
+    async (request) => {
+      const fetchMatch = /^FETCH FORWARD (\d+) FROM /u.exec(request.sql);
+      if (fetchMatch?.[1] !== undefined) {
+        requestedLimits.push(Number(fetchMatch[1]) - 1);
+      }
+      return cursorExecutor(request);
+    },
+  );
+
+  assert.deepEqual(requestedLimits, [MAX_SQL_ROWS, MAX_SQL_RETURNED_ROWS - 80]);
+  assert.deepEqual(executed.statements.map((statement) => statement.returnedRowCount), [80, 20]);
+  assert.deepEqual(executed.statements.map((statement) => statement.totalRowCount), [80, 75]);
+  assert.equal(executed.statements[1]?.truncated, true);
+});
+
+test("executeExpenseSql derives exact totals when request row capacity is exhausted", async (): Promise<void> => {
+  const requests: Array<RestrictedSqlExecutionRequest> = [];
+  const firstRows = Array.from({ length: MAX_SQL_RETURNED_ROWS }, (_value, index) => ({ value: index }));
+  const secondRows = [{ value: 1 }, { value: 2 }, { value: 3 }];
+  const executed = await executeExpenseSql(
+    "SELECT account_id FROM accounts; SELECT rate FROM fx_rates_daily",
+    createCursorExecutor({
+      api_sql_read_cursor_1: firstRows,
+      api_sql_read_cursor_2: secondRows,
+    }, requests),
+  );
+
+  assert.deepEqual(
+    requests.filter((request) => request.sql.startsWith("FETCH ")).map((request) => request.sql),
+    [
+      `FETCH FORWARD ${String(MAX_SQL_RETURNED_ROWS + 1)} FROM api_sql_read_cursor_1`,
+      "FETCH FORWARD 1 FROM api_sql_read_cursor_2",
+    ],
+  );
+  assert.deepEqual(executed.statements.map((statement) => statement.returnedRowCount), [100, 0]);
+  assert.deepEqual(executed.statements.map((statement) => statement.totalRowCount), [100, 3]);
+  assert.deepEqual(executed.statements.map((statement) => statement.truncated), [false, true]);
+});
+
+test("executeExpenseSql builds bounded requests for supported SELECT and VALUES CTEs", async (): Promise<void> => {
+  const acceptedSql: ReadonlyArray<string> = [
+    "WITH account_rows AS (SELECT account_id FROM accounts) SELECT account_id FROM account_rows",
+    "WITH rows(value) AS (VALUES (1), (2)) SELECT value FROM rows;",
+  ];
+
+  for (const sql of acceptedSql) {
+    const requests: Array<RestrictedSqlExecutionRequest> = [];
+    const executed = await executeExpenseSql(sql, createCursorExecutor({
+      api_sql_read_cursor_1: [{ value: 1 }],
+    }, requests));
+
+    assert.equal(
+      requests[0]?.sql,
+      `DECLARE api_sql_read_cursor_1 NO SCROLL CURSOR FOR ${sql.replace(/;$/u, "")}`,
+    );
+    assert.deepEqual(requests.map((request) => request.params), [[], [], [], []]);
+    assert.equal(executed.statements[0]?.isMutating, false);
+    assert.deepEqual(executed.statements[0]?.rows, [{ value: 1 }]);
+  }
+});
+
+test("executeExpenseSql rejects per-statement and request-wide mutation row overflows", async (): Promise<void> => {
+  await assert.rejects(
+    () => executeExpenseSql(
+      "UPDATE account_metadata SET liquidity = 'low'",
+      async () => ({ command: "UPDATE", rows: [], rowCount: MAX_SQL_MUTATION_ROWS + 1 }),
+    ),
+    (error: unknown) =>
+      error instanceof SqlPolicyError
+      && error.code === "mutation_statement_row_limit_exceeded",
+  );
+
+  await assert.rejects(
+    () => executeExpenseSql(
+      "UPDATE account_metadata SET liquidity = 'low'; DELETE FROM budget_lines",
+      async () => ({ command: "UPDATE", rows: [], rowCount: 60 }),
+    ),
+    (error: unknown) =>
+      error instanceof SqlPolicyError
+      && error.code === "mutation_request_row_limit_exceeded",
+  );
 });

--- a/packages/agent-shared/src/sql-policy.ts
+++ b/packages/agent-shared/src/sql-policy.ts
@@ -2,6 +2,10 @@
  * Shared SQL policy for machine-facing database access.
  */
 export const MAX_SQL_ROWS = 100;
+export const MAX_SQL_RETURNED_ROWS = 100;
+export const MAX_SQL_MUTATION_ROWS = 100;
+export const MAX_SQL_SCRIPT_LENGTH = 100_000;
+export const MAX_SQL_STATEMENTS = 100;
 export const SQL_STATEMENT_TIMEOUT_MS = 30_000;
 
 export const ALLOWED_SQL_FUNCTION_NAMES = [
@@ -23,6 +27,14 @@ const ALLOWED_SQL_FUNCTIONS_DESCRIPTION = ALLOWED_SQL_FUNCTION_NAMES
 
 const ALLOWED_FIRST_KEYWORDS = new Set([
   "SELECT", "WITH", "INSERT", "UPDATE", "DELETE",
+]);
+
+const ALLOWED_EFFECTIVE_STATEMENT_KEYWORDS: ReadonlySet<string> = new Set([
+  "select", "insert", "update", "delete",
+]);
+
+const ALLOWED_CTE_BODY_KEYWORDS: ReadonlySet<string> = new Set([
+  "select", "values",
 ]);
 
 const SOURCE_CLAUSE_END: ReadonlySet<string> = new Set([
@@ -111,6 +123,12 @@ type MutationTarget = Readonly<{
 
 type SqlPolicyErrorCode =
   | "unsupported_statement"
+  | "single_statement_required"
+  | "sql_script_too_long"
+  | "too_many_sql_statements"
+  | "mutation_statement_row_limit_exceeded"
+  | "mutation_request_row_limit_exceeded"
+  | "read_only_sql_required"
   | "on_conflict_not_allowed"
   | "set_config_not_allowed"
   | "function_calls_not_allowed"
@@ -138,12 +156,21 @@ export type ValidatedExpenseSql = Readonly<{
   statements: ReadonlyArray<ValidatedExpenseSqlStatement>;
 }>;
 
+export type ValidatedReadOnlyExpenseSql = ValidatedExpenseSql & Readonly<{
+  isReadOnly: true;
+}>;
+
 export type RestrictedSqlResultRow = Readonly<Record<string, unknown>>;
 
 export type RestrictedSqlQueryResult = Readonly<{
   command: string;
   rows: ReadonlyArray<RestrictedSqlResultRow>;
   rowCount: number | null;
+}>;
+
+export type RestrictedSqlExecutionRequest = Readonly<{
+  sql: string;
+  params: ReadonlyArray<unknown>;
 }>;
 
 export type ValidatedExpenseSqlStatement = Readonly<{
@@ -708,6 +735,118 @@ const parseCteDefinitions = (
   };
 };
 
+const unwrapParenthesizedSegment = (
+  tokens: ReadonlyArray<SqlToken>,
+  startIndex: number,
+  endIndex: number,
+): Readonly<{ startIndex: number; endIndex: number }> => {
+  let normalizedStartIndex = startIndex;
+  let normalizedEndIndex = endIndex;
+
+  while (
+    tokens[normalizedStartIndex]?.value === "("
+    && findMatchingParen(tokens, normalizedStartIndex, normalizedEndIndex) === normalizedEndIndex - 1
+  ) {
+    normalizedStartIndex += 1;
+    normalizedEndIndex -= 1;
+  }
+
+  return { startIndex: normalizedStartIndex, endIndex: normalizedEndIndex };
+};
+
+const assertSupportedNestedWithClauses = (
+  tokens: ReadonlyArray<SqlToken>,
+  startIndex: number,
+  endIndex: number,
+): void => {
+  for (let index = startIndex; index < endIndex; index += 1) {
+    if (tokens[index]?.value !== "(") {
+      continue;
+    }
+
+    const closeIndex = findMatchingParen(tokens, index, endIndex);
+    const nested = unwrapParenthesizedSegment(tokens, index + 1, closeIndex);
+    if (tokens[nested.startIndex]?.lower === "with") {
+      assertSupportedCteBodySegment(tokens, nested.startIndex, nested.endIndex);
+    } else {
+      assertSupportedNestedWithClauses(tokens, nested.startIndex, nested.endIndex);
+    }
+    index = closeIndex;
+  }
+};
+
+const assertSupportedCteBodySegment = (
+  tokens: ReadonlyArray<SqlToken>,
+  startIndex: number,
+  endIndex: number,
+): void => {
+  const normalized = unwrapParenthesizedSegment(tokens, startIndex, endIndex);
+  const effectiveStatement = tokens[normalized.startIndex];
+  if (effectiveStatement?.lower === "with") {
+    const { ctes, mainQueryStartIndex } = parseCteDefinitions(
+      tokens,
+      normalized.startIndex,
+      normalized.endIndex,
+    );
+    for (const cte of ctes) {
+      assertSupportedCteBodySegment(tokens, cte.bodyStartIndex, cte.bodyEndIndex);
+    }
+    assertSupportedCteBodySegment(tokens, mainQueryStartIndex, normalized.endIndex);
+    return;
+  }
+
+  if (
+    effectiveStatement === undefined
+    || effectiveStatement.kind !== "word"
+    || !ALLOWED_CTE_BODY_KEYWORDS.has(effectiveStatement.lower)
+  ) {
+    fail(
+      "unsupported_statement",
+      "Data-modifying CTE bodies are not supported; use SELECT, WITH, or VALUES in CTE bodies and move INSERT, UPDATE, or DELETE to the top-level statement. MERGE is not supported",
+    );
+  }
+
+  assertSupportedNestedWithClauses(tokens, normalized.startIndex, normalized.endIndex);
+};
+
+const assertSupportedEffectiveStatementsInSegment = (
+  tokens: ReadonlyArray<SqlToken>,
+  startIndex: number,
+  endIndex: number,
+): void => {
+  const normalized = unwrapParenthesizedSegment(tokens, startIndex, endIndex);
+  const effectiveStatement = tokens[normalized.startIndex];
+  if (effectiveStatement?.lower === "with") {
+    const { ctes, mainQueryStartIndex } = parseCteDefinitions(
+      tokens,
+      normalized.startIndex,
+      normalized.endIndex,
+    );
+    for (const cte of ctes) {
+      assertSupportedCteBodySegment(tokens, cte.bodyStartIndex, cte.bodyEndIndex);
+    }
+    assertSupportedEffectiveStatementsInSegment(
+      tokens,
+      mainQueryStartIndex,
+      normalized.endIndex,
+    );
+    return;
+  }
+
+  if (
+    effectiveStatement === undefined
+    || effectiveStatement.kind !== "word"
+    || !ALLOWED_EFFECTIVE_STATEMENT_KEYWORDS.has(effectiveStatement.lower)
+  ) {
+    fail(
+      "unsupported_statement",
+      "Only SELECT, WITH, INSERT, UPDATE, and DELETE statements are allowed",
+    );
+  }
+
+  assertSupportedNestedWithClauses(tokens, normalized.startIndex, normalized.endIndex);
+};
+
 const failFunctionCallNotAllowed = (functionName: string): never =>
   fail(
     "function_calls_not_allowed",
@@ -858,37 +997,42 @@ const collectMutationTargetsFromSegment = (
   startIndex: number,
   endIndex: number,
 ): ReadonlyArray<MutationTarget> => {
-  if (startIndex >= endIndex) {
+  const normalized = unwrapParenthesizedSegment(tokens, startIndex, endIndex);
+  if (normalized.startIndex >= normalized.endIndex) {
     return [];
   }
 
-  const firstToken = tokens[startIndex];
+  const firstToken = tokens[normalized.startIndex];
   if (firstToken === undefined || firstToken.kind !== "word") {
     return [];
   }
 
-  if (firstToken.lower === "insert" && tokens[startIndex + 1]?.lower === "into") {
-    return [collectMutationTarget(tokens, startIndex + 2, "INSERT")];
+  if (firstToken.lower === "insert" && tokens[normalized.startIndex + 1]?.lower === "into") {
+    return [collectMutationTarget(tokens, normalized.startIndex + 2, "INSERT")];
   }
 
   if (firstToken.lower === "update") {
-    return [collectMutationTarget(tokens, startIndex + 1, "UPDATE")];
+    return [collectMutationTarget(tokens, normalized.startIndex + 1, "UPDATE")];
   }
 
-  if (firstToken.lower === "delete" && tokens[startIndex + 1]?.lower === "from") {
-    return [collectMutationTarget(tokens, startIndex + 2, "DELETE")];
+  if (firstToken.lower === "delete" && tokens[normalized.startIndex + 1]?.lower === "from") {
+    return [collectMutationTarget(tokens, normalized.startIndex + 2, "DELETE")];
   }
 
   if (firstToken.lower !== "with") {
     return [];
   }
 
-  const { ctes, mainQueryStartIndex } = parseCteDefinitions(tokens, startIndex, endIndex);
+  const { ctes, mainQueryStartIndex } = parseCteDefinitions(
+    tokens,
+    normalized.startIndex,
+    normalized.endIndex,
+  );
   const targets: Array<MutationTarget> = [];
   for (const cte of ctes) {
     targets.push(...collectMutationTargetsFromSegment(tokens, cte.bodyStartIndex, cte.bodyEndIndex));
   }
-  targets.push(...collectMutationTargetsFromSegment(tokens, mainQueryStartIndex, endIndex));
+  targets.push(...collectMutationTargetsFromSegment(tokens, mainQueryStartIndex, normalized.endIndex));
   return targets;
 };
 
@@ -919,22 +1063,21 @@ const collectReferencedRelations = (sql: string): ReadonlyArray<AllowedRelationN
 /**
  * Classifies whether a validated SQL statement mutates persisted data.
  *
- * PostgreSQL command tags are not sufficient for this because a statement such
- * as `WITH changed AS (UPDATE ... RETURNING ...) SELECT ...` mutates data while
- * still reporting `SELECT` as the outer command. We therefore classify writes
- * from the validated SQL structure itself and carry that explicit flag through
- * downstream chat/runtime code.
+ * Write classification comes from the validated SQL structure rather than the
+ * eventual PostgreSQL command tag. Read-only CTE bodies may feed a top-level
+ * INSERT, UPDATE, or DELETE, so downstream code carries this explicit flag.
  */
 const statementMutatesDataFromSegment = (
   tokens: ReadonlyArray<SqlToken>,
   startIndex: number,
   endIndex: number,
 ): boolean => {
-  if (startIndex >= endIndex) {
+  const normalized = unwrapParenthesizedSegment(tokens, startIndex, endIndex);
+  if (normalized.startIndex >= normalized.endIndex) {
     return false;
   }
 
-  const firstToken = tokens[startIndex];
+  const firstToken = tokens[normalized.startIndex];
   if (firstToken === undefined || firstToken.kind !== "word") {
     return false;
   }
@@ -951,14 +1094,18 @@ const statementMutatesDataFromSegment = (
     return false;
   }
 
-  const { ctes, mainQueryStartIndex } = parseCteDefinitions(tokens, startIndex, endIndex);
+  const { ctes, mainQueryStartIndex } = parseCteDefinitions(
+    tokens,
+    normalized.startIndex,
+    normalized.endIndex,
+  );
   for (const cte of ctes) {
     if (statementMutatesDataFromSegment(tokens, cte.bodyStartIndex, cte.bodyEndIndex)) {
       return true;
     }
   }
 
-  return statementMutatesDataFromSegment(tokens, mainQueryStartIndex, endIndex);
+  return statementMutatesDataFromSegment(tokens, mainQueryStartIndex, normalized.endIndex);
 };
 
 export const getAllowedRelationNames = (): ReadonlyArray<AllowedRelationName> => ALLOWED_RELATION_NAMES;
@@ -986,6 +1133,7 @@ const validateExpenseSqlStatement = (sql: string): ValidatedExpenseSqlStatement 
     fail("on_conflict_not_allowed", "ON CONFLICT is not supported in restricted SQL");
   }
   const tokens = tokenizeSql(sanitizedSql);
+  assertSupportedEffectiveStatementsInSegment(tokens, 0, tokens.length);
   assertMutationTargetsAreWritable(tokens, 0, tokens.length);
   assertOnlyAllowedFunctionCallsInSegment(tokens, 0, tokens.length);
 
@@ -996,9 +1144,28 @@ const validateExpenseSqlStatement = (sql: string): ValidatedExpenseSqlStatement 
   };
 };
 
+const assertSqlScriptLength = (sql: string): void => {
+  if (sql.length > MAX_SQL_SCRIPT_LENGTH) {
+    fail(
+      "sql_script_too_long",
+      `SQL scripts must be ${MAX_SQL_SCRIPT_LENGTH} characters or fewer`,
+    );
+  }
+};
+
 export const validateExpenseSql = (sql: string): ValidatedExpenseSql => {
+  assertSqlScriptLength(sql);
+
   const trimmedSql = sql.trim();
-  const statements = splitSqlStatements(trimmedSql).map(validateExpenseSqlStatement);
+  const rawStatements = splitSqlStatements(trimmedSql);
+  if (rawStatements.length > MAX_SQL_STATEMENTS) {
+    fail(
+      "too_many_sql_statements",
+      `SQL scripts must contain ${MAX_SQL_STATEMENTS} statements or fewer`,
+    );
+  }
+
+  const statements = rawStatements.map(validateExpenseSqlStatement);
   if (statements.length === 0) {
     fail("unsupported_statement", "Only SELECT, WITH, INSERT, UPDATE, and DELETE statements are allowed");
   }
@@ -1009,23 +1176,161 @@ export const validateExpenseSql = (sql: string): ValidatedExpenseSql => {
   };
 };
 
+export const validateReadOnlyExpenseSql = (sql: string): ValidatedReadOnlyExpenseSql => {
+  const validated = validateExpenseSql(sql);
+  if (validated.statements.some((statement) => statement.isMutating)) {
+    fail(
+      "read_only_sql_required",
+      "Read-only SQL cannot contain INSERT, UPDATE, DELETE, or data-modifying CTEs",
+    );
+  }
+
+  return {
+    ...validated,
+    isReadOnly: true,
+  };
+};
+
+const assertSingleStatement = (validated: ValidatedExpenseSql): void => {
+  if (validated.statements.length !== 1) {
+    fail("single_statement_required", "This SQL endpoint accepts exactly one statement");
+  }
+};
+
+export const validateSingleExpenseSql = (sql: string): ValidatedExpenseSql => {
+  assertSqlScriptLength(sql);
+  if (splitSqlStatements(sql.trim()).length > 1) {
+    fail("single_statement_required", "This SQL endpoint accepts exactly one statement");
+  }
+  const validated = validateExpenseSql(sql);
+  assertSingleStatement(validated);
+  return validated;
+};
+
+export const validateSingleReadOnlyExpenseSql = (sql: string): ValidatedReadOnlyExpenseSql => {
+  const validated = validateSingleExpenseSql(sql);
+  if (validated.statements.some((statement) => statement.isMutating)) {
+    fail(
+      "read_only_sql_required",
+      "Read-only SQL cannot contain INSERT, UPDATE, DELETE, or data-modifying CTEs",
+    );
+  }
+
+  return {
+    ...validated,
+    isReadOnly: true,
+  };
+};
+
+const getAffectedRowCount = (result: RestrictedSqlQueryResult): number => {
+  const rowCount = result.rowCount;
+  if (rowCount === null || !Number.isSafeInteger(rowCount) || rowCount < 0) {
+    throw new TypeError("Restricted SQL execution returned an invalid affected row count");
+  }
+  return rowCount;
+};
+
+const executeBoundedRead = async (
+  statement: ValidatedExpenseSqlStatement,
+  statementIndex: number,
+  maxRows: number,
+  execute: (request: RestrictedSqlExecutionRequest) => Promise<RestrictedSqlQueryResult>,
+): Promise<Readonly<{
+  rows: ReadonlyArray<RestrictedSqlResultRow>;
+  totalRowCount: number;
+}>> => {
+  const cursorName = `api_sql_read_cursor_${String(statementIndex + 1)}`;
+  await execute({
+    sql: `DECLARE ${cursorName} NO SCROLL CURSOR FOR ${statement.sql}`,
+    params: [],
+  });
+  const fetched = await execute({
+    sql: `FETCH FORWARD ${String(maxRows + 1)} FROM ${cursorName}`,
+    params: [],
+  });
+  if (fetched.rowCount !== null && fetched.rowCount !== fetched.rows.length) {
+    throw new TypeError("Restricted SQL cursor FETCH returned inconsistent row metadata");
+  }
+
+  const moved = await execute({
+    sql: `MOVE FORWARD ALL FROM ${cursorName}`,
+    params: [],
+  });
+  const remainingRowCount = getAffectedRowCount(moved);
+  await execute({ sql: `CLOSE ${cursorName}`, params: [] });
+
+  return {
+    rows: fetched.rows.slice(0, maxRows),
+    totalRowCount: fetched.rows.length + remainingRowCount,
+  };
+};
+
 export const executeValidatedExpenseSql = async (
   validated: ValidatedExpenseSql,
-  execute: (validatedSql: string) => Promise<RestrictedSqlQueryResult>,
+  execute: (request: RestrictedSqlExecutionRequest) => Promise<RestrictedSqlQueryResult>,
 ): Promise<ExecutedExpenseSql> => {
   const statements: Array<ExecutedExpenseSqlStatement> = [];
+  let returnedRowCount = 0;
+  let mutationRowCount = 0;
 
-  for (const statement of validated.statements) {
-    const result = await execute(statement.sql);
-    const rows = result.rows.slice(0, MAX_SQL_ROWS);
-    const rowCount = rows.length > 0 ? rows.length : (result.rowCount ?? 0);
-    const totalRowCount = result.rows.length > 0 ? result.rows.length : (result.rowCount ?? 0);
+  for (let statementIndex = 0; statementIndex < validated.statements.length; statementIndex += 1) {
+    const statement = validated.statements[statementIndex];
+    if (statement === undefined) {
+      throw new TypeError(`Validated SQL statement ${String(statementIndex + 1)} is missing`);
+    }
+    const statementRowLimit = Math.min(
+      MAX_SQL_ROWS,
+      Math.max(MAX_SQL_RETURNED_ROWS - returnedRowCount, 0),
+    );
+
+    if (!statement.isMutating) {
+      const boundedRead = await executeBoundedRead(
+        statement,
+        statementIndex,
+        statementRowLimit,
+        execute,
+      );
+      returnedRowCount += boundedRead.rows.length;
+      statements.push({
+        sql: statement.sql,
+        command: "SELECT",
+        isMutating: false,
+        rows: boundedRead.rows,
+        rowCount: boundedRead.rows.length,
+        returnedRowCount: boundedRead.rows.length,
+        totalRowCount: boundedRead.totalRowCount,
+        truncated: boundedRead.totalRowCount > boundedRead.rows.length,
+        referencedRelations: statement.referencedRelations,
+      });
+      continue;
+    }
+
+    const result = await execute({ sql: statement.sql, params: [] });
+    const affectedRowCount = getAffectedRowCount(result);
+
+    if (affectedRowCount > MAX_SQL_MUTATION_ROWS) {
+      fail(
+        "mutation_statement_row_limit_exceeded",
+        `A SQL mutation may affect at most ${MAX_SQL_MUTATION_ROWS} rows per statement; this statement affected ${affectedRowCount}`,
+      );
+    }
+    mutationRowCount += affectedRowCount;
+    if (mutationRowCount > MAX_SQL_MUTATION_ROWS) {
+      fail(
+        "mutation_request_row_limit_exceeded",
+        `A SQL request may affect at most ${MAX_SQL_MUTATION_ROWS} rows; this request affected ${mutationRowCount}`,
+      );
+    }
+
+    const totalRowCount = result.rows.length > 0 ? result.rows.length : affectedRowCount;
+    const rows = result.rows.slice(0, statementRowLimit);
+    returnedRowCount += rows.length;
     statements.push({
       sql: statement.sql,
       command: result.command,
       isMutating: statement.isMutating,
       rows,
-      rowCount,
+      rowCount: rows.length === 0 ? affectedRowCount : rows.length,
       returnedRowCount: rows.length,
       totalRowCount,
       truncated: result.rows.length > rows.length,
@@ -1041,5 +1346,5 @@ export const executeValidatedExpenseSql = async (
 
 export const executeExpenseSql = async (
   sql: string,
-  execute: (validatedSql: string) => Promise<RestrictedSqlQueryResult>,
+  execute: (request: RestrictedSqlExecutionRequest) => Promise<RestrictedSqlQueryResult>,
 ): Promise<ExecutedExpenseSql> => executeValidatedExpenseSql(validateExpenseSql(sql), execute);


### PR DESCRIPTION
## Scope

- add canonical authenticated POST /sql/query and POST /sql/execute routes while retaining legacy POST /sql compatibility
- enforce single-statement canonical contracts, read-only SQL policy, atomic shared execution, bounded cursor reads, and mutation row limits
- add the dedicated api_sql_reader role and least-privilege grants
- add focused SQL API, shared-policy, and internal agent contract tests

## Validation

Executable validation is intentionally deferred to the main promotion PR because pull-request CI is configured only for PRs targeting main. This integration-branch PR was reviewed statically with no P0-P4 findings.

No OpenAPI or Swagger artifacts are changed or restored.