### PR TITLE
feat(auth): add MCP OAuth authorization server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,13 @@ COOKIE_DOMAIN=localhost
 # Allowed redirect URIs for auth service (comma-separated)
 ALLOWED_REDIRECT_URIS=http://localhost:3000
 
+# Local OAuth endpoints. HTTP is accepted only for loopback issuer/resource pairs.
+OAUTH_ISSUER=http://localhost:8081
+OAUTH_RESOURCE=http://localhost:8082/mcp
+# Production overrides must use an HTTPS issuer origin and exact MCP resource:
+# OAUTH_ISSUER=https://auth.expense-budget-tracker.com
+# OAUTH_RESOURCE=https://mcp.expense-budget-tracker.com/mcp
+
 # --- Demo email bypass (optional, for E2E smoke tests) ---
 
 # Comma-separated demo emails (must be @example.com)
@@ -106,6 +113,8 @@ ALLOWED_REDIRECT_URIS=http://localhost:3000
 # DB_USER=auth_service
 # DB_PASSWORD=<from Secrets Manager>
 # SESSION_ENCRYPTION_KEY=<from Secrets Manager>
+# OAUTH_ISSUER=https://auth.example.com
+# OAUTH_RESOURCE=https://mcp.example.com/mcp
 # OPENAI_API_KEY=<from Secrets Manager>
 # LANGFUSE_PUBLIC_KEY=<from Secrets Manager>
 # LANGFUSE_SECRET_KEY=<from Secrets Manager>

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@expense-budget-tracker/agent-shared": "1.2.0",
     "@hono/node-server": "^2.1.0",
+    "aws-jwt-verify": "^5.2.1",
     "hono": "^4.13.1",
     "pg": "^8.23.0"
   },

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -1,68 +1,19 @@
 /**
  * Auth service entry point.
  *
- * Standalone Hono service for email OTP authentication via Cognito.
- * Handles login page, OTP send/verify. Sets session cookies with
- * Domain=COOKIE_DOMAIN so they're visible on app.*.
+ * Standalone Hono service for email OTP authentication via Cognito and MCP OAuth.
+ * Handles login, OTP send/verify, public-client registration, consent, and
+ * tokens. Sets session cookies with Domain=COOKIE_DOMAIN so they're visible
+ * on app.*.
  * Runs on its own subdomain (auth.*), separate from the main web app.
  */
 import { serve } from "@hono/node-server";
-import { Hono } from "hono";
-import health from "./routes/health.js";
-import sendCode from "./routes/sendCode.js";
-import verifyCode from "./routes/verifyCode.js";
-import agentSendCode from "./routes/agentSendCode.js";
-import agentVerifyCode from "./routes/agentVerifyCode.js";
-import loginPage from "./routes/loginPage.js";
-import robots from "./routes/robots.js";
+import { createDefaultAuthApp } from "./server/app.js";
+import { validateAuthEnvironment } from "./server/config.js";
 
-const validateEnv = (): void => {
-  const errors: Array<string> = [];
-  if (!process.env.COGNITO_CLIENT_ID) errors.push("COGNITO_CLIENT_ID");
-  if (!process.env.COGNITO_REGION) errors.push("COGNITO_REGION");
-  if (!process.env.SESSION_ENCRYPTION_KEY) errors.push("SESSION_ENCRYPTION_KEY");
-  if (!process.env.ALLOWED_REDIRECT_URIS) errors.push("ALLOWED_REDIRECT_URIS");
-  if (!process.env.COOKIE_DOMAIN) errors.push("COOKIE_DOMAIN");
-  if (!(process.env.AUTH_DATABASE_URL ?? "") && !(process.env.DB_HOST ?? "")) {
-    errors.push("AUTH_DATABASE_URL or DB_HOST");
-  }
-  if ((process.env.AUTH_DATABASE_URL ?? "") === "") {
-    if (!process.env.DB_NAME) errors.push("DB_NAME");
-    if (!process.env.DB_USER) errors.push("DB_USER");
-    if (!process.env.DB_PASSWORD) errors.push("DB_PASSWORD");
-  }
-  if (errors.length > 0) {
-    throw new Error(`Auth service missing required env vars: ${errors.join(", ")}`);
-  }
-};
+validateAuthEnvironment();
 
-if (process.env.NODE_ENV !== "development") {
-  validateEnv();
-}
-
-const app = new Hono();
-
-// Deny cross-origin requests to API endpoints (defense-in-depth).
-// The login page JS makes same-origin fetches; cross-origin callers have
-// no legitimate reason to hit these endpoints.
-app.use("/api/*", async (c, next) => {
-  if (c.req.method === "OPTIONS") {
-    return new Response(null, { status: 204 });
-  }
-  const secFetchSite = c.req.header("sec-fetch-site");
-  if (secFetchSite !== undefined && secFetchSite !== "same-origin" && secFetchSite !== "none") {
-    return c.json({ error: "Cross-origin requests not allowed" }, 403);
-  }
-  await next();
-});
-
-app.route("/", health);
-app.route("/", sendCode);
-app.route("/", verifyCode);
-app.route("/", agentSendCode);
-app.route("/", agentVerifyCode);
-app.route("/", loginPage);
-app.route("/", robots);
+const app = createDefaultAuthApp();
 
 const port = parseInt(process.env.PORT ?? "8081", 10);
 

--- a/apps/auth/src/routes/loginPage.test.ts
+++ b/apps/auth/src/routes/loginPage.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createLoginPageApp } from "./loginPage.js";
+import { clearBrowserSessionCookies } from "../server/oauth/session.js";
+
+test("login clears an invalid non-empty session instead of redirecting in a loop", async (): Promise<void> => {
+  const previousAllowedRedirects = process.env.ALLOWED_REDIRECT_URIS;
+  const previousIssuer = process.env.OAUTH_ISSUER;
+  const previousCookieDomain = process.env.COOKIE_DOMAIN;
+  process.env.ALLOWED_REDIRECT_URIS = "https://app.example.com";
+  process.env.OAUTH_ISSUER = "https://auth.example.com";
+  process.env.COOKIE_DOMAIN = ".example.com";
+  const app = createLoginPageApp({
+    resolveBrowserSession: async (c) => {
+      clearBrowserSessionCookies(c);
+      return null;
+    },
+  });
+
+  try {
+    const redirectUri = "https://auth.example.com/oauth/authorize?client_id=client-1";
+    const response = await app.request(`/login?redirect_uri=${encodeURIComponent(redirectUri)}`, {
+      headers: { Cookie: "session=expired-session" },
+    });
+    assert.equal(response.status, 200);
+    const cookies = response.headers.getSetCookie().join("\n");
+    assert.match(cookies, /session=;/u);
+    assert.match(cookies, /refresh=;/u);
+    assert.match(cookies, /logged_in=;/u);
+    assert.match(cookies, /locale=en/u);
+  } finally {
+    if (previousAllowedRedirects === undefined) delete process.env.ALLOWED_REDIRECT_URIS;
+    else process.env.ALLOWED_REDIRECT_URIS = previousAllowedRedirects;
+    if (previousIssuer === undefined) delete process.env.OAUTH_ISSUER;
+    else process.env.OAUTH_ISSUER = previousIssuer;
+    if (previousCookieDomain === undefined) delete process.env.COOKIE_DOMAIN;
+    else process.env.COOKIE_DOMAIN = previousCookieDomain;
+  }
+});

--- a/apps/auth/src/routes/loginPage.ts
+++ b/apps/auth/src/routes/loginPage.ts
@@ -7,15 +7,23 @@
  * Only the origin is validated against ALLOWED_REDIRECT_URIS.
  */
 import { Hono } from "hono";
-import { getCookie } from "hono/cookie";
+import { setCookie } from "hono/cookie";
 import { renderLoginPage } from "../templates/login.js";
+import { resolveBrowserSession } from "../server/oauth/session.js";
 
