### PR TITLE
Add stateless OAuth MCP runtime

### DIFF
--- a/apps/sql-api/package.json
+++ b/apps/sql-api/package.json
@@ -14,7 +14,10 @@
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.1108.0",
     "@expense-budget-tracker/agent-shared": "1.2.0",
-    "pg": "^8.23.0"
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "hono": "^4.13.2",
+    "pg": "^8.23.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.162",

--- a/apps/sql-api/src/db.ts
+++ b/apps/sql-api/src/db.ts
@@ -33,7 +33,7 @@ async function getPool(): Promise<pg.Pool> {
 export const query = async (text: string, params: ReadonlyArray<unknown>): Promise<pg.QueryResult> =>
   (await getPool()).query(text, params as Array<unknown>);
 
-type QueryFn = (text: string, params: ReadonlyArray<unknown>) => Promise<pg.QueryResult>;
+export type QueryFn = (text: string, params: ReadonlyArray<unknown>) => Promise<pg.QueryResult>;
 type ResolvedWorkspaceRow = Readonly<{
   workspace_id: string;
   name: string;
@@ -212,6 +212,122 @@ export const queryAsTrustedIdentity = async (
   }
 };
 
+/**
+ * Query existing user-scoped data without provisioning or updating state.
+ */
+export const queryAsExistingTrustedIdentity = async (
+  identity: UserIdentity,
+  text: string,
+  params: ReadonlyArray<unknown>,
+): Promise<pg.QueryResult> => {
+  const client = await (await getPool()).connect();
+
+  try {
+    await client.query("BEGIN READ ONLY");
+    await client.query("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+    const result = await client.query(text, params as Array<unknown>);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+/**
+ * Query existing workspace-scoped data without provisioning or updating state.
+ */
+export const queryAsExistingTrustedWorkspace = async (
+  identity: UserIdentity,
+  workspaceId: string,
+  text: string,
+  params: ReadonlyArray<unknown>,
+): Promise<pg.QueryResult> => {
+  const client = await (await getPool()).connect();
+
+  try {
+    await client.query("BEGIN READ ONLY");
+    await client.query("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+    await client.query("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
+    const result = await client.query(text, params as Array<unknown>);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+const readTrustedUserIdentity = (row: unknown): UserIdentity => {
+  if (typeof row !== "object" || row === null || Array.isArray(row)) {
+    throw new Error("loadTrustedUserIdentity: database returned an invalid user row");
+  }
+
+  const record = row as Readonly<Record<string, unknown>>;
+  const userId = record["user_id"];
+  const email = record["email"];
+  const emailVerified = record["email_verified"];
+  const cognitoStatus = record["cognito_status"];
+  const cognitoEnabled = record["cognito_enabled"];
+  if (
+    typeof userId !== "string"
+    || userId === ""
+    || typeof email !== "string"
+    || email === ""
+    || typeof emailVerified !== "boolean"
+    || typeof cognitoStatus !== "string"
+    || cognitoStatus === ""
+    || typeof cognitoEnabled !== "boolean"
+  ) {
+    throw new Error("loadTrustedUserIdentity: database returned invalid user identity fields");
+  }
+
+  return {
+    userId,
+    email,
+    emailVerified,
+    cognitoStatus,
+    cognitoEnabled,
+  };
+};
+
+/**
+ * Load an existing user under that user's RLS context without provisioning or
+ * updating identity state.
+ */
+export const loadTrustedUserIdentity = async (
+  userId: string,
+): Promise<UserIdentity | null> => {
+  const client = await (await getPool()).connect();
+
+  try {
+    await client.query("BEGIN READ ONLY");
+    await client.query("SELECT set_config('app.user_id', $1, true)", [userId]);
+    const result = await client.query(
+      `SELECT user_id, email, email_verified, cognito_status, cognito_enabled
+       FROM users
+       WHERE user_id = $1`,
+      [userId],
+    );
+    if (result.rows.length > 1) {
+      throw new Error(`loadTrustedUserIdentity: expected at most 1 row, got ${result.rows.length}`);
+    }
+    const row = result.rows[0];
+    const identity = row === undefined ? null : readTrustedUserIdentity(row);
+    await client.query("COMMIT");
+    return identity;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
 export const withRestrictedTrustedIdentityContext = async <T>(
   identity: UserIdentity,
   workspaceId: string,
@@ -250,6 +366,36 @@ export const withReadOnlyRestrictedTrustedIdentityContext = async <T>(
   callback: (queryFn: QueryFn) => Promise<T>,
 ): Promise<T> => {
   await ensureTrustedIdentityProvisioned(identity, workspaceId);
+  const client = await (await getPool()).connect();
+
+  try {
+    await client.query("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY");
+    await client.query("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+    await client.query("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
+    await client.query("SELECT set_config('statement_timeout', $1, true)", [String(statementTimeoutMs)]);
+    await client.query("SET LOCAL ROLE api_sql_reader");
+    const boundQuery: QueryFn = (text, params) => client.query(text, params as Array<unknown>);
+    const result = await callback(boundQuery);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+/**
+ * Execute read-only user SQL for an existing workspace without provisioning or
+ * updating identity, membership, workspace, or settings state.
+ */
+export const withNonProvisioningReadOnlyRestrictedTrustedIdentityContext = async <T>(
+  identity: UserIdentity,
+  workspaceId: string,
+  statementTimeoutMs: number,
+  callback: (queryFn: QueryFn) => Promise<T>,
+): Promise<T> => {
   const client = await (await getPool()).connect();
 
   try {

--- a/apps/sql-api/src/logger.ts
+++ b/apps/sql-api/src/logger.ts
@@ -1,0 +1,20 @@
+export type SafeErrorType = "error" | "type_error" | "range_error" | "non_error";
+
+export const getSafeErrorType = (error: unknown): SafeErrorType => {
+  if (error instanceof TypeError) return "type_error";
+  if (error instanceof RangeError) return "range_error";
+  if (error instanceof Error) return "error";
+  return "non_error";
+};
+
+export type SqlApiLogEvent = Readonly<{
+  domain: "sql_api";
+  action: "mcp_unexpected_error";
+  boundary: "authentication" | "tool" | "transport";
+  operation: string;
+  errorType: SafeErrorType;
+}>;
+
+export const log = (event: SqlApiLogEvent): void => {
+  console.log(JSON.stringify(event));
+};

--- a/apps/sql-api/src/machineApi/schemaService.ts
+++ b/apps/sql-api/src/machineApi/schemaService.ts
@@ -1,19 +1,14 @@
 import { getAgentSchemaHints } from "@expense-budget-tracker/agent-shared";
 import { getAllowedRelationNames, type AllowedRelationName } from "@expense-budget-tracker/agent-shared/sql-policy";
-import { resolveOrCreateWorkspaceForTrustedIdentity, type UserIdentity } from "../db.js";
+import { resolveOrCreateWorkspaceForTrustedIdentity, type QueryFn, type UserIdentity } from "../db.js";
 import type { MachineApiDependencies, SchemaColumn, SchemaColumnRow, SchemaRelation } from "./types.js";
 
 export const ALLOWED_RELATION_NAMES = getAllowedRelationNames();
 
-export const loadAllowedSchemaWithResolver = async (
-  dependencies: MachineApiDependencies,
-  identity: UserIdentity,
-  resolveWorkspace: typeof resolveOrCreateWorkspaceForTrustedIdentity,
+export const loadAllowedSchemaWithQuery = async (
+  queryFn: QueryFn,
 ): Promise<ReadonlyArray<SchemaRelation>> => {
-  const contextWorkspace = await resolveWorkspace(identity);
-  const result = await dependencies.queryAsTrustedIdentity(
-    identity,
-    contextWorkspace.workspaceId,
+  const result = await queryFn(
     `SELECT table_name, column_name, data_type, udt_name, is_nullable, column_default
      FROM information_schema.columns
      WHERE table_schema = 'public'
@@ -64,6 +59,29 @@ export const loadAllowedSchemaWithResolver = async (
       ...(hints === undefined ? {} : { hints }),
     };
   });
+};
+
+export const loadAllowedSchemaForWorkspace = async (
+  dependencies: MachineApiDependencies,
+  identity: UserIdentity,
+  workspaceId: string,
+): Promise<ReadonlyArray<SchemaRelation>> =>
+  loadAllowedSchemaWithQuery(
+    (text, params) => dependencies.queryAsTrustedIdentity(
+      identity,
+      workspaceId,
+      text,
+      params,
+    ),
+  );
+
+export const loadAllowedSchemaWithResolver = async (
+  dependencies: MachineApiDependencies,
+  identity: UserIdentity,
+  resolveWorkspace: typeof resolveOrCreateWorkspaceForTrustedIdentity,
+): Promise<ReadonlyArray<SchemaRelation>> => {
+  const contextWorkspace = await resolveWorkspace(identity);
+  return loadAllowedSchemaForWorkspace(dependencies, identity, contextWorkspace.workspaceId);
 };
 
 export const loadAllowedSchema = async (

--- a/apps/sql-api/src/machineApi/sqlService.test.ts
+++ b/apps/sql-api/src/machineApi/sqlService.test.ts
@@ -4,6 +4,8 @@ import type { QueryResult } from "pg";
 import { SqlPolicyError } from "@expense-budget-tracker/agent-shared/sql-policy";
 import { createQueryResult } from "../handlerTestUtils.js";
 import {
+  getUserSqlExecutionMessage,
+  isUserSqlExecutionError,
   runReadOnlySqlWithWorkspaceGetter,
   runSqlWithWorkspaceGetter,
 } from "./sqlService.js";
@@ -362,4 +364,73 @@ test("runSql raises mutation batch overflow from inside the single transaction c
 
   assert.equal(restrictedContextCount, 1);
   assert.equal(statementCount, 2);
+});
+
+test("runSql tags safe PostgreSQL errors only when validated user SQL is executing", async (): Promise<void> => {
+  const databaseError = Object.assign(
+    new Error("column amountt does not exist"),
+    { code: "42703" },
+  );
+  const dependencies = createDependencies({
+    withRestrictedTrustedIdentityContext: async <T>(
+      _identity: AuthenticatedContext["identity"],
+      _workspaceId: string,
+      _statementTimeoutMs: number,
+      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+    ): Promise<T> => callback(async (): Promise<QueryResult> => {
+      throw databaseError;
+    }),
+  });
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "SELECT amount FROM ledger_entries",
+      workspaceGetter,
+    ),
+    (error: unknown) =>
+      isUserSqlExecutionError(error)
+      && getUserSqlExecutionMessage(error) === "column amountt does not exist",
+  );
+});
+
+test("runSql does not tag PostgreSQL errors from workspace lookup or transaction setup", async (): Promise<void> => {
+  const workspaceError = Object.assign(
+    new Error("workspace lookup exposed internal relation"),
+    { code: "42703" },
+  );
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      createDependencies(),
+      createAuthenticatedContext(),
+      "user-1",
+      "SELECT amount FROM ledger_entries",
+      async (): Promise<WorkspaceSummary> => {
+        throw workspaceError;
+      },
+    ),
+    (error: unknown) => error === workspaceError && !isUserSqlExecutionError(error),
+  );
+
+  const setupError = Object.assign(
+    new Error("SET LOCAL ROLE failed for internal role"),
+    { code: "42501" },
+  );
+  const dependencies = createDependencies({
+    withRestrictedTrustedIdentityContext: async () => {
+      throw setupError;
+    },
+  });
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "SELECT amount FROM ledger_entries",
+      workspaceGetter,
+    ),
+    (error: unknown) => error === setupError && !isUserSqlExecutionError(error),
+  );
 });

--- a/apps/sql-api/src/machineApi/sqlService.ts
+++ b/apps/sql-api/src/machineApi/sqlService.ts
@@ -10,7 +10,7 @@ import {
   type ValidatedExpenseSql,
   type ValidatedReadOnlyExpenseSql,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
-import type { AuthenticatedContext, EntityHints, MachineApiDependencies, PgError, WorkspaceSummary } from "./types.js";
+import type { EntityHints, MachineApiDependencies, PgError, TrustedIdentityContext, WorkspaceSummary } from "./types.js";
 import { getWorkspace } from "./workspaceService.js";
 
 const ENTITY_METADATA: Readonly<Record<AllowedRelationName, Readonly<{
@@ -48,6 +48,13 @@ const ENTITY_METADATA: Readonly<Record<AllowedRelationName, Readonly<{
 };
 
 const USER_SQL_ERROR_CLASSES: ReadonlySet<string> = new Set(["22", "23", "42"]);
+const DEFAULT_USER_SQL_EXECUTION_MESSAGE = "The SQL statement could not be executed";
+
+export class UserSqlExecutionError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
 
 const buildEntityHints = (relations: ReadonlyArray<AllowedRelationName>): EntityHints | undefined => {
   if (relations.length === 0) {
@@ -76,7 +83,10 @@ const buildEntityHints = (relations: ReadonlyArray<AllowedRelationName>): Entity
   };
 };
 
-export const isUserSqlExecutionError = (error: unknown): boolean => {
+const isSafeUserSqlDatabaseError = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
   const pgError = error as PgError;
   if (typeof pgError.code !== "string" || pgError.code.length < 2) {
     return false;
@@ -85,22 +95,45 @@ export const isUserSqlExecutionError = (error: unknown): boolean => {
   return USER_SQL_ERROR_CLASSES.has(pgError.code.slice(0, 2));
 };
 
-export const getUserSqlExecutionMessage = (error: unknown): string => {
+const getDatabaseErrorMessage = (error: unknown): string => {
   if (error instanceof Error && error.message !== "") {
     return error.message;
   }
+  return DEFAULT_USER_SQL_EXECUTION_MESSAGE;
+};
 
-  return "The SQL statement could not be executed";
+const throwUserSqlExecutionError = (error: unknown): never => {
+  if (!isSafeUserSqlDatabaseError(error)) {
+    throw error;
+  }
+  throw new UserSqlExecutionError(getDatabaseErrorMessage(error));
+};
+
+export const isUserSqlExecutionError = (error: unknown): error is UserSqlExecutionError =>
+  error instanceof UserSqlExecutionError;
+
+export const getUserSqlExecutionMessage = (error: unknown): string => {
+  if (error instanceof UserSqlExecutionError && error.message !== "") {
+    return error.message;
+  }
+  return DEFAULT_USER_SQL_EXECUTION_MESSAGE;
 };
 
 const isSchemaExplorationAttempt = (message: string): boolean =>
   /information_schema|pg_catalog|pg_/iu.test(message);
 
-type WorkspaceGetter = (
+type MachineApiWorkspaceGetter = (
   dependencies: MachineApiDependencies,
-  identity: AuthenticatedContext["identity"],
+  identity: TrustedIdentityContext["identity"],
   workspaceId: string,
 ) => Promise<WorkspaceSummary | null>;
+
+export type ExistingWorkspaceGetter = (
+  identity: TrustedIdentityContext["identity"],
+  workspaceId: string,
+) => Promise<WorkspaceSummary | null>;
+
+type RestrictedContextRunner = MachineApiDependencies["withRestrictedTrustedIdentityContext"];
 
 export const getSqlPolicyInstructions = (
   error: SqlPolicyError,
@@ -177,14 +210,13 @@ export const getSqlPolicyInstructions = (
 };
 
 const executeSqlWithWorkspaceGetter = async (
-  dependencies: MachineApiDependencies,
-  authenticated: AuthenticatedContext,
+  authenticated: TrustedIdentityContext,
   workspaceId: string,
   validated: ValidatedExpenseSql,
-  workspaceGetter: WorkspaceGetter,
-  runInRestrictedContext: MachineApiDependencies["withRestrictedTrustedIdentityContext"],
+  workspaceGetter: ExistingWorkspaceGetter,
+  runInRestrictedContext: RestrictedContextRunner,
 ): Promise<Readonly<Record<string, unknown>> | null> => {
-  const workspace = await workspaceGetter(dependencies, authenticated.identity, workspaceId);
+  const workspace = await workspaceGetter(authenticated.identity, workspaceId);
   if (workspace === null) {
     return null;
   }
@@ -196,12 +228,16 @@ const executeSqlWithWorkspaceGetter = async (
     async (queryFn) => executeValidatedExpenseSql(
       validated,
       async (request) => {
-        const queryResult = await queryFn(request.sql, request.params);
-        return {
-          command: queryResult.command,
-          rows: queryResult.rows as ReadonlyArray<Readonly<Record<string, unknown>>>,
-          rowCount: queryResult.rowCount,
-        };
+        try {
+          const queryResult = await queryFn(request.sql, request.params);
+          return {
+            command: queryResult.command,
+            rows: queryResult.rows as ReadonlyArray<Readonly<Record<string, unknown>>>,
+            rowCount: queryResult.rowCount,
+          };
+        } catch (error) {
+          throwUserSqlExecutionError(error);
+        }
       },
     ),
   );
@@ -231,62 +267,104 @@ const executeSqlWithWorkspaceGetter = async (
 
 export const runSqlWithWorkspaceGetter = async (
   dependencies: MachineApiDependencies,
-  authenticated: AuthenticatedContext,
+  authenticated: TrustedIdentityContext,
   workspaceId: string,
   sql: string,
-  workspaceGetter: WorkspaceGetter,
+  workspaceGetter: MachineApiWorkspaceGetter,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
   executeSqlWithWorkspaceGetter(
-    dependencies,
     authenticated,
     workspaceId,
     validateExpenseSql(sql),
-    workspaceGetter,
+    (identity, resolvedWorkspaceId) => workspaceGetter(
+      dependencies,
+      identity,
+      resolvedWorkspaceId,
+    ),
     dependencies.withRestrictedTrustedIdentityContext,
   );
 
 export const runReadOnlySqlWithWorkspaceGetter = async (
   dependencies: MachineApiDependencies,
-  authenticated: AuthenticatedContext,
+  authenticated: TrustedIdentityContext,
   workspaceId: string,
   sql: string,
-  workspaceGetter: WorkspaceGetter,
+  workspaceGetter: MachineApiWorkspaceGetter,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
   executeSqlWithWorkspaceGetter(
-    dependencies,
     authenticated,
     workspaceId,
     validateReadOnlyExpenseSql(sql),
-    workspaceGetter,
+    (identity, resolvedWorkspaceId) => workspaceGetter(
+      dependencies,
+      identity,
+      resolvedWorkspaceId,
+    ),
     dependencies.withReadOnlyRestrictedTrustedIdentityContext,
+  );
+
+export const runSqlWithServices = async (
+  authenticated: TrustedIdentityContext,
+  workspaceId: string,
+  validated: ValidatedExpenseSql,
+  workspaceGetter: ExistingWorkspaceGetter,
+  runInRestrictedContext: RestrictedContextRunner,
+): Promise<Readonly<Record<string, unknown>> | null> =>
+  executeSqlWithWorkspaceGetter(
+    authenticated,
+    workspaceId,
+    validated,
+    workspaceGetter,
+    runInRestrictedContext,
+  );
+
+export const runReadOnlySqlWithServices = async (
+  authenticated: TrustedIdentityContext,
+  workspaceId: string,
+  validated: ValidatedReadOnlyExpenseSql,
+  workspaceGetter: ExistingWorkspaceGetter,
+  runInReadOnlyRestrictedContext: RestrictedContextRunner,
+): Promise<Readonly<Record<string, unknown>> | null> =>
+  executeSqlWithWorkspaceGetter(
+    authenticated,
+    workspaceId,
+    validated,
+    workspaceGetter,
+    runInReadOnlyRestrictedContext,
   );
 
 export const runSql = async (
   dependencies: MachineApiDependencies,
-  authenticated: AuthenticatedContext,
+  authenticated: TrustedIdentityContext,
   workspaceId: string,
   validated: ValidatedExpenseSql,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
   executeSqlWithWorkspaceGetter(
-    dependencies,
     authenticated,
     workspaceId,
     validated,
-    getWorkspace,
+    (identity, resolvedWorkspaceId) => getWorkspace(
+      dependencies,
+      identity,
+      resolvedWorkspaceId,
+    ),
     dependencies.withRestrictedTrustedIdentityContext,
   );
 
 export const runReadOnlySql = async (
   dependencies: MachineApiDependencies,
-  authenticated: AuthenticatedContext,
+  authenticated: TrustedIdentityContext,
   workspaceId: string,
   validated: ValidatedReadOnlyExpenseSql,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
   executeSqlWithWorkspaceGetter(
-    dependencies,
     authenticated,
     workspaceId,
     validated,
-    getWorkspace,
+    (identity, resolvedWorkspaceId) => getWorkspace(
+      dependencies,
+      identity,
+      resolvedWorkspaceId,
+    ),
     dependencies.withReadOnlyRestrictedTrustedIdentityContext,
   );

--- a/apps/sql-api/src/machineApi/types.ts
+++ b/apps/sql-api/src/machineApi/types.ts
@@ -9,8 +9,11 @@ import {
   withRestrictedTrustedIdentityContext,
 } from "../db.js";
 
-export type AuthenticatedContext = Readonly<{
+export type TrustedIdentityContext = Readonly<{
   identity: UserIdentity;
+}>;
+
+export type AuthenticatedContext = TrustedIdentityContext & Readonly<{
   connectionId: string;
   label: string;
   createdAt: string;

--- a/apps/sql-api/src/machineApi/workspaceService.ts
+++ b/apps/sql-api/src/machineApi/workspaceService.ts
@@ -1,4 +1,4 @@
-import { resolveOrCreateWorkspaceForTrustedIdentity, type UserIdentity } from "../db.js";
+import { resolveOrCreateWorkspaceForTrustedIdentity, type QueryFn, type UserIdentity } from "../db.js";
 import type { AuthenticatedContext, MachineApiDependencies, WorkspaceSummary } from "./types.js";
 
 const WORKSPACES_SQL = `SELECT w.workspace_id, w.name
@@ -27,13 +27,53 @@ const mapWorkspaceRows = (rows: ReadonlyArray<unknown>): ReadonlyArray<Workspace
     };
   });
 
+export const listWorkspacesWithQuery = async (
+  queryFn: QueryFn,
+  identity: UserIdentity,
+): Promise<ReadonlyArray<WorkspaceSummary>> => {
+  const result = await queryFn(WORKSPACES_SQL, [identity.userId]);
+  return mapWorkspaceRows(result.rows);
+};
+
+export const getWorkspaceWithQuery = async (
+  queryFn: QueryFn,
+  identity: UserIdentity,
+  workspaceId: string,
+): Promise<WorkspaceSummary | null> => {
+  const result = await queryFn(
+    `SELECT w.workspace_id, w.name
+     FROM workspaces w
+     JOIN workspace_members wm ON wm.workspace_id = w.workspace_id
+     WHERE w.workspace_id = $1
+       AND wm.user_id = $2`,
+    [workspaceId, identity.userId],
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  const row = result.rows[0] as { workspace_id: string; name: string };
+  return {
+    workspaceId: row.workspace_id,
+    name: row.name,
+  };
+};
+
 export const listWorkspaces = async (
   dependencies: MachineApiDependencies,
   identity: UserIdentity,
 ): Promise<ReadonlyArray<WorkspaceSummary>> => {
   const contextWorkspace = await resolveOrCreateWorkspaceForTrustedIdentity(identity);
-  const result = await dependencies.queryAsTrustedIdentity(identity, contextWorkspace.workspaceId, WORKSPACES_SQL, [identity.userId]);
-  return mapWorkspaceRows(result.rows);
+  return listWorkspacesWithQuery(
+    (text, params) => dependencies.queryAsTrustedIdentity(
+      identity,
+      contextWorkspace.workspaceId,
+      text,
+      params,
+    ),
+    identity,
+  );
 };
 
 export const createWorkspace = async (
@@ -66,26 +106,16 @@ export const getWorkspace = async (
   workspaceId: string,
 ): Promise<WorkspaceSummary | null> => {
   const contextWorkspace = await resolveOrCreateWorkspaceForTrustedIdentity(identity);
-  const result = await dependencies.queryAsTrustedIdentity(
+  return getWorkspaceWithQuery(
+    (text, params) => dependencies.queryAsTrustedIdentity(
+      identity,
+      contextWorkspace.workspaceId,
+      text,
+      params,
+    ),
     identity,
-    contextWorkspace.workspaceId,
-    `SELECT w.workspace_id, w.name
-     FROM workspaces w
-     JOIN workspace_members wm ON wm.workspace_id = w.workspace_id
-     WHERE w.workspace_id = $1
-       AND wm.user_id = $2`,
-    [workspaceId, identity.userId],
+    workspaceId,
   );
-
-  if (result.rows.length === 0) {
-    return null;
-  }
-
-  const row = result.rows[0] as { workspace_id: string; name: string };
-  return {
-    workspaceId: row.workspace_id,
-    name: row.name,
-  };
 };
 
 export const persistSelectedWorkspace = async (

--- a/apps/sql-api/src/mcp-handler.test.ts
+++ b/apps/sql-api/src/mcp-handler.test.ts
@@ -1,0 +1,367 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { UserIdentity } from "./db.js";
+import { createQueryResult } from "./handlerTestUtils.js";
+import {
+  authenticateMcpAccessTokenWithDependencies,
+  McpAuthenticationError,
+  type AuthenticatedMcpAccessToken,
+} from "./mcp/auth.js";
+import type { McpRuntimeConfig } from "./mcp/config.js";
+import { createMcpServer } from "./mcp/server.js";
+import type { SqlApiLogEvent } from "./logger.js";
+import {
+  createMcpApp,
+  type McpHandlerDependencies,
+} from "./mcp-handler.js";
+
+const ACCESS_TOKEN = `ebt_at_${"A".repeat(43)}`;
+const RESOURCE = "https://mcp.example.com/mcp";
+const METADATA_URL = "https://mcp.example.com/.well-known/oauth-protected-resource/mcp";
+const CONFIG: McpRuntimeConfig = {
+  issuer: "https://auth.example.com",
+  resource: RESOURCE,
+  resourceOrigin: "https://mcp.example.com",
+  canonicalHost: "mcp.example.com",
+  protectedResourceMetadataUrl: METADATA_URL,
+};
+const CONNECTION: AuthenticatedMcpAccessToken = {
+  connectionId: "connection-1",
+  clientId: "client-1",
+  resource: RESOURCE,
+  scopes: ["expenses:read", "expenses:write"],
+  identity: {
+    userId: "user-1",
+    email: "user@example.com",
+    emailVerified: true,
+    cognitoStatus: "CONFIRMED",
+    cognitoEnabled: true,
+  },
+};
+
+type Authenticator = McpHandlerDependencies["authenticateMcpAccessToken"];
+
+const createDependencies = (
+  authenticator: Authenticator,
+  logEvents: Array<SqlApiLogEvent>,
+): McpHandlerDependencies => ({
+  authenticateMcpAccessToken: authenticator,
+  createMcpServer,
+  getMcpRuntimeConfig: () => CONFIG,
+  log: (event) => {
+    logEvents.push(event);
+  },
+});
+
+const authenticatedHeaders = (): Readonly<Record<string, string>> => ({
+  authorization: `Bearer ${ACCESS_TOKEN}`,
+  host: CONFIG.canonicalHost,
+});
+
+const initializeRequest = (): Request => new Request(RESOURCE, {
+  method: "POST",
+  headers: {
+    ...authenticatedHeaders(),
+    accept: "application/json, text/event-stream",
+    "content-type": "application/json",
+    origin: CONFIG.resourceOrigin,
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-11-25",
+      capabilities: {},
+      clientInfo: { name: "mcp-handler-test", version: "1.0.0" },
+    },
+  }),
+});
+
+test("MCP handler serves health and both protected-resource metadata locations", async (): Promise<void> => {
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const app = createMcpApp(createDependencies(async () => CONNECTION, logEvents));
+
+  const health = await app.request("https://mcp.example.com/health");
+  assert.equal(health.status, 200);
+  assert.deepEqual(await health.json(), { status: "ok" });
+
+  for (const path of [
+    "/.well-known/oauth-protected-resource/mcp",
+    "/.well-known/oauth-protected-resource",
+  ]) {
+    const response = await app.request(`https://mcp.example.com${path}`);
+    assert.equal(response.status, 200, path);
+    assert.deepEqual(await response.json(), {
+      resource: RESOURCE,
+      authorization_servers: [CONFIG.issuer],
+      bearer_methods_supported: ["header"],
+      scopes_supported: ["expenses:read", "expenses:write"],
+    });
+  }
+  assert.deepEqual(logEvents, []);
+});
+
+test("MCP handler does not serve any /v1 route aliases", async (): Promise<void> => {
+  let authenticationCalls = 0;
+  const app = createMcpApp(createDependencies(async () => {
+    authenticationCalls += 1;
+    return CONNECTION;
+  }, []));
+
+  for (const path of [
+    "/v1/health",
+    "/v1/.well-known/oauth-protected-resource/mcp",
+    "/v1/.well-known/oauth-protected-resource",
+  ]) {
+    const response = await app.request(`https://mcp.example.com${path}`);
+    assert.equal(response.status, 404, path);
+  }
+
+  const mcp = await app.request("https://mcp.example.com/v1/mcp", {
+    method: "POST",
+    headers: authenticatedHeaders(),
+  });
+  assert.equal(mcp.status, 404);
+  assert.equal(authenticationCalls, 0);
+});
+
+test("MCP handler returns a path-aware Bearer challenge for missing and invalid tokens", async (): Promise<void> => {
+  let authenticationCalls = 0;
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const app = createMcpApp(createDependencies(async () => {
+    authenticationCalls += 1;
+    throw new McpAuthenticationError();
+  }, logEvents));
+
+  const missing = await app.request(RESOURCE, {
+    method: "POST",
+    headers: { host: CONFIG.canonicalHost },
+  });
+  assert.equal(missing.status, 401);
+  assert.equal(
+    missing.headers.get("www-authenticate"),
+    `Bearer resource_metadata="${METADATA_URL}"`,
+  );
+
+  const apiKey = await app.request(RESOURCE, {
+    method: "POST",
+    headers: {
+      authorization: "ApiKey EBTA_12345678_0123456789ABCDEFGHJKMNPQRSTV",
+      host: CONFIG.canonicalHost,
+    },
+  });
+  assert.equal(apiKey.status, 401);
+
+  const invalid = await app.request(RESOURCE, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+  });
+  assert.equal(invalid.status, 401);
+  assert.equal(invalid.headers.get("www-authenticate"), `Bearer resource_metadata="${METADATA_URL}"`);
+  assert.equal(authenticationCalls, 1);
+  assert.deepEqual(logEvents, []);
+});
+
+test("MCP handler maps current identity trust failures to the generic Bearer challenge", async (): Promise<void> => {
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const disabledIdentity: UserIdentity = {
+    ...CONNECTION.identity,
+    cognitoEnabled: false,
+  };
+  const app = createMcpApp(createDependencies(
+    (token, resource) => authenticateMcpAccessTokenWithDependencies(
+      token,
+      resource,
+      {
+        query: async () => createQueryResult([{
+          connection_id: CONNECTION.connectionId,
+          user_id: CONNECTION.identity.userId,
+          client_id: CONNECTION.clientId,
+          resource: RESOURCE,
+          scopes: CONNECTION.scopes,
+          expires_at: new Date("2026-08-14T13:00:00.000Z"),
+        }]),
+        loadTrustedUserIdentity: async () => disabledIdentity,
+        now: () => new Date("2026-08-14T12:00:00.000Z"),
+      },
+    ),
+    logEvents,
+  ));
+
+  const response = await app.request(RESOURCE, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+  });
+  assert.equal(response.status, 401);
+  assert.equal(response.headers.get("www-authenticate"), `Bearer resource_metadata="${METADATA_URL}"`);
+  const responseText = await response.text();
+  assert.deepEqual(JSON.parse(responseText), {
+    error: "invalid_token",
+    error_description: "A valid OAuth Bearer access token is required for this MCP resource.",
+  });
+  assert.equal(responseText.includes("disabled"), false);
+  assert.deepEqual(logEvents, []);
+});
+
+test("MCP handler maps invalid scope snapshots to the generic Bearer challenge", async (): Promise<void> => {
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const app = createMcpApp(createDependencies(
+    (token, resource) => authenticateMcpAccessTokenWithDependencies(
+      token,
+      resource,
+      {
+        query: async () => createQueryResult([{
+          connection_id: CONNECTION.connectionId,
+          user_id: CONNECTION.identity.userId,
+          client_id: CONNECTION.clientId,
+          resource: RESOURCE,
+          scopes: ["expenses:write", "expenses:read"],
+          expires_at: new Date("2026-08-14T13:00:00.000Z"),
+        }]),
+        loadTrustedUserIdentity: async () => CONNECTION.identity,
+        now: () => new Date("2026-08-14T12:00:00.000Z"),
+      },
+    ),
+    logEvents,
+  ));
+
+  const response = await app.request(RESOURCE, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+  });
+  assert.equal(response.status, 401);
+  assert.equal(response.headers.get("www-authenticate"), `Bearer resource_metadata="${METADATA_URL}"`);
+  const responseText = await response.text();
+  assert.deepEqual(JSON.parse(responseText), {
+    error: "invalid_token",
+    error_description: "A valid OAuth Bearer access token is required for this MCP resource.",
+  });
+  assert.equal(responseText.includes(ACCESS_TOKEN), false);
+  assert.equal(responseText.includes("expenses:write"), false);
+  assert.deepEqual(logEvents, []);
+});
+
+test("MCP handler keeps unrelated access-token row corruption as an internal error", async (): Promise<void> => {
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const app = createMcpApp(createDependencies(
+    (token, resource) => authenticateMcpAccessTokenWithDependencies(
+      token,
+      resource,
+      {
+        query: async () => createQueryResult([{
+          connection_id: CONNECTION.connectionId,
+          user_id: CONNECTION.identity.userId,
+          client_id: 42,
+          resource: RESOURCE,
+          scopes: CONNECTION.scopes,
+          expires_at: new Date("2026-08-14T13:00:00.000Z"),
+        }]),
+        loadTrustedUserIdentity: async () => CONNECTION.identity,
+        now: () => new Date("2026-08-14T12:00:00.000Z"),
+      },
+    ),
+    logEvents,
+  ));
+
+  const response = await app.request(RESOURCE, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+  });
+  assert.equal(response.status, 500);
+  assert.equal(response.headers.get("www-authenticate"), null);
+  assert.deepEqual(await response.json(), {
+    error: "internal_error",
+    error_description: "The MCP request could not be authenticated.",
+  });
+  assert.deepEqual(logEvents, [{
+    domain: "sql_api",
+    action: "mcp_unexpected_error",
+    boundary: "authentication",
+    operation: "validate_oauth_access_token",
+    errorType: "error",
+  }]);
+});
+
+test("MCP handler rejects non-canonical Host and Origin before authentication", async (): Promise<void> => {
+  let authenticationCalls = 0;
+  const app = createMcpApp(createDependencies(async () => {
+    authenticationCalls += 1;
+    return CONNECTION;
+  }, []));
+
+  const wrongHost = await app.request("https://other.example/mcp", {
+    method: "POST",
+    headers: { ...authenticatedHeaders(), host: "other.example" },
+  });
+  assert.equal(wrongHost.status, 403);
+
+  const wrongOrigin = await app.request(RESOURCE, {
+    method: "POST",
+    headers: { ...authenticatedHeaders(), origin: "https://other.example" },
+  });
+  assert.equal(wrongOrigin.status, 403);
+  assert.equal(authenticationCalls, 0);
+});
+
+test("MCP handler returns 405 for authenticated GET and DELETE requests", async (): Promise<void> => {
+  const app = createMcpApp(createDependencies(async () => CONNECTION, []));
+
+  for (const method of ["GET", "DELETE"]) {
+    const response = await app.request(RESOURCE, {
+      method,
+      headers: authenticatedHeaders(),
+    });
+    assert.equal(response.status, 405, method);
+    assert.equal(response.headers.get("allow"), "POST", method);
+  }
+});
+
+test("MCP handler uses stateless JSON transport with no session identifier", async (): Promise<void> => {
+  let serverCreations = 0;
+  const dependencies = createDependencies(async (token, resource) => {
+    assert.equal(token, ACCESS_TOKEN);
+    assert.equal(resource, RESOURCE);
+    return CONNECTION;
+  }, []);
+  const app = createMcpApp({
+    ...dependencies,
+    createMcpServer: (connection) => {
+      serverCreations += 1;
+      return createMcpServer(connection);
+    },
+  });
+
+  for (let requestNumber = 0; requestNumber < 2; requestNumber += 1) {
+    const response = await app.request(initializeRequest());
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type") ?? "", /^application\/json/u);
+    assert.equal(response.headers.get("mcp-session-id"), null);
+    const body = await response.json() as Readonly<Record<string, unknown>>;
+    assert.equal(body["jsonrpc"], "2.0");
+    assert.equal(body["id"], 1);
+  }
+  assert.equal(serverCreations, 2);
+});
+
+test("MCP handler sanitizes and structurally logs unexpected authentication failures", async (): Promise<void> => {
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const app = createMcpApp(createDependencies(async () => {
+    throw new Error("password authentication failed for database db.internal.example");
+  }, logEvents));
+
+  const response = await app.request(RESOURCE, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+  });
+  assert.equal(response.status, 500);
+  const bodyText = await response.text();
+  assert.equal(bodyText.includes("db.internal.example"), false);
+  assert.deepEqual(logEvents, [{
+    domain: "sql_api",
+    action: "mcp_unexpected_error",
+    boundary: "authentication",
+    operation: "validate_oauth_access_token",
+    errorType: "error",
+  }]);
+});

--- a/apps/sql-api/src/mcp-handler.ts
+++ b/apps/sql-api/src/mcp-handler.ts
@@ -1,0 +1,175 @@
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { handle } from "hono/aws-lambda";
+import { type Context, Hono } from "hono";
+import {
+  authenticateMcpAccessToken,
+  McpAuthenticationError,
+  type AuthenticatedMcpAccessToken,
+} from "./mcp/auth.js";
+import { getMcpRuntimeConfig, type McpRuntimeConfig } from "./mcp/config.js";
+import {
+  buildBearerChallenge,
+  buildProtectedResourceMetadata,
+} from "./mcp/resourceMetadata.js";
+import { createMcpServer } from "./mcp/server.js";
+import { getSafeErrorType, log } from "./logger.js";
+
+const BEARER_AUTHORIZATION_PATTERN = /^[Bb][Ee][Aa][Rr][Ee][Rr]\s+(ebt_at_[A-Za-z0-9_-]{43})$/u;
+
+export type McpHandlerDependencies = Readonly<{
+  authenticateMcpAccessToken: typeof authenticateMcpAccessToken;
+  createMcpServer: typeof createMcpServer;
+  getMcpRuntimeConfig: typeof getMcpRuntimeConfig;
+  log: typeof log;
+}>;
+
+const defaultDependencies: McpHandlerDependencies = {
+  authenticateMcpAccessToken,
+  createMcpServer,
+  getMcpRuntimeConfig,
+  log,
+};
+
+const extractBearerAccessToken = (authorization: string | undefined): string | null => {
+  if (authorization === undefined) {
+    return null;
+  }
+  const match = BEARER_AUTHORIZATION_PATTERN.exec(authorization.trim());
+  return match?.[1] ?? null;
+};
+
+const buildBearerChallengeResponse = (
+  context: Context,
+  config: McpRuntimeConfig,
+): Response => context.json(
+  {
+    error: "invalid_token",
+    error_description: "A valid OAuth Bearer access token is required for this MCP resource.",
+  },
+  401,
+  { "WWW-Authenticate": buildBearerChallenge(config) },
+);
+
+const validateCanonicalRequestSource = (
+  request: Request,
+  config: McpRuntimeConfig,
+): boolean => {
+  const host = request.headers.get("host");
+  if (host === null || host.toLowerCase() !== config.canonicalHost.toLowerCase()) {
+    return false;
+  }
+  const origin = request.headers.get("origin");
+  return origin === null || origin === config.resourceOrigin;
+};
+
+const handleMcpTransportRequest = async (
+  request: Request,
+  connection: AuthenticatedMcpAccessToken,
+  config: McpRuntimeConfig,
+  dependencies: McpHandlerDependencies,
+): Promise<Response> => {
+  const server = dependencies.createMcpServer(connection);
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+    enableDnsRebindingProtection: true,
+    allowedHosts: [config.canonicalHost],
+    allowedOrigins: [config.resourceOrigin],
+  });
+
+  try {
+    await server.connect(transport);
+    return await transport.handleRequest(request);
+  } finally {
+    await transport.close();
+    await server.close();
+  }
+};
+
+const buildMcpRoutes = (app: Hono, dependencies: McpHandlerDependencies): Hono => {
+  app.get("/health", (context) => context.json({ status: "ok" }));
+
+  const protectedResourceMetadata = (context: Context): Response => {
+    const config = dependencies.getMcpRuntimeConfig();
+    return context.json(buildProtectedResourceMetadata(config));
+  };
+  app.get("/.well-known/oauth-protected-resource/mcp", protectedResourceMetadata);
+  app.get("/.well-known/oauth-protected-resource", protectedResourceMetadata);
+
+  app.all("/mcp", async (context): Promise<Response> => {
+    const config = dependencies.getMcpRuntimeConfig();
+    if (!validateCanonicalRequestSource(context.req.raw, config)) {
+      return context.json(
+        {
+          error: "invalid_request_source",
+          error_description: "The request Host or Origin is not allowed for this MCP resource.",
+        },
+        403,
+      );
+    }
+
+    const token = extractBearerAccessToken(context.req.header("authorization"));
+    if (token === null) {
+      return buildBearerChallengeResponse(context, config);
+    }
+
+    let connection: AuthenticatedMcpAccessToken;
+    try {
+      connection = await dependencies.authenticateMcpAccessToken(token, config.resource);
+    } catch (error) {
+      if (error instanceof McpAuthenticationError) {
+        return buildBearerChallengeResponse(context, config);
+      }
+      dependencies.log({
+        domain: "sql_api",
+        action: "mcp_unexpected_error",
+        boundary: "authentication",
+        operation: "validate_oauth_access_token",
+        errorType: getSafeErrorType(error),
+      });
+      return context.json(
+        { error: "internal_error", error_description: "The MCP request could not be authenticated." },
+        500,
+      );
+    }
+
+    if (context.req.method !== "POST") {
+      return context.json(
+        {
+          error: "method_not_allowed",
+          error_description: "The MCP resource only accepts POST in stateless JSON mode.",
+        },
+        405,
+        { Allow: "POST" },
+      );
+    }
+
+    return handleMcpTransportRequest(context.req.raw, connection, config, dependencies);
+  });
+
+  return app;
+};
+
+export const createMcpApp = (dependencies: McpHandlerDependencies): Hono => {
+  const app = new Hono();
+  app.route("/", buildMcpRoutes(new Hono(), dependencies));
+  app.onError((error, context) => {
+    dependencies.log({
+      domain: "sql_api",
+      action: "mcp_unexpected_error",
+      boundary: "transport",
+      operation: context.req.path,
+      errorType: getSafeErrorType(error),
+    });
+    return context.json(
+      { error: "internal_error", error_description: "The MCP request could not be completed." },
+      500,
+    );
+  });
+  return app;
+};
+
+export const createMcpHandler = (dependencies: McpHandlerDependencies) =>
+  handle(createMcpApp(dependencies));
+
+export const handler = createMcpHandler(defaultDependencies);

--- a/apps/sql-api/src/mcp/auth.test.ts
+++ b/apps/sql-api/src/mcp/auth.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import { createQueryResult } from "../handlerTestUtils.js";
+import type { UserIdentity } from "../db.js";
+import {
+  authenticateMcpAccessTokenWithDependencies,
+  McpAuthenticationError,
+  type McpAuthDependencies,
+} from "./auth.js";
+
+const ACCESS_TOKEN = `ebt_at_${"Ab-_".repeat(10)}Ab_`;
+const RESOURCE = "https://mcp.example.com/mcp";
+const NOW = new Date("2026-08-14T12:00:00.000Z");
+const IDENTITY: UserIdentity = {
+  userId: "user-1",
+  email: "user@example.com",
+  emailVerified: true,
+  cognitoStatus: "CONFIRMED",
+  cognitoEnabled: true,
+};
+
+type AuthCalls = {
+  queries: Array<Readonly<{ text: string; params: ReadonlyArray<unknown> }>>;
+  loadedUserIds: Array<string>;
+};
+
+const createDependencies = (
+  rows: ReadonlyArray<unknown>,
+  identity: UserIdentity | null,
+  calls: AuthCalls,
+): McpAuthDependencies => ({
+  query: async (text, params) => {
+    calls.queries.push({ text, params });
+    return createQueryResult(rows);
+  },
+  loadTrustedUserIdentity: async (userId) => {
+    calls.loadedUserIds.push(userId);
+    return identity;
+  },
+  now: () => NOW,
+});
+
+const validRow = (overrides: Readonly<Record<string, unknown>>): Readonly<Record<string, unknown>> => ({
+  connection_id: "connection-1",
+  user_id: IDENTITY.userId,
+  client_id: "ebt_cl_client",
+  resource: RESOURCE,
+  scopes: ["expenses:read", "expenses:write"],
+  expires_at: new Date("2026-08-14T13:00:00.000Z"),
+  ...overrides,
+});
+
+test("MCP auth hashes the entire opaque access token and loads the existing user identity", async (): Promise<void> => {
+  const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+  const result = await authenticateMcpAccessTokenWithDependencies(
+    ACCESS_TOKEN,
+    RESOURCE,
+    createDependencies([validRow({})], IDENTITY, calls),
+  );
+
+  assert.equal(calls.queries.length, 1);
+  assert.match(calls.queries[0]?.text ?? "", /FROM auth[.]validate_oauth_access_token[(][$]1[)]/u);
+  assert.deepEqual(calls.queries[0]?.params, [
+    createHash("sha256").update(ACCESS_TOKEN).digest("hex"),
+  ]);
+  assert.deepEqual(calls.loadedUserIds, [IDENTITY.userId]);
+  assert.deepEqual(result, {
+    connectionId: "connection-1",
+    clientId: "ebt_cl_client",
+    resource: RESOURCE,
+    scopes: ["expenses:read", "expenses:write"],
+    identity: IDENTITY,
+  });
+});
+
+test("MCP auth accepts the canonical read-only scope snapshot", async (): Promise<void> => {
+  const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+  const result = await authenticateMcpAccessTokenWithDependencies(
+    ACCESS_TOKEN,
+    RESOURCE,
+    createDependencies(
+      [validRow({ scopes: ["expenses:read"] })],
+      IDENTITY,
+      calls,
+    ),
+  );
+
+  assert.deepEqual(result.scopes, ["expenses:read"]);
+  assert.deepEqual(calls.loadedUserIds, [IDENTITY.userId]);
+});
+
+test("MCP auth rejects non-OAuth credentials before database access", async (): Promise<void> => {
+  for (const token of [
+    "EBTA_12345678_0123456789ABCDEFGHJKMNPQRSTV",
+    `EBT_AT_${"A".repeat(43)}`,
+    `ebt_at_${"A".repeat(42)}`,
+  ]) {
+    const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+    await assert.rejects(
+      () => authenticateMcpAccessTokenWithDependencies(
+        token,
+        RESOURCE,
+        createDependencies([], IDENTITY, calls),
+      ),
+      (error: unknown) => error instanceof McpAuthenticationError,
+    );
+    assert.deepEqual(calls.queries, []);
+  }
+});
+
+test("MCP auth rejects missing, expired, and wrong-resource access-token grants", async (): Promise<void> => {
+  for (const rows of [
+    [],
+    [validRow({ expires_at: NOW })],
+    [validRow({ resource: "https://mcp.other.example/mcp" })],
+  ]) {
+    const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+    await assert.rejects(
+      () => authenticateMcpAccessTokenWithDependencies(
+        ACCESS_TOKEN,
+        RESOURCE,
+        createDependencies(rows, IDENTITY, calls),
+      ),
+      (error: unknown) => error instanceof McpAuthenticationError,
+    );
+  }
+});
+
+test("MCP auth rejects invalid scope snapshots", async (): Promise<void> => {
+  const invalidSnapshots: ReadonlyArray<ReadonlyArray<string>> = [
+    ["expenses:write"],
+    ["expenses:read", "expenses:read"],
+    ["expenses:write", "expenses:read"],
+    ["expenses:read", "unsupported:scope"],
+  ];
+
+  for (const scopes of invalidSnapshots) {
+    const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+    await assert.rejects(
+      () => authenticateMcpAccessTokenWithDependencies(
+        ACCESS_TOKEN,
+        RESOURCE,
+        createDependencies([validRow({ scopes })], IDENTITY, calls),
+      ),
+      (error: unknown) =>
+        error instanceof McpAuthenticationError
+        && error.message === "Invalid OAuth access token",
+      scopes.join(","),
+    );
+    assert.deepEqual(calls.loadedUserIds, [], scopes.join(","));
+  }
+});
+
+test("MCP auth preserves unrelated database row corruption as an internal error", async (): Promise<void> => {
+  const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+  await assert.rejects(
+    () => authenticateMcpAccessTokenWithDependencies(
+      ACCESS_TOKEN,
+      RESOURCE,
+      createDependencies([validRow({ client_id: 42 })], IDENTITY, calls),
+    ),
+    (error: unknown) =>
+      error instanceof Error
+      && !(error instanceof McpAuthenticationError)
+      && error.message === "validate_oauth_access_token returned an invalid access-token row",
+  );
+});
+
+test("MCP auth rejects absent and currently untrusted user identities as invalid tokens", async (): Promise<void> => {
+  const cases: ReadonlyArray<Readonly<{
+    name: string;
+    identity: UserIdentity | null;
+  }>> = [
+    { name: "missing user", identity: null },
+    {
+      name: "mismatched user",
+      identity: { ...IDENTITY, userId: "user-other" },
+    },
+    {
+      name: "unverified email",
+      identity: { ...IDENTITY, emailVerified: false },
+    },
+    {
+      name: "disabled Cognito identity",
+      identity: { ...IDENTITY, cognitoEnabled: false },
+    },
+    {
+      name: "non-confirmed Cognito status",
+      identity: { ...IDENTITY, cognitoStatus: "FORCE_CHANGE_PASSWORD" },
+    },
+  ];
+
+  for (const testCase of cases) {
+    const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+    await assert.rejects(
+      () => authenticateMcpAccessTokenWithDependencies(
+        ACCESS_TOKEN,
+        RESOURCE,
+        createDependencies([validRow({})], testCase.identity, calls),
+      ),
+      (error: unknown) =>
+        error instanceof McpAuthenticationError
+        && error.message === "Invalid OAuth access token",
+      testCase.name,
+    );
+    assert.deepEqual(calls.loadedUserIds, [IDENTITY.userId], testCase.name);
+  }
+});

--- a/apps/sql-api/src/mcp/auth.ts
+++ b/apps/sql-api/src/mcp/auth.ts
@@ -1,0 +1,130 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import {
+  loadTrustedUserIdentity,
+  query,
+  type QueryFn,
+  type UserIdentity,
+} from "../db.js";
+import type { McpScope } from "./config.js";
+
+const ACCESS_TOKEN_PATTERN = /^ebt_at_[A-Za-z0-9_-]{43}$/u;
+
+const accessTokenRowSchema = z.object({
+  connection_id: z.string().min(1),
+  user_id: z.string().min(1),
+  client_id: z.string().min(1),
+  resource: z.string().min(1),
+  scopes: z.array(z.string().min(1)),
+  expires_at: z.union([z.date(), z.string().min(1)]),
+});
+
+export type AuthenticatedMcpAccessToken = Readonly<{
+  connectionId: string;
+  clientId: string;
+  resource: string;
+  scopes: ReadonlyArray<McpScope>;
+  identity: UserIdentity;
+}>;
+
+export class McpAuthenticationError extends Error {
+  constructor() {
+    super("Invalid OAuth access token");
+  }
+}
+
+export type McpAuthDependencies = Readonly<{
+  query: QueryFn;
+  loadTrustedUserIdentity: (userId: string) => Promise<UserIdentity | null>;
+  now: () => Date;
+}>;
+
+const defaultDependencies: McpAuthDependencies = {
+  query,
+  loadTrustedUserIdentity,
+  now: () => new Date(),
+};
+
+const hashAccessToken = (token: string): string =>
+  createHash("sha256").update(token).digest("hex");
+
+const readExpirationTime = (value: Date | string): number => {
+  const timestamp = value instanceof Date ? value.getTime() : Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new Error("validate_oauth_access_token returned an invalid expires_at value");
+  }
+  return timestamp;
+};
+
+const readCanonicalScopeSnapshot = (
+  scopes: ReadonlyArray<string>,
+): ReadonlyArray<McpScope> => {
+  if (scopes.length === 1 && scopes[0] === "expenses:read") {
+    return ["expenses:read"];
+  }
+  if (
+    scopes.length === 2
+    && scopes[0] === "expenses:read"
+    && scopes[1] === "expenses:write"
+  ) {
+    return ["expenses:read", "expenses:write"];
+  }
+  throw new McpAuthenticationError();
+};
+
+export const authenticateMcpAccessTokenWithDependencies = async (
+  token: string,
+  expectedResource: string,
+  dependencies: McpAuthDependencies,
+): Promise<AuthenticatedMcpAccessToken> => {
+  if (!ACCESS_TOKEN_PATTERN.test(token)) {
+    throw new McpAuthenticationError();
+  }
+
+  const result = await dependencies.query(
+    `SELECT connection_id, user_id, client_id, resource, scopes, expires_at
+     FROM auth.validate_oauth_access_token($1)`,
+    [hashAccessToken(token)],
+  );
+  if (result.rows.length !== 1) {
+    throw new McpAuthenticationError();
+  }
+
+  const parsed = accessTokenRowSchema.safeParse(result.rows[0]);
+  if (!parsed.success) {
+    throw new Error("validate_oauth_access_token returned an invalid access-token row");
+  }
+  const row = parsed.data;
+  const scopes = readCanonicalScopeSnapshot(row.scopes);
+  if (
+    row.resource !== expectedResource
+    || readExpirationTime(row.expires_at) <= dependencies.now().getTime()
+  ) {
+    throw new McpAuthenticationError();
+  }
+
+  const identity = await dependencies.loadTrustedUserIdentity(row.user_id);
+  if (
+    identity === null
+    || identity.userId !== row.user_id
+    || !identity.emailVerified
+    || !identity.cognitoEnabled
+    || identity.cognitoStatus !== "CONFIRMED"
+  ) {
+    throw new McpAuthenticationError();
+  }
+
+  return {
+    connectionId: row.connection_id,
+    clientId: row.client_id,
+    resource: row.resource,
+    scopes,
+    identity,
+  };
+};
+
+export const authenticateMcpAccessToken = (
+  token: string,
+  expectedResource: string,
+): Promise<AuthenticatedMcpAccessToken> =>
+  authenticateMcpAccessTokenWithDependencies(token, expectedResource, defaultDependencies);

--- a/apps/sql-api/src/mcp/config.ts
+++ b/apps/sql-api/src/mcp/config.ts
@@ -1,0 +1,55 @@
+export const MCP_SCOPES = ["expenses:read", "expenses:write"] as const;
+
+export type McpScope = typeof MCP_SCOPES[number];
+
+export type McpRuntimeConfig = Readonly<{
+  issuer: string;
+  resource: string;
+  resourceOrigin: string;
+  canonicalHost: string;
+  protectedResourceMetadataUrl: string;
+}>;
+
+const parseAbsoluteUrl = (value: string, variableName: string): URL => {
+  try {
+    return new URL(value);
+  } catch {
+    throw new Error(`MCP runtime is misconfigured: ${variableName} must be an absolute URL`);
+  }
+};
+
+export const getMcpRuntimeConfig = (): McpRuntimeConfig => {
+  const issuer = process.env.OAUTH_ISSUER ?? "";
+  const resource = process.env.OAUTH_RESOURCE ?? "";
+  if (issuer === "" || resource === "") {
+    throw new Error("MCP runtime is not configured: OAUTH_ISSUER and OAUTH_RESOURCE are required");
+  }
+
+  const issuerUrl = parseAbsoluteUrl(issuer, "OAUTH_ISSUER");
+  const resourceUrl = parseAbsoluteUrl(resource, "OAUTH_RESOURCE");
+  if (
+    issuer !== issuerUrl.origin
+    || issuerUrl.username !== ""
+    || issuerUrl.password !== ""
+  ) {
+    throw new Error("MCP runtime is misconfigured: OAUTH_ISSUER must be an origin URL");
+  }
+  if (
+    resource !== `${resourceUrl.origin}/mcp`
+    || resourceUrl.pathname !== "/mcp"
+    || resourceUrl.search !== ""
+    || resourceUrl.hash !== ""
+    || resourceUrl.username !== ""
+    || resourceUrl.password !== ""
+  ) {
+    throw new Error("MCP runtime is misconfigured: OAUTH_RESOURCE must be an absolute /mcp URL");
+  }
+
+  return {
+    issuer,
+    resource,
+    resourceOrigin: resourceUrl.origin,
+    canonicalHost: resourceUrl.host,
+    protectedResourceMetadataUrl: `${resourceUrl.origin}/.well-known/oauth-protected-resource/mcp`,
+  };
+};

--- a/apps/sql-api/src/mcp/dataService.test.ts
+++ b/apps/sql-api/src/mcp/dataService.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { QueryResult } from "pg";
+import {
+  validateSingleExpenseSql,
+  validateSingleReadOnlyExpenseSql,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import type { QueryFn, UserIdentity } from "../db.js";
+import { createQueryResult } from "../handlerTestUtils.js";
+import {
+  createMcpDataServices,
+  type McpDataDependencies,
+} from "./dataService.js";
+
+const IDENTITY: UserIdentity = {
+  userId: "user-1",
+  email: "user@example.com",
+  emailVerified: true,
+  cognitoStatus: "CONFIRMED",
+  cognitoEnabled: true,
+};
+const WORKSPACE_ID = "workspace-1";
+
+type DataCalls = {
+  userQueries: Array<Readonly<{
+    userId: string;
+    text: string;
+    params: ReadonlyArray<unknown>;
+  }>>;
+  workspaceQueries: Array<Readonly<{
+    userId: string;
+    workspaceId: string;
+    text: string;
+    params: ReadonlyArray<unknown>;
+  }>>;
+  readContextWorkspaceIds: Array<string>;
+  writeContextWorkspaceIds: Array<string>;
+};
+
+const createCalls = (): DataCalls => ({
+  userQueries: [],
+  workspaceQueries: [],
+  readContextWorkspaceIds: [],
+  writeContextWorkspaceIds: [],
+});
+
+const createRestrictedQueryResult = (sql: string): QueryResult => {
+  if (sql.startsWith("FETCH ")) {
+    return createQueryResult([]);
+  }
+  if (sql.startsWith("MOVE ")) {
+    return {
+      command: "MOVE",
+      rowCount: 0,
+      oid: 0,
+      fields: [],
+      rows: [],
+    } as QueryResult;
+  }
+  if (sql.startsWith("DECLARE ") || sql.startsWith("CLOSE ")) {
+    return {
+      command: sql.startsWith("DECLARE ") ? "DECLARE" : "CLOSE",
+      rowCount: null,
+      oid: 0,
+      fields: [],
+      rows: [],
+    } as QueryResult;
+  }
+  return {
+    command: "DELETE",
+    rowCount: 1,
+    oid: 0,
+    fields: [],
+    rows: [],
+  } as QueryResult;
+};
+
+const createDependencies = (
+  userRows: ReadonlyArray<unknown>,
+  workspaceRows: ReadonlyArray<unknown>,
+  calls: DataCalls,
+): McpDataDependencies => ({
+  queryAsExistingTrustedIdentity: async (identity, text, params) => {
+    calls.userQueries.push({ userId: identity.userId, text, params });
+    return createQueryResult(userRows);
+  },
+  queryAsExistingTrustedWorkspace: async (identity, workspaceId, text, params) => {
+    calls.workspaceQueries.push({
+      userId: identity.userId,
+      workspaceId,
+      text,
+      params,
+    });
+    return createQueryResult(workspaceRows);
+  },
+  withNonProvisioningReadOnlyRestrictedTrustedIdentityContext: async <T>(
+    _identity: UserIdentity,
+    workspaceId: string,
+    _statementTimeoutMs: number,
+    callback: (queryFn: QueryFn) => Promise<T>,
+  ): Promise<T> => {
+    calls.readContextWorkspaceIds.push(workspaceId);
+    return callback(async (text): Promise<QueryResult> => createRestrictedQueryResult(text));
+  },
+  withRestrictedTrustedIdentityContext: async <T>(
+    _identity: UserIdentity,
+    workspaceId: string,
+    _statementTimeoutMs: number,
+    callback: (queryFn: QueryFn) => Promise<T>,
+  ): Promise<T> => {
+    calls.writeContextWorkspaceIds.push(workspaceId);
+    return callback(async (text): Promise<QueryResult> => createRestrictedQueryResult(text));
+  },
+});
+
+test("MCP data services preserve zero workspaces without provisioning or write calls", async (): Promise<void> => {
+  const calls = createCalls();
+  const services = createMcpDataServices(createDependencies([], [], calls));
+
+  const workspaces = await services.listWorkspaces(IDENTITY);
+  const queryResult = await services.runReadOnlySql(
+    { identity: IDENTITY },
+    WORKSPACE_ID,
+    validateSingleReadOnlyExpenseSql("SELECT account_id FROM accounts"),
+  );
+
+  assert.deepEqual(workspaces, []);
+  assert.equal(queryResult, null);
+  assert.equal(calls.userQueries.length, 2);
+  for (const query of calls.userQueries) {
+    assert.equal(query.userId, IDENTITY.userId);
+    assert.doesNotMatch(query.text, /\b(?:INSERT|UPDATE|DELETE)\b|ensure_/iu);
+  }
+  assert.deepEqual(calls.workspaceQueries, []);
+  assert.deepEqual(calls.readContextWorkspaceIds, []);
+  assert.deepEqual(calls.writeContextWorkspaceIds, []);
+});
+
+test("MCP workspace lookup requires exact existing user membership", async (): Promise<void> => {
+  const calls = createCalls();
+  const services = createMcpDataServices(createDependencies([], [], calls));
+
+  const workspace = await services.getWorkspace(IDENTITY, WORKSPACE_ID);
+
+  assert.equal(workspace, null);
+  assert.equal(calls.userQueries.length, 1);
+  assert.deepEqual(calls.userQueries[0]?.params, [WORKSPACE_ID, IDENTITY.userId]);
+  assert.match(calls.userQueries[0]?.text ?? "", /JOIN workspace_members/u);
+  assert.deepEqual(calls.readContextWorkspaceIds, []);
+  assert.deepEqual(calls.writeContextWorkspaceIds, []);
+});
+
+test("MCP schema reads use only the existing workspace read context", async (): Promise<void> => {
+  const calls = createCalls();
+  const services = createMcpDataServices(createDependencies([], [], calls));
+
+  await services.loadAllowedSchemaForWorkspace(IDENTITY, WORKSPACE_ID);
+
+  assert.deepEqual(calls.userQueries, []);
+  assert.equal(calls.workspaceQueries.length, 1);
+  assert.equal(calls.workspaceQueries[0]?.userId, IDENTITY.userId);
+  assert.equal(calls.workspaceQueries[0]?.workspaceId, WORKSPACE_ID);
+  assert.match(calls.workspaceQueries[0]?.text ?? "", /FROM information_schema[.]columns/u);
+  assert.deepEqual(calls.readContextWorkspaceIds, []);
+  assert.deepEqual(calls.writeContextWorkspaceIds, []);
+});
+
+test("MCP SQL routes reads through the non-provisioning reader and writes through the executor", async (): Promise<void> => {
+  const calls = createCalls();
+  const services = createMcpDataServices(createDependencies(
+    [{ workspace_id: WORKSPACE_ID, name: "Personal" }],
+    [],
+    calls,
+  ));
+
+  await services.runReadOnlySql(
+    { identity: IDENTITY },
+    WORKSPACE_ID,
+    validateSingleReadOnlyExpenseSql("SELECT account_id FROM accounts"),
+  );
+  await services.runSql(
+    { identity: IDENTITY },
+    WORKSPACE_ID,
+    validateSingleExpenseSql("DELETE FROM budget_lines WHERE category = 'Food'"),
+  );
+
+  assert.deepEqual(calls.readContextWorkspaceIds, [WORKSPACE_ID]);
+  assert.deepEqual(calls.writeContextWorkspaceIds, [WORKSPACE_ID]);
+  assert.equal(calls.userQueries.length, 2);
+  assert.deepEqual(calls.userQueries.map((query) => query.params), [
+    [WORKSPACE_ID, IDENTITY.userId],
+    [WORKSPACE_ID, IDENTITY.userId],
+  ]);
+});

--- a/apps/sql-api/src/mcp/dataService.ts
+++ b/apps/sql-api/src/mcp/dataService.ts
@@ -1,0 +1,122 @@
+import type {
+  ValidatedExpenseSql,
+  ValidatedReadOnlyExpenseSql,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import {
+  queryAsExistingTrustedIdentity,
+  queryAsExistingTrustedWorkspace,
+  type UserIdentity,
+  withNonProvisioningReadOnlyRestrictedTrustedIdentityContext,
+  withRestrictedTrustedIdentityContext,
+} from "../db.js";
+import { loadAllowedSchemaWithQuery } from "../machineApi/schemaService.js";
+import {
+  runReadOnlySqlWithServices,
+  runSqlWithServices,
+} from "../machineApi/sqlService.js";
+import type {
+  SchemaRelation,
+  TrustedIdentityContext,
+  WorkspaceSummary,
+} from "../machineApi/types.js";
+import {
+  getWorkspaceWithQuery,
+  listWorkspacesWithQuery,
+} from "../machineApi/workspaceService.js";
+
+export type McpDataDependencies = Readonly<{
+  queryAsExistingTrustedIdentity: typeof queryAsExistingTrustedIdentity;
+  queryAsExistingTrustedWorkspace: typeof queryAsExistingTrustedWorkspace;
+  withNonProvisioningReadOnlyRestrictedTrustedIdentityContext: typeof withNonProvisioningReadOnlyRestrictedTrustedIdentityContext;
+  withRestrictedTrustedIdentityContext: typeof withRestrictedTrustedIdentityContext;
+}>;
+
+export type McpDataServices = Readonly<{
+  listWorkspaces: (identity: UserIdentity) => Promise<ReadonlyArray<WorkspaceSummary>>;
+  getWorkspace: (identity: UserIdentity, workspaceId: string) => Promise<WorkspaceSummary | null>;
+  loadAllowedSchemaForWorkspace: (identity: UserIdentity, workspaceId: string) => Promise<ReadonlyArray<SchemaRelation>>;
+  runReadOnlySql: (
+    authenticated: TrustedIdentityContext,
+    workspaceId: string,
+    validated: ValidatedReadOnlyExpenseSql,
+  ) => Promise<Readonly<Record<string, unknown>> | null>;
+  runSql: (
+    authenticated: TrustedIdentityContext,
+    workspaceId: string,
+    validated: ValidatedExpenseSql,
+  ) => Promise<Readonly<Record<string, unknown>> | null>;
+}>;
+
+export const createMcpDataServices = (
+  dependencies: McpDataDependencies,
+): McpDataServices => {
+  const listWorkspaces = (identity: UserIdentity): Promise<ReadonlyArray<WorkspaceSummary>> =>
+    listWorkspacesWithQuery(
+      (text, params) => dependencies.queryAsExistingTrustedIdentity(identity, text, params),
+      identity,
+    );
+
+  const getWorkspace = (
+    identity: UserIdentity,
+    workspaceId: string,
+  ): Promise<WorkspaceSummary | null> =>
+    getWorkspaceWithQuery(
+      (text, params) => dependencies.queryAsExistingTrustedIdentity(identity, text, params),
+      identity,
+      workspaceId,
+    );
+
+  const loadAllowedSchemaForWorkspace = (
+    identity: UserIdentity,
+    workspaceId: string,
+  ): Promise<ReadonlyArray<SchemaRelation>> =>
+    loadAllowedSchemaWithQuery(
+      (text, params) => dependencies.queryAsExistingTrustedWorkspace(
+        identity,
+        workspaceId,
+        text,
+        params,
+      ),
+    );
+
+  const runReadOnlySql = (
+    authenticated: TrustedIdentityContext,
+    workspaceId: string,
+    validated: ValidatedReadOnlyExpenseSql,
+  ): Promise<Readonly<Record<string, unknown>> | null> =>
+    runReadOnlySqlWithServices(
+      authenticated,
+      workspaceId,
+      validated,
+      getWorkspace,
+      dependencies.withNonProvisioningReadOnlyRestrictedTrustedIdentityContext,
+    );
+
+  const runSql = (
+    authenticated: TrustedIdentityContext,
+    workspaceId: string,
+    validated: ValidatedExpenseSql,
+  ): Promise<Readonly<Record<string, unknown>> | null> =>
+    runSqlWithServices(
+      authenticated,
+      workspaceId,
+      validated,
+      getWorkspace,
+      dependencies.withRestrictedTrustedIdentityContext,
+    );
+
+  return {
+    listWorkspaces,
+    getWorkspace,
+    loadAllowedSchemaForWorkspace,
+    runReadOnlySql,
+    runSql,
+  };
+};
+
+export const mcpDataServices = createMcpDataServices({
+  queryAsExistingTrustedIdentity,
+  queryAsExistingTrustedWorkspace,
+  withNonProvisioningReadOnlyRestrictedTrustedIdentityContext,
+  withRestrictedTrustedIdentityContext,
+});

--- a/apps/sql-api/src/mcp/resourceMetadata.ts
+++ b/apps/sql-api/src/mcp/resourceMetadata.ts
@@ -1,0 +1,20 @@
+import { MCP_SCOPES, type McpRuntimeConfig } from "./config.js";
+
+export type ProtectedResourceMetadata = Readonly<{
+  resource: string;
+  authorization_servers: ReadonlyArray<string>;
+  bearer_methods_supported: ReadonlyArray<"header">;
+  scopes_supported: ReadonlyArray<string>;
+}>;
+
+export const buildProtectedResourceMetadata = (
+  config: McpRuntimeConfig,
+): ProtectedResourceMetadata => ({
+  resource: config.resource,
+  authorization_servers: [config.issuer],
+  bearer_methods_supported: ["header"],
+  scopes_supported: [...MCP_SCOPES],
+});
+
+export const buildBearerChallenge = (config: McpRuntimeConfig): string =>
+  `Bearer resource_metadata="${config.protectedResourceMetadataUrl}"`;

--- a/apps/sql-api/src/mcp/results.test.ts
+++ b/apps/sql-api/src/mcp/results.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { SqlApiLogEvent } from "../logger.js";
+import { UserSqlExecutionError } from "../machineApi/sqlService.js";
+import { buildMcpToolErrorResultWithDependencies } from "./results.js";
+
+type JsonObject = Readonly<Record<string, unknown>>;
+
+const parsePayload = (text: string): JsonObject => {
+  const value: unknown = JSON.parse(text);
+  assert.equal(typeof value, "object");
+  assert.notEqual(value, null);
+  assert.equal(Array.isArray(value), false);
+  return value as JsonObject;
+};
+
+const readResultPayload = (
+  result: ReturnType<typeof buildMcpToolErrorResultWithDependencies>,
+): JsonObject => {
+  assert.equal(result.isError, true);
+  assert.equal(result.content.length, 1);
+  const content = result.content[0];
+  assert.equal(content?.type, "text");
+  if (content?.type !== "text") {
+    throw new Error("Expected MCP text content");
+  }
+  return parsePayload(content.text);
+};
+
+test("MCP error results preserve actionable user SQL errors", (): void => {
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const sqlError = new UserSqlExecutionError("column amountt does not exist");
+  const payload = readResultPayload(buildMcpToolErrorResultWithDependencies(
+    sqlError,
+    "sql_query",
+    { log: (event) => logEvents.push(event) },
+  ));
+
+  const error = payload["error"] as JsonObject;
+  assert.equal(error["code"], "sql_execution_failed");
+  assert.equal(error["message"], "column amountt does not exist");
+  assert.deepEqual(logEvents, []);
+});
+
+test("MCP error results sanitize untagged PostgreSQL failures", (): void => {
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const databaseError = Object.assign(
+    new Error("column internal_secret does not exist on db.internal.example"),
+    { code: "42703" },
+  );
+  const payload = readResultPayload(buildMcpToolErrorResultWithDependencies(
+    databaseError,
+    "sql_query",
+    { log: (event) => logEvents.push(event) },
+  ));
+  const serialized = JSON.stringify(payload);
+  const error = payload["error"] as JsonObject;
+
+  assert.equal(error["code"], "internal_error");
+  assert.equal(serialized.includes("internal_secret"), false);
+  assert.equal(serialized.includes("db.internal.example"), false);
+  assert.deepEqual(logEvents, [{
+    domain: "sql_api",
+    action: "mcp_unexpected_error",
+    boundary: "tool",
+    operation: "sql_query",
+    errorType: "error",
+  }]);
+});
+
+test("MCP error results sanitize and structurally log unexpected failures", (): void => {
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const payload = readResultPayload(buildMcpToolErrorResultWithDependencies(
+    new Error("connection to db.internal.example failed with password secret"),
+    "get_schema",
+    { log: (event) => logEvents.push(event) },
+  ));
+  const serialized = JSON.stringify(payload);
+
+  assert.equal(serialized.includes("db.internal.example"), false);
+  assert.equal(serialized.includes("secret"), false);
+  assert.deepEqual(logEvents, [{
+    domain: "sql_api",
+    action: "mcp_unexpected_error",
+    boundary: "tool",
+    operation: "get_schema",
+    errorType: "error",
+  }]);
+});
+
+test("unexpected sql_execute errors warn against blind mutation retries", (): void => {
+  const databaseError = Object.assign(
+    new Error("duplicate key value exposes internal_constraint"),
+    { code: "23505" },
+  );
+  const payload = readResultPayload(buildMcpToolErrorResultWithDependencies(
+    databaseError,
+    "sql_execute",
+    { log: () => undefined },
+  ));
+  const instructions = payload["instructions"];
+  const serialized = JSON.stringify(payload);
+  const error = payload["error"] as JsonObject;
+
+  assert.equal(error["code"], "internal_error");
+  assert.equal(serialized.includes("internal_constraint"), false);
+  assert.equal(typeof instructions, "string");
+  assert.match(instructions as string, /Do not blindly retry/u);
+  assert.match(instructions as string, /Use sql_query to verify/u);
+});

--- a/apps/sql-api/src/mcp/results.ts
+++ b/apps/sql-api/src/mcp/results.ts
@@ -1,0 +1,135 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { SqlPolicyError } from "@expense-budget-tracker/agent-shared/sql-policy";
+import { getSafeErrorType, log } from "../logger.js";
+import {
+  getUserSqlExecutionMessage,
+  isUserSqlExecutionError,
+} from "../machineApi/sqlService.js";
+
+export class McpToolError extends Error {
+  readonly code: string;
+  readonly instructions: string;
+  readonly details: Readonly<Record<string, unknown>>;
+
+  constructor(
+    code: string,
+    message: string,
+    instructions: string,
+    details: Readonly<Record<string, unknown>>,
+  ) {
+    super(message);
+    this.code = code;
+    this.instructions = instructions;
+    this.details = details;
+  }
+}
+
+export type McpResultDependencies = Readonly<{
+  log: typeof log;
+}>;
+
+const defaultDependencies: McpResultDependencies = { log };
+
+const buildTextContent = (payload: Readonly<Record<string, unknown>>): CallToolResult["content"] => {
+  const text = JSON.stringify(payload, null, 2);
+  if (text === undefined) {
+    throw new Error("MCP result payload could not be serialized");
+  }
+  return [{ type: "text", text }];
+};
+
+export const buildMcpSuccessResult = (
+  data: Readonly<Record<string, unknown>>,
+  instructions: string,
+): CallToolResult => ({
+  content: buildTextContent({ ok: true, data, instructions }),
+});
+
+const getSqlPolicyInstructions = (error: SqlPolicyError, toolName: string): string => {
+  if (error.code === "relation_not_allowed" || error.code === "invalid_relation_reference") {
+    return `Call get_schema to inspect the allowed relations and columns, fix the SQL, then call ${toolName} again.`;
+  }
+  if (error.code === "read_only_sql_required") {
+    return "Send reads to sql_query and approved INSERT, UPDATE, or DELETE statements to sql_execute.";
+  }
+  if (
+    error.code === "mutation_statement_row_limit_exceeded"
+    || error.code === "mutation_request_row_limit_exceeded"
+  ) {
+    return `Narrow or split the mutation as directed by the error message, then call ${toolName} again.`;
+  }
+  if (error.code === "read_only_relation_mutation_not_allowed") {
+    return `Use sql_query to read this relation and write only to relations allowed by get_schema, then call ${toolName} again.`;
+  }
+  return `Fix the SQL using the policy error message, then call ${toolName} again.`;
+};
+
+const buildMcpErrorContent = (
+  code: string,
+  message: string,
+  instructions: string,
+  details: Readonly<Record<string, unknown>>,
+): CallToolResult => ({
+  isError: true,
+  content: buildTextContent({
+    ok: false,
+    error: {
+      code,
+      message,
+      ...(Object.keys(details).length === 0 ? {} : { details }),
+    },
+    instructions,
+  }),
+});
+
+const getUnexpectedErrorInstructions = (toolName: string): string =>
+  toolName === "sql_execute"
+    ? "Do not blindly retry the mutation. Use sql_query to verify whether it applied, and retry sql_execute only if the change is confirmed absent."
+    : `Retry ${toolName} once. If it fails again, stop and report the server error.`;
+
+export const buildMcpToolErrorResultWithDependencies = (
+  error: unknown,
+  toolName: string,
+  dependencies: McpResultDependencies,
+): CallToolResult => {
+  if (error instanceof McpToolError) {
+    return buildMcpErrorContent(error.code, error.message, error.instructions, error.details);
+  }
+
+  if (error instanceof SqlPolicyError) {
+    return buildMcpErrorContent(
+      error.code,
+      error.message,
+      getSqlPolicyInstructions(error, toolName),
+      {},
+    );
+  }
+
+  if (isUserSqlExecutionError(error)) {
+    return buildMcpErrorContent(
+      "sql_execution_failed",
+      getUserSqlExecutionMessage(error),
+      `Review SQL syntax, relation names, values, and constraints, then call ${toolName} again.`,
+      {},
+    );
+  }
+
+  dependencies.log({
+    domain: "sql_api",
+    action: "mcp_unexpected_error",
+    boundary: "tool",
+    operation: toolName,
+    errorType: getSafeErrorType(error),
+  });
+  return buildMcpErrorContent(
+    "internal_error",
+    "The MCP tool request could not be completed",
+    getUnexpectedErrorInstructions(toolName),
+    {},
+  );
+};
+
+export const buildMcpToolErrorResult = (
+  error: unknown,
+  toolName: string,
+): CallToolResult => buildMcpToolErrorResultWithDependencies(error, toolName, defaultDependencies);

--- a/apps/sql-api/src/mcp/server.test.ts
+++ b/apps/sql-api/src/mcp/server.test.ts
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  validateSingleExpenseSql,
+  validateSingleReadOnlyExpenseSql,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import type { AuthenticatedMcpAccessToken } from "./auth.js";
+import {
+  createMcpServerWithDependencies,
+  type McpServerDependencies,
+} from "./server.js";
+
+const PERSONAL_WORKSPACE_ID = "workspace-personal";
+const BUSINESS_WORKSPACE_ID = "workspace-business";
+
+type ToolCalls = {
+  listedUserIds: Array<string>;
+  membershipWorkspaceIds: Array<string>;
+  schemaWorkspaceIds: Array<string>;
+  queriedWorkspaceIds: Array<string>;
+  executedWorkspaceIds: Array<string>;
+};
+
+type JsonObject = Readonly<Record<string, unknown>>;
+
+const isJsonObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseToolPayload = (result: Awaited<ReturnType<Client["callTool"]>>): JsonObject => {
+  assert.ok(Array.isArray(result.content));
+  assert.equal(result.content.length, 1);
+  const content = result.content[0];
+  assert.ok(isJsonObject(content));
+  assert.equal(content["type"], "text");
+  const text = content["text"];
+  assert.equal(typeof text, "string");
+  const payload: unknown = JSON.parse(text as string);
+  assert.ok(isJsonObject(payload));
+  return payload;
+};
+
+const readErrorCode = (payload: JsonObject): string => {
+  const error = payload["error"];
+  assert.ok(isJsonObject(error));
+  const code = error["code"];
+  assert.equal(typeof code, "string");
+  return code as string;
+};
+
+const createConnection = (
+  scopes: AuthenticatedMcpAccessToken["scopes"],
+): AuthenticatedMcpAccessToken => ({
+  connectionId: "connection-1",
+  clientId: "client-1",
+  resource: "https://mcp.example.com/mcp",
+  scopes,
+  identity: {
+    userId: "user-1",
+    email: "user@example.com",
+    emailVerified: true,
+    cognitoStatus: "CONFIRMED",
+    cognitoEnabled: true,
+  },
+});
+
+const createDependencies = (
+  workspaceIds: ReadonlyArray<string>,
+  calls: ToolCalls,
+): McpServerDependencies => ({
+  listWorkspaces: async (identity) => {
+    calls.listedUserIds.push(identity.userId);
+    return workspaceIds.map((workspaceId) => ({
+      workspaceId,
+      name: workspaceId === PERSONAL_WORKSPACE_ID ? "Personal" : "Business",
+    }));
+  },
+  getWorkspace: async (_identity, workspaceId) => {
+    calls.membershipWorkspaceIds.push(workspaceId);
+    if (!workspaceIds.includes(workspaceId)) {
+      return null;
+    }
+    return {
+      workspaceId,
+      name: workspaceId === PERSONAL_WORKSPACE_ID ? "Personal" : "Business",
+    };
+  },
+  loadAllowedSchemaForWorkspace: async (_identity, workspaceId) => {
+    calls.schemaWorkspaceIds.push(workspaceId);
+    return [];
+  },
+  validateSingleReadOnlyExpenseSql,
+  validateSingleExpenseSql,
+  runReadOnlySql: async (_authenticated, workspaceId, validated) => {
+    calls.queriedWorkspaceIds.push(workspaceId);
+    return {
+      statements: [{ sql: validated.sql, rows: [{ amount: "10.00" }] }],
+      workspace: { workspaceId, name: "Personal" },
+    };
+  },
+  runSql: async (_authenticated, workspaceId, validated) => {
+    calls.executedWorkspaceIds.push(workspaceId);
+    return {
+      statements: [{ sql: validated.sql, command: "INSERT", rowCount: 1 }],
+      workspace: { workspaceId, name: "Personal" },
+    };
+  },
+});
+
+const createCalls = (): ToolCalls => ({
+  listedUserIds: [],
+  membershipWorkspaceIds: [],
+  schemaWorkspaceIds: [],
+  queriedWorkspaceIds: [],
+  executedWorkspaceIds: [],
+});
+
+const withClient = async (
+  connection: AuthenticatedMcpAccessToken,
+  dependencies: McpServerDependencies,
+  callback: (client: Client) => Promise<void>,
+): Promise<void> => {
+  const server = createMcpServerWithDependencies(connection, dependencies);
+  const client = new Client({ name: "mcp-server-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  try {
+    await callback(client);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+};
+
+test("MCP server registers four annotated tools and routes explicit workspaces", async (): Promise<void> => {
+  const calls = createCalls();
+  const dependencies = createDependencies(
+    [PERSONAL_WORKSPACE_ID, BUSINESS_WORKSPACE_ID],
+    calls,
+  );
+
+  await withClient(
+    createConnection(["expenses:read", "expenses:write"]),
+    dependencies,
+    async (client): Promise<void> => {
+      const tools = (await client.listTools()).tools;
+      assert.deepEqual(tools.map((tool) => tool.name).sort(), [
+        "get_schema",
+        "list_workspaces",
+        "sql_execute",
+        "sql_query",
+      ]);
+      for (const toolName of ["get_schema", "list_workspaces", "sql_query"]) {
+        assert.deepEqual(tools.find((tool) => tool.name === toolName)?.annotations, {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        });
+      }
+      assert.deepEqual(tools.find((tool) => tool.name === "sql_execute")?.annotations, {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      });
+
+      const listed = await client.callTool({ name: "list_workspaces", arguments: {} });
+      assert.equal(parseToolPayload(listed)["ok"], true);
+      const schema = await client.callTool({
+        name: "get_schema",
+        arguments: { workspaceId: BUSINESS_WORKSPACE_ID },
+      });
+      assert.equal(parseToolPayload(schema)["ok"], true);
+      const query = await client.callTool({
+        name: "sql_query",
+        arguments: {
+          workspaceId: PERSONAL_WORKSPACE_ID,
+          sql: "SELECT amount FROM ledger_entries",
+        },
+      });
+      assert.equal(parseToolPayload(query)["ok"], true);
+      const execute = await client.callTool({
+        name: "sql_execute",
+        arguments: {
+          workspaceId: BUSINESS_WORKSPACE_ID,
+          sql: "DELETE FROM budget_lines WHERE category = 'Food'",
+        },
+      });
+      assert.equal(parseToolPayload(execute)["ok"], true);
+    },
+  );
+
+  assert.deepEqual(calls.schemaWorkspaceIds, [BUSINESS_WORKSPACE_ID]);
+  assert.deepEqual(calls.queriedWorkspaceIds, [PERSONAL_WORKSPACE_ID]);
+  assert.deepEqual(calls.executedWorkspaceIds, [BUSINESS_WORKSPACE_ID]);
+});
+
+test("MCP tools require explicit workspace membership when selection is ambiguous", async (): Promise<void> => {
+  const calls = createCalls();
+  await withClient(
+    createConnection(["expenses:read", "expenses:write"]),
+    createDependencies([PERSONAL_WORKSPACE_ID, BUSINESS_WORKSPACE_ID], calls),
+    async (client): Promise<void> => {
+      const ambiguous = await client.callTool({
+        name: "sql_query",
+        arguments: { sql: "SELECT amount FROM ledger_entries" },
+      });
+      assert.equal(ambiguous.isError, true);
+      assert.equal(readErrorCode(parseToolPayload(ambiguous)), "workspace_selection_required");
+
+      const inaccessible = await client.callTool({
+        name: "get_schema",
+        arguments: { workspaceId: "workspace-other" },
+      });
+      assert.equal(inaccessible.isError, true);
+      assert.equal(readErrorCode(parseToolPayload(inaccessible)), "workspace_not_found");
+    },
+  );
+  assert.deepEqual(calls.schemaWorkspaceIds, []);
+  assert.deepEqual(calls.queriedWorkspaceIds, []);
+});
+
+test("MCP read tools preserve an empty workspace list without provisioning state", async (): Promise<void> => {
+  const calls = createCalls();
+  await withClient(
+    createConnection(["expenses:read"]),
+    createDependencies([], calls),
+    async (client): Promise<void> => {
+      const listed = await client.callTool({ name: "list_workspaces", arguments: {} });
+      const listedPayload = parseToolPayload(listed);
+      assert.equal(listedPayload["ok"], true);
+      const listedData = listedPayload["data"];
+      assert.ok(isJsonObject(listedData));
+      assert.deepEqual(listedData["workspaces"], []);
+
+      const schema = await client.callTool({ name: "get_schema", arguments: {} });
+      assert.equal(schema.isError, true);
+      assert.equal(readErrorCode(parseToolPayload(schema)), "no_workspaces");
+
+      const query = await client.callTool({
+        name: "sql_query",
+        arguments: { sql: "SELECT account_id FROM accounts" },
+      });
+      assert.equal(query.isError, true);
+      assert.equal(readErrorCode(parseToolPayload(query)), "no_workspaces");
+    },
+  );
+
+  assert.deepEqual(calls.schemaWorkspaceIds, []);
+  assert.deepEqual(calls.queriedWorkspaceIds, []);
+  assert.deepEqual(calls.executedWorkspaceIds, []);
+});
+
+test("MCP tools enforce read and write scopes before service execution", async (): Promise<void> => {
+  const readOnlyCalls = createCalls();
+  await withClient(
+    createConnection(["expenses:read"]),
+    createDependencies([PERSONAL_WORKSPACE_ID], readOnlyCalls),
+    async (client): Promise<void> => {
+      const result = await client.callTool({
+        name: "sql_execute",
+        arguments: {
+          sql: "DELETE FROM budget_lines WHERE category = 'Food'",
+        },
+      });
+      assert.equal(result.isError, true);
+      assert.equal(readErrorCode(parseToolPayload(result)), "insufficient_scope");
+    },
+  );
+  assert.deepEqual(readOnlyCalls.executedWorkspaceIds, []);
+
+  const writeOnlyCalls = createCalls();
+  await withClient(
+    createConnection(["expenses:write"]),
+    createDependencies([PERSONAL_WORKSPACE_ID], writeOnlyCalls),
+    async (client): Promise<void> => {
+      const result = await client.callTool({ name: "list_workspaces", arguments: {} });
+      assert.equal(result.isError, true);
+      assert.equal(readErrorCode(parseToolPayload(result)), "insufficient_scope");
+    },
+  );
+  assert.deepEqual(writeOnlyCalls.listedUserIds, []);
+});
+
+test("sql_query preserves read-only policy errors without calling the SQL runner", async (): Promise<void> => {
+  const calls = createCalls();
+  await withClient(
+    createConnection(["expenses:read"]),
+    createDependencies([PERSONAL_WORKSPACE_ID], calls),
+    async (client): Promise<void> => {
+      const result = await client.callTool({
+        name: "sql_query",
+        arguments: { sql: "DELETE FROM ledger_entries" },
+      });
+      assert.equal(result.isError, true);
+      assert.equal(readErrorCode(parseToolPayload(result)), "read_only_sql_required");
+    },
+  );
+  assert.deepEqual(calls.queriedWorkspaceIds, []);
+});
+
+test("MCP SQL tools reject multi-statement input before either runner is called", async (): Promise<void> => {
+  const calls = createCalls();
+  await withClient(
+    createConnection(["expenses:read", "expenses:write"]),
+    createDependencies([PERSONAL_WORKSPACE_ID], calls),
+    async (client): Promise<void> => {
+      const query = await client.callTool({
+        name: "sql_query",
+        arguments: {
+          sql: "SELECT account_id FROM accounts; SELECT amount FROM ledger_entries",
+        },
+      });
+      assert.equal(query.isError, true);
+      assert.equal(readErrorCode(parseToolPayload(query)), "single_statement_required");
+
+      const execute = await client.callTool({
+        name: "sql_execute",
+        arguments: {
+          sql: "INSERT INTO budget_lines (workspace_id) VALUES ('workspace-personal'); DELETE FROM budget_lines",
+        },
+      });
+      assert.equal(execute.isError, true);
+      assert.equal(readErrorCode(parseToolPayload(execute)), "single_statement_required");
+    },
+  );
+
+  assert.deepEqual(calls.queriedWorkspaceIds, []);
+  assert.deepEqual(calls.executedWorkspaceIds, []);
+});

--- a/apps/sql-api/src/mcp/server.ts
+++ b/apps/sql-api/src/mcp/server.ts
@@ -1,0 +1,284 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  MAX_SQL_ROWS,
+  SQL_STATEMENT_TIMEOUT_MS,
+  validateSingleExpenseSql,
+  validateSingleReadOnlyExpenseSql,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import { z } from "zod";
+import type { WorkspaceSummary } from "../machineApi/types.js";
+import type { AuthenticatedMcpAccessToken } from "./auth.js";
+import type { McpScope } from "./config.js";
+import { mcpDataServices, type McpDataServices } from "./dataService.js";
+import {
+  buildMcpSuccessResult,
+  buildMcpToolErrorResult,
+  McpToolError,
+} from "./results.js";
+
+const SERVER_NAME = "expense-budget-tracker";
+const SERVER_VERSION = "v1";
+const LIST_WORKSPACES_TOOL_NAME = "list_workspaces";
+const GET_SCHEMA_TOOL_NAME = "get_schema";
+const SQL_QUERY_TOOL_NAME = "sql_query";
+const SQL_EXECUTE_TOOL_NAME = "sql_execute";
+
+const workspaceIdSchema = z.string().trim().min(1).optional().describe(
+  "Optional workspaceId returned by list_workspaces. Omit only when exactly one workspace is available.",
+);
+
+export type McpServerDependencies = McpDataServices & Readonly<{
+  validateSingleReadOnlyExpenseSql: typeof validateSingleReadOnlyExpenseSql;
+  validateSingleExpenseSql: typeof validateSingleExpenseSql;
+}>;
+
+const defaultDependencies: McpServerDependencies = {
+  ...mcpDataServices,
+  validateSingleReadOnlyExpenseSql,
+  validateSingleExpenseSql,
+};
+
+const requireScope = (
+  connection: AuthenticatedMcpAccessToken,
+  scope: McpScope,
+): void => {
+  if (!connection.scopes.includes(scope)) {
+    throw new McpToolError(
+      "insufficient_scope",
+      `The OAuth access token does not grant ${scope}`,
+      `Reauthorize the MCP connection with the ${scope} scope, then call the tool again.`,
+      { requiredScope: scope, grantedScopes: connection.scopes },
+    );
+  }
+};
+
+const resolveWorkspace = async (
+  connection: AuthenticatedMcpAccessToken,
+  requestedWorkspaceId: string | undefined,
+  dependencies: McpServerDependencies,
+): Promise<WorkspaceSummary> => {
+  const workspaces = await dependencies.listWorkspaces(connection.identity);
+  if (requestedWorkspaceId !== undefined) {
+    const requestedWorkspace = workspaces.find(
+      (workspace) => workspace.workspaceId === requestedWorkspaceId,
+    );
+    if (requestedWorkspace === undefined) {
+      throw new McpToolError(
+        "workspace_not_found",
+        `Workspace ${requestedWorkspaceId} is not accessible to this user`,
+        "Call list_workspaces and retry with one of the returned workspaceId values.",
+        { workspaceId: requestedWorkspaceId },
+      );
+    }
+    return requestedWorkspace;
+  }
+
+  if (workspaces.length === 0) {
+    throw new McpToolError(
+      "no_workspaces",
+      "No workspaces are available to this user",
+      "Create a workspace in Expense Budget Tracker or ask a workspace owner to add you, then call list_workspaces again.",
+      { workspaces },
+    );
+  }
+
+  if (workspaces.length !== 1) {
+    throw new McpToolError(
+      "workspace_selection_required",
+      `workspaceId is required because ${workspaces.length} workspaces are available`,
+      "Call list_workspaces, choose a workspaceId, and retry the tool with that explicit workspaceId.",
+      { workspaces },
+    );
+  }
+
+  const onlyWorkspace = workspaces[0];
+  if (onlyWorkspace === undefined) {
+    throw new Error("Expected exactly one workspace after workspace resolution");
+  }
+  return onlyWorkspace;
+};
+
+const requireSqlResult = (
+  result: Readonly<Record<string, unknown>> | null,
+  workspaceId: string,
+): Readonly<Record<string, unknown>> => {
+  if (result === null) {
+    throw new McpToolError(
+      "workspace_not_found",
+      `Workspace ${workspaceId} is no longer accessible to this user`,
+      "Call list_workspaces and retry with one of the returned workspaceId values.",
+      { workspaceId },
+    );
+  }
+  return result;
+};
+
+const getWorkspaceListInstructions = (workspaceCount: number): string => {
+  if (workspaceCount === 0) {
+    return "No workspaces are available. Create one in Expense Budget Tracker or ask a workspace owner to add you, then call list_workspaces again.";
+  }
+  if (workspaceCount === 1) {
+    return "Exactly one workspace is available, so workspaceId may be omitted from other tool calls.";
+  }
+  return "Choose one returned workspaceId and pass it explicitly to get_schema, sql_query, or sql_execute.";
+};
+
+export const createMcpServerWithDependencies = (
+  connection: AuthenticatedMcpAccessToken,
+  dependencies: McpServerDependencies,
+): McpServer => {
+  const server = new McpServer(
+    {
+      name: SERVER_NAME,
+      version: SERVER_VERSION,
+      title: "Expense Budget Tracker",
+    },
+    {
+      instructions: "Call list_workspaces first. Use get_schema before writing SQL, sql_query for reads, and sql_execute for approved mutations. Always pass workspaceId when more than one workspace is available.",
+    },
+  );
+
+  server.registerTool(
+    LIST_WORKSPACES_TOOL_NAME,
+    {
+      title: "List workspaces",
+      description: "Lists every workspace accessible to the authenticated user. Use returned workspaceId values with the other tools.",
+      inputSchema: {},
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (): Promise<CallToolResult> => {
+      try {
+        requireScope(connection, "expenses:read");
+        const workspaces = await dependencies.listWorkspaces(connection.identity);
+        return buildMcpSuccessResult(
+          { workspaces },
+          getWorkspaceListInstructions(workspaces.length),
+        );
+      } catch (error) {
+        return buildMcpToolErrorResult(error, LIST_WORKSPACES_TOOL_NAME);
+      }
+    },
+  );
+
+  server.registerTool(
+    GET_SCHEMA_TOOL_NAME,
+    {
+      title: "Get expense schema",
+      description: "Returns the allowed SQL relations, columns, constraints, and agent hints for an accessible workspace.",
+      inputSchema: { workspaceId: workspaceIdSchema },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ workspaceId }): Promise<CallToolResult> => {
+      try {
+        requireScope(connection, "expenses:read");
+        const workspace = await resolveWorkspace(connection, workspaceId, dependencies);
+        const relations = await dependencies.loadAllowedSchemaForWorkspace(
+          connection.identity,
+          workspace.workspaceId,
+        );
+        return buildMcpSuccessResult(
+          {
+            workspace,
+            relations,
+            limits: {
+              maxRows: MAX_SQL_ROWS,
+              statementTimeoutMs: SQL_STATEMENT_TIMEOUT_MS,
+            },
+          },
+          "Use only the returned relations and columns. Send reads to sql_query and approved mutations to sql_execute.",
+        );
+      } catch (error) {
+        return buildMcpToolErrorResult(error, GET_SCHEMA_TOOL_NAME);
+      }
+    },
+  );
+
+  server.registerTool(
+    SQL_QUERY_TOOL_NAME,
+    {
+      title: "Query expense data",
+      description: "Runs exactly one policy-approved read-only SQL statement in a repeatable-read, read-only transaction under the restricted SQL reader role.",
+      inputSchema: {
+        sql: z.string().trim().min(1).describe("Exactly one policy-approved SELECT or WITH...SELECT statement."),
+        workspaceId: workspaceIdSchema,
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ sql, workspaceId }): Promise<CallToolResult> => {
+      try {
+        requireScope(connection, "expenses:read");
+        const workspace = await resolveWorkspace(connection, workspaceId, dependencies);
+        const validated = dependencies.validateSingleReadOnlyExpenseSql(sql);
+        const result = await dependencies.runReadOnlySql(
+          { identity: connection.identity },
+          workspace.workspaceId,
+          validated,
+        );
+        return buildMcpSuccessResult(
+          requireSqlResult(result, workspace.workspaceId),
+          "Use the returned rows and truncation metadata to answer the request. Narrow and retry if truncated data is insufficient.",
+        );
+      } catch (error) {
+        return buildMcpToolErrorResult(error, SQL_QUERY_TOOL_NAME);
+      }
+    },
+  );
+
+  server.registerTool(
+    SQL_EXECUTE_TOOL_NAME,
+    {
+      title: "Execute expense mutations",
+      description: "Runs exactly one policy-approved SQL mutation under the restricted SQL executor role.",
+      inputSchema: {
+        sql: z.string().trim().min(1).describe("Exactly one policy-approved INSERT, UPDATE, or DELETE statement."),
+        workspaceId: workspaceIdSchema,
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async ({ sql, workspaceId }): Promise<CallToolResult> => {
+      try {
+        requireScope(connection, "expenses:write");
+        const workspace = await resolveWorkspace(connection, workspaceId, dependencies);
+        const validated = dependencies.validateSingleExpenseSql(sql);
+        const result = await dependencies.runSql(
+          { identity: connection.identity },
+          workspace.workspaceId,
+          validated,
+        );
+        return buildMcpSuccessResult(
+          requireSqlResult(result, workspace.workspaceId),
+          "The SQL transaction completed. Use sql_query if you need to verify the resulting state.",
+        );
+      } catch (error) {
+        return buildMcpToolErrorResult(error, SQL_EXECUTE_TOOL_NAME);
+      }
+    },
+  );
+
+  return server;
+};
+
+export const createMcpServer = (
+  connection: AuthenticatedMcpAccessToken,
+): McpServer => createMcpServerWithDependencies(connection, defaultDependencies);

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,10 @@
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1108.0",
         "@expense-budget-tracker/agent-shared": "1.2.0",
-        "pg": "^8.23.0"
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "hono": "^4.13.2",
+        "pg": "^8.23.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.162",
@@ -2183,6 +2186,46 @@
         "@opentelemetry/api": "^1.9.0"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
@@ -3384,6 +3427,52 @@
         "node": ">=14.6"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3645,11 +3734,102 @@
       "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
@@ -3730,11 +3910,82 @@
       "integrity": "sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==",
       "license": "Apache-2.0"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4170,6 +4421,15 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4195,6 +4455,20 @@
         "underscore": "^1.13.1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexify": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
@@ -4207,11 +4481,26 @@
         "stream-shift": "^1.0.2"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -4222,11 +4511,41 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.2",
@@ -4279,6 +4598,42 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expense-budget-tracker-aws": {
       "resolved": "infra/aws",
       "link": true
@@ -4298,6 +4653,90 @@
     "node_modules/expense-tracker-auth": {
       "resolved": "apps/auth",
       "link": true
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -4353,6 +4792,45 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -4367,6 +4845,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -4376,6 +4863,79 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/heic-to": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
@@ -4383,9 +4943,9 @@
       "license": "LGPL-3.0"
     },
     "node_modules/hono": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4398,6 +4958,26 @@
       "license": "MIT",
       "funding": {
         "url": "https://locize.com"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/i18next": {
@@ -4475,6 +5055,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4483,6 +5081,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-unsafe": {
       "version": "2.0.0",
@@ -4501,6 +5105,33 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -4612,6 +5243,65 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -4664,6 +5354,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/next": {
@@ -4728,11 +5427,44 @@
         "node": ">=20"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -4788,6 +5520,15 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-expression-matcher": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
@@ -4810,6 +5551,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pg": {
@@ -4906,6 +5666,15 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/playwright": {
       "version": "1.62.1",
@@ -5035,6 +5804,79 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
@@ -5106,6 +5948,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
@@ -5124,6 +5975,22 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/rw": {
       "version": "1.3.3",
@@ -5175,11 +6042,62 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.35.3",
@@ -5231,6 +6149,99 @@
         }
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5254,6 +6265,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
@@ -5334,6 +6354,15 @@
         }
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5374,6 +6403,37 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -5399,6 +6459,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
@@ -5426,6 +6495,30 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -5560,6 +6653,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "packages/agent-shared": {


### PR DESCRIPTION
## Summary
- add the stateless Streamable HTTP MCP handler and protected-resource metadata
- authenticate canonical OAuth Bearer tokens and enforce workspace/scopes
- reuse non-provisioning workspace/schema reads and restricted SQL services
- add focused runtime, transport, auth, scope, and error-envelope specs

## Validation
- not run locally; integration/deployment CI owns executable validation