-const app = new Hono();
+export type LoginPageDependencies = Readonly<{
+  resolveBrowserSession: typeof resolveBrowserSession;
+}>;
+
+const defaultDependencies: LoginPageDependencies = {
+  resolveBrowserSession,
+};
 
 const getAllowedOrigins = (): ReadonlyArray<string> => {
   const raw = process.env.ALLOWED_REDIRECT_URIS ?? "";
-  if (raw === "") return [];
-  return raw.split(",").map((u) => {
+  const configured = raw === "" ? [] : raw.split(",");
+  const oauthIssuer = process.env.OAUTH_ISSUER ?? "";
+  return [...configured, ...(oauthIssuer === "" ? [] : [oauthIssuer])].map((u) => {
     try {
       return new URL(u.trim()).origin;
     } catch {
@@ -50,38 +58,45 @@ const parseLocale = (acceptLanguage: string | null): Locale => {
   return "en";
 };
 
-app.get("/login", (c) => {
-  const redirectUri = c.req.query("redirect_uri") ?? "";
+export const createLoginPageApp = (dependencies: LoginPageDependencies): Hono => {
+  const app = new Hono();
 
-  if (redirectUri === "") {
-    return c.text("Missing redirect_uri parameter", 400);
-  }
+  app.get("/login", async (c) => {
+    const redirectUri = c.req.query("redirect_uri") ?? "";
 
-  if (!isAllowedRedirectUri(redirectUri)) {
-    return c.text("Invalid redirect_uri", 400);
-  }
+    if (redirectUri === "") {
+      return c.text("Missing redirect_uri parameter", 400);
+    }
 
-  // If the user already has a session, skip the login form and redirect.
-  // Real JWT verification happens on app.* — if the session is expired,
-  // the proxy refreshes it or clears cookies and sends the user back here.
-  const sessionCookie = getCookie(c, "session") ?? "";
-  if (sessionCookie !== "") {
-    return c.redirect(redirectUri, 302);
-  }
+    if (!isAllowedRedirectUri(redirectUri)) {
+      return c.text("Invalid redirect_uri", 400);
+    }
 
-  const langParam = c.req.query("lang") ?? "";
-  const locale: Locale = (SUPPORTED_LOCALES as ReadonlyArray<string>).includes(langParam)
-    ? (langParam as Locale)
-    : parseLocale(c.req.header("accept-language") ?? null);
+    const identity = await dependencies.resolveBrowserSession(c);
+    if (identity !== null) return c.redirect(redirectUri, 302);
 
-  const domain = process.env.COOKIE_DOMAIN ?? "";
-  const websiteUrl = domain.startsWith(".")
-    ? `https://${domain.slice(1)}`
-    : `https://${domain}`;
-  const html = renderLoginPage(locale, redirectUri, websiteUrl, domain);
+    const langParam = c.req.query("lang") ?? "";
+    const locale: Locale = (SUPPORTED_LOCALES as ReadonlyArray<string>).includes(langParam)
+      ? (langParam as Locale)
+      : parseLocale(c.req.header("accept-language") ?? null);
 
-  c.header("Set-Cookie", `locale=${locale}; Domain=${domain}; Path=/; Max-Age=31536000; Secure; SameSite=Lax`);
-  return c.html(html);
-});
+    const domain = process.env.COOKIE_DOMAIN ?? "";
+    const websiteUrl = domain.startsWith(".")
+      ? `https://${domain.slice(1)}`
+      : `https://${domain}`;
+    const html = renderLoginPage(locale, redirectUri, websiteUrl, domain);
 
-export default app;
+    setCookie(c, "locale", locale, {
+      domain: domain === "" ? undefined : domain,
+      path: "/",
+      maxAge: 31536000,
+      secure: true,
+      sameSite: "Lax",
+    });
+    return c.html(html);
+  });
+
+  return app;
+};
+
+export default createLoginPageApp(defaultDependencies);

--- a/apps/auth/src/routes/oauth.test.ts
+++ b/apps/auth/src/routes/oauth.test.ts
@@ -1,0 +1,609 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import {
+  createOAuthApp,
+  MAX_CONSENT_REQUEST_BYTES,
+  MAX_DCR_REQUEST_BYTES,
+  MAX_TOKEN_REQUEST_BYTES,
+  type OAuthRouteDependencies,
+} from "./oauth.js";
+import { clearBrowserSessionCookies } from "../server/oauth/session.js";
+import type { OAuthClient } from "../server/oauth/core.js";
+import type {
+  OAuthAuthorizationServerErrorEvent,
+  OAuthEndpointServerErrorEvent,
+} from "../server/logger.js";
+
+type OAuthTestLogEvent = OAuthAuthorizationServerErrorEvent | OAuthEndpointServerErrorEvent;
+
+const issuer = "https://auth.example.com";
+const resource = "https://mcp.example.com/mcp";
+const verifier = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+const challenge = createHash("sha256").update(verifier).digest("base64url");
+const client: OAuthClient = {
+  clientId: "ebt_cl_registered-client",
+  clientName: "Desktop <MCP>",
+  redirectUris: ["https://client.example/callback?next=a&source=b"],
+};
+const exactRedirectUri = "https://client.example/callback?code=registered-code&error=registered-error&error_description=registered-description&state=registered-state&next=a%2Fb%20c";
+const exactRedirectClient: OAuthClient = {
+  clientId: "ebt_cl_exact-redirect-client",
+  clientName: "Exact redirect client",
+  redirectUris: [exactRedirectUri],
+};
+
+const createDependencies = (
+  overrides: Partial<OAuthRouteDependencies>,
+): OAuthRouteDependencies => ({
+  getOAuthConfig: () => ({ issuer, resource }),
+  getOAuthClient: async (clientId) => clientId === client.clientId ? client : null,
+  registerOAuthClient: async (clientName, redirectUris) => ({
+    clientId: "ebt_cl_created-client", clientName, redirectUris,
+  }),
+  issueAuthorizationCode: async () => "ebt_ac_issued-code",
+  exchangeAuthorizationCode: async () => ({
+    accessToken: "ebt_at_access", refreshToken: "ebt_rt_refresh",
+    expiresIn: 3600, scope: "expenses:read",
+  }),
+  exchangeRefreshToken: async () => ({
+    accessToken: "ebt_at_access", refreshToken: "ebt_rt_refresh",
+    expiresIn: 3600, scope: "expenses:read",
+  }),
+  resolveBrowserSession: async () => ({ userId: "user-1", email: "user@example.com" }),
+  log: () => {},
+  ...overrides,
+});
+
+const authorizationParamsForClient = (oauthClient: OAuthClient, state: string): URLSearchParams => new URLSearchParams({
+  response_type: "code",
+  client_id: oauthClient.clientId,
+  redirect_uri: oauthClient.redirectUris[0] ?? "",
+  scope: "expenses:read expenses:write",
+  resource,
+  state,
+  code_challenge: challenge,
+  code_challenge_method: "S256",
+});
+
+const authorizationParams = (): URLSearchParams => authorizationParamsForClient(client, "state-1");
+
+const consentRequest = (params: URLSearchParams, origin: string): Request => new Request(
+  `${issuer}/oauth/authorize`,
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Cookie: "session=valid-session",
+      Origin: origin,
+      "Sec-Fetch-Site": origin === issuer ? "same-origin" : "cross-site",
+    },
+    body: params.toString(),
+  },
+);
+
+type BodyLimitCase = Readonly<{
+  name: string;
+  url: string;
+  contentType: string;
+  maxBytes: number;
+  expectedError: "invalid_client_metadata" | "invalid_request";
+  headers: Readonly<Record<string, string>>;
+}>;
+
+const bodyLimitCases: ReadonlyArray<BodyLimitCase> = [
+  {
+    name: "DCR JSON",
+    url: `${issuer}/oauth/register`,
+    contentType: "application/json",
+    maxBytes: MAX_DCR_REQUEST_BYTES,
+    expectedError: "invalid_client_metadata",
+    headers: {},
+  },
+  {
+    name: "consent form",
+    url: `${issuer}/oauth/authorize`,
+    contentType: "application/x-www-form-urlencoded",
+    maxBytes: MAX_CONSENT_REQUEST_BYTES,
+    expectedError: "invalid_request",
+    headers: { Origin: issuer, "Sec-Fetch-Site": "same-origin" },
+  },
+  {
+    name: "token form",
+    url: `${issuer}/oauth/token`,
+    contentType: "application/x-www-form-urlencoded",
+    maxBytes: MAX_TOKEN_REQUEST_BYTES,
+    expectedError: "invalid_request",
+    headers: {},
+  },
+];
+
+const requestHeaders = (bodyCase: BodyLimitCase): Headers => {
+  const headers = new Headers(bodyCase.headers);
+  headers.set("Content-Type", bodyCase.contentType);
+  return headers;
+};
+
+const streamedOverflowRequest = (
+  bodyCase: BodyLimitCase,
+): Readonly<{ request: Request; wasCancelled: () => boolean }> => {
+  let cancelled = false;
+  const body = new ReadableStream<Uint8Array>({
+    start: (controller) => {
+      controller.enqueue(new Uint8Array(bodyCase.maxBytes));
+      controller.enqueue(new Uint8Array(1));
+    },
+    cancel: () => { cancelled = true; },
+  });
+  const init: RequestInit & Readonly<{ duplex: "half" }> = {
+    method: "POST",
+    headers: requestHeaders(bodyCase),
+    body,
+    duplex: "half",
+  };
+  return {
+    request: new Request(bodyCase.url, init),
+    wasCancelled: () => cancelled,
+  };
+};
+
+for (const bodyCase of bodyLimitCases) {
+  test(`${bodyCase.name} rejects an oversized Content-Length before parsing`, async (): Promise<void> => {
+    const app = createOAuthApp(createDependencies({}));
+    const headers = requestHeaders(bodyCase);
+    headers.set("Content-Length", String(bodyCase.maxBytes + 1));
+    const response = await app.fetch(new Request(bodyCase.url, {
+      method: "POST",
+      headers,
+      body: "x",
+    }));
+
+    assert.equal(response.status, 400);
+    const payload = await response.json() as Readonly<Record<string, unknown>>;
+    assert.equal(payload["error"], bodyCase.expectedError);
+    assert.match(String(payload["error_description"]), /must not exceed/u);
+  });
+
+  test(`${bodyCase.name} cancels a streamed body as soon as it exceeds the byte limit`, async (): Promise<void> => {
+    const app = createOAuthApp(createDependencies({}));
+    const streamed = streamedOverflowRequest(bodyCase);
+    const response = await app.fetch(streamed.request);
+
+    assert.equal(response.status, 400);
+    const payload = await response.json() as Readonly<Record<string, unknown>>;
+    assert.equal(payload["error"], bodyCase.expectedError);
+    assert.match(String(payload["error_description"]), /must not exceed/u);
+    assert.equal(streamed.wasCancelled(), true);
+  });
+}
+
+test("DCR validates public callbacks before persisting registration", async (): Promise<void> => {
+  const registrations: Array<Readonly<{ clientName: string; redirectUris: ReadonlyArray<string> }>> = [];
+  const app = createOAuthApp(createDependencies({
+    registerOAuthClient: async (clientName, redirectUris) => {
+      registrations.push({ clientName, redirectUris });
+      return { clientId: "ebt_cl_created-client", clientName, redirectUris };
+    },
+  }));
+
+  const accepted = await app.request(`${issuer}/oauth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_name: "CLI",
+      redirect_uris: ["http://127.0.0.1:43123/callback"],
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      application_type: "native",
+    }),
+  });
+  assert.equal(accepted.status, 201);
+  assert.equal(accepted.headers.get("cache-control"), "no-store");
+  const registration = await accepted.json() as Readonly<Record<string, unknown>>;
+  assert.equal(registration["token_endpoint_auth_method"], "none");
+  assert.equal("client_secret" in registration, false);
+  assert.deepEqual(registrations, [{
+    clientName: "CLI",
+    redirectUris: ["http://127.0.0.1:43123/callback"],
+  }]);
+
+  const percentEncoded = await app.request(`${issuer}/oauth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ redirect_uris: ["https://client.example/callback%0Adata"] }),
+  });
+  assert.equal(percentEncoded.status, 201);
+  assert.deepEqual(registrations[1]?.redirectUris, ["https://client.example/callback%0Adata"]);
+
+  const invalidRawRedirects = [
+    "https://client.example/call back",
+    "https://client.example/call\tback",
+    "https://client.example/call\nback",
+    "https://client.example/call\rback",
+    "https://client.example/call\u0000back",
+    "https://client.example/call\u001fback",
+    "https://client.example/call\u007fback",
+    "https://client.example/callback%ZZ",
+    "https://client.example\\callback",
+    "https:client.example/callback",
+    "https:///client.example/callback",
+  ];
+  for (const redirectUri of invalidRawRedirects) {
+    const invalidRaw = await app.request(`${issuer}/oauth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ redirect_uris: [redirectUri] }),
+    });
+    assert.equal(invalidRaw.status, 400);
+    const error = await invalidRaw.json() as Readonly<Record<string, unknown>>;
+    assert.equal(error["error"], "invalid_redirect_uri");
+  }
+
+  const rejected = await app.request(`${issuer}/oauth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ redirect_uris: ["http://attacker.example/callback"] }),
+  });
+  assert.equal(rejected.status, 400);
+  assert.equal(registrations.length, 2);
+});
+
+test("DCR persistence failures return generic JSON and log no registration body values", async (): Promise<void> => {
+  const clientName = "client-name-must-not-log";
+  const redirectUri = "https://client.example/callback%2Fmust-not-log";
+  const events: OAuthTestLogEvent[] = [];
+  const app = createOAuthApp(createDependencies({
+    registerOAuthClient: async () => {
+      throw new Error(`Database rejected ${clientName} and ${redirectUri}`);
+    },
+    log: (event) => { events.push(event); },
+  }));
+
+  const response = await app.request(`${issuer}/oauth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ client_name: clientName, redirect_uris: [redirectUri] }),
+  });
+
+  assert.equal(response.status, 500);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.equal(response.headers.get("pragma"), "no-cache");
+  assert.deepEqual(await response.json(), {
+    error: "server_error",
+    error_description: "Client registration could not be completed",
+  });
+  assert.deepEqual(events, [{
+    domain: "auth",
+    action: "oauth_endpoint_server_error",
+    endpoint: "registration",
+    errorType: "error",
+  }]);
+  const serializedEvents = JSON.stringify(events);
+  assert.equal(serializedEvents.includes(clientName), false);
+  assert.equal(serializedEvents.includes(redirectUri), false);
+});
+
+const registrationBody = (padding: string): string => JSON.stringify({
+  client_name: "CLI",
+  redirect_uris: ["http://127.0.0.1:43123/callback"],
+  padding,
+});
+
+const utf8Length = (value: string): number => new TextEncoder().encode(value).byteLength;
+
+const consentParametersWithEncodedSize = (targetBytes: number): URLSearchParams => {
+  const params = authorizationParams();
+  const prefix = "é/?&=+";
+  params.set("state", prefix);
+  params.set("decision", "allow");
+  const remainingBytes = targetBytes - utf8Length(params.toString());
+  if (remainingBytes < 0) throw new RangeError("Target consent size is smaller than the fixed form fields");
+  const multibyteCharacters = Math.floor(remainingBytes / 6);
+  const asciiCharacters = remainingBytes % 6;
+  params.set("state", `${prefix}${"é".repeat(multibyteCharacters)}${"x".repeat(asciiCharacters)}`);
+  const state = params.get("state");
+  if (state === null || state.length > 2048 || utf8Length(params.toString()) !== targetBytes) {
+    throw new RangeError("Target consent size cannot be represented within the state parameter limit");
+  }
+  params.delete("decision");
+  return params;
+};
+
+test("DCR enforces its request ceiling in UTF-8 bytes before JSON parsing", async (): Promise<void> => {
+  let registrationCount = 0;
+  const app = createOAuthApp(createDependencies({
+    registerOAuthClient: async (clientName, redirectUris) => {
+      registrationCount += 1;
+      return { clientId: "ebt_cl_created-client", clientName, redirectUris };
+    },
+  }));
+  const emptyBody = registrationBody("");
+  const exactBody = registrationBody("x".repeat(MAX_DCR_REQUEST_BYTES - utf8Length(emptyBody)));
+  assert.equal(utf8Length(exactBody), MAX_DCR_REQUEST_BYTES);
+  const accepted = await app.request(`${issuer}/oauth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: exactBody,
+  });
+  assert.equal(accepted.status, 201);
+
+  const overBoundaryBody = registrationBody("x".repeat(MAX_DCR_REQUEST_BYTES - utf8Length(emptyBody) + 1));
+  assert.equal(utf8Length(overBoundaryBody), MAX_DCR_REQUEST_BYTES + 1);
+  const overBoundary = await app.request(`${issuer}/oauth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: overBoundaryBody,
+  });
+  assert.equal(overBoundary.status, 400);
+  const overBoundaryError = await overBoundary.json() as Readonly<Record<string, unknown>>;
+  assert.equal(overBoundaryError["error"], "invalid_client_metadata");
+  assert.match(String(overBoundaryError["error_description"]), /must not exceed 7500 UTF-8 bytes/u);
+
+  const multibyteBody = registrationBody("é".repeat(Math.ceil((MAX_DCR_REQUEST_BYTES - utf8Length(emptyBody) + 1) / 2)));
+  assert.ok(multibyteBody.length < MAX_DCR_REQUEST_BYTES);
+  assert.ok(utf8Length(multibyteBody) > MAX_DCR_REQUEST_BYTES);
+  const multibyte = await app.request(`${issuer}/oauth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: multibyteBody,
+  });
+  assert.equal(multibyte.status, 400);
+  const multibyteError = await multibyte.json() as Readonly<Record<string, unknown>>;
+  assert.equal(multibyteError["error"], "invalid_client_metadata");
+  assert.equal(registrationCount, 1);
+});
+
+test("consent is no-store, anti-clickjacking, and same-origin protected", async (): Promise<void> => {
+  let issueCount = 0;
+  const app = createOAuthApp(createDependencies({
+    issueAuthorizationCode: async () => {
+      issueCount += 1;
+      return "ebt_ac_issued-code";
+    },
+  }));
+  const query = authorizationParams();
+  const consentPage = await app.request(`${issuer}/oauth/authorize?${query.toString()}`, {
+    headers: { Cookie: "session=valid-session" },
+  });
+  assert.equal(consentPage.status, 200);
+  assert.equal(consentPage.headers.get("cache-control"), "no-store");
+  assert.equal(consentPage.headers.get("x-frame-options"), "DENY");
+  assert.match(consentPage.headers.get("content-security-policy") ?? "", /frame-ancestors 'none'/u);
+  const consentHtml = await consentPage.text();
+  assert.match(consentHtml, /Desktop &lt;MCP&gt;/u);
+  assert.equal(consentHtml.includes("Desktop <MCP>"), false);
+  assert.match(consentHtml, /Unverified client name/u);
+  assert.match(consentHtml, /Client ID<\/dt><dd>ebt_cl_registered-client/u);
+  assert.match(consentHtml, /Callback origin<\/dt><dd>https:\/\/client\.example/u);
+  assert.match(consentHtml, /Exact redirect URI<\/dt><dd>https:\/\/client\.example\/callback\?next=a&amp;source=b/u);
+  assert.equal(consentHtml.includes("callback?next=a&source=b</dd>"), false);
+
+  const form = authorizationParams();
+  form.set("decision", "allow");
+  const crossOrigin = await app.fetch(consentRequest(form, "https://attacker.example"));
+  assert.equal(crossOrigin.status, 403);
+  assert.equal(issueCount, 0);
+
+  const allowed = await app.fetch(consentRequest(form, issuer));
+  assert.equal(allowed.status, 302);
+  assert.match(allowed.headers.get("location") ?? "", /code=ebt_ac_issued-code/u);
+  assert.equal(issueCount, 1);
+});
+
+test("consent renders only when both encoded decisions fit the POST byte limit", async (): Promise<void> => {
+  let sessionResolutionCount = 0;
+  const app = createOAuthApp(createDependencies({
+    resolveBrowserSession: async () => {
+      sessionResolutionCount += 1;
+      return { userId: "user-1", email: "user@example.com" };
+    },
+  }));
+  const exactBoundary = consentParametersWithEncodedSize(MAX_CONSENT_REQUEST_BYTES);
+  const page = await app.request(`${issuer}/oauth/authorize?${exactBoundary.toString()}`);
+  assert.equal(page.status, 200);
+  assert.match(await page.text(), /<form method="post" action="\/oauth\/authorize">/u);
+
+  const allowed = new URLSearchParams(exactBoundary);
+  allowed.set("decision", "allow");
+  assert.equal(utf8Length(allowed.toString()), MAX_CONSENT_REQUEST_BYTES);
+  const denied = new URLSearchParams(exactBoundary);
+  denied.set("decision", "deny");
+  assert.ok(utf8Length(denied.toString()) <= MAX_CONSENT_REQUEST_BYTES);
+  const submission = await app.fetch(consentRequest(allowed, issuer));
+  assert.equal(submission.status, 302);
+
+  const oversized = consentParametersWithEncodedSize(MAX_CONSENT_REQUEST_BYTES + 1);
+  const rejected = await app.request(`${issuer}/oauth/authorize?${oversized.toString()}`);
+  assert.equal(rejected.status, 302);
+  const location = rejected.headers.get("location") ?? "";
+  assert.match(location, /[?&]error=invalid_request(?:&|$)/u);
+  assert.match(location, /error_description=Consent%20request%20must%20not%20exceed%207500%20UTF-8%20bytes/u);
+  const oversizedState = oversized.get("state");
+  assert.notEqual(oversizedState, null);
+  assert.ok(location.endsWith(`&state=${encodeURIComponent(oversizedState ?? "")}`));
+  assert.equal(sessionResolutionCount, 2);
+});
+
+test("authorization success appends parameters without rewriting the registered redirect URI", async (): Promise<void> => {
+  const app = createOAuthApp(createDependencies({
+    getOAuthClient: async (clientId) => clientId === exactRedirectClient.clientId ? exactRedirectClient : null,
+  }));
+  const form = authorizationParamsForClient(exactRedirectClient, "state value/%");
+  form.set("decision", "allow");
+
+  const response = await app.fetch(consentRequest(form, issuer));
+
+  assert.equal(response.status, 302);
+  assert.equal(
+    response.headers.get("location"),
+    `${exactRedirectUri}&code=ebt_ac_issued-code&state=state%20value%2F%25`,
+  );
+});
+
+test("authorization errors append parameters without rewriting the registered redirect URI", async (): Promise<void> => {
+  const app = createOAuthApp(createDependencies({
+    getOAuthClient: async (clientId) => clientId === exactRedirectClient.clientId ? exactRedirectClient : null,
+  }));
+  const params = authorizationParamsForClient(exactRedirectClient, "state value/%");
+  params.set("scope", "expenses:write");
+
+  const response = await app.request(`${issuer}/oauth/authorize?${params.toString()}`, {
+    headers: { Cookie: "session=valid-session" },
+  });
+
+  assert.equal(response.status, 302);
+  assert.equal(
+    response.headers.get("location"),
+    `${exactRedirectUri}&error=invalid_scope&error_description=Scope%20must%20include%20expenses%3Aread%20and%20may%20include%20expenses%3Awrite&state=state%20value%2F%25`,
+  );
+});
+
+test("authorization GET logs and redirects unexpected failures after callback validation", async (): Promise<void> => {
+  const accessToken = "ebt_at_must-not-log";
+  const events: OAuthTestLogEvent[] = [];
+  const app = createOAuthApp(createDependencies({
+    resolveBrowserSession: async () => { throw new Error(`JWKS lookup failed near ${accessToken}`); },
+    log: (event) => { events.push(event); },
+  }));
+
+  const response = await app.request(`${issuer}/oauth/authorize?${authorizationParams().toString()}`);
+
+  assert.equal(response.status, 302);
+  assert.equal(
+    response.headers.get("location"),
+    "https://client.example/callback?next=a&source=b&error=server_error&error_description=Authorization%20server%20could%20not%20complete%20the%20request&state=state-1",
+  );
+  assert.deepEqual(events, [{
+    domain: "auth",
+    action: "oauth_authorization_server_error",
+    method: "GET",
+    clientId: client.clientId,
+    errorType: "error",
+  }]);
+  assert.equal(JSON.stringify(events).includes(accessToken), false);
+});
+
+test("authorization POST logs and redirects code-persistence failures after callback validation", async (): Promise<void> => {
+  const authorizationCode = "ebt_ac_must-not-log";
+  const events: OAuthTestLogEvent[] = [];
+  const app = createOAuthApp(createDependencies({
+    issueAuthorizationCode: async () => { throw new Error(`Authorization code insert failed near ${authorizationCode}`); },
+    log: (event) => { events.push(event); },
+  }));
+  const form = authorizationParams();
+  form.set("decision", "allow");
+
+  const response = await app.fetch(consentRequest(form, issuer));
+
+  assert.equal(response.status, 302);
+  assert.equal(
+    response.headers.get("location"),
+    "https://client.example/callback?next=a&source=b&error=server_error&error_description=Authorization%20server%20could%20not%20complete%20the%20request&state=state-1",
+  );
+  assert.deepEqual(events, [{
+    domain: "auth",
+    action: "oauth_authorization_server_error",
+    method: "POST",
+    clientId: client.clientId,
+    errorType: "error",
+  }]);
+  assert.equal(JSON.stringify(events).includes(authorizationCode), false);
+});
+
+test("token failures return generic OAuth JSON without logging credentials or validation errors", async (): Promise<void> => {
+  const authorizationCode = "ebt_ac_token-must-not-log";
+  const events: OAuthTestLogEvent[] = [];
+  const app = createOAuthApp(createDependencies({
+    exchangeAuthorizationCode: async () => {
+      throw new RangeError(`Exchange failed for ${authorizationCode} and ${verifier}`);
+    },
+    log: (event) => { events.push(event); },
+  }));
+  const validRequest = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: client.clientId,
+    redirect_uri: client.redirectUris[0] ?? "",
+    resource,
+    code: authorizationCode,
+    code_verifier: verifier,
+  });
+
+  const response = await app.request(`${issuer}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: validRequest.toString(),
+  });
+
+  assert.equal(response.status, 500);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.equal(response.headers.get("pragma"), "no-cache");
+  assert.deepEqual(await response.json(), {
+    error: "server_error",
+    error_description: "Token request could not be completed",
+  });
+  assert.deepEqual(events, [{
+    domain: "auth",
+    action: "oauth_endpoint_server_error",
+    endpoint: "token",
+    errorType: "range_error",
+  }]);
+  const serializedEvents = JSON.stringify(events);
+  assert.equal(serializedEvents.includes(authorizationCode), false);
+  assert.equal(serializedEvents.includes(verifier), false);
+
+  const invalidResponse = await app.request(`${issuer}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: "authorization_code" }).toString(),
+  });
+  assert.equal(invalidResponse.status, 400);
+  assert.equal(events.length, 1);
+});
+
+test("consent revalidates every submitted authorization field", async (): Promise<void> => {
+  let issueCount = 0;
+  const app = createOAuthApp(createDependencies({
+    issueAuthorizationCode: async () => {
+      issueCount += 1;
+      return "ebt_ac_must-not-issue";
+    },
+  }));
+  const mutations: ReadonlyArray<Readonly<[string, string]>> = [
+    ["response_type", "token"],
+    ["client_id", "unknown-client"],
+    ["redirect_uri", "https://client.example/other"],
+    ["scope", "expenses:write"],
+    ["resource", "https://mcp.other.example/mcp"],
+    ["state", "x".repeat(2049)],
+    ["code_challenge", "invalid"],
+    ["code_challenge_method", "plain"],
+    ["decision", "unexpected"],
+  ];
+
+  for (const [name, value] of mutations) {
+    const form = authorizationParams();
+    form.set("decision", "allow");
+    form.set(name, value);
+    const response = await app.fetch(consentRequest(form, issuer));
+    const location = response.headers.get("location") ?? "";
+    assert.equal(location.includes("code="), false, `${name} mutation must not issue a code`);
+  }
+  assert.equal(issueCount, 0);
+});
+
+test("invalid non-empty session cookies are cleared before authorize redirects to login", async (): Promise<void> => {
+  const app = createOAuthApp(createDependencies({
+    resolveBrowserSession: async (c) => {
+      clearBrowserSessionCookies(c);
+      return null;
+    },
+  }));
+  const response = await app.request(`${issuer}/oauth/authorize?${authorizationParams().toString()}`, {
+    headers: { Cookie: "session=expired-session" },
+  });
+
+  assert.equal(response.status, 302);
+  assert.match(response.headers.get("location") ?? "", /^https:\/\/auth\.example\.com\/login\?/u);
+  assert.match(response.headers.getSetCookie().join("\n"), /session=;/u);
+});

--- a/apps/auth/src/routes/oauth.ts
+++ b/apps/auth/src/routes/oauth.ts
@@ -1,0 +1,499 @@
+import { Hono, type Context } from "hono";
+import {
+  getOAuthConfig,
+  isOAuthProtocolError,
+  isValidClientRedirectUri,
+  normalizeScopes,
+  oauthError,
+  parseAuthorizationRequest,
+  type AuthorizationRequest,
+  type OAuthClient,
+  type OAuthProtocolError,
+} from "../server/oauth/core.js";
+import {
+  exchangeAuthorizationCode,
+  exchangeRefreshToken,
+  getOAuthClient,
+  issueAuthorizationCode,
+  registerOAuthClient,
+} from "../server/oauth/store.js";
+import { resolveBrowserSession, type BrowserIdentity } from "../server/oauth/session.js";
+import {
+  getSafeErrorType,
+  log,
+  type OAuthAuthorizationServerErrorEvent,
+  type OAuthEndpointServerErrorEvent,
+} from "../server/logger.js";
+
+type OAuthServerErrorEvent = OAuthAuthorizationServerErrorEvent | OAuthEndpointServerErrorEvent;
+
+export type OAuthRouteDependencies = Readonly<{
+  getOAuthConfig: typeof getOAuthConfig;
+  getOAuthClient: typeof getOAuthClient;
+  registerOAuthClient: typeof registerOAuthClient;
+  issueAuthorizationCode: typeof issueAuthorizationCode;
+  exchangeAuthorizationCode: typeof exchangeAuthorizationCode;
+  exchangeRefreshToken: typeof exchangeRefreshToken;
+  resolveBrowserSession: typeof resolveBrowserSession;
+  log: (event: OAuthServerErrorEvent) => void;
+}>;
+
+const defaultDependencies: OAuthRouteDependencies = {
+  getOAuthConfig,
+  getOAuthClient,
+  registerOAuthClient,
+  issueAuthorizationCode,
+  exchangeAuthorizationCode,
+  exchangeRefreshToken,
+  resolveBrowserSession,
+  log,
+};
+
+const noStore = (c: Context): void => {
+  c.header("Cache-Control", "no-store");
+  c.header("Pragma", "no-cache");
+};
+
+// Leave headroom below the managed WAF's 8 KiB inspected-body threshold.
+const MAX_OAUTH_REQUEST_BYTES = 7_500;
+export const MAX_DCR_REQUEST_BYTES = MAX_OAUTH_REQUEST_BYTES;
+export const MAX_CONSENT_REQUEST_BYTES = MAX_OAUTH_REQUEST_BYTES;
+export const MAX_TOKEN_REQUEST_BYTES = MAX_OAUTH_REQUEST_BYTES;
+
+type RequestBodyTooLargeError = Error & Readonly<{
+  requestBodyTooLarge: true;
+  maxBytes: number;
+}>;
+
+const requestBodyTooLargeError = (
+  maxBytes: number,
+  cause: unknown,
+): RequestBodyTooLargeError => Object.assign(
+  cause === undefined
+    ? new Error(`Request body exceeds ${maxBytes} bytes`)
+    : new Error(`Request body exceeds ${maxBytes} bytes`, { cause }),
+  { requestBodyTooLarge: true as const, maxBytes },
+);
+
+const isRequestBodyTooLargeError = (error: unknown): error is RequestBodyTooLargeError =>
+  error instanceof Error
+  && (error as Partial<RequestBodyTooLargeError>).requestBodyTooLarge === true;
+
+const hasOversizedContentLength = (request: Request, maxBytes: number): boolean => {
+  const rawContentLength = request.headers.get("content-length");
+  if (rawContentLength === null) return false;
+  const contentLength = rawContentLength.trim();
+  return /^\d+$/u.test(contentLength) && BigInt(contentLength) > BigInt(maxBytes);
+};
+
+const readBoundedRequestBody = async (request: Request, maxBytes: number): Promise<string> => {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new RangeError("Request body byte limit must be a non-negative safe integer");
+  }
+  if (hasOversizedContentLength(request, maxBytes)) {
+    throw requestBodyTooLargeError(maxBytes, undefined);
+  }
+  if (request.body === null) return "";
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let byteLength = 0;
+  let body = "";
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      byteLength += chunk.value.byteLength;
+      if (byteLength > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch (cause) {
+          throw requestBodyTooLargeError(maxBytes, cause);
+        }
+        throw requestBodyTooLargeError(maxBytes, undefined);
+      }
+      body += decoder.decode(chunk.value, { stream: true });
+    }
+    return body + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+};
+
+const escapeHtml = (value: string): string => value
+  .replace(/&/gu, "&amp;")
+  .replace(/</gu, "&lt;")
+  .replace(/>/gu, "&gt;")
+  .replace(/"/gu, "&quot;")
+  .replace(/'/gu, "&#39;");
+
+const CONSENT_DECISIONS = ["deny", "allow"] as const;
+type ConsentDecision = typeof CONSENT_DECISIONS[number];
+type ConsentFormField = Readonly<[string, string]>;
+
+const consentHiddenFields = (request: AuthorizationRequest): ReadonlyArray<ConsentFormField> => [
+  ["response_type", request.responseType], ["client_id", request.clientId],
+  ["redirect_uri", request.redirectUri], ["scope", request.scope],
+  ["resource", request.resource], ["state", request.state],
+  ["code_challenge", request.codeChallenge], ["code_challenge_method", request.codeChallengeMethod],
+];
+
+const encodeConsentSubmission = (
+  request: AuthorizationRequest,
+  decision: ConsentDecision,
+): string => {
+  const params = new URLSearchParams();
+  for (const [name, value] of consentHiddenFields(request)) params.append(name, value);
+  params.append("decision", decision);
+  return params.toString();
+};
+
+const validateConsentSubmissionSize = (request: AuthorizationRequest): void => {
+  const encoder = new TextEncoder();
+  for (const decision of CONSENT_DECISIONS) {
+    if (encoder.encode(encodeConsentSubmission(request, decision)).byteLength > MAX_CONSENT_REQUEST_BYTES) {
+      throw oauthError("invalid_request", `Consent request must not exceed ${MAX_CONSENT_REQUEST_BYTES} UTF-8 bytes`, 400);
+    }
+  }
+};
+
+const renderConsent = (client: OAuthClient, request: AuthorizationRequest): string => {
+  const hidden = consentHiddenFields(request)
+    .map(([name, value]) => `<input type="hidden" name="${name}" value="${escapeHtml(value)}">`)
+    .join("");
+  const permissions = request.scopes.map((scope) => `<li>${scope === "expenses:read" ? "Read expenses and budgets" : "Create and update expenses and budgets"}</li>`).join("");
+  const callbackUrl = new URL(request.redirectUri);
+  const callbackOrigin = callbackUrl.origin === "null" ? callbackUrl.protocol : callbackUrl.origin;
+  const actions = CONSENT_DECISIONS
+    .map((decision) => `<button name="decision" value="${decision}" type="submit">${decision === "allow" ? "Allow" : "Deny"}</button>`)
+    .join("");
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Authorize MCP client</title><style>
+*{box-sizing:border-box}body{margin:0;min-height:100vh;display:grid;place-items:center;padding:16px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:#111;background:#fff}.card{width:100%;max-width:560px;border:1px solid #232323;padding:28px}h1{font-size:20px;margin:0 0 20px}p,li,dt,dd{font-size:14px;line-height:1.5}.client{font-weight:700;overflow-wrap:anywhere}.warning{padding:10px;border:1px solid #8a5a00;background:#fff8e6}.details{display:grid;grid-template-columns:max-content 1fr;gap:6px 12px}.details dt{font-weight:700}.details dd{margin:0;overflow-wrap:anywhere}.resource{color:#666;overflow-wrap:anywhere}.actions{display:flex;gap:10px;margin-top:24px}button{flex:1;padding:10px;border:1px solid #232323;background:#fff;color:#111;font:inherit;cursor:pointer}button[value=allow]{background:#232323;color:#fff}@media(max-width:540px){body{padding:0}.card{border:0;min-height:100vh;padding:24px 16px}.details{grid-template-columns:1fr}}
+</style></head><body><main class="card"><h1>Authorize MCP client</h1><p><span class="client">${escapeHtml(client.clientName)}</span> is requesting access to your Expense Budget Tracker data.</p><p class="warning"><strong>Unverified client name:</strong> this name was provided by the client and is not endorsed by Expense Budget Tracker.</p><dl class="details"><dt>Client ID</dt><dd>${escapeHtml(client.clientId)}</dd><dt>Callback origin</dt><dd>${escapeHtml(callbackOrigin)}</dd><dt>Exact redirect URI</dt><dd>${escapeHtml(request.redirectUri)}</dd></dl><ul>${permissions}</ul><p class="resource">Resource: ${escapeHtml(request.resource)}</p><form method="post" action="/oauth/authorize">${hidden}<div class="actions">${actions}</div></form></main></body></html>`;
+};
+
+const readSingleParameter = (params: URLSearchParams, name: string): string | undefined => {
+  const values = params.getAll(name);
+  if (values.length > 1) {
+    throw oauthError("invalid_request", `OAuth parameter ${name} must appear exactly once`, 400);
+  }
+  const value = values[0];
+  if ((value?.length ?? 0) > 4096) throw oauthError("invalid_request", `OAuth parameter ${name} is too long`, 400);
+  return value;
+};
+
+const readRequiredParameter = (params: URLSearchParams, name: string): string => {
+  const value = readSingleParameter(params, name);
+  if (value === undefined || value === "") {
+    throw oauthError("invalid_request", `OAuth parameter ${name} must appear exactly once`, 400);
+  }
+  return value;
+};
+
+const loadAuthorizationRequest = async (
+  params: URLSearchParams,
+  resource: string,
+  getClient: typeof getOAuthClient,
+): Promise<Readonly<{ client: OAuthClient; request: AuthorizationRequest }>> => {
+  const clientId = readRequiredParameter(params, "client_id");
+  const client = await getClient(clientId);
+  if (client === null) throw oauthError("invalid_request", "Unknown OAuth client", 400);
+  return { client, request: parseAuthorizationRequest(params, client, resource) };
+};
+
+const appendAuthorizationResult = (
+  redirectUri: string,
+  values: Readonly<Record<string, string>>,
+): string => {
+  const pairs = Object.entries(values)
+    .filter(([, value]) => value !== "")
+    .map(([name, value]) => `${encodeURIComponent(name)}=${encodeURIComponent(value)}`);
+  if (pairs.length === 0) return redirectUri;
+  const separator = redirectUri.includes("?")
+    ? redirectUri.endsWith("?") || redirectUri.endsWith("&") ? "" : "&"
+    : "?";
+  return `${redirectUri}${separator}${pairs.join("&")}`;
+};
+
+const validatedAuthorizationErrorResponse = (
+  c: Context,
+  request: AuthorizationRequest,
+  oauthCode: string,
+  description: string,
+): Response => {
+  noStore(c);
+  return c.redirect(appendAuthorizationResult(request.redirectUri, {
+    error: oauthCode,
+    error_description: description,
+    state: request.state,
+  }), 302);
+};
+
+const authorizationErrorResponse = async (
+  c: Context,
+  params: URLSearchParams,
+  error: OAuthProtocolError,
+  getClient: typeof getOAuthClient,
+): Promise<Response> => {
+  noStore(c);
+  const clientId = params.getAll("client_id");
+  const redirectUri = params.getAll("redirect_uri");
+  if (clientId.length === 1 && redirectUri.length === 1) {
+    const client = await getClient(clientId[0] ?? "");
+    if (client?.redirectUris.includes(redirectUri[0] ?? "")) {
+      const stateValues = params.getAll("state");
+      const state = stateValues.length === 1 && (stateValues[0]?.length ?? 0) <= 2048
+        ? stateValues[0] ?? ""
+        : "";
+      return c.redirect(appendAuthorizationResult(redirectUri[0] ?? "", {
+        error: error.oauthCode,
+        error_description: error.message,
+        state,
+      }), 302);
+    }
+  }
+  return c.json({ error: error.oauthCode, error_description: error.message }, error.status);
+};
+
+const authorizationServerErrorResponse = (
+  c: Context,
+  request: AuthorizationRequest,
+  method: "GET" | "POST",
+  error: unknown,
+  writeLog: (event: OAuthAuthorizationServerErrorEvent) => void,
+): Response => {
+  writeLog({
+    domain: "auth",
+    action: "oauth_authorization_server_error",
+    method,
+    clientId: request.clientId,
+    errorType: getSafeErrorType(error),
+  });
+  return validatedAuthorizationErrorResponse(
+    c,
+    request,
+    "server_error",
+    "Authorization server could not complete the request",
+  );
+};
+
+const oauthEndpointServerErrorResponse = (
+  c: Context,
+  endpoint: "registration" | "token",
+  description: string,
+  error: unknown,
+  writeLog: (event: OAuthEndpointServerErrorEvent) => void,
+): Response => {
+  writeLog({
+    domain: "auth",
+    action: "oauth_endpoint_server_error",
+    endpoint,
+    errorType: getSafeErrorType(error),
+  });
+  noStore(c);
+  return c.json({ error: "server_error", error_description: description }, 500);
+};
+
+const buildLoginRedirect = (issuer: string, request: AuthorizationRequest): string => {
+  const authorizationUrl = new URL("/oauth/authorize", issuer);
+  for (const [name, value] of Object.entries({
+    response_type: request.responseType, client_id: request.clientId,
+    redirect_uri: request.redirectUri, scope: request.scope, resource: request.resource,
+    state: request.state, code_challenge: request.codeChallenge,
+    code_challenge_method: request.codeChallengeMethod,
+  })) authorizationUrl.searchParams.set(name, value);
+  const loginUrl = new URL("/login", issuer);
+  loginUrl.searchParams.set("redirect_uri", authorizationUrl.toString());
+  return loginUrl.toString();
+};
+
+const requireBrowserIdentity = async (
+  c: Context,
+  loginRedirect: string,
+  dependencies: OAuthRouteDependencies,
+): Promise<BrowserIdentity | Response> => {
+  const identity = await dependencies.resolveBrowserSession(c);
+  return identity === null ? c.redirect(loginRedirect, 302) : identity;
+};
+
+export const createOAuthApp = (dependencies: OAuthRouteDependencies): Hono => {
+const app = new Hono();
+
+app.get("/.well-known/oauth-authorization-server", (c) => {
+  const { issuer } = dependencies.getOAuthConfig();
+  c.header("Cache-Control", "public, max-age=3600");
+  return c.json({
+    issuer,
+    authorization_endpoint: `${issuer}/oauth/authorize`,
+    token_endpoint: `${issuer}/oauth/token`,
+    registration_endpoint: `${issuer}/oauth/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    token_endpoint_auth_methods_supported: ["none"],
+    code_challenge_methods_supported: ["S256"],
+    scopes_supported: ["expenses:read", "expenses:write"],
+  });
+});
+
+app.post("/oauth/register", async (c) => {
+  noStore(c);
+  if (!(c.req.header("content-type") ?? "").toLowerCase().startsWith("application/json")) {
+    return c.json({ error: "invalid_client_metadata", error_description: "Registration request must be JSON" }, 400);
+  }
+  let rawBody: string;
+  try {
+    rawBody = await readBoundedRequestBody(c.req.raw, MAX_DCR_REQUEST_BYTES);
+  } catch (error) {
+    if (isRequestBodyTooLargeError(error)) {
+      return c.json({ error: "invalid_client_metadata", error_description: `Registration request must not exceed ${MAX_DCR_REQUEST_BYTES} UTF-8 bytes` }, 400);
+    }
+    return c.json({ error: "invalid_client_metadata", error_description: "Registration request body could not be read" }, 400);
+  }
+  let body: unknown;
+  try { body = JSON.parse(rawBody) as unknown; } catch { return c.json({ error: "invalid_client_metadata", error_description: "Request body must be JSON" }, 400); }
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return c.json({ error: "invalid_client_metadata", error_description: "Request body must be a JSON object" }, 400);
+  const metadata = body as Readonly<Record<string, unknown>>;
+  const redirectUris = metadata["redirect_uris"];
+  if (!Array.isArray(redirectUris) || redirectUris.length < 1 || redirectUris.length > 10 || redirectUris.some((uri) => typeof uri !== "string" || !isValidClientRedirectUri(uri)) || new Set(redirectUris).size !== redirectUris.length) {
+    return c.json({ error: "invalid_redirect_uri", error_description: "Provide 1-10 unique HTTPS, loopback HTTP, or private-use redirect URIs without fragments" }, 400);
+  }
+  const clientNameValue = metadata["client_name"];
+  const clientName = clientNameValue === undefined ? "MCP client" : clientNameValue;
+  const authMethod = metadata["token_endpoint_auth_method"];
+  const grants = metadata["grant_types"];
+  const responses = metadata["response_types"];
+  const applicationType = metadata["application_type"];
+  if (
+    typeof clientName !== "string" || clientName.trim() === "" || clientName.length > 200
+    || (authMethod !== undefined && authMethod !== "none")
+    || metadata["client_secret"] !== undefined
+    || (grants !== undefined && (!Array.isArray(grants) || !grants.includes("authorization_code") || new Set(grants).size !== grants.length || grants.some((grant) => grant !== "authorization_code" && grant !== "refresh_token")))
+    || (responses !== undefined && (!Array.isArray(responses) || responses.length !== 1 || responses[0] !== "code"))
+    || (applicationType !== undefined && applicationType !== "native" && applicationType !== "web")
+  ) return c.json({ error: "invalid_client_metadata", error_description: "Only public authorization-code clients with optional refresh tokens are supported" }, 400);
+  const registeredApplicationType = applicationType === "native" || applicationType === "web"
+    ? applicationType
+    : undefined;
+  let client: OAuthClient;
+  try {
+    client = await dependencies.registerOAuthClient(clientName.trim(), redirectUris as ReadonlyArray<string>);
+  } catch (error) {
+    return oauthEndpointServerErrorResponse(
+      c,
+      "registration",
+      "Client registration could not be completed",
+      error,
+      dependencies.log,
+    );
+  }
+  return c.json({ client_id: client.clientId, client_name: client.clientName, redirect_uris: client.redirectUris, token_endpoint_auth_method: "none", grant_types: ["authorization_code", "refresh_token"], response_types: ["code"], ...(registeredApplicationType === undefined ? {} : { application_type: registeredApplicationType }) }, 201);
+});
+
+app.get("/oauth/authorize", async (c) => {
+  noStore(c);
+  const config = dependencies.getOAuthConfig();
+  const params = new URL(c.req.url).searchParams;
+  let authorizationRequest: AuthorizationRequest | null = null;
+  try {
+    const { client, request } = await loadAuthorizationRequest(params, config.resource, dependencies.getOAuthClient);
+    authorizationRequest = request;
+    validateConsentSubmissionSize(request);
+    const identity = await requireBrowserIdentity(c, buildLoginRedirect(config.issuer, request), dependencies);
+    if (identity instanceof Response) return identity;
+    c.header("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'");
+    c.header("X-Frame-Options", "DENY");
+    c.header("Referrer-Policy", "no-referrer");
+    return c.html(renderConsent(client, request));
+  } catch (error) {
+    if (isOAuthProtocolError(error)) {
+      return authorizationRequest === null
+        ? authorizationErrorResponse(c, params, error, dependencies.getOAuthClient)
+        : validatedAuthorizationErrorResponse(c, authorizationRequest, error.oauthCode, error.message);
+    }
+    if (authorizationRequest === null) throw error;
+    return authorizationServerErrorResponse(c, authorizationRequest, "GET", error, dependencies.log);
+  }
+});
+
+app.post("/oauth/authorize", async (c) => {
+  noStore(c);
+  const config = dependencies.getOAuthConfig();
+  if (c.req.header("origin") !== config.issuer || ![undefined, "same-origin"].includes(c.req.header("sec-fetch-site"))) return c.text("Cross-origin consent submission rejected", 403);
+  if (!(c.req.header("content-type") ?? "").toLowerCase().startsWith("application/x-www-form-urlencoded")) return c.text("Consent form must be URL encoded", 415);
+  let params = new URLSearchParams();
+  let authorizationRequest: AuthorizationRequest | null = null;
+  try {
+    let rawBody: string;
+    try {
+      rawBody = await readBoundedRequestBody(c.req.raw, MAX_CONSENT_REQUEST_BYTES);
+    } catch (error) {
+      if (isRequestBodyTooLargeError(error)) {
+        throw oauthError("invalid_request", `Consent request must not exceed ${MAX_CONSENT_REQUEST_BYTES} UTF-8 bytes`, 400);
+      }
+      throw error;
+    }
+    params = new URLSearchParams(rawBody);
+    const { request } = await loadAuthorizationRequest(params, config.resource, dependencies.getOAuthClient);
+    authorizationRequest = request;
+    const decision = readRequiredParameter(params, "decision");
+    const identity = await requireBrowserIdentity(c, buildLoginRedirect(config.issuer, request), dependencies);
+    if (identity instanceof Response) return identity;
+    if (decision === "deny") return c.redirect(appendAuthorizationResult(request.redirectUri, { error: "access_denied", state: request.state }), 302);
+    if (decision !== "allow") throw oauthError("invalid_request", "Consent decision must be allow or deny", 400);
+    const code = await dependencies.issueAuthorizationCode(request, identity.userId, identity.email);
+    return c.redirect(appendAuthorizationResult(request.redirectUri, { code, state: request.state }), 302);
+  } catch (error) {
+    if (isOAuthProtocolError(error)) {
+      return authorizationRequest === null
+        ? authorizationErrorResponse(c, params, error, dependencies.getOAuthClient)
+        : validatedAuthorizationErrorResponse(c, authorizationRequest, error.oauthCode, error.message);
+    }
+    if (authorizationRequest === null) throw error;
+    return authorizationServerErrorResponse(c, authorizationRequest, "POST", error, dependencies.log);
+  }
+});
+
+app.post("/oauth/token", async (c) => {
+  noStore(c);
+  try {
+    if (c.req.header("authorization") !== undefined) throw oauthError("invalid_client", "Client authentication is not supported", 401);
+    if (!(c.req.header("content-type") ?? "").toLowerCase().startsWith("application/x-www-form-urlencoded")) throw oauthError("invalid_request", "Token request must be URL encoded", 400);
+    let rawBody: string;
+    try {
+      rawBody = await readBoundedRequestBody(c.req.raw, MAX_TOKEN_REQUEST_BYTES);
+    } catch (error) {
+      if (isRequestBodyTooLargeError(error)) {
+        throw oauthError("invalid_request", `Token request must not exceed ${MAX_TOKEN_REQUEST_BYTES} UTF-8 bytes`, 400);
+      }
+      throw error;
+    }
+    const params = new URLSearchParams(rawBody);
+    const grantType = readRequiredParameter(params, "grant_type");
+    const clientId = readRequiredParameter(params, "client_id");
+    const resource = readRequiredParameter(params, "resource");
+    if (resource !== dependencies.getOAuthConfig().resource) throw oauthError("invalid_target", "resource does not match this MCP server", 400);
+    const result = grantType === "authorization_code"
+      ? await dependencies.exchangeAuthorizationCode(readRequiredParameter(params, "code"), clientId, readRequiredParameter(params, "redirect_uri"), resource, readRequiredParameter(params, "code_verifier"))
+      : grantType === "refresh_token"
+        ? await dependencies.exchangeRefreshToken(readRequiredParameter(params, "refresh_token"), clientId, resource, params.has("scope") ? normalizeScopes(readRequiredParameter(params, "scope")) : null)
+        : (() => { throw oauthError("unsupported_grant_type", "Only authorization_code and refresh_token grants are supported", 400); })();
+    return c.json({ access_token: result.accessToken, token_type: "Bearer", expires_in: result.expiresIn, refresh_token: result.refreshToken, scope: result.scope });
+  } catch (error) {
+    if (isOAuthProtocolError(error)) {
+      if (error.status === 401) c.header("WWW-Authenticate", "Basic realm=\"oauth-token\"");
+      return c.json({ error: error.oauthCode, error_description: error.message }, error.status);
+    }
+    return oauthEndpointServerErrorResponse(
+      c,
+      "token",
+      "Token request could not be completed",
+      error,
+      dependencies.log,
+    );
+  }
+});
+
+return app;
+};
+
+export default createOAuthApp(defaultDependencies);

--- a/apps/auth/src/server/app.test.ts
+++ b/apps/auth/src/server/app.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Hono } from "hono";
+import { createLoginPageApp } from "../routes/loginPage.js";
+import { createAuthApp } from "./app.js";
+import type { AuthUnhandledErrorEvent } from "./logger.js";
+
+test("root failures are structured and generic without logging request credentials", async (): Promise<void> => {
+  const authorizationCode = "ebt_ac_must-not-log";
+  const sessionCookie = "session=session-must-not-log";
+  const routes = new Hono();
+  routes.get("/.well-known/oauth-authorization-server", () => {
+    throw new Error(`Metadata failed near ${authorizationCode}`);
+  });
+  routes.get("/oauth/authorize", () => {
+    throw new RangeError(`Client lookup failed near ${authorizationCode}`);
+  });
+  const loginPage = createLoginPageApp({
+    resolveBrowserSession: async () => {
+      throw new TypeError(`Session failed near ${sessionCookie}`);
+    },
+  });
+  const events: AuthUnhandledErrorEvent[] = [];
+  const app = createAuthApp({
+    routes: [routes, loginPage],
+    log: (event) => { events.push(event); },
+  });
+
+  const previousRedirects = process.env.ALLOWED_REDIRECT_URIS;
+  process.env.ALLOWED_REDIRECT_URIS = "https://app.example.com";
+  try {
+    const metadata = await app.request(
+      `https://auth.example.com/.well-known/oauth-authorization-server?code=${authorizationCode}`,
+      { headers: { Cookie: sessionCookie } },
+    );
+    const login = await app.request(
+      `https://auth.example.com/login?redirect_uri=${encodeURIComponent(`https://app.example.com/?code=${authorizationCode}`)}`,
+      { headers: { Cookie: sessionCookie } },
+    );
+    const unvalidatedAuthorization = await app.request(
+      `https://auth.example.com/oauth/authorize?redirect_uri=${encodeURIComponent("https://attacker.example/callback")}&state=state-1&code=${authorizationCode}`,
+      { headers: { Cookie: sessionCookie } },
+    );
+
+    for (const response of [metadata, login, unvalidatedAuthorization]) {
+      assert.equal(response.status, 500);
+      assert.equal(response.headers.get("cache-control"), "no-store");
+      assert.equal(response.headers.get("pragma"), "no-cache");
+      assert.deepEqual(await response.json(), { error: "Internal server error" });
+    }
+    assert.equal(unvalidatedAuthorization.headers.get("location"), null);
+  } finally {
+    if (previousRedirects === undefined) delete process.env.ALLOWED_REDIRECT_URIS;
+    else process.env.ALLOWED_REDIRECT_URIS = previousRedirects;
+  }
+  assert.deepEqual(events, [
+    { domain: "auth", action: "unhandled_error", surface: "oauth", method: "GET", errorType: "error" },
+    { domain: "auth", action: "unhandled_error", surface: "login", method: "GET", errorType: "type_error" },
+    { domain: "auth", action: "unhandled_error", surface: "oauth", method: "GET", errorType: "range_error" },
+  ]);
+  const serializedEvents = JSON.stringify(events);
+  assert.equal(serializedEvents.includes(authorizationCode), false);
+  assert.equal(serializedEvents.includes(sessionCookie), false);
+});

--- a/apps/auth/src/server/app.ts
+++ b/apps/auth/src/server/app.ts
@@ -1,0 +1,62 @@
+import { Hono } from "hono";
+import health from "../routes/health.js";
+import sendCode from "../routes/sendCode.js";
+import verifyCode from "../routes/verifyCode.js";
+import agentSendCode from "../routes/agentSendCode.js";
+import agentVerifyCode from "../routes/agentVerifyCode.js";
+import loginPage from "../routes/loginPage.js";
+import robots from "../routes/robots.js";
+import oauth from "../routes/oauth.js";
+import { getSafeErrorType, log, type AuthUnhandledErrorEvent } from "./logger.js";
+
+export type AuthAppDependencies = Readonly<{
+  routes: ReadonlyArray<Hono>;
+  log: (event: AuthUnhandledErrorEvent) => void;
+}>;
+
+const getErrorSurface = (path: string): AuthUnhandledErrorEvent["surface"] => {
+  if (path === "/.well-known/oauth-authorization-server" || path.startsWith("/oauth/")) return "oauth";
+  if (path === "/login") return "login";
+  if (path.startsWith("/api/")) return "api";
+  return "other";
+};
+
+const getErrorMethod = (method: string): AuthUnhandledErrorEvent["method"] => {
+  if (method === "GET" || method === "POST" || method === "OPTIONS") return method;
+  return "OTHER";
+};
+
+export const createAuthApp = (dependencies: AuthAppDependencies): Hono => {
+  const app = new Hono();
+
+  app.onError((error, c) => {
+    dependencies.log({
+      domain: "auth",
+      action: "unhandled_error",
+      surface: getErrorSurface(c.req.path),
+      method: getErrorMethod(c.req.method),
+      errorType: getSafeErrorType(error),
+    });
+    c.header("Cache-Control", "no-store");
+    c.header("Pragma", "no-cache");
+    return c.json({ error: "Internal server error" }, 500);
+  });
+
+  // API endpoints are same-origin only; login-page JavaScript is their browser caller.
+  app.use("/api/*", async (c, next) => {
+    if (c.req.method === "OPTIONS") return new Response(null, { status: 204 });
+    const secFetchSite = c.req.header("sec-fetch-site");
+    if (secFetchSite !== undefined && secFetchSite !== "same-origin" && secFetchSite !== "none") {
+      return c.json({ error: "Cross-origin requests not allowed" }, 403);
+    }
+    await next();
+  });
+
+  for (const route of dependencies.routes) app.route("/", route);
+  return app;
+};
+
+export const createDefaultAuthApp = (): Hono => createAuthApp({
+  routes: [health, sendCode, verifyCode, agentSendCode, agentVerifyCode, loginPage, robots, oauth],
+  log,
+});

--- a/apps/auth/src/server/cognitoAuth.test.ts
+++ b/apps/auth/src/server/cognitoAuth.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isDefinitiveCognitoRefreshRejection,
+  refreshCognitoSessionWithDependencies,
+  type RefreshCognitoSessionDependencies,
+} from "./cognitoAuth.js";
+import type { CognitoRefreshRetryEvent } from "./logger.js";
+
+const refreshedAuthenticationResult: Readonly<Record<string, unknown>> = {
+  AuthenticationResult: {
+    IdToken: "fresh-id-token",
+    RefreshToken: "rotated-refresh-token",
+  },
+};
+
+const cognitoError = (cognitoType: string, status: number): Error => Object.assign(
+  new Error(`Cognito InitiateAuth failed with ${cognitoType} (HTTP ${status})`),
+  { cognitoType, cognitoStatus: status, cognitoTarget: "InitiateAuth" },
+);
+
+const withCognitoClientId = async (operation: () => Promise<void>): Promise<void> => {
+  const previous = process.env.COGNITO_CLIENT_ID;
+  process.env.COGNITO_CLIENT_ID = "test-client-id";
+  try {
+    await operation();
+  } finally {
+    if (previous === undefined) delete process.env.COGNITO_CLIENT_ID;
+    else process.env.COGNITO_CLIENT_ID = previous;
+  }
+};
+
+test("Cognito refresh retries a transient network failure and then succeeds", async (): Promise<void> => {
+  await withCognitoClientId(async () => {
+    let requests = 0;
+    const delays: Array<number> = [];
+    const events: Array<CognitoRefreshRetryEvent> = [];
+    const dependencies: RefreshCognitoSessionDependencies = {
+      request: async () => {
+        requests += 1;
+        if (requests === 1) throw new TypeError("fetch failed");
+        return refreshedAuthenticationResult;
+      },
+      delay: async (milliseconds) => { delays.push(milliseconds); },
+      logRetry: (event) => { events.push(event); },
+    };
+
+    const result = await refreshCognitoSessionWithDependencies("sensitive-refresh-token", dependencies);
+
+    assert.deepEqual(result, { idToken: "fresh-id-token", refreshToken: "rotated-refresh-token" });
+    assert.equal(requests, 2);
+    assert.deepEqual(delays, [100]);
+    assert.deepEqual(events, [{
+      domain: "auth",
+      action: "cognito_refresh_retry",
+      level: "warn",
+      attempt: 1,
+      retryInMs: 100,
+      cognitoType: null,
+      status: null,
+      error: "fetch failed",
+    }]);
+    assert.equal(JSON.stringify(events).includes("sensitive-refresh-token"), false);
+  });
+});
+
+test("Cognito refresh raises the final transient error after bounded retries", async (): Promise<void> => {
+  await withCognitoClientId(async () => {
+    let requests = 0;
+    const delays: Array<number> = [];
+    const events: Array<CognitoRefreshRetryEvent> = [];
+    const finalError = cognitoError("InternalErrorException", 503);
+    const dependencies: RefreshCognitoSessionDependencies = {
+      request: async () => {
+        requests += 1;
+        throw finalError;
+      },
+      delay: async (milliseconds) => { delays.push(milliseconds); },
+      logRetry: (event) => { events.push(event); },
+    };
+
+    await assert.rejects(
+      refreshCognitoSessionWithDependencies("sensitive-refresh-token", dependencies),
+      (error: unknown) => error === finalError,
+    );
+    assert.equal(requests, 3);
+    assert.deepEqual(delays, [100, 200]);
+    assert.deepEqual(events.map(({ attempt, retryInMs, cognitoType, status }) => ({
+      attempt, retryInMs, cognitoType, status,
+    })), [
+      { attempt: 1, retryInMs: 100, cognitoType: "InternalErrorException", status: 503 },
+      { attempt: 2, retryInMs: 200, cognitoType: "InternalErrorException", status: 503 },
+    ]);
+  });
+});
+
+test("Cognito refresh does not retry a definitive authentication rejection", async (): Promise<void> => {
+  await withCognitoClientId(async () => {
+    let requests = 0;
+    const delays: Array<number> = [];
+    const events: Array<CognitoRefreshRetryEvent> = [];
+    const rejection = cognitoError("NotAuthorizedException", 400);
+    const dependencies: RefreshCognitoSessionDependencies = {
+      request: async () => {
+        requests += 1;
+        throw rejection;
+      },
+      delay: async (milliseconds) => { delays.push(milliseconds); },
+      logRetry: (event) => { events.push(event); },
+    };
+
+    await assert.rejects(
+      refreshCognitoSessionWithDependencies("invalid-refresh-token", dependencies),
+      (error: unknown) => error === rejection,
+    );
+    assert.equal(isDefinitiveCognitoRefreshRejection(rejection), true);
+    assert.equal(isDefinitiveCognitoRefreshRejection(cognitoError("InternalErrorException", 503)), false);
+    assert.equal(requests, 1);
+    assert.deepEqual(delays, []);
+    assert.deepEqual(events, []);
+  });
+});

--- a/apps/auth/src/server/cognitoAuth.ts
+++ b/apps/auth/src/server/cognitoAuth.ts
@@ -4,15 +4,21 @@
  * Calls the Cognito IDP endpoint directly via fetch — no AWS SDK needed.
  * Uses USER_AUTH flow with EMAIL_OTP challenge (Essentials tier).
  *
- * Auth-service scope: only initiateEmailOtp and verifyEmailOtp.
- * JWT verification and token refresh stay in the web app.
+ * Auth-service scope: OTP sign-in plus browser-session refresh.
+ * JWT verification stays in the OAuth session module.
  */
 import { randomBytes } from "node:crypto";
-import { log, maskEmail } from "./logger.js";
+import { log, maskEmail, type CognitoRefreshRetryEvent } from "./logger.js";
 
 type CognitoErrorResponse = Readonly<{
-  __type?: string;
-  message?: string;
+  type: string;
+  message: string;
+}>;
+
+type CognitoRequestError = Error & Readonly<{
+  cognitoType: string;
+  cognitoStatus: number;
+  cognitoTarget: string;
 }>;
 
 type InitiateAuthResult = Readonly<{
@@ -24,6 +30,11 @@ export type TokenResult = Readonly<{
   accessToken: string;
   refreshToken: string;
   expiresIn: number;
+}>;
+
+export type SessionRefreshResult = Readonly<{
+  idToken: string;
+  refreshToken: string | undefined;
 }>;
 
 type AgentIdentity = Readonly<{
@@ -43,6 +54,17 @@ const getClientId = (): string => {
   return clientId;
 };
 
+const parseCognitoErrorResponse = (payload: unknown): CognitoErrorResponse => {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return { type: "", message: "No Cognito error message" };
+  }
+  const record = payload as Readonly<Record<string, unknown>>;
+  return {
+    type: typeof record["__type"] === "string" ? record["__type"] : "",
+    message: typeof record["message"] === "string" ? record["message"] : "No Cognito error message",
+  };
+};
+
 const cognitoFetch = async (
   target: string,
   body: Record<string, unknown>,
@@ -59,12 +81,20 @@ const cognitoFetch = async (
   });
 
   if (!response.ok) {
-    const error = await response.json() as CognitoErrorResponse;
-    const errorType = error.__type ?? "";
-    const errorMessage = error.message ?? `Cognito ${target} failed: ${response.status}`;
-    const err = new Error(errorMessage);
-    (err as Error & { cognitoType: string }).cognitoType = errorType;
-    throw err;
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch (cause) {
+      throw Object.assign(
+        new Error(`Cognito ${target} failed with HTTP ${response.status} and an invalid JSON error response`, { cause }),
+        { cognitoType: "", cognitoStatus: response.status, cognitoTarget: target },
+      ) as CognitoRequestError;
+    }
+    const error = parseCognitoErrorResponse(payload);
+    throw Object.assign(
+      new Error(`Cognito ${target} failed with ${error.type || "an unknown error"} (HTTP ${response.status}): ${error.message}`),
+      { cognitoType: error.type, cognitoStatus: response.status, cognitoTarget: target },
+    ) as CognitoRequestError;
   }
 
   return response.json() as Promise<Record<string, unknown>>;
@@ -148,6 +178,123 @@ export const verifyEmailOtp = async (
     expiresIn: authResult.ExpiresIn as number,
   };
 };
+
+export type RefreshCognitoSessionDependencies = Readonly<{
+  request: (target: string, body: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  delay: (milliseconds: number) => Promise<void>;
+  logRetry: (event: CognitoRefreshRetryEvent) => void;
+}>;
+
+const REFRESH_MAX_ATTEMPTS = 3;
+const REFRESH_RETRY_BASE_DELAY_MS = 100;
+const TRANSIENT_COGNITO_TYPES = new Set([
+  "InternalErrorException",
+  "InternalFailure",
+  "LimitExceededException",
+  "ServiceUnavailableException",
+  "ThrottlingException",
+  "TooManyRequestsException",
+]);
+const DEFINITIVE_REFRESH_REJECTION_TYPES = new Set([
+  "InvalidRefreshTokenException",
+  "NotAuthorizedException",
+  "PasswordResetRequiredException",
+  "RefreshTokenExpiredException",
+  "UserNotConfirmedException",
+  "UserNotFoundException",
+]);
+
+const getCognitoErrorContext = (
+  error: unknown,
+): Readonly<{ cognitoType: string | null; status: number | null }> => {
+  if (!(error instanceof Error)) return { cognitoType: null, status: null };
+  const context = error as Partial<CognitoRequestError>;
+  return {
+    cognitoType: typeof context.cognitoType === "string" && context.cognitoType !== ""
+      ? context.cognitoType
+      : null,
+    status: typeof context.cognitoStatus === "number" ? context.cognitoStatus : null,
+  };
+};
+
+const getUnqualifiedCognitoType = (cognitoType: string): string =>
+  cognitoType.split("#").at(-1)?.split(":").at(-1) ?? cognitoType;
+
+export const isDefinitiveCognitoRefreshRejection = (error: unknown): boolean => {
+  const { cognitoType } = getCognitoErrorContext(error);
+  return cognitoType !== null
+    && DEFINITIVE_REFRESH_REJECTION_TYPES.has(getUnqualifiedCognitoType(cognitoType));
+};
+
+const isTransientRefreshError = (error: unknown): boolean => {
+  if (error instanceof TypeError) return true;
+  const { cognitoType, status } = getCognitoErrorContext(error);
+  return status === 429
+    || (status !== null && status >= 500 && status <= 599)
+    || (cognitoType !== null && TRANSIENT_COGNITO_TYPES.has(getUnqualifiedCognitoType(cognitoType)));
+};
+
+const extractSessionRefreshResult = (result: Record<string, unknown>): SessionRefreshResult => {
+  const authResult = result.AuthenticationResult;
+  if (typeof authResult !== "object" || authResult === null || Array.isArray(authResult)) {
+    throw new Error("Cognito REFRESH_TOKEN_AUTH did not return AuthenticationResult");
+  }
+  const idToken = (authResult as Readonly<Record<string, unknown>>)["IdToken"];
+  const rotatedRefreshToken = (authResult as Readonly<Record<string, unknown>>)["RefreshToken"];
+  if (typeof idToken !== "string" || idToken === "") {
+    throw new Error("Cognito REFRESH_TOKEN_AUTH did not return an ID token");
+  }
+  if (rotatedRefreshToken !== undefined && typeof rotatedRefreshToken !== "string") {
+    throw new Error("Cognito REFRESH_TOKEN_AUTH returned an invalid refresh token");
+  }
+  return {
+    idToken,
+    refreshToken: rotatedRefreshToken === "" ? undefined : rotatedRefreshToken,
+  };
+};
+
+export const refreshCognitoSessionWithDependencies = async (
+  refreshToken: string,
+  dependencies: RefreshCognitoSessionDependencies,
+): Promise<SessionRefreshResult> => {
+  for (let attempt = 1; attempt <= REFRESH_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const result = await dependencies.request("InitiateAuth", {
+        AuthFlow: "REFRESH_TOKEN_AUTH",
+        ClientId: getClientId(),
+        AuthParameters: { REFRESH_TOKEN: refreshToken },
+      });
+      return extractSessionRefreshResult(result);
+    } catch (error) {
+      if (!isTransientRefreshError(error) || attempt === REFRESH_MAX_ATTEMPTS) throw error;
+      const retryInMs = REFRESH_RETRY_BASE_DELAY_MS * (2 ** (attempt - 1));
+      const context = getCognitoErrorContext(error);
+      dependencies.logRetry({
+        domain: "auth",
+        action: "cognito_refresh_retry",
+        level: "warn",
+        attempt,
+        retryInMs,
+        cognitoType: context.cognitoType,
+        status: context.status,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await dependencies.delay(retryInMs);
+    }
+  }
+  throw new Error("Cognito refresh retry loop ended without a result");
+};
+
+const refreshDependencies: RefreshCognitoSessionDependencies = {
+  request: cognitoFetch,
+  delay: async (milliseconds) => new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  }),
+  logRetry: log,
+};
+
+export const refreshCognitoSession = (refreshToken: string): Promise<SessionRefreshResult> =>
+  refreshCognitoSessionWithDependencies(refreshToken, refreshDependencies);
 
 /**
  * Read user identity from a Cognito IdToken received directly from Cognito.

--- a/apps/auth/src/server/config.test.ts
+++ b/apps/auth/src/server/config.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { validateAuthEnvironment } from "./config.js";
+
+const AUTH_ENV_KEYS = [
+  "COGNITO_CLIENT_ID",
+  "COGNITO_USER_POOL_ID",
+  "COGNITO_REGION",
+  "SESSION_ENCRYPTION_KEY",
+  "ALLOWED_REDIRECT_URIS",
+  "COOKIE_DOMAIN",
+  "OAUTH_ISSUER",
+  "OAUTH_RESOURCE",
+  "AUTH_DATABASE_URL",
+  "NODE_ENV",
+] as const;
+
+const withAuthEnvironment = (
+  nodeEnvironment: string,
+  issuer: string,
+  resource: string,
+  operation: () => void,
+): void => {
+  const previous = new Map<string, string | undefined>(
+    AUTH_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+  Object.assign(process.env, {
+    COGNITO_CLIENT_ID: "client-id",
+    COGNITO_USER_POOL_ID: "eu-west-1_pool",
+    COGNITO_REGION: "eu-west-1",
+    SESSION_ENCRYPTION_KEY: "test-key",
+    ALLOWED_REDIRECT_URIS: "https://app.example.com",
+    COOKIE_DOMAIN: ".example.com",
+    OAUTH_ISSUER: issuer,
+    OAUTH_RESOURCE: resource,
+    AUTH_DATABASE_URL: "postgres://auth@example.invalid/auth",
+    NODE_ENV: nodeEnvironment,
+  });
+  try {
+    operation();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+};
+
+test("auth startup validates the complete OAuth issuer/resource pair", (): void => {
+  withAuthEnvironment(
+    "production",
+    "https://auth.example.com",
+    "https://mcp.example.com/mcp",
+    () => assert.doesNotThrow(validateAuthEnvironment),
+  );
+  withAuthEnvironment(
+    "development",
+    "https://auth.example.com",
+    "https://mcp.other.example/mcp",
+    () => assert.throws(validateAuthEnvironment, /misconfigured/u),
+  );
+});

--- a/apps/auth/src/server/config.ts
+++ b/apps/auth/src/server/config.ts
@@ -1,0 +1,25 @@
+import { getOAuthConfig } from "./oauth/core.js";
+
+export const validateAuthEnvironment = (): void => {
+  const errors: Array<string> = [];
+  if (!process.env.COGNITO_CLIENT_ID) errors.push("COGNITO_CLIENT_ID");
+  if (!process.env.COGNITO_USER_POOL_ID) errors.push("COGNITO_USER_POOL_ID");
+  if (!process.env.COGNITO_REGION) errors.push("COGNITO_REGION");
+  if (!process.env.SESSION_ENCRYPTION_KEY) errors.push("SESSION_ENCRYPTION_KEY");
+  if (!process.env.ALLOWED_REDIRECT_URIS) errors.push("ALLOWED_REDIRECT_URIS");
+  if (!process.env.COOKIE_DOMAIN) errors.push("COOKIE_DOMAIN");
+  if (!process.env.OAUTH_ISSUER) errors.push("OAUTH_ISSUER");
+  if (!process.env.OAUTH_RESOURCE) errors.push("OAUTH_RESOURCE");
+  if (!(process.env.AUTH_DATABASE_URL ?? "") && !(process.env.DB_HOST ?? "")) {
+    errors.push("AUTH_DATABASE_URL or DB_HOST");
+  }
+  if ((process.env.AUTH_DATABASE_URL ?? "") === "") {
+    if (!process.env.DB_NAME) errors.push("DB_NAME");
+    if (!process.env.DB_USER) errors.push("DB_USER");
+    if (!process.env.DB_PASSWORD) errors.push("DB_PASSWORD");
+  }
+  if (errors.length > 0) {
+    throw new Error(`Auth service missing required env vars: ${errors.join(", ")}`);
+  }
+  getOAuthConfig();
+};

--- a/apps/auth/src/server/db.ts
+++ b/apps/auth/src/server/db.ts
@@ -39,9 +39,15 @@ const getPool = (): pg.Pool => {
   return pool;
 };
 
-type QueryFn = (text: string, params: ReadonlyArray<unknown>) => Promise<pg.QueryResult>;
+export type QueryFn = (
+  text: string,
+  params: ReadonlyArray<unknown>,
+) => Promise<pg.QueryResult<pg.QueryResultRow>>;
 
-export const query = (text: string, params: ReadonlyArray<unknown>): Promise<pg.QueryResult> =>
+export const query = (
+  text: string,
+  params: ReadonlyArray<unknown>,
+): Promise<pg.QueryResult<pg.QueryResultRow>> =>
   getPool().query(text, params as Array<unknown>);
 
 export const withTransaction = async <T>(

--- a/apps/auth/src/server/logger.ts
+++ b/apps/auth/src/server/logger.ts
@@ -3,6 +3,49 @@
  *
  * Auth-only event types. Chat/API/SQL events stay in the web app.
  */
+export type CognitoRefreshRetryEvent = Readonly<{
+  domain: "auth";
+  action: "cognito_refresh_retry";
+  level: "warn";
+  attempt: number;
+  retryInMs: number;
+  cognitoType: string | null;
+  status: number | null;
+  error: string;
+}>;
+
+export type SafeErrorType = "error" | "type_error" | "range_error" | "non_error";
+
+export const getSafeErrorType = (error: unknown): SafeErrorType => {
+  if (error instanceof TypeError) return "type_error";
+  if (error instanceof RangeError) return "range_error";
+  if (error instanceof Error) return "error";
+  return "non_error";
+};
+
+export type OAuthAuthorizationServerErrorEvent = Readonly<{
+  domain: "auth";
+  action: "oauth_authorization_server_error";
+  method: "GET" | "POST";
+  clientId: string;
+  errorType: SafeErrorType;
+}>;
+
+export type OAuthEndpointServerErrorEvent = Readonly<{
+  domain: "auth";
+  action: "oauth_endpoint_server_error";
+  endpoint: "registration" | "token";
+  errorType: SafeErrorType;
+}>;
+
+export type AuthUnhandledErrorEvent = Readonly<{
+  domain: "auth";
+  action: "unhandled_error";
+  surface: "oauth" | "login" | "api" | "other";
+  method: "GET" | "POST" | "OPTIONS" | "OTHER";
+  errorType: SafeErrorType;
+}>;
+
 type AuthEvent =
   | Readonly<{ domain: "auth"; action: "send_code"; maskedEmail: string }>
   | Readonly<{ domain: "auth"; action: "send_code_rate_limited"; maskedEmail: string; decision: "blocked_email_limit" | "blocked_ip_limit" }>
@@ -17,6 +60,10 @@ type AuthEvent =
   | Readonly<{ domain: "auth"; action: "verify_code_challenge_expired"; transport: "browser" | "agent"; maskedEmail: string }>
   | Readonly<{ domain: "auth"; action: "verify_code_error"; error: string }>
   | Readonly<{ domain: "auth"; action: "otp_sweep_error"; error: string }>
+  | CognitoRefreshRetryEvent
+  | OAuthAuthorizationServerErrorEvent
+  | OAuthEndpointServerErrorEvent
+  | AuthUnhandledErrorEvent
   | Readonly<{ domain: "auth"; action: "error"; error: string }>;
 
 type LogEvent = AuthEvent;

--- a/apps/auth/src/server/oauth/core.test.ts
+++ b/apps/auth/src/server/oauth/core.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import {
+  getOAuthConfig,
+  isValidClientRedirectUri,
+  parseAuthorizationRequest,
+  verifyCodeVerifier,
+  type OAuthClient,
+} from "./core.js";
+
+const withOAuthConfig = (
+  issuer: string,
+  resource: string,
+  operation: () => void,
+): void => {
+  const previousIssuer = process.env.OAUTH_ISSUER;
+  const previousResource = process.env.OAUTH_RESOURCE;
+  process.env.OAUTH_ISSUER = issuer;
+  process.env.OAUTH_RESOURCE = resource;
+  try {
+    operation();
+  } finally {
+    if (previousIssuer === undefined) delete process.env.OAUTH_ISSUER;
+    else process.env.OAUTH_ISSUER = previousIssuer;
+    if (previousResource === undefined) delete process.env.OAUTH_RESOURCE;
+    else process.env.OAUTH_RESOURCE = previousResource;
+  }
+};
+
+const client: OAuthClient = {
+  clientId: "ebt_cl_registered-client",
+  clientName: "Test client",
+  redirectUris: ["https://client.example/callback"],
+};
+
+const verifier = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+const challenge = createHash("sha256").update(verifier).digest("base64url");
+
+const authorizationParams = (): URLSearchParams => new URLSearchParams({
+  response_type: "code",
+  client_id: client.clientId,
+  redirect_uri: client.redirectUris[0] ?? "",
+  scope: "expenses:read expenses:write",
+  resource: "https://mcp.example.com/mcp",
+  state: "state-1",
+  code_challenge: challenge,
+  code_challenge_method: "S256",
+});
+
+test("OAuth config accepts a production issuer and resource on the same base domain", (): void => {
+  withOAuthConfig(
+    "https://auth.example.com",
+    "https://mcp.example.com/mcp",
+    () => assert.deepEqual(getOAuthConfig(), {
+      issuer: "https://auth.example.com",
+      resource: "https://mcp.example.com/mcp",
+    }),
+  );
+});
+
+test("OAuth config accepts loopback pairs only on the same hostname", (): void => {
+  const configurations: ReadonlyArray<Readonly<[string, string]>> = [
+    ["http://localhost:8081", "http://localhost:8082/mcp"],
+    ["http://127.10.20.30:8081", "http://127.10.20.30:8082/mcp"],
+    ["http://[::1]:8081", "http://[::1]:8082/mcp"],
+  ];
+  for (const [issuer, resource] of configurations) {
+    withOAuthConfig(issuer, resource, () => assert.deepEqual(getOAuthConfig(), { issuer, resource }));
+  }
+});
+
+test("OAuth config rejects different production base domains and loopback hosts", (): void => {
+  const configurations: ReadonlyArray<Readonly<[string, string]>> = [
+    ["https://auth.example.com", "https://mcp.other.example/mcp"],
+    ["http://127.10.20.30:8081", "http://127.0.0.1:8082/mcp"],
+    ["http://localhost:8081", "http://127.0.0.1:8082/mcp"],
+  ];
+  for (const [issuer, resource] of configurations) {
+    withOAuthConfig(issuer, resource, () => assert.throws(getOAuthConfig, /misconfigured/u));
+  }
+});
+
+test("OAuth config rejects malformed or mixed-class pairs", (): void => {
+  const configurations: ReadonlyArray<Readonly<[string, string]>> = [
+    ["http://auth.example.com", "http://mcp.example.com/mcp"],
+    ["https://auth.example.com", "http://localhost:8082/mcp"],
+    ["http://localhost:8081", "https://mcp.example.com/mcp"],
+    ["https://login.example.com", "https://mcp.example.com/mcp"],
+    ["https://auth.example.com:8443", "https://mcp.example.com/mcp"],
+    ["http://localhost:8081/path", "http://localhost:8082/mcp"],
+    ["http://localhost:8081", "http://localhost:8082/mcp?query=1"],
+    ["http://user@localhost:8081", "http://localhost:8082/mcp"],
+  ];
+  for (const [issuer, resource] of configurations) {
+    withOAuthConfig(issuer, resource, () => assert.throws(getOAuthConfig, /misconfigured/u));
+  }
+});
+
+test("OAuth config rejects bare query and fragment delimiters on resources", (): void => {
+  const configurations: ReadonlyArray<Readonly<[string, string]>> = [
+    ["https://auth.example.com", "https://mcp.example.com/mcp?"],
+    ["https://auth.example.com", "https://mcp.example.com/mcp#"],
+    ["http://localhost:8081", "http://localhost:8082/mcp?"],
+    ["http://localhost:8081", "http://localhost:8082/mcp#"],
+  ];
+  for (const [issuer, resource] of configurations) {
+    withOAuthConfig(issuer, resource, () => assert.throws(getOAuthConfig, /misconfigured/u));
+  }
+});
+
+test("DCR redirect validation accepts supported public-client callbacks", (): void => {
+  assert.equal(isValidClientRedirectUri("https://client.example/callback"), true);
+  assert.equal(isValidClientRedirectUri("HTTPS://CLIENT.EXAMPLE:443/callback"), true);
+  assert.equal(isValidClientRedirectUri("http://127.0.0.1:49152/callback"), true);
+  assert.equal(isValidClientRedirectUri("http://[::1]:49152/callback"), true);
+  assert.equal(isValidClientRedirectUri("http://localhost:49152/callback"), true);
+  assert.equal(isValidClientRedirectUri("com.example.client:/callback"), true);
+  assert.equal(isValidClientRedirectUri("expense-tracker://callback"), true);
+  assert.equal(isValidClientRedirectUri("https://client.example/callback%0Adata"), true);
+});
+
+test("DCR redirect validation rejects unsafe callbacks", (): void => {
+  assert.equal(isValidClientRedirectUri("http://client.example/callback"), false);
+  assert.equal(isValidClientRedirectUri("https://user:password@client.example/callback"), false);
+  assert.equal(isValidClientRedirectUri("https://client.example/callback#fragment"), false);
+  assert.equal(isValidClientRedirectUri("javascript:alert(1)"), false);
+  assert.equal(isValidClientRedirectUri("https://client.example/call back"), false);
+  assert.equal(isValidClientRedirectUri("https://client.example/call\tback"), false);
+  assert.equal(isValidClientRedirectUri("https://client.example/call\nback"), false);
+  assert.equal(isValidClientRedirectUri("https://client.example/call\rback"), false);
+  assert.equal(isValidClientRedirectUri("https://client.example/call\u0000back"), false);
+  assert.equal(isValidClientRedirectUri("https://client.example/call\u001fback"), false);
+  assert.equal(isValidClientRedirectUri("https://client.example/call\u007fback"), false);
+  assert.equal(isValidClientRedirectUri("https://client.example/callback%ZZ"), false);
+  assert.equal(isValidClientRedirectUri("https://client.example\\callback"), false);
+  assert.equal(isValidClientRedirectUri("https:client.example/callback"), false);
+  assert.equal(isValidClientRedirectUri("https:///client.example/callback"), false);
+});
+
+test("authorization request requires exact bindings and mandatory read scope", (): void => {
+  const parsed = parseAuthorizationRequest(authorizationParams(), client, "https://mcp.example.com/mcp");
+  assert.deepEqual(parsed.scopes, ["expenses:read", "expenses:write"]);
+
+  const wrongRedirect = authorizationParams();
+  wrongRedirect.set("redirect_uri", "https://client.example/other");
+  assert.throws(() => parseAuthorizationRequest(wrongRedirect, client, "https://mcp.example.com/mcp"), /not registered/u);
+
+  const missingRead = authorizationParams();
+  missingRead.set("scope", "expenses:write");
+  assert.throws(() => parseAuthorizationRequest(missingRead, client, "https://mcp.example.com/mcp"), /must include expenses:read/u);
+});
+
+test("authorization request rejects duplicate hidden values", (): void => {
+  const params = authorizationParams();
+  params.append("resource", "https://mcp.example.com/mcp");
+  assert.throws(() => parseAuthorizationRequest(params, client, "https://mcp.example.com/mcp"), /must appear exactly once/u);
+});
+
+test("PKCE verifier accepts only the verifier bound to the S256 challenge", (): void => {
+  assert.equal(verifyCodeVerifier(verifier, challenge), true);
+  assert.equal(verifyCodeVerifier(`${verifier}x`, challenge), false);
+  assert.equal(verifyCodeVerifier("too-short", challenge), false);
+});

--- a/apps/auth/src/server/oauth/core.ts
+++ b/apps/auth/src/server/oauth/core.ts
@@ -1,0 +1,232 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+
+export const OAUTH_SCOPES = ["expenses:read", "expenses:write"] as const;
+const CODE_CHALLENGE_RE = /^[A-Za-z0-9_-]{43}$/u;
+const CODE_VERIFIER_RE = /^[A-Za-z0-9._~-]{43,128}$/u;
+const RAW_REDIRECT_URI_RE = /^[A-Za-z][A-Za-z0-9+.-]*:[A-Za-z0-9._~:/?@!$&'()*+,;=%\[\]-]*$/u;
+const RAW_HTTPS_REDIRECT_URI_RE = /^https:\/\/[^/?]+(?:[/?].*)?$/iu;
+const RAW_HTTP_REDIRECT_URI_RE = /^http:\/\/[^/?]+(?:[/?].*)?$/iu;
+
+export type OAuthClient = Readonly<{
+  clientId: string;
+  clientName: string;
+  redirectUris: ReadonlyArray<string>;
+}>;
+
+export type AuthorizationRequest = Readonly<{
+  responseType: "code";
+  clientId: string;
+  redirectUri: string;
+  scope: string;
+  scopes: ReadonlyArray<string>;
+  resource: string;
+  state: string;
+  codeChallenge: string;
+  codeChallengeMethod: "S256";
+}>;
+
+export type OAuthProtocolError = Error & Readonly<{
+  oauthCode: string;
+  status: 400 | 401;
+}>;
+
+export const oauthError = (
+  oauthCode: string,
+  message: string,
+  status: 400 | 401,
+): OAuthProtocolError => Object.assign(new Error(message), { oauthCode, status });
+
+export const isOAuthProtocolError = (error: unknown): error is OAuthProtocolError =>
+  error instanceof Error
+  && typeof (error as Partial<OAuthProtocolError>).oauthCode === "string"
+  && ((error as Partial<OAuthProtocolError>).status === 400 || (error as Partial<OAuthProtocolError>).status === 401);
+
+const isLoopbackHostname = (hostname: string): boolean =>
+  hostname === "localhost"
+  || hostname === "[::1]"
+  || /^127(?:\.\d{1,3}){3}$/u.test(hostname);
+
+const getProductionIssuerBaseDomain = (value: string, url: URL): string | null => {
+  const prefix = "auth.";
+  if (
+    url.protocol !== "https:"
+    || url.origin !== value
+    || url.port !== ""
+    || !url.hostname.startsWith(prefix)
+    || url.hostname.length === prefix.length
+  ) {
+    return null;
+  }
+  return url.hostname.slice(prefix.length);
+};
+
+const isLoopbackIssuer = (value: string, url: URL): boolean =>
+  url.protocol === "http:" && url.origin === value && isLoopbackHostname(url.hostname);
+
+const getProductionResourceBaseDomain = (value: string, url: URL): string | null => {
+  const prefix = "mcp.";
+  if (
+    value !== `${url.origin}/mcp`
+    || url.protocol !== "https:"
+    || !url.hostname.startsWith(prefix)
+    || url.hostname.length === prefix.length
+    || url.port !== ""
+    || url.pathname !== "/mcp"
+    || url.search !== ""
+    || url.hash !== ""
+    || url.username !== ""
+    || url.password !== ""
+  ) {
+    return null;
+  }
+  return url.hostname.slice(prefix.length);
+};
+
+const isLoopbackResource = (value: string, url: URL): boolean =>
+  value === `${url.origin}/mcp`
+  && url.protocol === "http:"
+  && isLoopbackHostname(url.hostname)
+  && url.pathname === "/mcp"
+  && url.search === ""
+  && url.hash === ""
+  && url.username === ""
+  && url.password === "";
+
+export const getOAuthConfig = (): Readonly<{ issuer: string; resource: string }> => {
+  const issuer = process.env.OAUTH_ISSUER ?? "";
+  const resource = process.env.OAUTH_RESOURCE ?? "";
+  if (issuer === "" || resource === "") {
+    throw new Error("OAuth server is not configured: OAUTH_ISSUER and OAUTH_RESOURCE are required");
+  }
+  let issuerUrl: URL;
+  let resourceUrl: URL;
+  try {
+    issuerUrl = new URL(issuer);
+    resourceUrl = new URL(resource);
+  } catch {
+    throw new Error("OAuth server is misconfigured: OAUTH_ISSUER and OAUTH_RESOURCE must be absolute URLs");
+  }
+  const issuerBaseDomain = getProductionIssuerBaseDomain(issuer, issuerUrl);
+  const resourceBaseDomain = getProductionResourceBaseDomain(resource, resourceUrl);
+  const productionPair = issuerBaseDomain !== null
+    && resourceBaseDomain !== null
+    && issuerBaseDomain === resourceBaseDomain;
+  const loopbackPair = isLoopbackIssuer(issuer, issuerUrl)
+    && isLoopbackResource(resource, resourceUrl)
+    && issuerUrl.hostname === resourceUrl.hostname;
+  if (!productionPair && !loopbackPair) {
+    throw new Error("OAuth server is misconfigured: expected HTTPS auth.<domain> and mcp.<same-domain>/mcp URLs or HTTP URLs on the same loopback hostname");
+  }
+  return { issuer, resource };
+};
+
+export const isValidClientRedirectUri = (value: string): boolean => {
+  if (
+    value.length === 0
+    || value.length > 2048
+    || value.includes("#")
+    || /[\u0000-\u001F\u007F]/u.test(value)
+    || /%(?![0-9A-Fa-f]{2})/u.test(value)
+    || !RAW_REDIRECT_URI_RE.test(value)
+    || (/^https:/iu.test(value) && !RAW_HTTPS_REDIRECT_URI_RE.test(value))
+    || (/^http:/iu.test(value) && !RAW_HTTP_REDIRECT_URI_RE.test(value))
+  ) return false;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.hash !== "" || url.username !== "" || url.password !== "") return false;
+  if (url.protocol === "https:") return url.hostname !== "";
+  if (url.protocol === "http:") return isLoopbackHostname(url.hostname);
+  const scheme = url.protocol.slice(0, -1);
+  const reserved = ["about", "blob", "data", "file", "ftp", "javascript", "mailto", "tel", "urn"];
+  return /^[a-z][a-z0-9+.-]*$/u.test(scheme)
+    && !reserved.includes(scheme)
+    && (url.hostname !== "" || url.pathname.startsWith("/"));
+};
+
+export const normalizeScopes = (scope: string): ReadonlyArray<string> => {
+  const requested = scope.split(" ").filter((value) => value !== "");
+  const unique = new Set(requested);
+  if (
+    requested.length !== unique.size
+    || !unique.has("expenses:read")
+    || requested.some((value) => !(OAUTH_SCOPES as ReadonlyArray<string>).includes(value))
+  ) {
+    throw oauthError("invalid_scope", "Scope must include expenses:read and may include expenses:write", 400);
+  }
+  return OAUTH_SCOPES.filter((value) => unique.has(value));
+};
+
+export const narrowScopes = (
+  grantedScopes: ReadonlyArray<string>,
+  requestedScopes: ReadonlyArray<string> | null,
+): ReadonlyArray<string> => {
+  const granted = normalizeScopes(grantedScopes.join(" "));
+  if (requestedScopes === null) return granted;
+  const requested = normalizeScopes(requestedScopes.join(" "));
+  if (requested.some((scope) => !granted.includes(scope))) {
+    throw oauthError("invalid_scope", "Refresh scope cannot exceed the original grant", 400);
+  }
+  return requested;
+};
+
+const readSingleParameter = (params: URLSearchParams, name: string): string | undefined => {
+  const values = params.getAll(name);
+  if (values.length > 1) {
+    throw oauthError("invalid_request", `OAuth parameter ${name} must appear exactly once`, 400);
+  }
+  const value = values[0];
+  if ((value?.length ?? 0) > 2048) throw oauthError("invalid_request", `OAuth parameter ${name} is too long`, 400);
+  return value;
+};
+
+const readRequiredParameter = (params: URLSearchParams, name: string): string => {
+  const value = readSingleParameter(params, name);
+  if (value === undefined || value === "") {
+    throw oauthError("invalid_request", `OAuth parameter ${name} must appear exactly once`, 400);
+  }
+  return value;
+};
+
+const readOptionalParameter = (params: URLSearchParams, name: string): string =>
+  readSingleParameter(params, name) ?? "";
+
+export const parseAuthorizationRequest = (
+  params: URLSearchParams,
+  client: OAuthClient,
+  expectedResource: string,
+): AuthorizationRequest => {
+  const responseType = readRequiredParameter(params, "response_type");
+  const clientId = readRequiredParameter(params, "client_id");
+  const redirectUri = readRequiredParameter(params, "redirect_uri");
+  const scope = readRequiredParameter(params, "scope");
+  const resource = readRequiredParameter(params, "resource");
+  const state = readOptionalParameter(params, "state");
+  const codeChallenge = readRequiredParameter(params, "code_challenge");
+  const codeChallengeMethod = readRequiredParameter(params, "code_challenge_method");
+
+  if (responseType !== "code") throw oauthError("unsupported_response_type", "Only response_type=code is supported", 400);
+  if (clientId !== client.clientId) throw oauthError("invalid_request", "client_id does not match the registered client", 400);
+  if (!client.redirectUris.includes(redirectUri)) throw oauthError("invalid_request", "redirect_uri is not registered", 400);
+  if (resource !== expectedResource) throw oauthError("invalid_target", "resource does not match this MCP server", 400);
+  if (codeChallengeMethod !== "S256" || !CODE_CHALLENGE_RE.test(codeChallenge)) {
+    throw oauthError("invalid_request", "S256 PKCE with a valid code_challenge is required", 400);
+  }
+  const scopes = normalizeScopes(scope);
+  return { responseType: "code", clientId, redirectUri, scope: scopes.join(" "), scopes, resource, state, codeChallenge, codeChallengeMethod: "S256" };
+};
+
+export const verifyCodeVerifier = (verifier: string, challenge: string): boolean => {
+  if (!CODE_VERIFIER_RE.test(verifier) || !CODE_CHALLENGE_RE.test(challenge)) return false;
+  const actual = createHash("sha256").update(verifier).digest("base64url");
+  return timingSafeEqual(Buffer.from(actual), Buffer.from(challenge));
+};
+
+export const createOpaqueToken = (prefix: "cl" | "ac" | "at" | "rt"): string =>
+  `ebt_${prefix}_${randomBytes(32).toString("base64url")}`;
+
+export const hashOpaqueToken = (token: string): string =>
+  createHash("sha256").update(token).digest("hex");

--- a/apps/auth/src/server/oauth/session.test.ts
+++ b/apps/auth/src/server/oauth/session.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  JwkInvalidKtyError,
+  JwkInvalidUseError,
+  JwtExpiredError,
+  JwtParseError,
+} from "aws-jwt-verify/error";
+import { Hono } from "hono";
+import {
+  clearBrowserSessionCookies,
+  isExpiredBrowserSessionError,
+  isInvalidBrowserSessionError,
+  readBrowserIdentityClaims,
+  resolveBrowserSessionWithDependencies,
+  type BrowserIdentity,
+  type BrowserSessionDependencies,
+} from "./session.js";
+
+const identity: BrowserIdentity = { userId: "user-1", email: "user@example.com" };
+
+const createDependencies = (
+  overrides: Partial<BrowserSessionDependencies>,
+): BrowserSessionDependencies => ({
+  verifyBrowserSession: async () => identity,
+  refreshCognitoSession: async () => ({ idToken: "fresh-id-token", refreshToken: undefined }),
+  isDefinitiveCognitoRefreshRejection: () => false,
+  isExpiredBrowserSessionError,
+  isInvalidBrowserSessionError,
+  clearBrowserSessionCookies,
+  ...overrides,
+});
+
+const requestSession = (
+  cookie: string,
+  dependencies: BrowserSessionDependencies,
+): Promise<Response> => {
+  const app = new Hono();
+  app.onError((error) => { throw error; });
+  app.get("/", async (c) => c.json(await resolveBrowserSessionWithDependencies(c, dependencies)));
+  return app.request("https://auth.example.com/", { headers: { Cookie: cookie } });
+};
+
+test("Cognito expiry is distinct from malformed browser sessions", (): void => {
+  const expired = new JwtExpiredError("expired", 0);
+  assert.equal(isExpiredBrowserSessionError(expired), true);
+  assert.equal(isInvalidBrowserSessionError(expired), false);
+  assert.equal(isExpiredBrowserSessionError(new JwtParseError("malformed")), false);
+  assert.equal(isInvalidBrowserSessionError(new JwtParseError("malformed")), true);
+  assert.equal(isInvalidBrowserSessionError(new JwkInvalidUseError("invalid JWK use", "enc", "sig")), false);
+  assert.equal(isInvalidBrowserSessionError(new JwkInvalidKtyError("invalid JWK type", "EC", "RSA")), false);
+  assert.equal(isInvalidBrowserSessionError(new Error("JWKS unavailable")), false);
+});
+
+test("an initial-token JWK verifier failure propagates without clearing cookies", async (): Promise<void> => {
+  const jwkError = new JwkInvalidUseError("invalid JWK use", "enc", "sig");
+  let cookiesCleared = false;
+  await assert.rejects(
+    requestSession(
+      "session=existing-id-token; refresh=existing-refresh-token",
+      createDependencies({
+        verifyBrowserSession: async () => { throw jwkError; },
+        clearBrowserSessionCookies: () => { cookiesCleared = true; },
+      }),
+    ),
+    (error: unknown) => error === jwkError,
+  );
+  assert.equal(cookiesCleared, false);
+});
+
+test("an expired ID token refreshes and continues the browser session", async (): Promise<void> => {
+  const expired = new Error("expired");
+  const response = await requestSession(
+    "session=expired-id-token; refresh=existing-refresh-token",
+    createDependencies({
+      verifyBrowserSession: async (token) => {
+        if (token === "expired-id-token") throw expired;
+        assert.equal(token, "fresh-id-token");
+        return identity;
+      },
+      refreshCognitoSession: async (token) => {
+        assert.equal(token, "existing-refresh-token");
+        return { idToken: "fresh-id-token", refreshToken: "rotated-refresh-token" };
+      },
+      isExpiredBrowserSessionError: (error) => error === expired,
+    }),
+  );
+
+  assert.deepEqual(await response.json(), identity);
+  const cookies = response.headers.getSetCookie().join("\n");
+  assert.match(cookies, /session=fresh-id-token/u);
+  assert.match(cookies, /refresh=rotated-refresh-token/u);
+  assert.match(cookies, /logged_in=1/u);
+});
+
+test("an expired ID token without a refresh cookie clears the cookie family", async (): Promise<void> => {
+  const expired = new Error("expired");
+  let refreshCalled = false;
+  const response = await requestSession("session=expired-id-token", createDependencies({
+    verifyBrowserSession: async () => { throw expired; },
+    refreshCognitoSession: async () => {
+      refreshCalled = true;
+      return { idToken: "unused", refreshToken: undefined };
+    },
+    isExpiredBrowserSessionError: (error) => error === expired,
+  }));
+
+  assert.equal(await response.json(), null);
+  assert.equal(refreshCalled, false);
+  assert.match(response.headers.getSetCookie().join("\n"), /session=;[\s\S]*refresh=;[\s\S]*logged_in=;/u);
+});
+
+test("a definitive Cognito refresh rejection clears the cookie family", async (): Promise<void> => {
+  const expired = new Error("expired");
+  const rejected = new Error("refresh rejected");
+  const response = await requestSession(
+    "session=expired-id-token; refresh=invalid-refresh-token",
+    createDependencies({
+      verifyBrowserSession: async () => { throw expired; },
+      refreshCognitoSession: async () => { throw rejected; },
+      isDefinitiveCognitoRefreshRejection: (error) => error === rejected,
+      isExpiredBrowserSessionError: (error) => error === expired,
+    }),
+  );
+
+  assert.equal(await response.json(), null);
+  assert.match(response.headers.getSetCookie().join("\n"), /session=;[\s\S]*refresh=;[\s\S]*logged_in=;/u);
+});
+
+test("a transient Cognito refresh failure propagates without clearing cookies", async (): Promise<void> => {
+  const expired = new Error("expired");
+  const unavailable = new Error("Cognito refresh unavailable after retries");
+  let cookiesCleared = false;
+  await assert.rejects(
+    requestSession(
+      "session=expired-id-token; refresh=existing-refresh-token",
+      createDependencies({
+        verifyBrowserSession: async () => { throw expired; },
+        refreshCognitoSession: async () => { throw unavailable; },
+        isExpiredBrowserSessionError: (error) => error === expired,
+        clearBrowserSessionCookies: () => { cookiesCleared = true; },
+      }),
+    ),
+    (error: unknown) => error === unavailable,
+  );
+  assert.equal(cookiesCleared, false);
+});
+
+test("a refreshed ID token that fails verification clears the cookie family", async (): Promise<void> => {
+  const expired = new Error("expired");
+  const invalid = new Error("refreshed token rejected");
+  const response = await requestSession(
+    "session=expired-id-token; refresh=existing-refresh-token",
+    createDependencies({
+      verifyBrowserSession: async (token) => {
+        if (token === "expired-id-token") throw expired;
+        throw invalid;
+      },
+      isExpiredBrowserSessionError: (error) => error === expired,
+      isInvalidBrowserSessionError: (error) => error === invalid,
+    }),
+  );
+
+  assert.equal(await response.json(), null);
+  assert.match(response.headers.getSetCookie().join("\n"), /session=;[\s\S]*refresh=;[\s\S]*logged_in=;/u);
+});
+
+test("a refreshed-token JWK verifier failure propagates without clearing cookies", async (): Promise<void> => {
+  const expired = new Error("expired");
+  const jwkError = new JwkInvalidKtyError("invalid JWK type", "EC", "RSA");
+  let cookiesCleared = false;
+  await assert.rejects(
+    requestSession(
+      "session=expired-id-token; refresh=existing-refresh-token",
+      createDependencies({
+        verifyBrowserSession: async (token) => {
+          if (token === "expired-id-token") throw expired;
+          throw jwkError;
+        },
+        isExpiredBrowserSessionError: (error) => error === expired,
+        clearBrowserSessionCookies: () => { cookiesCleared = true; },
+      }),
+    ),
+    (error: unknown) => error === jwkError,
+  );
+  assert.equal(cookiesCleared, false);
+});
+
+test("an empty initial subject claim clears the browser cookie family", async (): Promise<void> => {
+  const response = await requestSession(
+    "session=empty-subject-id-token; refresh=existing-refresh-token",
+    createDependencies({
+      verifyBrowserSession: async () => readBrowserIdentityClaims({
+        sub: "",
+        email: "user@example.com",
+        email_verified: true,
+      }),
+    }),
+  );
+
+  assert.equal(await response.json(), null);
+  assert.match(response.headers.getSetCookie().join("\n"), /session=;[\s\S]*refresh=;[\s\S]*logged_in=;/u);
+});
+
+test("an empty refreshed subject claim clears the browser cookie family", async (): Promise<void> => {
+  const expired = new Error("expired");
+  const response = await requestSession(
+    "session=expired-id-token; refresh=existing-refresh-token",
+    createDependencies({
+      verifyBrowserSession: async (token) => {
+        if (token === "expired-id-token") throw expired;
+        return readBrowserIdentityClaims({
+          sub: "",
+          email: "user@example.com",
+          email_verified: true,
+        });
+      },
+      isExpiredBrowserSessionError: (error) => error === expired,
+    }),
+  );
+
+  assert.equal(await response.json(), null);
+  assert.match(response.headers.getSetCookie().join("\n"), /session=;[\s\S]*refresh=;[\s\S]*logged_in=;/u);
+});
+
+test("a malformed non-expired ID token clears cookies without attempting refresh", async (): Promise<void> => {
+  const invalid = new Error("invalid");
+  let refreshCalled = false;
+  const response = await requestSession(
+    "session=malformed-id-token; refresh=existing-refresh-token",
+    createDependencies({
+      verifyBrowserSession: async () => { throw invalid; },
+      refreshCognitoSession: async () => {
+        refreshCalled = true;
+        return { idToken: "unused", refreshToken: undefined };
+      },
+      isInvalidBrowserSessionError: (error) => error === invalid,
+    }),
+  );
+
+  assert.equal(await response.json(), null);
+  assert.equal(refreshCalled, false);
+  assert.match(response.headers.getSetCookie().join("\n"), /session=;[\s\S]*refresh=;[\s\S]*logged_in=;/u);
+});

--- a/apps/auth/src/server/oauth/session.ts
+++ b/apps/auth/src/server/oauth/session.ts
@@ -1,0 +1,163 @@
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+import {
+  JwtExpiredError,
+  JwtInvalidClaimError,
+  JwtInvalidSignatureError,
+  JwtInvalidSignatureAlgorithmError,
+  JwtParseError,
+  JwtWithoutValidKidError,
+  KidNotFoundInJwksError,
+} from "aws-jwt-verify/error";
+import type { Context } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import {
+  isDefinitiveCognitoRefreshRejection,
+  refreshCognitoSession,
+  type SessionRefreshResult,
+} from "../cognitoAuth.js";
+
+export type BrowserIdentity = Readonly<{ userId: string; email: string }>;
+
+let verifier: ReturnType<typeof CognitoJwtVerifier.create> | undefined;
+
+const getVerifier = (): ReturnType<typeof CognitoJwtVerifier.create> => {
+  if (verifier !== undefined) return verifier;
+  const userPoolId = process.env.COGNITO_USER_POOL_ID ?? "";
+  const clientId = process.env.COGNITO_CLIENT_ID ?? "";
+  if (userPoolId === "" || clientId === "") {
+    throw new Error("Browser session verification requires COGNITO_USER_POOL_ID and COGNITO_CLIENT_ID");
+  }
+  verifier = CognitoJwtVerifier.create({ userPoolId, tokenUse: "id", clientId });
+  return verifier;
+};
+
+type InvalidSessionClaimsError = Error & Readonly<{ invalidSessionClaims: true }>;
+
+export const readBrowserIdentityClaims = (payload: unknown): BrowserIdentity => {
+  const claims = typeof payload === "object" && payload !== null && !Array.isArray(payload)
+    ? payload as Readonly<Record<string, unknown>>
+    : {};
+  const userId = claims["sub"];
+  const email = claims["email"];
+  if (
+    typeof userId !== "string"
+    || userId === ""
+    || typeof email !== "string"
+    || email === ""
+    || claims["email_verified"] !== true
+  ) {
+    throw Object.assign(new Error("Cognito session is missing verified identity claims"), {
+      invalidSessionClaims: true,
+    }) as InvalidSessionClaimsError;
+  }
+  return { userId, email };
+};
+
+export const verifyBrowserSession = async (token: string): Promise<BrowserIdentity> =>
+  readBrowserIdentityClaims(await getVerifier().verify(token));
+
+export const isExpiredBrowserSessionError = (error: unknown): boolean => error instanceof JwtExpiredError;
+
+export const isInvalidBrowserSessionError = (error: unknown): boolean => {
+  if (isExpiredBrowserSessionError(error)) return false;
+  return error instanceof JwtParseError
+  || error instanceof JwtInvalidSignatureError
+  || error instanceof JwtInvalidSignatureAlgorithmError
+  || error instanceof JwtInvalidClaimError
+  || error instanceof JwtWithoutValidKidError
+  || error instanceof KidNotFoundInJwksError
+  || (error instanceof Error && (error as Partial<InvalidSessionClaimsError>).invalidSessionClaims === true);
+};
+
+export const clearBrowserSessionCookies = (c: Context): void => {
+  const configuredDomain = process.env.COOKIE_DOMAIN ?? "";
+  const domain = configuredDomain === "" ? undefined : configuredDomain;
+  for (const name of ["session", "refresh", "logged_in"] as const) {
+    deleteCookie(c, name, { path: "/", secure: true, domain });
+  }
+};
+
+export type BrowserSessionDependencies = Readonly<{
+  verifyBrowserSession: typeof verifyBrowserSession;
+  refreshCognitoSession: typeof refreshCognitoSession;
+  isDefinitiveCognitoRefreshRejection: typeof isDefinitiveCognitoRefreshRejection;
+  isExpiredBrowserSessionError: typeof isExpiredBrowserSessionError;
+  isInvalidBrowserSessionError: typeof isInvalidBrowserSessionError;
+  clearBrowserSessionCookies: typeof clearBrowserSessionCookies;
+}>;
+
+const setRefreshedBrowserSessionCookies = (
+  c: Context,
+  tokens: SessionRefreshResult,
+): void => {
+  const configuredDomain = process.env.COOKIE_DOMAIN ?? "";
+  const domain = configuredDomain === "" ? undefined : configuredDomain;
+  const protectedCookie = {
+    path: "/",
+    maxAge: 3024000,
+    httpOnly: true,
+    secure: true,
+    sameSite: "Lax" as const,
+    domain,
+  };
+  setCookie(c, "session", tokens.idToken, protectedCookie);
+  if (tokens.refreshToken !== undefined) setCookie(c, "refresh", tokens.refreshToken, protectedCookie);
+  setCookie(c, "logged_in", "1", { ...protectedCookie, httpOnly: false });
+};
+
+export const resolveBrowserSessionWithDependencies = async (
+  c: Context,
+  dependencies: BrowserSessionDependencies,
+): Promise<BrowserIdentity | null> => {
+  const sessionToken = getCookie(c, "session") ?? "";
+  if (sessionToken === "") return null;
+  try {
+    return await dependencies.verifyBrowserSession(sessionToken);
+  } catch (error) {
+    if (!dependencies.isExpiredBrowserSessionError(error)) {
+      if (!dependencies.isInvalidBrowserSessionError(error)) throw error;
+      dependencies.clearBrowserSessionCookies(c);
+      return null;
+    }
+  }
+
+  const refreshToken = getCookie(c, "refresh") ?? "";
+  if (refreshToken === "") {
+    dependencies.clearBrowserSessionCookies(c);
+    return null;
+  }
+  let refreshedTokens: SessionRefreshResult;
+  try {
+    refreshedTokens = await dependencies.refreshCognitoSession(refreshToken);
+  } catch (error) {
+    if (!dependencies.isDefinitiveCognitoRefreshRejection(error)) throw error;
+    dependencies.clearBrowserSessionCookies(c);
+    return null;
+  }
+  try {
+    const identity = await dependencies.verifyBrowserSession(refreshedTokens.idToken);
+    setRefreshedBrowserSessionCookies(c, refreshedTokens);
+    return identity;
+  } catch (error) {
+    if (
+      !dependencies.isExpiredBrowserSessionError(error)
+      && !dependencies.isInvalidBrowserSessionError(error)
+    ) {
+      throw error;
+    }
+    dependencies.clearBrowserSessionCookies(c);
+    return null;
+  }
+};
+
+const defaultDependencies: BrowserSessionDependencies = {
+  verifyBrowserSession,
+  refreshCognitoSession,
+  isDefinitiveCognitoRefreshRejection,
+  isExpiredBrowserSessionError,
+  isInvalidBrowserSessionError,
+  clearBrowserSessionCookies,
+};
+
+export const resolveBrowserSession = (c: Context): Promise<BrowserIdentity | null> =>
+  resolveBrowserSessionWithDependencies(c, defaultDependencies);

--- a/apps/auth/src/server/oauth/store.test.ts
+++ b/apps/auth/src/server/oauth/store.test.ts
@@ -1,0 +1,640 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import type { QueryResult, QueryResultRow } from "pg";
+import type { QueryFn } from "../db.js";
+import {
+  exchangeAuthorizationCodeWithDependencies,
+  exchangeRefreshTokenWithDependencies,
+  issueAuthorizationCodeWithDependencies,
+  registerOAuthClientWithDependencies,
+  type OAuthStoreDependencies,
+} from "./store.js";
+import type { AuthorizationRequest } from "./core.js";
+
+type QueryCall = Readonly<{ text: string; params: ReadonlyArray<unknown> }>;
+
+const result = (rows: Array<QueryResultRow>): QueryResult<QueryResultRow> => ({
+  command: "",
+  rowCount: rows.length,
+  oid: 0,
+  rows,
+  fields: [],
+});
+
+const createDependencies = (
+  queryFn: QueryFn,
+  tokens: Readonly<Record<"cl" | "ac" | "at" | "rt", ReadonlyArray<string>>>,
+): OAuthStoreDependencies => {
+  const offsets: Record<"cl" | "ac" | "at" | "rt", number> = { cl: 0, ac: 0, at: 0, rt: 0 };
+  return {
+    query: queryFn,
+    withTransaction: async <T>(callback: (transactionQuery: QueryFn) => Promise<T>): Promise<T> => callback(queryFn),
+    createOpaqueToken: (prefix) => {
+      const token = tokens[prefix][offsets[prefix]];
+      if (token === undefined) throw new Error(`Missing test token for ${prefix}`);
+      offsets[prefix] += 1;
+      return token;
+    },
+  };
+};
+
+const hash = (value: string): string => createHash("sha256").update(value).digest("hex");
+const emptyTokens = (): Readonly<Record<"cl" | "ac" | "at" | "rt", ReadonlyArray<string>>> => ({
+  cl: [], ac: [], at: [], rt: [],
+});
+
+const verifier = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+const challenge = createHash("sha256").update(verifier).digest("base64url");
+const authorizationRequest: AuthorizationRequest = {
+  responseType: "code",
+  clientId: "client-1",
+  redirectUri: "https://client.example/callback",
+  scope: "expenses:read expenses:write",
+  scopes: ["expenses:read", "expenses:write"],
+  resource: "https://mcp.example.com/mcp",
+  state: "state-1",
+  codeChallenge: challenge,
+  codeChallengeMethod: "S256",
+};
+
+test("DCR and authorization-code issuance persist identifiers but only code hashes", async (): Promise<void> => {
+  const calls: Array<QueryCall> = [];
+  const queryFn: QueryFn = async (text, params) => {
+    calls.push({ text, params });
+    if (text.includes("RETURNING connection_id")) return result([{ connection_id: "connection-1" }]);
+    return result([]);
+  };
+  const tokens = { ...emptyTokens(), cl: ["ebt_cl_plain-client"], ac: ["ebt_ac_plain-code"] };
+  const dependencies = createDependencies(queryFn, tokens);
+
+  const client = await registerOAuthClientWithDependencies("Desktop", [authorizationRequest.redirectUri], dependencies);
+  const code = await issueAuthorizationCodeWithDependencies(authorizationRequest, "user-1", "user@example.com", dependencies);
+
+  assert.equal(client.clientId, "ebt_cl_plain-client");
+  assert.equal(code, "ebt_ac_plain-code");
+  const codeInsert = calls.find((call) => call.text.includes("oauth_authorization_codes"));
+  assert.ok(codeInsert);
+  assert.equal(codeInsert.params[0], hash(code));
+  assert.deepEqual(codeInsert.params[4], authorizationRequest.scopes);
+  assert.equal(calls.some((call) => call.params.includes(code)), false);
+});
+
+test("authorization-code replay revokes the family and its previously minted credentials", async (): Promise<void> => {
+  let used = false;
+  let connectionRevoked = false;
+  let storedRefreshTokenHash: string | null = null;
+  const accessTokenHashes = new Set<string>();
+  const tokenInserts: Array<QueryCall> = [];
+  const queryFn: QueryFn = async (text, params) => {
+    if (text.includes("FROM auth.oauth_authorization_codes")) {
+      assert.match(text, /FOR UPDATE OF oac, oc/u);
+      return result([{
+        connection_id: "connection-1",
+        redirect_uri: authorizationRequest.redirectUri,
+        code_challenge: challenge,
+        scopes: authorizationRequest.scopes,
+        used,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: connectionRevoked,
+      }]);
+    }
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      return params[0] === storedRefreshTokenHash ? result([{
+        connection_id: "connection-1",
+        scopes: authorizationRequest.scopes,
+        used: false,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: connectionRevoked,
+      }]) : result([]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_authorization_codes")) used = true;
+    if (text.startsWith("UPDATE auth.oauth_connections")) {
+      connectionRevoked = true;
+      return result([{ connection_id: "connection-1" }]);
+    }
+    if (text.startsWith("INSERT INTO auth.oauth_access_tokens")) {
+      tokenInserts.push({ text, params });
+      accessTokenHashes.add(params[0] as string);
+    }
+    if (text.startsWith("INSERT INTO auth.oauth_refresh_tokens")) {
+      tokenInserts.push({ text, params });
+      storedRefreshTokenHash = params[0] as string;
+    }
+    return result([]);
+  };
+  const accessToken = "ebt_at_plain-access";
+  const refreshToken = "ebt_rt_plain-refresh";
+  const dependencies = createDependencies(queryFn, { ...emptyTokens(), at: [accessToken], rt: [refreshToken] });
+
+  const issued = await exchangeAuthorizationCodeWithDependencies(
+    "ebt_ac_presented", authorizationRequest.clientId, authorizationRequest.redirectUri,
+    authorizationRequest.resource, verifier, dependencies,
+  );
+
+  assert.equal(issued.scope, authorizationRequest.scope);
+  assert.deepEqual(tokenInserts.map((call) => call.params[2]), [authorizationRequest.scopes, authorizationRequest.scopes]);
+  assert.deepEqual(tokenInserts.map((call) => call.params[0]), [hash(accessToken), hash(refreshToken)]);
+  assert.equal(tokenInserts.some((call) => call.params.includes(accessToken) || call.params.includes(refreshToken)), false);
+  await assert.rejects(
+    exchangeAuthorizationCodeWithDependencies(
+      "ebt_ac_presented", authorizationRequest.clientId, authorizationRequest.redirectUri,
+      authorizationRequest.resource, verifier, dependencies,
+    ),
+    /already used/u,
+  );
+  assert.equal(accessTokenHashes.has(hash(issued.accessToken)) && !connectionRevoked, false);
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      issued.refreshToken, authorizationRequest.clientId, authorizationRequest.resource,
+      null, dependencies,
+    ),
+    /invalid, expired, or already used/u,
+  );
+});
+
+test("unknown and unused misbound credentials do not revoke a connection", async (): Promise<void> => {
+  const knownCode = "ebt_ac_known-unused";
+  const knownRefreshToken = "ebt_rt_known-unused";
+  let revocationAttempted = false;
+  const queryFn: QueryFn = async (text, params) => {
+    if (text.includes("FROM auth.oauth_authorization_codes")) {
+      if (params[0] !== hash(knownCode)) return result([]);
+      return result([{
+        connection_id: "connection-1",
+        redirect_uri: authorizationRequest.redirectUri,
+        code_challenge: challenge,
+        scopes: authorizationRequest.scopes,
+        used: false,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: false,
+      }]);
+    }
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      if (params[0] !== hash(knownRefreshToken)) return result([]);
+      return result([{
+        connection_id: "connection-1",
+        scopes: authorizationRequest.scopes,
+        used: false,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: false,
+      }]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_connections")) revocationAttempted = true;
+    return result([]);
+  };
+  const dependencies = createDependencies(queryFn, emptyTokens());
+
+  await assert.rejects(
+    exchangeAuthorizationCodeWithDependencies(
+      knownCode, "mismatched-client", authorizationRequest.redirectUri,
+      authorizationRequest.resource, verifier, dependencies,
+    ),
+    /binding validation failed/u,
+  );
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      knownRefreshToken, authorizationRequest.clientId, "https://mcp.other.example/mcp",
+      null, dependencies,
+    ),
+    /binding validation failed/u,
+  );
+  await assert.rejects(
+    exchangeAuthorizationCodeWithDependencies(
+      "ebt_ac_unknown", authorizationRequest.clientId, authorizationRequest.redirectUri,
+      authorizationRequest.resource, verifier, dependencies,
+    ),
+    /invalid, expired, or already used/u,
+  );
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      "ebt_rt_unknown", authorizationRequest.clientId, authorizationRequest.resource,
+      null, dependencies,
+    ),
+    /invalid, expired, or already used/u,
+  );
+  assert.equal(revocationAttempted, false);
+});
+
+const createRefreshDependencies = (
+  grantedScopes: ReadonlyArray<string>,
+  tokenScopes: Array<ReadonlyArray<string>>,
+  updateCount: { value: number },
+): OAuthStoreDependencies => {
+  let connectionRevoked = false;
+  const queryFn: QueryFn = async (text, params) => {
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      assert.match(text, /FOR UPDATE OF ort, oc/u);
+      return result([{
+        connection_id: "connection-1",
+        scopes: grantedScopes,
+        used: updateCount.value > 0,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: connectionRevoked,
+      }]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_refresh_tokens")) updateCount.value += 1;
+    if (text.startsWith("UPDATE auth.oauth_connections")) {
+      connectionRevoked = true;
+      return result([{ connection_id: "connection-1" }]);
+    }
+    if (text.includes("oauth_access_tokens") || text.startsWith("INSERT INTO auth.oauth_refresh_tokens")) {
+      tokenScopes.push(params[2] as ReadonlyArray<string>);
+    }
+    return result([]);
+  };
+  return createDependencies(queryFn, { ...emptyTokens(), at: ["ebt_at_rotated"], rt: ["ebt_rt_rotated"] });
+};
+
+test("refresh rotation supports down-scope, rejects replay and expansion, and preserves omitted scope", async (): Promise<void> => {
+  const narrowedScopes: Array<ReadonlyArray<string>> = [];
+  const narrowedUpdates = { value: 0 };
+  const narrowedDependencies = createRefreshDependencies(
+    ["expenses:read", "expenses:write"], narrowedScopes, narrowedUpdates,
+  );
+  const narrowed = await exchangeRefreshTokenWithDependencies(
+    "ebt_rt_presented", authorizationRequest.clientId, authorizationRequest.resource,
+    ["expenses:read"], narrowedDependencies,
+  );
+  assert.equal(narrowed.scope, "expenses:read");
+  assert.deepEqual(narrowedScopes, [["expenses:read"], ["expenses:read"]]);
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      "ebt_rt_presented", authorizationRequest.clientId, authorizationRequest.resource,
+      null, narrowedDependencies,
+    ),
+    /already used/u,
+  );
+
+  const expansionUpdates = { value: 0 };
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      "ebt_rt_read-only", authorizationRequest.clientId, authorizationRequest.resource,
+      ["expenses:read", "expenses:write"],
+      createRefreshDependencies(["expenses:read"], [], expansionUpdates),
+    ),
+    /cannot exceed/u,
+  );
+  assert.equal(expansionUpdates.value, 0);
+
+  const unchangedScopes: Array<ReadonlyArray<string>> = [];
+  const unchanged = await exchangeRefreshTokenWithDependencies(
+    "ebt_rt_unchanged", authorizationRequest.clientId, authorizationRequest.resource,
+    null,
+    createRefreshDependencies(["expenses:read", "expenses:write"], unchangedScopes, { value: 0 }),
+  );
+  assert.equal(unchanged.scope, "expenses:read expenses:write");
+  assert.deepEqual(unchangedScopes, [authorizationRequest.scopes, authorizationRequest.scopes]);
+});
+
+test("binding-mismatched replay of a used refresh token revokes its replacement credentials", async (): Promise<void> => {
+  const originalToken = "ebt_rt_original";
+  let originalUsed = false;
+  let connectionRevoked = false;
+  let rotatedTokenHash: string | null = null;
+  const accessTokenHashes = new Set<string>();
+  const queryFn: QueryFn = async (text, params) => {
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      const tokenHash = params[0];
+      if (tokenHash !== hash(originalToken) && tokenHash !== rotatedTokenHash) return result([]);
+      return result([{
+        connection_id: "connection-1",
+        scopes: authorizationRequest.scopes,
+        used: tokenHash === hash(originalToken) ? originalUsed : false,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: connectionRevoked,
+      }]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_refresh_tokens")) {
+      if (params[0] === hash(originalToken)) originalUsed = true;
+      return result([]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_connections")) {
+      connectionRevoked = true;
+      return result([{ connection_id: "connection-1" }]);
+    }
+    if (text.startsWith("INSERT INTO auth.oauth_access_tokens")) {
+      accessTokenHashes.add(params[0] as string);
+      return result([]);
+    }
+    if (text.startsWith("INSERT INTO auth.oauth_refresh_tokens")) {
+      rotatedTokenHash = params[0] as string;
+      return result([]);
+    }
+    return result([]);
+  };
+  const dependencies = createDependencies(queryFn, {
+    ...emptyTokens(),
+    at: ["ebt_at_replacement"],
+    rt: ["ebt_rt_replacement"],
+  });
+
+  const replacement = await exchangeRefreshTokenWithDependencies(
+    originalToken, authorizationRequest.clientId, authorizationRequest.resource,
+    null, dependencies,
+  );
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      originalToken, "mismatched-client", authorizationRequest.resource,
+      null, dependencies,
+    ),
+    /invalid, expired, or already used/u,
+  );
+
+  assert.equal(connectionRevoked, true);
+  assert.equal(accessTokenHashes.has(hash(replacement.accessToken)) && !connectionRevoked, false);
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      replacement.refreshToken, authorizationRequest.clientId, authorizationRequest.resource,
+      null, dependencies,
+    ),
+    /invalid, expired, or already used/u,
+  );
+});
+
+type Deferred = Readonly<{ promise: Promise<void>; resolve: () => void }>;
+
+const createDeferred = (): Deferred => {
+  let resolvePromise!: () => void;
+  const promise = new Promise<void>((resolve) => { resolvePromise = () => resolve(); });
+  return { promise, resolve: resolvePromise };
+};
+
+type StoredRefreshToken = Readonly<{
+  connectionId: string;
+  scopes: ReadonlyArray<string>;
+  used: boolean;
+}>;
+
+const createConcurrentRefreshStore = (): Readonly<{
+  dependencies: OAuthStoreDependencies;
+  validatesAccessToken: (token: string) => boolean;
+}> => {
+  const connectionId = "connection-1";
+  const presentedToken = "ebt_rt_concurrent";
+  const refreshTokens = new Map<string, StoredRefreshToken>([[
+    hash(presentedToken),
+    { connectionId, scopes: authorizationRequest.scopes, used: false },
+  ]]);
+  const accessTokens = new Set<string>();
+  const secondTransactionWaiting = createDeferred();
+  const firstTransactionCommitted = createDeferred();
+  let connectionRevoked = false;
+  let transactionCount = 0;
+
+  const withTransaction = async <T>(callback: (queryFn: QueryFn) => Promise<T>): Promise<T> => {
+    transactionCount += 1;
+    const transactionNumber = transactionCount;
+    let consumedTokenHash: string | null = null;
+    let revokeConnection = false;
+    const pendingAccessTokens: Array<string> = [];
+    const pendingRefreshTokens: Array<Readonly<{ tokenHash: string; token: StoredRefreshToken }>> = [];
+
+    const transactionQuery: QueryFn = async (text, params) => {
+      if (text.includes("FROM auth.oauth_refresh_tokens")) {
+        assert.match(text, /FOR UPDATE OF ort, oc/u);
+        const tokenHash = params[0];
+        if (typeof tokenHash !== "string") throw new Error("Concurrent refresh test expected a token hash");
+        if (transactionNumber === 1) {
+          await secondTransactionWaiting.promise;
+        } else if (transactionNumber === 2) {
+          secondTransactionWaiting.resolve();
+          await firstTransactionCommitted.promise;
+        }
+        const token = refreshTokens.get(tokenHash);
+        if (token === undefined) return result([]);
+        return result([{
+          connection_id: token.connectionId,
+          scopes: token.scopes,
+          used: token.used,
+          unexpired: true,
+          client_id: authorizationRequest.clientId,
+          resource: authorizationRequest.resource,
+          revoked: connectionRevoked,
+        }]);
+      }
+      if (text.startsWith("UPDATE auth.oauth_refresh_tokens")) {
+        const tokenHash = params[0];
+        if (typeof tokenHash !== "string") throw new Error("Concurrent refresh test expected a consumed token hash");
+        consumedTokenHash = tokenHash;
+        return result([]);
+      }
+      if (text.startsWith("INSERT INTO auth.oauth_access_tokens")) {
+        const tokenHash = params[0];
+        if (typeof tokenHash !== "string") throw new Error("Concurrent refresh test expected an access token hash");
+        pendingAccessTokens.push(tokenHash);
+        return result([]);
+      }
+      if (text.startsWith("INSERT INTO auth.oauth_refresh_tokens")) {
+        const tokenHash = params[0];
+        const storedConnectionId = params[1];
+        const scopes = params[2];
+        if (
+          typeof tokenHash !== "string"
+          || typeof storedConnectionId !== "string"
+          || !Array.isArray(scopes)
+          || scopes.some((scope: unknown) => typeof scope !== "string")
+        ) {
+          throw new Error("Concurrent refresh test received an invalid rotated refresh token");
+        }
+        pendingRefreshTokens.push({
+          tokenHash,
+          token: { connectionId: storedConnectionId, scopes: scopes as ReadonlyArray<string>, used: false },
+        });
+        return result([]);
+      }
+      if (text.startsWith("UPDATE auth.oauth_connections")) {
+        assert.equal(params[0], connectionId);
+        revokeConnection = true;
+        return result([{ connection_id: connectionId }]);
+      }
+      throw new Error(`Concurrent refresh test received an unexpected query: ${text}`);
+    };
+
+    try {
+      const value = await callback(transactionQuery);
+      if (consumedTokenHash !== null) {
+        const token = refreshTokens.get(consumedTokenHash);
+        if (token === undefined) throw new Error("Concurrent refresh test could not commit token consumption");
+        refreshTokens.set(consumedTokenHash, { ...token, used: true });
+      }
+      for (const tokenHash of pendingAccessTokens) accessTokens.add(tokenHash);
+      for (const pending of pendingRefreshTokens) refreshTokens.set(pending.tokenHash, pending.token);
+      if (revokeConnection) connectionRevoked = true;
+      if (transactionNumber === 1) firstTransactionCommitted.resolve();
+      return value;
+    } catch (error) {
+      if (transactionNumber === 1) firstTransactionCommitted.resolve();
+      throw error;
+    }
+  };
+
+  const tokens = {
+    ...emptyTokens(),
+    at: ["ebt_at_concurrent-replacement"],
+    rt: ["ebt_rt_concurrent-replacement"],
+  };
+  const dependencies = { ...createDependencies(async () => result([]), tokens), withTransaction };
+  return {
+    dependencies,
+    validatesAccessToken: (token) => accessTokens.has(hash(token)) && !connectionRevoked,
+  };
+};
+
+test("concurrent refresh replay revokes the family and its replacement credentials", async (): Promise<void> => {
+  const store = createConcurrentRefreshStore();
+  const exchanges = await Promise.allSettled([
+    exchangeRefreshTokenWithDependencies(
+      "ebt_rt_concurrent", authorizationRequest.clientId, authorizationRequest.resource,
+      null, store.dependencies,
+    ),
+    exchangeRefreshTokenWithDependencies(
+      "ebt_rt_concurrent", authorizationRequest.clientId, authorizationRequest.resource,
+      null, store.dependencies,
+    ),
+  ]);
+
+  assert.equal(exchanges[0]?.status, "fulfilled");
+  assert.equal(exchanges[1]?.status, "rejected");
+  const winner = exchanges[0];
+  if (winner?.status !== "fulfilled") throw new Error("Concurrent refresh test expected one successful rotation");
+  assert.equal(store.validatesAccessToken(winner.value.accessToken), false);
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      winner.value.refreshToken, authorizationRequest.clientId, authorizationRequest.resource,
+      null, store.dependencies,
+    ),
+    /invalid, expired, or already used/u,
+  );
+});
+
+test("an expired unused refresh token is rejected without revoking its connection", async (): Promise<void> => {
+  let revocationAttempted = false;
+  const queryFn: QueryFn = async (text) => {
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      return result([{
+        connection_id: "connection-1",
+        scopes: authorizationRequest.scopes,
+        used: false,
+        unexpired: false,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: false,
+      }]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_connections")) revocationAttempted = true;
+    return result([]);
+  };
+
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      "ebt_rt_expired", authorizationRequest.clientId, authorizationRequest.resource,
+      null, createDependencies(queryFn, emptyTokens()),
+    ),
+    /invalid, expired, or already used/u,
+  );
+  assert.equal(revocationAttempted, false);
+});
+
+test("replaying an expired used refresh token revokes its active family", async (): Promise<void> => {
+  let connectionRevoked = false;
+  const queryFn: QueryFn = async (text) => {
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      return result([{
+        connection_id: "connection-1",
+        scopes: authorizationRequest.scopes,
+        used: true,
+        unexpired: false,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: false,
+      }]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_connections")) {
+      connectionRevoked = true;
+      return result([{ connection_id: "connection-1" }]);
+    }
+    return result([]);
+  };
+
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      "ebt_rt_used-and-expired", authorizationRequest.clientId, authorizationRequest.resource,
+      null, createDependencies(queryFn, emptyTokens()),
+    ),
+    /invalid, expired, or already used/u,
+  );
+  assert.equal(connectionRevoked, true);
+});
+
+test("revoked connections cannot exchange authorization codes or refresh tokens", async (): Promise<void> => {
+  let codeLoaded = false;
+  let refreshTokenLoaded = false;
+  let codeConsumed = false;
+  let accessTokenInserted = false;
+  let refreshTokenInserted = false;
+  const revokedConnection: QueryFn = async (text) => {
+    if (text.includes("FROM auth.oauth_authorization_codes")) {
+      codeLoaded = true;
+      return result([{
+        connection_id: "connection-1",
+        redirect_uri: authorizationRequest.redirectUri,
+        code_challenge: challenge,
+        scopes: authorizationRequest.scopes,
+        used: false,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: true,
+      }]);
+    }
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      refreshTokenLoaded = true;
+      return result([{
+        connection_id: "connection-1",
+        scopes: authorizationRequest.scopes,
+        used: false,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: true,
+      }]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_authorization_codes")) codeConsumed = true;
+    if (text.startsWith("INSERT INTO auth.oauth_access_tokens")) accessTokenInserted = true;
+    if (text.startsWith("INSERT INTO auth.oauth_refresh_tokens")) refreshTokenInserted = true;
+    return result([]);
+  };
+  const dependencies = createDependencies(revokedConnection, emptyTokens());
+  await assert.rejects(
+    exchangeAuthorizationCodeWithDependencies(
+      "ebt_ac_revoked", authorizationRequest.clientId, authorizationRequest.redirectUri,
+      authorizationRequest.resource, verifier, dependencies,
+    ),
+    /invalid, expired, or already used/u,
+  );
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      "ebt_rt_revoked", authorizationRequest.clientId, authorizationRequest.resource,
+      null, dependencies,
+    ),
+    /invalid, expired, or already used/u,
+  );
+  assert.equal(codeLoaded, true);
+  assert.equal(refreshTokenLoaded, true);
+  assert.equal(codeConsumed, false);
+  assert.equal(accessTokenInserted, false);
+  assert.equal(refreshTokenInserted, false);
+});

--- a/apps/auth/src/server/oauth/store.ts
+++ b/apps/auth/src/server/oauth/store.ts
@@ -1,0 +1,295 @@
+import { query, withTransaction, type QueryFn } from "../db.js";
+import {
+  createOpaqueToken,
+  hashOpaqueToken,
+  narrowScopes,
+  oauthError,
+  verifyCodeVerifier,
+  type AuthorizationRequest,
+  type OAuthClient,
+} from "./core.js";
+
+type Row = Readonly<Record<string, unknown>>;
+type TransactionRunner = <T>(callback: (queryFn: QueryFn) => Promise<T>) => Promise<T>;
+
+export type OAuthStoreDependencies = Readonly<{
+  query: QueryFn;
+  withTransaction: TransactionRunner;
+  createOpaqueToken: (prefix: "cl" | "ac" | "at" | "rt") => string;
+}>;
+
+const defaultDependencies: OAuthStoreDependencies = { query, withTransaction, createOpaqueToken };
+
+export type OAuthTokenResult = Readonly<{
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: 3600;
+  scope: string;
+}>;
+
+const readRow = (value: unknown, operation: string): Row => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${operation}: database returned an invalid row`);
+  }
+  return value as Row;
+};
+
+const readString = (row: Row, key: string, operation: string): string => {
+  const value = row[key];
+  if (typeof value !== "string" || value === "") {
+    throw new Error(`${operation}: database column ${key} must be a non-empty string`);
+  }
+  return value;
+};
+
+const readScopes = (row: Row, operation: string): ReadonlyArray<string> => {
+  const value = row["scopes"];
+  if (!Array.isArray(value) || value.some((scope) => typeof scope !== "string")) {
+    throw new Error(`${operation}: database column scopes must be a string array`);
+  }
+  return value as ReadonlyArray<string>;
+};
+
+const readBoolean = (row: Row, key: string, operation: string): boolean => {
+  const value = row[key];
+  if (typeof value !== "boolean") {
+    throw new Error(`${operation}: database column ${key} must be a boolean`);
+  }
+  return value;
+};
+
+export const registerOAuthClientWithDependencies = async (
+  clientName: string,
+  redirectUris: ReadonlyArray<string>,
+  dependencies: OAuthStoreDependencies,
+): Promise<OAuthClient> => {
+  const clientId = dependencies.createOpaqueToken("cl");
+  await dependencies.query(
+    `INSERT INTO auth.oauth_clients (client_id, client_name, redirect_uris)
+     VALUES ($1, $2, $3)`,
+    [clientId, clientName, redirectUris],
+  );
+  return { clientId, clientName, redirectUris };
+};
+
+export const registerOAuthClient = (
+  clientName: string,
+  redirectUris: ReadonlyArray<string>,
+): Promise<OAuthClient> => registerOAuthClientWithDependencies(clientName, redirectUris, defaultDependencies);
+
+export const getOAuthClientWithDependencies = async (
+  clientId: string,
+  dependencies: OAuthStoreDependencies,
+): Promise<OAuthClient | null> => {
+  const result = await dependencies.query(
+    `SELECT client_id, client_name, redirect_uris
+     FROM auth.oauth_clients
+     WHERE client_id = $1`,
+    [clientId],
+  );
+  if (result.rows.length === 0) return null;
+  if (result.rows.length !== 1) throw new Error(`getOAuthClient: expected at most 1 row, got ${result.rows.length}`);
+  const row = readRow(result.rows[0], "getOAuthClient");
+  const redirectUris = row["redirect_uris"];
+  if (!Array.isArray(redirectUris) || redirectUris.some((uri) => typeof uri !== "string")) {
+    throw new Error("getOAuthClient: database column redirect_uris must be a string array");
+  }
+  return {
+    clientId: readString(row, "client_id", "getOAuthClient"),
+    clientName: readString(row, "client_name", "getOAuthClient"),
+    redirectUris: redirectUris as ReadonlyArray<string>,
+  };
+};
+
+export const getOAuthClient = (clientId: string): Promise<OAuthClient | null> =>
+  getOAuthClientWithDependencies(clientId, defaultDependencies);
+
+export const issueAuthorizationCodeWithDependencies = async (
+  request: AuthorizationRequest,
+  userId: string,
+  email: string,
+  dependencies: OAuthStoreDependencies,
+): Promise<string> => {
+  const code = dependencies.createOpaqueToken("ac");
+  const codeHash = hashOpaqueToken(code);
+  return dependencies.withTransaction(async (queryFn: QueryFn) => {
+    await queryFn("SELECT auth.sync_authenticated_user($1, $2)", [userId, email]);
+    const connectionResult = await queryFn(
+      `INSERT INTO auth.oauth_connections (client_id, user_id, resource)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (client_id, user_id, resource) WHERE revoked_at IS NULL DO UPDATE
+         SET updated_at = now()
+       RETURNING connection_id`,
+      [request.clientId, userId, request.resource],
+    );
+    if (connectionResult.rows.length !== 1) {
+      throw new Error(`issueAuthorizationCode: expected 1 connection row, got ${connectionResult.rows.length}`);
+    }
+    const connectionId = readString(readRow(connectionResult.rows[0], "issueAuthorizationCode"), "connection_id", "issueAuthorizationCode");
+    await queryFn(
+      `INSERT INTO auth.oauth_authorization_codes
+         (code_hash, connection_id, redirect_uri, code_challenge, scopes, expires_at)
+       VALUES ($1, $2, $3, $4, $5, now() + INTERVAL '5 minutes')`,
+      [codeHash, connectionId, request.redirectUri, request.codeChallenge, request.scopes],
+    );
+    return code;
+  });
+};
+
+export const issueAuthorizationCode = (
+  request: AuthorizationRequest,
+  userId: string,
+  email: string,
+): Promise<string> => issueAuthorizationCodeWithDependencies(request, userId, email, defaultDependencies);
+
+const insertTokenPair = async (
+  queryFn: QueryFn,
+  connectionId: string,
+  scopes: ReadonlyArray<string>,
+  dependencies: OAuthStoreDependencies,
+): Promise<OAuthTokenResult> => {
+  const accessToken = dependencies.createOpaqueToken("at");
+  const refreshToken = dependencies.createOpaqueToken("rt");
+  await queryFn(
+    `INSERT INTO auth.oauth_access_tokens (token_hash, connection_id, scopes, expires_at)
+     VALUES ($1, $2, $3, now() + INTERVAL '1 hour')`,
+    [hashOpaqueToken(accessToken), connectionId, scopes],
+  );
+  await queryFn(
+    `INSERT INTO auth.oauth_refresh_tokens (token_hash, connection_id, scopes, expires_at)
+     VALUES ($1, $2, $3, now() + INTERVAL '30 days')`,
+    [hashOpaqueToken(refreshToken), connectionId, scopes],
+  );
+  return { accessToken, refreshToken, expiresIn: 3600, scope: scopes.join(" ") };
+};
+
+const revokeActiveConnection = async (
+  queryFn: QueryFn,
+  connectionId: string,
+  operation: string,
+): Promise<void> => {
+  const result = await queryFn(
+    `UPDATE auth.oauth_connections
+     SET revoked_at = now()
+     WHERE connection_id = $1 AND revoked_at IS NULL
+     RETURNING connection_id`,
+    [connectionId],
+  );
+  if (result.rows.length !== 1) {
+    throw new Error(`${operation}: expected 1 revoked connection row, got ${result.rows.length}`);
+  }
+};
+
+export const exchangeAuthorizationCodeWithDependencies = async (
+  code: string,
+  clientId: string,
+  redirectUri: string,
+  resource: string,
+  codeVerifier: string,
+  dependencies: OAuthStoreDependencies,
+): Promise<OAuthTokenResult> => {
+  const invalidGrant = (): ReturnType<typeof oauthError> =>
+    oauthError("invalid_grant", "Authorization code is invalid, expired, or already used", 400);
+  const codeHash = hashOpaqueToken(code);
+  const exchangeResult = await dependencies.withTransaction(async (queryFn: QueryFn): Promise<OAuthTokenResult | null> => {
+    const result = await queryFn(
+      `SELECT oac.connection_id, oac.redirect_uri, oac.code_challenge,
+              oac.scopes, oac.used_at IS NOT NULL AS used,
+              oac.expires_at > now() AS unexpired,
+              oc.client_id, oc.resource, oc.revoked_at IS NOT NULL AS revoked
+       FROM auth.oauth_authorization_codes oac
+       JOIN auth.oauth_connections oc ON oc.connection_id = oac.connection_id
+       WHERE oac.code_hash = $1
+       FOR UPDATE OF oac, oc`,
+      [codeHash],
+    );
+    if (result.rows.length !== 1) throw invalidGrant();
+    const row = readRow(result.rows[0], "exchangeAuthorizationCode");
+    const connectionId = readString(row, "connection_id", "exchangeAuthorizationCode");
+    const revoked = readBoolean(row, "revoked", "exchangeAuthorizationCode");
+    if (readBoolean(row, "used", "exchangeAuthorizationCode")) {
+      if (!revoked) await revokeActiveConnection(queryFn, connectionId, "exchangeAuthorizationCode");
+      return null;
+    }
+    if (revoked || !readBoolean(row, "unexpired", "exchangeAuthorizationCode")) throw invalidGrant();
+    if (
+      readString(row, "client_id", "exchangeAuthorizationCode") !== clientId
+      || readString(row, "redirect_uri", "exchangeAuthorizationCode") !== redirectUri
+      || readString(row, "resource", "exchangeAuthorizationCode") !== resource
+      || !verifyCodeVerifier(codeVerifier, readString(row, "code_challenge", "exchangeAuthorizationCode"))
+    ) {
+      throw oauthError("invalid_grant", "Authorization code binding validation failed", 400);
+    }
+    const scopes = readScopes(row, "exchangeAuthorizationCode");
+    await queryFn("UPDATE auth.oauth_authorization_codes SET used_at = now() WHERE code_hash = $1", [codeHash]);
+    return insertTokenPair(queryFn, connectionId, scopes, dependencies);
+  });
+  if (exchangeResult === null) throw invalidGrant();
+  return exchangeResult;
+};
+
+export const exchangeAuthorizationCode = (
+  code: string,
+  clientId: string,
+  redirectUri: string,
+  resource: string,
+  codeVerifier: string,
+): Promise<OAuthTokenResult> => exchangeAuthorizationCodeWithDependencies(
+  code, clientId, redirectUri, resource, codeVerifier, defaultDependencies,
+);
+
+export const exchangeRefreshTokenWithDependencies = async (
+  refreshToken: string,
+  clientId: string,
+  resource: string,
+  requestedScopes: ReadonlyArray<string> | null,
+  dependencies: OAuthStoreDependencies,
+): Promise<OAuthTokenResult> => {
+  const invalidGrant = (): ReturnType<typeof oauthError> =>
+    oauthError("invalid_grant", "Refresh token is invalid, expired, or already used", 400);
+  const tokenHash = hashOpaqueToken(refreshToken);
+  const exchangeResult = await dependencies.withTransaction(async (queryFn: QueryFn): Promise<OAuthTokenResult | null> => {
+    const result = await queryFn(
+      `SELECT ort.connection_id, ort.scopes,
+              ort.used_at IS NOT NULL AS used,
+              ort.expires_at > now() AS unexpired,
+              oc.client_id, oc.resource,
+              oc.revoked_at IS NOT NULL AS revoked
+       FROM auth.oauth_refresh_tokens ort
+       JOIN auth.oauth_connections oc ON oc.connection_id = ort.connection_id
+       WHERE ort.token_hash = $1
+       FOR UPDATE OF ort, oc`,
+      [tokenHash],
+    );
+    if (result.rows.length !== 1) throw invalidGrant();
+    const row = readRow(result.rows[0], "exchangeRefreshToken");
+    const connectionId = readString(row, "connection_id", "exchangeRefreshToken");
+    const revoked = readBoolean(row, "revoked", "exchangeRefreshToken");
+    if (readBoolean(row, "used", "exchangeRefreshToken")) {
+      if (!revoked) await revokeActiveConnection(queryFn, connectionId, "exchangeRefreshToken");
+      return null;
+    }
+    if (revoked) throw invalidGrant();
+    if (
+      readString(row, "client_id", "exchangeRefreshToken") !== clientId
+      || readString(row, "resource", "exchangeRefreshToken") !== resource
+    ) {
+      throw oauthError("invalid_grant", "Refresh token binding validation failed", 400);
+    }
+    if (!readBoolean(row, "unexpired", "exchangeRefreshToken")) throw invalidGrant();
+    const effectiveScopes = narrowScopes(readScopes(row, "exchangeRefreshToken"), requestedScopes);
+    await queryFn("UPDATE auth.oauth_refresh_tokens SET used_at = now() WHERE token_hash = $1", [tokenHash]);
+    return insertTokenPair(queryFn, connectionId, effectiveScopes, dependencies);
+  });
+  if (exchangeResult === null) throw invalidGrant();
+  return exchangeResult;
+};
+
+export const exchangeRefreshToken = (
+  refreshToken: string,
+  clientId: string,
+  resource: string,
+  requestedScopes: ReadonlyArray<string> | null,
+): Promise<OAuthTokenResult> => exchangeRefreshTokenWithDependencies(
+  refreshToken, clientId, resource, requestedScopes, defaultDependencies,
+);

--- a/db/migrations/0067_oauth_mcp_authorization.sql
+++ b/db/migrations/0067_oauth_mcp_authorization.sql
@@ -1,0 +1,112 @@
+-- OAuth 2.1 authorization state for public MCP clients.
+
+CREATE TABLE auth.oauth_clients (
+  client_id       TEXT        NOT NULL PRIMARY KEY CHECK (length(client_id) BETWEEN 20 AND 128),
+  client_name     TEXT        NOT NULL CHECK (btrim(client_name) <> '' AND length(client_name) <= 200),
+  redirect_uris   TEXT[]      NOT NULL CHECK (cardinality(redirect_uris) BETWEEN 1 AND 10),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE auth.oauth_connections (
+  connection_id   TEXT        NOT NULL DEFAULT gen_random_uuid()::text PRIMARY KEY,
+  client_id       TEXT        NOT NULL REFERENCES auth.oauth_clients(client_id) ON DELETE CASCADE,
+  user_id         TEXT        NOT NULL CHECK (btrim(user_id) <> ''),
+  resource        TEXT        NOT NULL CHECK (
+    resource ~ '^https://mcp[.][A-Za-z0-9.-]+/mcp$'
+    OR resource ~ '^http://localhost(:[0-9]{1,5})?/mcp$'
+    OR resource ~ '^http://127([.][0-9]{1,3}){3}(:[0-9]{1,5})?/mcp$'
+    OR resource ~ '^http://[[]::1[]](:[0-9]{1,5})?/mcp$'
+  ),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  revoked_at      TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX idx_oauth_connections_active_grant
+  ON auth.oauth_connections (client_id, user_id, resource)
+  WHERE revoked_at IS NULL;
+
+CREATE TABLE auth.oauth_authorization_codes (
+  code_hash        TEXT        NOT NULL PRIMARY KEY CHECK (length(code_hash) = 64),
+  connection_id    TEXT        NOT NULL REFERENCES auth.oauth_connections(connection_id) ON DELETE CASCADE,
+  redirect_uri     TEXT        NOT NULL CHECK (btrim(redirect_uri) <> ''),
+  code_challenge   TEXT        NOT NULL CHECK (code_challenge ~ '^[A-Za-z0-9_-]{43}$'),
+  scopes           TEXT[]      NOT NULL CHECK (
+    scopes = ARRAY['expenses:read']::TEXT[]
+    OR scopes = ARRAY['expenses:read', 'expenses:write']::TEXT[]
+  ),
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at       TIMESTAMPTZ NOT NULL CHECK (expires_at > created_at AND expires_at <= created_at + INTERVAL '5 minutes'),
+  used_at          TIMESTAMPTZ
+);
+
+CREATE INDEX idx_oauth_authorization_codes_expires_at
+  ON auth.oauth_authorization_codes (expires_at);
+
+CREATE TABLE auth.oauth_access_tokens (
+  token_hash       TEXT        NOT NULL PRIMARY KEY CHECK (length(token_hash) = 64),
+  connection_id    TEXT        NOT NULL REFERENCES auth.oauth_connections(connection_id) ON DELETE CASCADE,
+  scopes           TEXT[]      NOT NULL CHECK (
+    scopes = ARRAY['expenses:read']::TEXT[]
+    OR scopes = ARRAY['expenses:read', 'expenses:write']::TEXT[]
+  ),
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at       TIMESTAMPTZ NOT NULL CHECK (expires_at > created_at AND expires_at <= created_at + INTERVAL '1 hour')
+);
+
+CREATE INDEX idx_oauth_access_tokens_expires_at
+  ON auth.oauth_access_tokens (expires_at);
+
+CREATE TABLE auth.oauth_refresh_tokens (
+  token_hash       TEXT        NOT NULL PRIMARY KEY CHECK (length(token_hash) = 64),
+  connection_id    TEXT        NOT NULL REFERENCES auth.oauth_connections(connection_id) ON DELETE CASCADE,
+  scopes           TEXT[]      NOT NULL CHECK (
+    scopes = ARRAY['expenses:read']::TEXT[]
+    OR scopes = ARRAY['expenses:read', 'expenses:write']::TEXT[]
+  ),
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at       TIMESTAMPTZ NOT NULL CHECK (expires_at > created_at AND expires_at <= created_at + INTERVAL '30 days'),
+  used_at          TIMESTAMPTZ
+);
+
+CREATE INDEX idx_oauth_refresh_tokens_expires_at
+  ON auth.oauth_refresh_tokens (expires_at);
+
+GRANT SELECT, INSERT ON TABLE auth.oauth_clients TO auth_service;
+GRANT SELECT, INSERT ON TABLE auth.oauth_connections TO auth_service;
+GRANT UPDATE (updated_at, revoked_at) ON TABLE auth.oauth_connections TO auth_service;
+GRANT SELECT, INSERT ON TABLE auth.oauth_authorization_codes TO auth_service;
+GRANT UPDATE (used_at) ON TABLE auth.oauth_authorization_codes TO auth_service;
+GRANT INSERT ON TABLE auth.oauth_access_tokens TO auth_service;
+GRANT SELECT, INSERT ON TABLE auth.oauth_refresh_tokens TO auth_service;
+GRANT UPDATE (used_at) ON TABLE auth.oauth_refresh_tokens TO auth_service;
+
+CREATE FUNCTION auth.validate_oauth_access_token(p_token_hash TEXT)
+RETURNS TABLE(
+  connection_id TEXT,
+  user_id TEXT,
+  client_id TEXT,
+  resource TEXT,
+  scopes TEXT[],
+  expires_at TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, auth
+AS $$
+  SELECT oat.connection_id,
+         oc.user_id,
+         oc.client_id,
+         oc.resource,
+         oat.scopes,
+         oat.expires_at
+  FROM auth.oauth_access_tokens oat
+  JOIN auth.oauth_connections oc ON oc.connection_id = oat.connection_id
+  WHERE oat.token_hash = p_token_hash
+    AND oat.expires_at > now()
+    AND oc.revoked_at IS NULL;
+$$;
+
+REVOKE ALL ON FUNCTION auth.validate_oauth_access_token(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION auth.validate_oauth_access_token(TEXT) TO app;

--- a/infra/aws/lib/compute.ts
+++ b/infra/aws/lib/compute.ts
@@ -246,9 +246,12 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
     environment: {
       PORT: "8081",
       COGNITO_CLIENT_ID: props.userPoolClientId,
+      COGNITO_USER_POOL_ID: props.userPoolId,
       COGNITO_REGION: cdk.Aws.REGION,
       ALLOWED_REDIRECT_URIS: `https://${props.appDomain}`,
       COOKIE_DOMAIN: `.${props.appDomain.split(".").slice(1).join(".")}`,
+      OAUTH_ISSUER: `https://${props.authDomain}`,
+      OAUTH_RESOURCE: `https://mcp.${props.appDomain.split(".").slice(1).join(".")}/mcp`,
       DB_HOST: props.db.dbInstanceEndpointAddress,
       DB_NAME: "tracker",
       DB_USER: "auth_service",

--- a/infra/docker/compose.yml
+++ b/infra/docker/compose.yml
@@ -80,7 +80,10 @@ services:
       ALLOWED_REDIRECT_URIS: ${ALLOWED_REDIRECT_URIS:-http://localhost:3000}
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:-localhost}
       COGNITO_CLIENT_ID: ${COGNITO_CLIENT_ID:-}
+      COGNITO_USER_POOL_ID: ${COGNITO_USER_POOL_ID:-}
       COGNITO_REGION: ${COGNITO_REGION:-}
+      OAUTH_ISSUER: ${OAUTH_ISSUER:-http://localhost:8081}
+      OAUTH_RESOURCE: ${OAUTH_RESOURCE:-http://localhost:8082/mcp}
       AUTH_DATABASE_URL: ${AUTH_DATABASE_URL:-postgresql://auth_service:${AUTH_DB_PASSWORD:-auth_service}@postgres:5432/tracker}
       SESSION_ENCRYPTION_KEY: ${SESSION_ENCRYPTION_KEY:-}
     healthcheck:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "dependencies": {
         "@expense-budget-tracker/agent-shared": "1.2.0",
         "@hono/node-server": "^2.1.0",
+        "aws-jwt-verify": "^5.2.1",
         "hono": "^4.13.1",
         "pg": "^8.23.0"
       },


### PR DESCRIPTION
## Summary
- add OAuth 2.1 authorization-code and refresh flows for public MCP clients with mandatory S256 PKCE
- add Cognito browser-session renewal, consent and DCR hardening, opaque token-family storage, and migration grants
- wire auth/MCP configuration for AWS and Docker and add focused security tests-as-code

## Testing
- Not run locally; cloud CI owns project checks for this reviewed snapshot.

## Scope
- Targets `integration-mcp-readonly-sql`; no OpenAPI or Swagger artifacts are included.