### PR TITLE
feat: publish MCP HTTP API infrastructure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
+      - name: Require MCP certificate secret
+        env:
+          CDK_MCP_CERTIFICATE_ARN: ${{ secrets.CDK_MCP_CERTIFICATE_ARN }}
+        run: |
+          if [[ -z "${CDK_MCP_CERTIFICATE_ARN//[[:space:]]/}" ]]; then
+            echo "::error::Required secret CDK_MCP_CERTIFICATE_ARN is not configured. MCP deployment is stopped to preserve the existing custom domain."
+            exit 1
+          fi
+
       - name: Detect changed paths
         id: changes
         if: github.event_name == 'push'
@@ -110,6 +119,7 @@ jobs:
             "domainName": "${{ vars.CDK_DOMAIN_NAME }}",
             "certificateArn": "${{ secrets.CDK_CERTIFICATE_ARN }}",
             "apiCertificateArn": "${{ secrets.CDK_API_CERTIFICATE_ARN }}",
+            "mcpCertificateArn": "${{ secrets.CDK_MCP_CERTIFICATE_ARN }}",
             "resendApiKeySecretArn": "${{ vars.CDK_RESEND_API_KEY_SECRET_ARN }}",
             "resendSenderEmail": "${{ vars.CDK_RESEND_SENDER_EMAIL }}",
             "langfuseBaseUrl": "${{ vars.CDK_LANGFUSE_BASE_URL }}",

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       auth_tests: ${{ steps.changes.outputs.auth_tests }}
+      infra_tests: ${{ steps.changes.outputs.infra_tests }}
       shared_tests: ${{ steps.changes.outputs.shared_tests }}
       sql_api_tests: ${{ steps.changes.outputs.sql_api_tests }}
       web_tests: ${{ steps.changes.outputs.web_tests }}
@@ -41,6 +42,14 @@ jobs:
               - 'package-lock.json'
             auth_tests:
               - 'apps/auth/**'
+              - 'packages/agent-shared/**'
+              - '.github/workflows/pull-request.yml'
+              - '.npmrc'
+              - '.nvmrc'
+              - 'package.json'
+              - 'package-lock.json'
+            infra_tests:
+              - 'infra/aws/**'
               - 'packages/agent-shared/**'
               - '.github/workflows/pull-request.yml'
               - '.npmrc'
@@ -98,6 +107,7 @@ jobs:
         !cancelled()
         && (
           needs.quality_gate.outputs.auth_tests == 'true'
+          || needs.quality_gate.outputs.infra_tests == 'true'
           || needs.quality_gate.outputs.shared_tests == 'true'
           || needs.quality_gate.outputs.sql_api_tests == 'true'
           || needs.quality_gate.outputs.web_tests == 'true'
@@ -124,6 +134,10 @@ jobs:
       - name: Run auth unit tests
         if: ${{ !cancelled() && steps.install.outcome == 'success' && needs.quality_gate.outputs.auth_tests == 'true' }}
         run: npm --workspace expense-tracker-auth run test
+
+      - name: Run AWS infrastructure unit tests
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && needs.quality_gate.outputs.infra_tests == 'true' }}
+        run: npm --workspace expense-budget-tracker-aws run test
 
       - name: Run SQL API unit tests
         if: ${{ !cancelled() && steps.install.outcome == 'success' && needs.quality_gate.outputs.sql_api_tests == 'true' }}

--- a/README.md
+++ b/README.md
@@ -30,20 +30,30 @@ Start at `GET https://api.expense-budget-tracker.com/v1/`. The discovery respons
 1. **Open `GET https://api.expense-budget-tracker.com/v1/` in your agent** — it will discover the OTP onboarding flow automatically
 2. **Complete email OTP login** — the auth service returns a long-lived `ApiKey`
 3. **Give the key to your AI agent** — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://openai.com/index/codex/), or any agent that can call HTTP APIs
-4. **Send the agent screenshots, CSV files, or PDF bank statements** — it parses them and inserts transactions via the SQL API
+4. **Send the agent screenshots, CSV files, or PDF bank statements** — it parses them and inserts transactions through the single-statement SQL execute endpoint
 5. **Open the web UI** — view actual spending by category and plan the budget for the next month
 
-Example request the agent sends:
+For readonly work, agents send one `SELECT` or `WITH...SELECT` statement to the primary query endpoint:
 
 ```bash
-curl -X POST https://api.expense-budget-tracker.com/v1/sql \
+curl -X POST https://api.expense-budget-tracker.com/v1/sql/query \
+  -H "Authorization: ApiKey ebta_..." \
+  -H "X-Workspace-Id: workspace-id" \
+  -H "Content-Type: application/json" \
+  -d '{"sql": "SELECT ts, amount, currency, category FROM ledger_entries ORDER BY ts DESC LIMIT 20"}'
+```
+
+For an explicitly approved write, agents send one `INSERT`, `UPDATE`, or `DELETE` statement to the primary execute endpoint:
+
+```bash
+curl -X POST https://api.expense-budget-tracker.com/v1/sql/execute \
   -H "Authorization: ApiKey ebta_..." \
   -H "X-Workspace-Id: workspace-id" \
   -H "Content-Type: application/json" \
   -d '{"sql": "INSERT INTO ledger_entries (event_id, ts, account_id, amount, currency, kind, category, counterparty, note) VALUES ('"'"'evt-001'"'"', '"'"'2025-03-15 12:30:00+00'"'"', '"'"'chase-checking'"'"', -42.50, '"'"'USD'"'"', '"'"'spend'"'"', '"'"'groceries'"'"', '"'"'Whole Foods'"'"', '"'"'Weekly groceries'"'"')"}'
 ```
 
-After `POST /v1/workspaces/{workspaceId}/select`, the API key remembers that workspace, so `X-Workspace-Id` becomes optional on later `/v1/sql` calls. If the user has exactly one workspace and no saved selection yet, the API auto-saves and uses that single workspace.
+After `POST /v1/workspaces/{workspaceId}/select`, the API key remembers that workspace, so `X-Workspace-Id` becomes optional on later `/v1/sql/query`, `/v1/sql/execute`, and compatibility `/v1/sql` calls; send the header to override the saved selection. If the user has exactly one workspace and no saved selection yet, the API auto-saves and uses that single workspace. `POST /v1/sql` remains available only for compatibility when an atomic multi-statement script is required.
 
 ## Documentation
 

--- a/apps/auth/src/routes/loginPage.test.ts
+++ b/apps/auth/src/routes/loginPage.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { MAX_OAUTH_LOGIN_QUERY_BYTES } from "@expense-budget-tracker/agent-shared";
 import { createLoginPageApp } from "./loginPage.js";
 import { clearBrowserSessionCookies } from "../server/oauth/session.js";
 
@@ -28,6 +29,18 @@ test("login clears an invalid non-empty session instead of redirecting in a loop
     assert.match(cookies, /refresh=;/u);
     assert.match(cookies, /logged_in=;/u);
     assert.match(cookies, /locale=en/u);
+
+    const fixedQuery = `redirect_uri=${encodeURIComponent(redirectUri)}&padding=`;
+    const exactQuery = `${fixedQuery}${"x".repeat(MAX_OAUTH_LOGIN_QUERY_BYTES - fixedQuery.length)}`;
+    const exactBoundary = await app.request(`/login?${exactQuery}`);
+    assert.equal(exactBoundary.status, 200);
+
+    const oversized = await app.request(`/login?${exactQuery}x`);
+    assert.equal(oversized.status, 400);
+    assert.equal(
+      await oversized.text(),
+      `Login query must not exceed ${MAX_OAUTH_LOGIN_QUERY_BYTES} UTF-8 bytes`,
+    );
   } finally {
     if (previousAllowedRedirects === undefined) delete process.env.ALLOWED_REDIRECT_URIS;
     else process.env.ALLOWED_REDIRECT_URIS = previousAllowedRedirects;

--- a/apps/auth/src/routes/loginPage.ts
+++ b/apps/auth/src/routes/loginPage.ts
@@ -7,6 +7,10 @@
  * Only the origin is validated against ALLOWED_REDIRECT_URIS.
  */
 import { Hono } from "hono";
+import {
+  getRawQueryByteLength,
+  MAX_OAUTH_LOGIN_QUERY_BYTES,
+} from "@expense-budget-tracker/agent-shared";
 import { setCookie } from "hono/cookie";
 import { renderLoginPage } from "../templates/login.js";
 import { resolveBrowserSession } from "../server/oauth/session.js";
@@ -62,6 +66,9 @@ export const createLoginPageApp = (dependencies: LoginPageDependencies): Hono =>
   const app = new Hono();
 
   app.get("/login", async (c) => {
+    if (getRawQueryByteLength(c.req.url) > MAX_OAUTH_LOGIN_QUERY_BYTES) {
+      return c.text(`Login query must not exceed ${MAX_OAUTH_LOGIN_QUERY_BYTES} UTF-8 bytes`, 400);
+    }
     const redirectUri = c.req.query("redirect_uri") ?? "";
 
     if (redirectUri === "") {

--- a/apps/auth/src/routes/oauth.test.ts
+++ b/apps/auth/src/routes/oauth.test.ts
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
 import {
+  MAX_OAUTH_AUTHORIZE_QUERY_BYTES,
+  MAX_OAUTH_LOGIN_QUERY_BYTES,
+} from "@expense-budget-tracker/agent-shared";
+import {
   createOAuthApp,
   MAX_CONSENT_REQUEST_BYTES,
   MAX_DCR_REQUEST_BYTES,
@@ -310,6 +314,22 @@ const consentParametersWithEncodedSize = (targetBytes: number): URLSearchParams 
   return params;
 };
 
+const authorizationParametersWithEncodedSize = (targetBytes: number): URLSearchParams => {
+  const params = authorizationParams();
+  const prefix = "é/?&=+";
+  params.set("state", prefix);
+  const remainingBytes = targetBytes - utf8Length(params.toString());
+  if (remainingBytes < 0) throw new RangeError("Target authorization query is too small");
+  const multibyteCharacters = Math.floor(remainingBytes / 6);
+  const asciiCharacters = remainingBytes % 6;
+  params.set("state", `${prefix}${"é".repeat(multibyteCharacters)}${"x".repeat(asciiCharacters)}`);
+  const state = params.get("state");
+  if (state === null || state.length > 2048 || utf8Length(params.toString()) !== targetBytes) {
+    throw new RangeError("Target authorization query cannot fit within the state parameter limit");
+  }
+  return params;
+};
+
 test("DCR enforces its request ceiling in UTF-8 bytes before JSON parsing", async (): Promise<void> => {
   let registrationCount = 0;
   const app = createOAuthApp(createDependencies({
@@ -389,6 +409,40 @@ test("consent is no-store, anti-clickjacking, and same-origin protected", async 
   assert.equal(allowed.status, 302);
   assert.match(allowed.headers.get("location") ?? "", /code=ebt_ac_issued-code/u);
   assert.equal(issueCount, 1);
+});
+
+test("authorization GET enforces its raw query ceiling and keeps nested login below its ceiling", async (): Promise<void> => {
+  const exactBoundary = authorizationParametersWithEncodedSize(
+    MAX_OAUTH_AUTHORIZE_QUERY_BYTES,
+  );
+  const authenticatedApp = createOAuthApp(createDependencies({}));
+  const accepted = await authenticatedApp.request(
+    `${issuer}/oauth/authorize?${exactBoundary.toString()}`,
+  );
+  assert.equal(accepted.status, 200);
+
+  const oversized = authorizationParametersWithEncodedSize(
+    MAX_OAUTH_AUTHORIZE_QUERY_BYTES + 1,
+  );
+  const rejected = await authenticatedApp.request(
+    `${issuer}/oauth/authorize?${oversized.toString()}`,
+  );
+  assert.equal(rejected.status, 400);
+  assert.deepEqual(await rejected.json(), {
+    error: "invalid_request",
+    error_description: `Authorization query must not exceed ${MAX_OAUTH_AUTHORIZE_QUERY_BYTES} UTF-8 bytes`,
+  });
+
+  const anonymousApp = createOAuthApp(createDependencies({
+    resolveBrowserSession: async () => null,
+  }));
+  const redirected = await anonymousApp.request(
+    `${issuer}/oauth/authorize?${exactBoundary.toString()}`,
+  );
+  assert.equal(redirected.status, 302);
+  const loginLocation = redirected.headers.get("location") ?? "";
+  assert.match(loginLocation, /^https:\/\/auth\.example\.com\/login\?/u);
+  assert.ok(utf8Length(new URL(loginLocation).search.slice(1)) <= MAX_OAUTH_LOGIN_QUERY_BYTES);
 });
 
 test("consent renders only when both encoded decisions fit the POST byte limit", async (): Promise<void> => {

--- a/apps/auth/src/routes/oauth.ts
+++ b/apps/auth/src/routes/oauth.ts
@@ -1,5 +1,10 @@
 import { Hono, type Context } from "hono";
 import {
+  getRawQueryByteLength,
+  MAX_OAUTH_AUTHORIZE_QUERY_BYTES,
+  MAX_OAUTH_LOGIN_QUERY_BYTES,
+} from "@expense-budget-tracker/agent-shared";
+import {
   getOAuthConfig,
   isOAuthProtocolError,
   isValidClientRedirectUri,
@@ -78,6 +83,12 @@ const requestBodyTooLargeError = (
 const isRequestBodyTooLargeError = (error: unknown): error is RequestBodyTooLargeError =>
   error instanceof Error
   && (error as Partial<RequestBodyTooLargeError>).requestBodyTooLarge === true;
+
+const assertQueryWithinLimit = (url: string, maxBytes: number, name: string): void => {
+  if (getRawQueryByteLength(url) > maxBytes) {
+    throw oauthError("invalid_request", `${name} query must not exceed ${maxBytes} UTF-8 bytes`, 400);
+  }
+};
 
 const hasOversizedContentLength = (request: Request, maxBytes: number): boolean => {
   const rawContentLength = request.headers.get("content-length");
@@ -304,7 +315,9 @@ const buildLoginRedirect = (issuer: string, request: AuthorizationRequest): stri
   })) authorizationUrl.searchParams.set(name, value);
   const loginUrl = new URL("/login", issuer);
   loginUrl.searchParams.set("redirect_uri", authorizationUrl.toString());
-  return loginUrl.toString();
+  const redirect = loginUrl.toString();
+  assertQueryWithinLimit(redirect, MAX_OAUTH_LOGIN_QUERY_BYTES, "Login");
+  return redirect;
 };
 
 const requireBrowserIdentity = async (
@@ -392,9 +405,15 @@ app.post("/oauth/register", async (c) => {
 app.get("/oauth/authorize", async (c) => {
   noStore(c);
   const config = dependencies.getOAuthConfig();
-  const params = new URL(c.req.url).searchParams;
+  let params = new URLSearchParams();
   let authorizationRequest: AuthorizationRequest | null = null;
   try {
+    assertQueryWithinLimit(
+      c.req.url,
+      MAX_OAUTH_AUTHORIZE_QUERY_BYTES,
+      "Authorization",
+    );
+    params = new URL(c.req.url).searchParams;
     const { client, request } = await loadAuthorizationRequest(params, config.resource, dependencies.getOAuthClient);
     authorizationRequest = request;
     validateConsentSubmissionSize(request);

--- a/apps/sql-api/src/config.test.ts
+++ b/apps/sql-api/src/config.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GetSecretValueCommandOutput } from "@aws-sdk/client-secrets-manager";
+import {
+  createDatabaseUrlResolver,
+  DatabaseSecretTimeoutError,
+  type DatabaseConfigRuntime,
+  type DatabaseConfigTimerHandle,
+} from "./config.js";
+
+type ScheduledTask = {
+  callback: () => void;
+  delayMs: number;
+  cancelled: boolean;
+};
+
+const createManualRuntime = (): Readonly<{
+  runtime: DatabaseConfigRuntime;
+  tasks: Array<ScheduledTask>;
+}> => {
+  const tasks: Array<ScheduledTask> = [];
+  return {
+    tasks,
+    runtime: {
+      schedule: (callback, delayMs): DatabaseConfigTimerHandle => {
+        const task: ScheduledTask = { callback, delayMs, cancelled: false };
+        tasks.push(task);
+        return task;
+      },
+      cancel: (handle): void => {
+        (handle as ScheduledTask).cancelled = true;
+      },
+    },
+  };
+};
+
+const createSecretOutput = (): GetSecretValueCommandOutput => ({
+  SecretString: JSON.stringify({ username: "database-user", password: "database-password" }),
+  $metadata: {},
+});
+
+const databaseEnvironment = (): NodeJS.ProcessEnv => ({
+  DB_SECRET_ARN: "arn:aws:secretsmanager:eu-west-1:123456789012:secret:database",
+  DB_HOST: "database.example.internal",
+  DB_NAME: "expense_tracker",
+});
+
+test("database secret retrieval aborts the AWS request at its deadline and destroys the client", async (): Promise<void> => {
+  const { runtime, tasks } = createManualRuntime();
+  let receivedSignal: AbortSignal | undefined;
+  let destroyed = false;
+  const resolver = createDatabaseUrlResolver({
+    createSecretsClient: () => ({
+      send: (_command, options) => {
+        receivedSignal = options.abortSignal;
+        return new Promise<GetSecretValueCommandOutput>((_resolve, reject) => {
+          options.abortSignal.addEventListener("abort", () => reject(options.abortSignal.reason), { once: true });
+        });
+      },
+      destroy: (): void => {
+        destroyed = true;
+      },
+    }),
+    readEnvironment: databaseEnvironment,
+    runtime,
+  });
+
+  const resolution = resolver.getDatabaseUrl(2_000);
+  const timeoutTask = tasks[0];
+  assert.ok(timeoutTask !== undefined);
+  assert.equal(timeoutTask.delayMs, 2_000);
+  timeoutTask.callback();
+
+  await assert.rejects(
+    resolution,
+    (error: unknown) =>
+      error instanceof DatabaseSecretTimeoutError
+      && error.timeoutMs === 2_000
+      && error.secretArn === databaseEnvironment().DB_SECRET_ARN,
+  );
+  assert.ok(receivedSignal !== undefined);
+  assert.equal(receivedSignal.aborted, true);
+  assert.equal(destroyed, true);
+  assert.equal(timeoutTask.cancelled, true);
+});
+
+test("database URL initialization clears a failed cache entry before retrying", async (): Promise<void> => {
+  const { runtime } = createManualRuntime();
+  let requestCount = 0;
+  const resolver = createDatabaseUrlResolver({
+    createSecretsClient: () => ({
+      send: async (): Promise<GetSecretValueCommandOutput> => {
+        requestCount += 1;
+        if (requestCount === 1) {
+          throw new Error("temporary Secrets Manager failure");
+        }
+        return createSecretOutput();
+      },
+      destroy: (): void => undefined,
+    }),
+    readEnvironment: databaseEnvironment,
+    runtime,
+  });
+
+  await assert.rejects(
+    resolver.getDatabaseUrl(2_000),
+    /Failed to retrieve database secret/u,
+  );
+  const databaseUrl = await resolver.getDatabaseUrl(2_000);
+
+  assert.equal(requestCount, 2);
+  assert.equal(
+    databaseUrl,
+    "postgresql://database-user:database-password@database.example.internal:5432/expense_tracker",
+  );
+});
+
+test("concurrent database URL callers share one bounded secret request", async (): Promise<void> => {
+  const { runtime } = createManualRuntime();
+  let requestCount = 0;
+  let resolveSecret: ((output: GetSecretValueCommandOutput) => void) | undefined;
+  const resolver = createDatabaseUrlResolver({
+    createSecretsClient: () => ({
+      send: () => {
+        requestCount += 1;
+        return new Promise<GetSecretValueCommandOutput>((resolve) => {
+          resolveSecret = resolve;
+        });
+      },
+      destroy: (): void => undefined,
+    }),
+    readEnvironment: databaseEnvironment,
+    runtime,
+  });
+
+  const first = resolver.getDatabaseUrl(2_000);
+  const second = resolver.getDatabaseUrl(1_000);
+  assert.equal(first, second);
+  assert.equal(requestCount, 1);
+  assert.ok(resolveSecret !== undefined);
+  resolveSecret(createSecretOutput());
+
+  assert.equal(await first, await second);
+});

--- a/apps/sql-api/src/config.ts
+++ b/apps/sql-api/src/config.ts
@@ -5,24 +5,186 @@
  * then constructs the URL from DB_HOST and DB_NAME.
  */
 
-import { SecretsManagerClient, GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+  type GetSecretValueCommandOutput,
+} from "@aws-sdk/client-secrets-manager";
 
-let resolvedDatabaseUrl: string | undefined;
+export const DATABASE_SECRET_TIMEOUT_MS = 5_000;
 
-export async function getDatabaseUrl(): Promise<string> {
-  if (resolvedDatabaseUrl) return resolvedDatabaseUrl;
+export type DatabaseConfigTimerHandle = object;
 
-  const secretArn = process.env.DB_SECRET_ARN;
-  if (secretArn) {
-    const client = new SecretsManagerClient({});
-    const resp = await client.send(new GetSecretValueCommand({ SecretId: secretArn }));
-    const secret: { username: string; password: string } = JSON.parse(resp.SecretString!);
-    const host = process.env.DB_HOST!;
-    const dbName = process.env.DB_NAME!;
-    resolvedDatabaseUrl = `postgresql://${secret.username}:${encodeURIComponent(secret.password)}@${host}:5432/${dbName}`;
-  } else {
-    resolvedDatabaseUrl = process.env.DATABASE_URL!;
+export type DatabaseConfigRuntime = Readonly<{
+  schedule: (callback: () => void, delayMs: number) => DatabaseConfigTimerHandle;
+  cancel: (handle: DatabaseConfigTimerHandle) => void;
+}>;
+
+type SecretValueClient = Readonly<{
+  send: (
+    command: GetSecretValueCommand,
+    options: Readonly<{ abortSignal: AbortSignal }>,
+  ) => Promise<GetSecretValueCommandOutput>;
+  destroy: () => void;
+}>;
+
+type DatabaseUrlResolverDependencies = Readonly<{
+  createSecretsClient: () => SecretValueClient;
+  readEnvironment: () => NodeJS.ProcessEnv;
+  runtime: DatabaseConfigRuntime;
+}>;
+
+export type DatabaseUrlResolver = Readonly<{
+  getDatabaseUrl: (timeoutMs: number) => Promise<string>;
+}>;
+
+type SecretCredentials = Readonly<{
+  username: string;
+  password: string;
+}>;
+
+export class DatabaseSecretTimeoutError extends Error {
+  readonly secretArn: string;
+  readonly timeoutMs: number;
+
+  constructor(secretArn: string, timeoutMs: number, cause: unknown) {
+    super(`Database secret ${secretArn} retrieval exceeded its ${String(timeoutMs)} ms deadline`, { cause });
+    this.secretArn = secretArn;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+const systemDatabaseConfigRuntime: DatabaseConfigRuntime = {
+  schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+  cancel: (handle) => clearTimeout(handle as NodeJS.Timeout),
+};
+
+const requireEnvironmentValue = (
+  environment: NodeJS.ProcessEnv,
+  name: string,
+): string => {
+  const value = environment[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Database configuration requires a non-empty ${name} environment variable`);
+  }
+  return value;
+};
+
+const parseSecretCredentials = (
+  secretArn: string,
+  secretString: string | undefined,
+): SecretCredentials => {
+  if (secretString === undefined) {
+    throw new Error(`Database secret ${secretArn} does not contain SecretString credentials`);
   }
 
-  return resolvedDatabaseUrl;
-}
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(secretString);
+  } catch (error) {
+    throw new Error(`Database secret ${secretArn} is not valid JSON`, { cause: error });
+  }
+
+  if (
+    typeof parsed !== "object"
+    || parsed === null
+    || !("username" in parsed)
+    || typeof parsed.username !== "string"
+    || parsed.username.length === 0
+    || !("password" in parsed)
+    || typeof parsed.password !== "string"
+  ) {
+    throw new Error(`Database secret ${secretArn} must contain non-empty username and string password fields`);
+  }
+
+  return {
+    username: parsed.username,
+    password: parsed.password,
+  };
+};
+
+const loadDatabaseUrl = async (
+  dependencies: DatabaseUrlResolverDependencies,
+  timeoutMs: number,
+): Promise<string> => {
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError("Database secret timeout must be a positive safe integer number of milliseconds");
+  }
+
+  const environment = dependencies.readEnvironment();
+  const secretArn = environment.DB_SECRET_ARN;
+  if (typeof secretArn !== "string" || secretArn.length === 0) {
+    return requireEnvironmentValue(environment, "DATABASE_URL");
+  }
+
+  const host = requireEnvironmentValue(environment, "DB_HOST");
+  const dbName = requireEnvironmentValue(environment, "DB_NAME");
+  const client = dependencies.createSecretsClient();
+  const controller = new AbortController();
+  const timeoutError = new DatabaseSecretTimeoutError(secretArn, timeoutMs, undefined);
+  const timeoutHandle = dependencies.runtime.schedule(
+    () => controller.abort(timeoutError),
+    timeoutMs,
+  );
+
+  try {
+    const response = await client.send(
+      new GetSecretValueCommand({ SecretId: secretArn }),
+      { abortSignal: controller.signal },
+    );
+    const credentials = parseSecretCredentials(secretArn, response.SecretString);
+    return `postgresql://${credentials.username}:${encodeURIComponent(credentials.password)}@${host}:5432/${dbName}`;
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new DatabaseSecretTimeoutError(secretArn, timeoutMs, error);
+    }
+    throw new Error(`Failed to retrieve database secret ${secretArn}`, { cause: error });
+  } finally {
+    dependencies.runtime.cancel(timeoutHandle);
+    client.destroy();
+  }
+};
+
+export const createDatabaseUrlResolver = (
+  dependencies: DatabaseUrlResolverDependencies,
+): DatabaseUrlResolver => {
+  let resolvedDatabaseUrl: string | undefined;
+  let initialization: Promise<string> | undefined;
+
+  const getDatabaseUrl = (timeoutMs: number): Promise<string> => {
+    if (resolvedDatabaseUrl !== undefined) {
+      return Promise.resolve(resolvedDatabaseUrl);
+    }
+    if (initialization !== undefined) {
+      return initialization;
+    }
+
+    const startedInitialization = loadDatabaseUrl(dependencies, timeoutMs);
+    initialization = startedInitialization;
+    void startedInitialization.then(
+      (databaseUrl) => {
+        resolvedDatabaseUrl = databaseUrl;
+        if (initialization === startedInitialization) {
+          initialization = undefined;
+        }
+      },
+      () => {
+        if (initialization === startedInitialization) {
+          initialization = undefined;
+        }
+      },
+    );
+    return startedInitialization;
+  };
+
+  return { getDatabaseUrl };
+};
+
+const databaseUrlResolver = createDatabaseUrlResolver({
+  createSecretsClient: () => new SecretsManagerClient({}),
+  readEnvironment: () => process.env,
+  runtime: systemDatabaseConfigRuntime,
+});
+
+export const getDatabaseUrl = (timeoutMs: number): Promise<string> =>
+  databaseUrlResolver.getDatabaseUrl(timeoutMs);

--- a/apps/sql-api/src/db.ts
+++ b/apps/sql-api/src/db.ts
@@ -5,8 +5,22 @@
  * is resolved from Secrets Manager (async), so eager creation is not possible.
  */
 
-import pg from "pg";
-import { getDatabaseUrl } from "./config.js";
+import type pg from "pg";
+import {
+  getRemainingSqlExecutionMs,
+  type SqlExecutionDeadline,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import {
+  type ReadOnlyTransactionStart,
+  systemDeadlineRuntime,
+  withDeadlineTransactionUsingPool,
+  withReadOnlyDeadlineTransactionUsingPool,
+} from "./dbDeadline.js";
+import {
+  databasePoolProvider,
+  getPool,
+  waitForPoolBeforeDeadline,
+} from "./dbPool.js";
 
 export type UserIdentity = Readonly<{
   userId: string;
@@ -16,24 +30,94 @@ export type UserIdentity = Readonly<{
   cognitoEnabled: boolean;
 }>;
 
-let pool: pg.Pool | undefined;
-
-async function getPool(): Promise<pg.Pool> {
-  if (!pool) {
-    const connectionString = await getDatabaseUrl();
-    // ssl:true enables full certificate verification. RDS certs are signed by
-    // Amazon's CA (not in Node.js defaults), so NODE_EXTRA_CA_CERTS must point
-    // to the RDS CA bundle (set in CDK, bundle downloaded during Lambda bundling).
-    const ssl = process.env.DB_SECRET_ARN ? true : false;
-    pool = new pg.Pool({ connectionString, ssl });
-  }
-  return pool;
-}
-
 export const query = async (text: string, params: ReadonlyArray<unknown>): Promise<pg.QueryResult> =>
   (await getPool()).query(text, params as Array<unknown>);
 
 export type QueryFn = (text: string, params: ReadonlyArray<unknown>) => Promise<pg.QueryResult>;
+export type RestrictedQueryFn = (
+  text: string,
+  params: ReadonlyArray<unknown>,
+  statementTimeoutMs: number,
+  onDispatch: () => void,
+) => Promise<pg.QueryResult>;
+type RestrictedDatabaseQueryFn = (
+  text: string,
+  params: ReadonlyArray<unknown>,
+  statementTimeoutMs: number,
+  onDispatch: () => void,
+) => Promise<pg.QueryResult>;
+type RestrictedRole = "api_sql_executor" | "api_sql_reader";
+
+const createRestrictedQueryFn = (
+  queryFn: QueryFn,
+  restrictedQueryFn: RestrictedDatabaseQueryFn,
+  role: RestrictedRole,
+): RestrictedQueryFn => async (text, params, requestedStatementTimeoutMs, onDispatch) => {
+  if (!Number.isSafeInteger(requestedStatementTimeoutMs) || requestedStatementTimeoutMs <= 0) {
+    throw new TypeError("Restricted SQL statement timeout must be a positive safe integer number of milliseconds");
+  }
+  await queryFn("RESET ROLE", []);
+  await queryFn(`SET LOCAL ROLE ${role}`, []);
+  return restrictedQueryFn(text, params, requestedStatementTimeoutMs, onDispatch);
+};
+
+const withDeadlineTransaction = async <T>(
+  deadline: SqlExecutionDeadline,
+  beginSql: string,
+  callback: (queryFn: QueryFn, restrictedQueryFn: RestrictedDatabaseQueryFn) => Promise<T>,
+): Promise<T> => {
+  getRemainingSqlExecutionMs(deadline);
+  const deadlinePool = await waitForPoolBeforeDeadline(
+    databasePoolProvider,
+    deadline,
+    systemDeadlineRuntime,
+  );
+  getRemainingSqlExecutionMs(deadline);
+  return withDeadlineTransactionUsingPool(
+    deadlinePool,
+    deadline,
+    beginSql,
+    async (transaction): Promise<T> => callback(
+      (text, params) => transaction.query(text, params, deadline.timeoutMs),
+      (text, params, statementTimeoutMs, onDispatch) => transaction.queryWithDispatchMarker(
+        text,
+        params,
+        statementTimeoutMs,
+        onDispatch,
+      ),
+    ),
+    systemDeadlineRuntime,
+  );
+};
+
+const withReadOnlyDeadlineTransaction = async <T>(
+  deadline: SqlExecutionDeadline,
+  beginSql: ReadOnlyTransactionStart,
+  callback: (queryFn: QueryFn, restrictedQueryFn: RestrictedDatabaseQueryFn) => Promise<T>,
+): Promise<T> => {
+  getRemainingSqlExecutionMs(deadline);
+  const deadlinePool = await waitForPoolBeforeDeadline(
+    databasePoolProvider,
+    deadline,
+    systemDeadlineRuntime,
+  );
+  getRemainingSqlExecutionMs(deadline);
+  return withReadOnlyDeadlineTransactionUsingPool(
+    deadlinePool,
+    deadline,
+    beginSql,
+    async (transaction): Promise<T> => callback(
+      (text, params) => transaction.query(text, params, deadline.timeoutMs),
+      (text, params, statementTimeoutMs, onDispatch) => transaction.queryWithDispatchMarker(
+        text,
+        params,
+        statementTimeoutMs,
+        onDispatch,
+      ),
+    ),
+    systemDeadlineRuntime,
+  );
+};
 type ResolvedWorkspaceRow = Readonly<{
   workspace_id: string;
   name: string;
@@ -83,10 +167,10 @@ export const withTransaction = async <T>(
 };
 
 const upsertUserIdentity = async (
-  client: pg.PoolClient,
+  queryFn: QueryFn,
   identity: UserIdentity,
 ): Promise<void> => {
-  await client.query(
+  await queryFn(
     `INSERT INTO users (
        user_id,
        email,
@@ -119,7 +203,7 @@ export const resolveOrCreateWorkspaceForTrustedIdentity = async (
   try {
     await client.query("BEGIN");
     await client.query("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
-    await upsertUserIdentity(client, identity);
+    await upsertUserIdentity((text, params) => client.query(text, params as Array<unknown>), identity);
 
     const workspaceResult = await client.query(
       "SELECT workspace_id, name, created FROM ensure_current_user_has_workspace($1, $2)",
@@ -159,7 +243,7 @@ export const ensureTrustedIdentityProvisioned = async (
     await client.query("BEGIN");
     await client.query("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
     await client.query("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
-    await upsertUserIdentity(client, identity);
+    await upsertUserIdentity((text, params) => client.query(text, params as Array<unknown>), identity);
 
     const membershipResult = await client.query(
       "SELECT 1 FROM workspace_members WHERE workspace_id = $1 AND user_id = $2",
@@ -187,6 +271,122 @@ export const ensureTrustedIdentityProvisioned = async (
     client.release();
   }
 };
+
+export const resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline = async (
+  identity: UserIdentity,
+  deadline: SqlExecutionDeadline,
+): Promise<ResolvedWorkspace> => withDeadlineTransaction(
+  deadline,
+  "BEGIN",
+  async (queryFn): Promise<ResolvedWorkspace> => {
+    await queryFn("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+    await upsertUserIdentity(queryFn, identity);
+    const workspaceResult = await queryFn(
+      "SELECT workspace_id, name, created FROM ensure_current_user_has_workspace($1, $2)",
+      [DEFAULT_FIRST_WORKSPACE_NAME, DEFAULT_WORKSPACE_TIMEZONE],
+    );
+    if (workspaceResult.rows.length !== 1) {
+      throw new Error(`ensure_current_user_has_workspace returned ${workspaceResult.rows.length} rows`);
+    }
+    await queryFn(
+      "INSERT INTO user_settings (user_id, locale) VALUES ($1, $2) ON CONFLICT (user_id) DO NOTHING",
+      [identity.userId, DEFAULT_USER_LOCALE],
+    );
+    const row = workspaceResult.rows[0] as ResolvedWorkspaceRow;
+    return {
+      workspaceId: row.workspace_id,
+      created: row.created,
+    };
+  },
+);
+
+export const ensureTrustedIdentityProvisionedBeforeDeadline = async (
+  identity: UserIdentity,
+  workspaceId: string,
+  deadline: SqlExecutionDeadline,
+): Promise<void> => withDeadlineTransaction(
+  deadline,
+  "BEGIN",
+  async (queryFn): Promise<void> => {
+    await queryFn("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+    await queryFn("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
+    await upsertUserIdentity(queryFn, identity);
+    const membershipResult = await queryFn(
+      "SELECT 1 FROM workspace_members WHERE workspace_id = $1 AND user_id = $2",
+      [workspaceId, identity.userId],
+    );
+    if (membershipResult.rows.length === 0) {
+      throw new Error(`User ${identity.userId} is not a member of workspace ${workspaceId}`);
+    }
+    await queryFn(
+      "INSERT INTO workspace_settings (workspace_id, reporting_currency) VALUES ($1, 'USD') ON CONFLICT (workspace_id) DO NOTHING",
+      [workspaceId],
+    );
+    await queryFn(
+      "INSERT INTO user_settings (user_id, locale) VALUES ($1, $2) ON CONFLICT (user_id) DO NOTHING",
+      [identity.userId, DEFAULT_USER_LOCALE],
+    );
+  },
+);
+
+export const queryAsTrustedIdentityBeforeDeadline = async (
+  identity: UserIdentity,
+  workspaceId: string,
+  text: string,
+  params: ReadonlyArray<unknown>,
+  deadline: SqlExecutionDeadline,
+): Promise<pg.QueryResult> => {
+  await ensureTrustedIdentityProvisionedBeforeDeadline(identity, workspaceId, deadline);
+  return withDeadlineTransaction(
+    deadline,
+    "BEGIN",
+    async (queryFn): Promise<pg.QueryResult> => {
+      await queryFn("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+      await queryFn("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
+      return queryFn(text, params);
+    },
+  );
+};
+
+export const queryAsExistingTrustedIdentityBeforeDeadline = async (
+  identity: UserIdentity,
+  text: string,
+  params: ReadonlyArray<unknown>,
+  deadline: SqlExecutionDeadline,
+): Promise<pg.QueryResult> => withReadOnlyDeadlineTransaction(
+  deadline,
+  "BEGIN READ ONLY",
+  async (queryFn): Promise<pg.QueryResult> => {
+    await queryFn("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+    return queryFn(text, params);
+  },
+);
+
+export const queryBeforeDeadline = async (
+  text: string,
+  params: ReadonlyArray<unknown>,
+  deadline: SqlExecutionDeadline,
+): Promise<pg.QueryResult> => withReadOnlyDeadlineTransaction(
+  deadline,
+  "BEGIN READ ONLY",
+  (queryFn): Promise<pg.QueryResult> => queryFn(text, params),
+);
+
+export const queryAsExistingTrustedWorkspaceBeforeDeadline = async (
+  identity: UserIdentity,
+  workspaceId: string,
+  text: string,
+  params: ReadonlyArray<unknown>,
+  deadline: SqlExecutionDeadline,
+): Promise<pg.QueryResult> => withReadOnlyDeadlineTransaction(
+  deadline,
+  "BEGIN READ ONLY",
+  async (queryFn): Promise<pg.QueryResult> => {
+    await queryFn("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+    await queryFn("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
+    return queryFn(text, params);
+  },
+);
 
 export const queryAsTrustedIdentity = async (
   identity: UserIdentity,
@@ -328,31 +528,44 @@ export const loadTrustedUserIdentity = async (
   }
 };
 
+export const loadTrustedUserIdentityBeforeDeadline = async (
+  userId: string,
+  deadline: SqlExecutionDeadline,
+): Promise<UserIdentity | null> => withReadOnlyDeadlineTransaction(
+  deadline,
+  "BEGIN READ ONLY",
+  async (queryFn): Promise<UserIdentity | null> => {
+    await queryFn("SELECT set_config('app.user_id', $1, true)", [userId]);
+    const result = await queryFn(
+      `SELECT user_id, email, email_verified, cognito_status, cognito_enabled
+       FROM users
+       WHERE user_id = $1`,
+      [userId],
+    );
+    if (result.rows.length > 1) {
+      throw new Error(`loadTrustedUserIdentity: expected at most 1 row, got ${result.rows.length}`);
+    }
+    const row = result.rows[0];
+    return row === undefined ? null : readTrustedUserIdentity(row);
+  },
+);
+
 export const withRestrictedTrustedIdentityContext = async <T>(
   identity: UserIdentity,
   workspaceId: string,
-  statementTimeoutMs: number,
-  callback: (queryFn: QueryFn) => Promise<T>,
+  deadline: SqlExecutionDeadline,
+  callback: (queryFn: RestrictedQueryFn) => Promise<T>,
 ): Promise<T> => {
-  await ensureTrustedIdentityProvisioned(identity, workspaceId);
-  const client = await (await getPool()).connect();
-
-  try {
-    await client.query("BEGIN");
-    await client.query("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
-    await client.query("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
-    await client.query("SELECT set_config('statement_timeout', $1, true)", [String(statementTimeoutMs)]);
-    await client.query("SET LOCAL ROLE api_sql_executor");
-    const boundQuery: QueryFn = (text, params) => client.query(text, params as Array<unknown>);
-    const result = await callback(boundQuery);
-    await client.query("COMMIT");
-    return result;
-  } catch (error) {
-    await client.query("ROLLBACK");
-    throw error;
-  } finally {
-    client.release();
-  }
+  await ensureTrustedIdentityProvisionedBeforeDeadline(identity, workspaceId, deadline);
+  return withDeadlineTransaction(
+    deadline,
+    "BEGIN",
+    async (queryFn, restrictedQueryFn): Promise<T> => {
+      await queryFn("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+      await queryFn("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
+      return callback(createRestrictedQueryFn(queryFn, restrictedQueryFn, "api_sql_executor"));
+    },
+  );
 };
 
 /**
@@ -362,28 +575,19 @@ export const withRestrictedTrustedIdentityContext = async <T>(
 export const withReadOnlyRestrictedTrustedIdentityContext = async <T>(
   identity: UserIdentity,
   workspaceId: string,
-  statementTimeoutMs: number,
-  callback: (queryFn: QueryFn) => Promise<T>,
+  deadline: SqlExecutionDeadline,
+  callback: (queryFn: RestrictedQueryFn) => Promise<T>,
 ): Promise<T> => {
-  await ensureTrustedIdentityProvisioned(identity, workspaceId);
-  const client = await (await getPool()).connect();
-
-  try {
-    await client.query("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY");
-    await client.query("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
-    await client.query("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
-    await client.query("SELECT set_config('statement_timeout', $1, true)", [String(statementTimeoutMs)]);
-    await client.query("SET LOCAL ROLE api_sql_reader");
-    const boundQuery: QueryFn = (text, params) => client.query(text, params as Array<unknown>);
-    const result = await callback(boundQuery);
-    await client.query("COMMIT");
-    return result;
-  } catch (error) {
-    await client.query("ROLLBACK");
-    throw error;
-  } finally {
-    client.release();
-  }
+  await ensureTrustedIdentityProvisionedBeforeDeadline(identity, workspaceId, deadline);
+  return withReadOnlyDeadlineTransaction(
+    deadline,
+    "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY",
+    async (queryFn, restrictedQueryFn): Promise<T> => {
+      await queryFn("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+      await queryFn("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
+      return callback(createRestrictedQueryFn(queryFn, restrictedQueryFn, "api_sql_reader"));
+    },
+  );
 };
 
 /**
@@ -393,25 +597,16 @@ export const withReadOnlyRestrictedTrustedIdentityContext = async <T>(
 export const withNonProvisioningReadOnlyRestrictedTrustedIdentityContext = async <T>(
   identity: UserIdentity,
   workspaceId: string,
-  statementTimeoutMs: number,
-  callback: (queryFn: QueryFn) => Promise<T>,
+  deadline: SqlExecutionDeadline,
+  callback: (queryFn: RestrictedQueryFn) => Promise<T>,
 ): Promise<T> => {
-  const client = await (await getPool()).connect();
-
-  try {
-    await client.query("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY");
-    await client.query("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
-    await client.query("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
-    await client.query("SELECT set_config('statement_timeout', $1, true)", [String(statementTimeoutMs)]);
-    await client.query("SET LOCAL ROLE api_sql_reader");
-    const boundQuery: QueryFn = (text, params) => client.query(text, params as Array<unknown>);
-    const result = await callback(boundQuery);
-    await client.query("COMMIT");
-    return result;
-  } catch (error) {
-    await client.query("ROLLBACK");
-    throw error;
-  } finally {
-    client.release();
-  }
+  return withReadOnlyDeadlineTransaction(
+    deadline,
+    "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY",
+    async (queryFn, restrictedQueryFn): Promise<T> => {
+      await queryFn("SELECT set_config('app.user_id', $1, true)", [identity.userId]);
+      await queryFn("SELECT set_config('app.workspace_id', $1, true)", [workspaceId]);
+      return callback(createRestrictedQueryFn(queryFn, restrictedQueryFn, "api_sql_reader"));
+    },
+  );
 };

--- a/apps/sql-api/src/dbDeadline.test.ts
+++ b/apps/sql-api/src/dbDeadline.test.ts
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import {
+  createSqlExecutionDeadline,
+  SqlExecutionDeadlineError,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import { createQueryResult } from "./handlerTestUtils.js";
+import {
+  acquirePoolClientBeforeDeadline,
+  type DeadlinePool,
+  type DeadlineRuntime,
+  type DeadlineTimerHandle,
+  type DeadlineTransaction,
+  SQL_TRANSACTION_CLEANUP_TIMEOUT_MS,
+  SqlTransactionOutcomeUnknownError,
+  withDeadlineTransactionUsingPool,
+  withReadOnlyDeadlineTransactionUsingPool,
+} from "./dbDeadline.js";
+
+type ScheduledTask = {
+  callback: () => void;
+  delayMs: number;
+  cancelled: boolean;
+};
+
+const createManualRuntime = (
+  readTimeMs: () => number,
+): Readonly<{
+  runtime: DeadlineRuntime;
+  tasks: Array<ScheduledTask>;
+}> => {
+  const tasks: Array<ScheduledTask> = [];
+  return {
+    tasks,
+    runtime: {
+      now: readTimeMs,
+      schedule: (callback, delayMs): DeadlineTimerHandle => {
+        const task: ScheduledTask = { callback, delayMs, cancelled: false };
+        tasks.push(task);
+        return task;
+      },
+      cancel: (handle): void => {
+        (handle as ScheduledTask).cancelled = true;
+      },
+    },
+  };
+};
+
+const createPoolClient = (
+  queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<pg.QueryResult>,
+  releases: Array<Error | undefined>,
+): pg.PoolClient => ({
+  query: queryFn,
+  release: (error?: Error | boolean): void => {
+    releases.push(error instanceof Error ? error : undefined);
+  },
+} as pg.PoolClient);
+
+test("deadline-aware pool acquisition rejects wait expiry and discards a late client", async (): Promise<void> => {
+  let poolCallback: Parameters<DeadlinePool["connect"]>[0] | undefined;
+  const pool: DeadlinePool = {
+    connect: (callback): void => {
+      poolCallback = callback;
+    },
+  };
+  const { runtime, tasks } = createManualRuntime(() => 1_000);
+  const deadline = createSqlExecutionDeadline(20_000, () => 1_000);
+  const releases: Array<Error | undefined> = [];
+  const client = createPoolClient(async () => createQueryResult([]), releases);
+
+  const acquisition = acquirePoolClientBeforeDeadline(pool, deadline, runtime);
+  const rejected = assert.rejects(
+    acquisition,
+    (error: unknown) => error instanceof SqlExecutionDeadlineError,
+  );
+  const acquisitionTimeout = tasks[0];
+  assert.ok(acquisitionTimeout !== undefined);
+  assert.equal(acquisitionTimeout.delayMs, 20_000);
+  acquisitionTimeout.callback();
+  await rejected;
+  assert.ok(poolCallback !== undefined);
+  poolCallback(undefined, client);
+
+  assert.equal(releases.length, 1);
+  assert.ok(releases[0] instanceof SqlExecutionDeadlineError);
+});
+
+test("bounded transactions refresh server and hard deadlines before setup, role, mutation, and commit", async (): Promise<void> => {
+  let currentTimeMs = 5_000;
+  let mutationDispatchCallCount: number | undefined;
+  const calls: Array<Readonly<{ text: string; params: ReadonlyArray<unknown> }>> = [];
+  const releases: Array<Error | undefined> = [];
+  const client = createPoolClient(async (text, params) => {
+    calls.push({ text, params });
+    currentTimeMs += 25;
+    return createQueryResult([]);
+  }, releases);
+  const pool: DeadlinePool = {
+    connect: (callback): void => callback(undefined, client),
+  };
+  const { runtime, tasks } = createManualRuntime(() => currentTimeMs);
+  const deadline = createSqlExecutionDeadline(20_000, () => currentTimeMs);
+
+  await withDeadlineTransactionUsingPool(
+    pool,
+    deadline,
+    "BEGIN",
+    async (transaction): Promise<void> => {
+      await transaction.query("SELECT set_config('app.user_id', $1, true)", ["user-1"], 20_000);
+      await transaction.query("SET LOCAL ROLE api_sql_executor", [], 20_000);
+      await transaction.queryWithDispatchMarker(
+        "DELETE FROM budget_lines WHERE category = $1",
+        ["Food"],
+        20_000,
+        () => {
+          mutationDispatchCallCount = calls.length;
+        },
+      );
+    },
+    runtime,
+  );
+
+  assert.deepEqual(calls.map((call) => call.text), [
+    "BEGIN; SET LOCAL statement_timeout = 20000; SET LOCAL transaction_timeout = 20000",
+    "SET LOCAL statement_timeout = 19975",
+    "SELECT set_config('app.user_id', $1, true)",
+    "SET LOCAL statement_timeout = 19925",
+    "SET LOCAL ROLE api_sql_executor",
+    "SET LOCAL statement_timeout = 19875",
+    "DELETE FROM budget_lines WHERE category = $1",
+    "SET LOCAL statement_timeout = 19825",
+    "RESET ROLE",
+    "SET LOCAL statement_timeout = 19775",
+    "COMMIT",
+  ]);
+  const configuredTimeouts = calls
+    .map((call) => /statement_timeout = ([0-9]+)/u.exec(call.text)?.[1])
+    .filter((value): value is string => value !== undefined)
+    .map(Number);
+  assert.deepEqual(configuredTimeouts, [20_000, 19_975, 19_925, 19_875, 19_825, 19_775]);
+  assert.ok(mutationDispatchCallCount !== undefined);
+  assert.equal(mutationDispatchCallCount, 6);
+  assert.equal(calls[mutationDispatchCallCount - 1]?.text, "SET LOCAL statement_timeout = 19875");
+  assert.equal(calls[mutationDispatchCallCount]?.text, "DELETE FROM budget_lines WHERE category = $1");
+  assert.equal(configuredTimeouts.every(
+    (timeout, index) => index === 0 || timeout < configuredTimeouts[index - 1]!,
+  ), true);
+  assert.equal(tasks.length, calls.length + 1);
+  assert.deepEqual(tasks.map((task) => task.delayMs), [
+    20_000,
+    20_000,
+    19_975,
+    19_950,
+    19_925,
+    19_900,
+    19_875,
+    19_850,
+    19_825,
+    19_800,
+    19_775,
+    19_750,
+  ]);
+  assert.equal(tasks.every((task) => task.cancelled), true);
+  assert.deepEqual(releases, [undefined]);
+});
+
+test("rollback cleanup is bounded and discards a client that cannot become transaction-idle", async (): Promise<void> => {
+  const calls: Array<string> = [];
+  const releases: Array<Error | undefined> = [];
+  const client = createPoolClient(async (text) => {
+    calls.push(text);
+    if (text === "ROLLBACK") {
+      return new Promise<pg.QueryResult>(() => undefined);
+    }
+    return createQueryResult([]);
+  }, releases);
+  const pool: DeadlinePool = {
+    connect: (callback): void => callback(undefined, client),
+  };
+  const { runtime, tasks } = createManualRuntime(() => 10_000);
+  const deadline = createSqlExecutionDeadline(20_000, () => 10_000);
+  const transactionError = new Error("transaction callback failed");
+  const transaction = withDeadlineTransactionUsingPool(
+    pool,
+    deadline,
+    "BEGIN",
+    async (): Promise<void> => {
+      throw transactionError;
+    },
+    runtime,
+  );
+  const rejected = assert.rejects(
+    transaction,
+    (error: unknown) =>
+      error instanceof SqlTransactionOutcomeUnknownError
+      && error.failurePhase === "transaction"
+      && error.originalError === transactionError
+      && error.rollbackOutcome === "unknown"
+      && error.cleanupError instanceof SqlExecutionDeadlineError,
+  );
+
+  while (!calls.includes("ROLLBACK")) {
+    await Promise.resolve();
+  }
+  const cleanupTimeout = [...tasks].reverse().find(
+    (task) => !task.cancelled && task.delayMs === SQL_TRANSACTION_CLEANUP_TIMEOUT_MS,
+  );
+  assert.ok(cleanupTimeout !== undefined);
+  cleanupTimeout.callback();
+  await rejected;
+
+  assert.deepEqual(calls, [
+    "BEGIN; SET LOCAL statement_timeout = 20000; SET LOCAL transaction_timeout = 20000",
+    "ROLLBACK",
+  ]);
+  assert.equal(releases.length, 1);
+  assert.ok(releases[0] instanceof SqlExecutionDeadlineError);
+  assert.equal(transactionError.cause, undefined);
+});
+
+test("an expired transaction rolls back without dispatching role reset or commit", async (): Promise<void> => {
+  let currentTimeMs = 30_000;
+  const calls: Array<string> = [];
+  const releases: Array<Error | undefined> = [];
+  const client = createPoolClient(async (text) => {
+    calls.push(text);
+    return createQueryResult([]);
+  }, releases);
+  const pool: DeadlinePool = {
+    connect: (callback): void => callback(undefined, client),
+  };
+  const { runtime } = createManualRuntime(() => currentTimeMs);
+  const deadline = createSqlExecutionDeadline(20_000, () => currentTimeMs);
+
+  await assert.rejects(
+    () => withDeadlineTransactionUsingPool(
+      pool,
+      deadline,
+      "BEGIN",
+      async (): Promise<void> => {
+        currentTimeMs += 20_000;
+      },
+      runtime,
+    ),
+    (error: unknown) => error instanceof SqlExecutionDeadlineError,
+  );
+
+  assert.deepEqual(calls, [
+    "BEGIN; SET LOCAL statement_timeout = 20000; SET LOCAL transaction_timeout = 20000",
+    "ROLLBACK",
+  ]);
+  assert.deepEqual(releases, [undefined]);
+});
+
+const readOnlyDeadlineScenarios: ReadonlyArray<Readonly<{
+  name: string;
+  isBlockedCommand: (text: string) => boolean;
+  callback: (transaction: DeadlineTransaction) => Promise<void>;
+}>> = [
+  {
+    name: "begin",
+    isBlockedCommand: (text) => text.startsWith("BEGIN READ ONLY;"),
+    callback: async () => undefined,
+  },
+  {
+    name: "query",
+    isBlockedCommand: (text) => text === "SELECT 1",
+    callback: async (transaction) => {
+      await transaction.query("SELECT 1", [], 20_000);
+    },
+  },
+  {
+    name: "commit",
+    isBlockedCommand: (text) => text === "COMMIT",
+    callback: async () => undefined,
+  },
+];
+
+for (const scenario of readOnlyDeadlineScenarios) {
+  test(`read-only ${scenario.name} deadline remains a retryable deadline error`, async (): Promise<void> => {
+    const calls: Array<string> = [];
+    const releases: Array<Error | undefined> = [];
+    const client = createPoolClient(async (text) => {
+      calls.push(text);
+      if (scenario.isBlockedCommand(text)) {
+        return new Promise<pg.QueryResult>(() => undefined);
+      }
+      return createQueryResult([]);
+    }, releases);
+    const pool: DeadlinePool = {
+      connect: (callback): void => callback(undefined, client),
+    };
+    const { runtime, tasks } = createManualRuntime(() => 10_000);
+    const deadline = createSqlExecutionDeadline(20_000, () => 10_000);
+    const transaction = withReadOnlyDeadlineTransactionUsingPool(
+      pool,
+      deadline,
+      "BEGIN READ ONLY",
+      scenario.callback,
+      runtime,
+    );
+    const rejected = assert.rejects(
+      transaction,
+      (error: unknown) => error instanceof SqlExecutionDeadlineError,
+    );
+
+    while (!calls.some(scenario.isBlockedCommand)) {
+      await Promise.resolve();
+    }
+    const activeTimeout = [...tasks].reverse().find((task) => !task.cancelled);
+    assert.ok(activeTimeout !== undefined);
+    activeTimeout.callback();
+    await rejected;
+
+    assert.equal(releases.length, 1);
+    assert.ok(releases[0] instanceof SqlExecutionDeadlineError);
+  });
+}

--- a/apps/sql-api/src/dbDeadline.ts
+++ b/apps/sql-api/src/dbDeadline.ts
@@ -1,0 +1,425 @@
+import type pg from "pg";
+import {
+  createSqlExecutionDeadline,
+  getRemainingSqlExecutionMs,
+  SqlExecutionDeadlineError,
+  type SqlExecutionDeadline,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+
+export const SQL_TRANSACTION_CLEANUP_TIMEOUT_MS = 1_000;
+
+export type DeadlineTimerHandle = object;
+
+export type DeadlineRuntime = Readonly<{
+  now: () => number;
+  schedule: (callback: () => void, delayMs: number) => DeadlineTimerHandle;
+  cancel: (handle: DeadlineTimerHandle) => void;
+}>;
+
+export type DeadlinePool = Readonly<{
+  connect: (
+    callback: (error: Error | undefined, client: pg.PoolClient | undefined) => void,
+  ) => void;
+}>;
+
+export type DeadlineTransaction = Readonly<{
+  query: (
+    text: string,
+    params: ReadonlyArray<unknown>,
+    statementTimeoutCapMs: number,
+  ) => Promise<pg.QueryResult>;
+  queryWithDispatchMarker: (
+    text: string,
+    params: ReadonlyArray<unknown>,
+    statementTimeoutCapMs: number,
+    onDispatch: () => void,
+  ) => Promise<pg.QueryResult>;
+}>;
+
+export type SqlTransactionFailurePhase = "transaction" | "commit";
+export type SqlTransactionRollbackOutcome = "rolled_back" | "unknown";
+export type ReadOnlyTransactionStart =
+  | "BEGIN READ ONLY"
+  | "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY";
+
+export class SqlTransactionOutcomeUnknownError extends Error {
+  readonly failurePhase: SqlTransactionFailurePhase;
+  readonly originalError: unknown;
+  readonly rollbackOutcome: SqlTransactionRollbackOutcome;
+  readonly cleanupError: Error | undefined;
+
+  constructor(
+    failurePhase: SqlTransactionFailurePhase,
+    originalError: unknown,
+    rollbackOutcome: SqlTransactionRollbackOutcome,
+    cleanupError: Error | undefined,
+  ) {
+    const cause = cleanupError === undefined
+      ? originalError
+      : new AggregateError(
+        [originalError, cleanupError],
+        "PostgreSQL transaction failure and rollback cleanup failure",
+      );
+    super(`PostgreSQL ${failurePhase} outcome is unknown`, { cause });
+    this.failurePhase = failurePhase;
+    this.originalError = originalError;
+    this.rollbackOutcome = rollbackOutcome;
+    this.cleanupError = cleanupError;
+  }
+}
+
+export const getReadOnlyTransactionDeadlineError = (
+  error: unknown,
+): SqlExecutionDeadlineError | null => {
+  if (error instanceof SqlExecutionDeadlineError) {
+    return error;
+  }
+  if (
+    error instanceof SqlTransactionOutcomeUnknownError
+    && error.originalError instanceof SqlExecutionDeadlineError
+  ) {
+    return error.originalError;
+  }
+  return null;
+};
+
+type ClientLease = Readonly<{
+  client: pg.PoolClient;
+  isReleased: () => boolean;
+  release: () => void;
+  discard: (error: Error) => void;
+}>;
+
+const ignoreDispatch = (): void => undefined;
+
+export const systemDeadlineRuntime: DeadlineRuntime = {
+  now: Date.now,
+  schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+  cancel: (handle) => clearTimeout(handle as NodeJS.Timeout),
+};
+
+const createClientLease = (client: pg.PoolClient): ClientLease => {
+  let released = false;
+
+  return {
+    client,
+    isReleased: () => released,
+    release: () => {
+      if (released) return;
+      released = true;
+      client.release();
+    },
+    discard: (error) => {
+      if (released) return;
+      released = true;
+      // pg-pool removes a client released with an error. node-postgres then
+      // destroys the socket when a query is active, so PostgreSQL work cannot
+      // continue after this local deadline backstop fires.
+      client.release(error);
+    },
+  };
+};
+
+export const acquirePoolClientBeforeDeadline = (
+  pool: DeadlinePool,
+  deadline: SqlExecutionDeadline,
+  runtime: DeadlineRuntime,
+): Promise<ClientLease> => {
+  const remainingMs = getRemainingSqlExecutionMs(deadline);
+
+  return new Promise<ClientLease>((resolve, reject) => {
+    let completed = false;
+    const timeoutHandle = runtime.schedule(() => {
+      if (completed) return;
+      completed = true;
+      reject(new SqlExecutionDeadlineError(deadline.timeoutMs));
+    }, remainingMs);
+
+    const handleConnection = (error: Error | undefined, client: pg.PoolClient | undefined): void => {
+      if (completed) {
+        if (client !== undefined) {
+          client.release(new SqlExecutionDeadlineError(deadline.timeoutMs));
+        }
+        return;
+      }
+
+      completed = true;
+      runtime.cancel(timeoutHandle);
+      if (error !== undefined) {
+        reject(error);
+        return;
+      }
+      if (client === undefined) {
+        reject(new Error("PostgreSQL pool acquisition completed without a client"));
+        return;
+      }
+
+      try {
+        getRemainingSqlExecutionMs(deadline);
+      } catch (deadlineError) {
+        const errorToRaise = deadlineError instanceof Error
+          ? deadlineError
+          : new Error("PostgreSQL pool acquisition exceeded its SQL execution deadline");
+        client.release(errorToRaise);
+        reject(errorToRaise);
+        return;
+      }
+      resolve(createClientLease(client));
+    };
+
+    try {
+      pool.connect(handleConnection);
+    } catch (error) {
+      if (completed) return;
+      completed = true;
+      runtime.cancel(timeoutHandle);
+      reject(error);
+    }
+  });
+};
+
+const executeWithDeadlineBackstop = (
+  lease: ClientLease,
+  deadline: SqlExecutionDeadline,
+  runtime: DeadlineRuntime,
+  text: string,
+  params: ReadonlyArray<unknown>,
+  statementTimeoutCapMs: number,
+  onDispatch: () => void,
+): Promise<pg.QueryResult> => {
+  const remainingMs = Math.min(
+    statementTimeoutCapMs,
+    getRemainingSqlExecutionMs(deadline),
+  );
+
+  return new Promise<pg.QueryResult>((resolve, reject) => {
+    let completed = false;
+    const timeoutHandle = runtime.schedule(() => {
+      if (completed) return;
+      completed = true;
+      const error = new SqlExecutionDeadlineError(deadline.timeoutMs);
+      lease.discard(error);
+      reject(error);
+    }, remainingMs);
+
+    let dispatchedQuery: Promise<pg.QueryResult>;
+    try {
+      onDispatch();
+      dispatchedQuery = lease.client.query(text, params as Array<unknown>);
+    } catch (error) {
+      completed = true;
+      runtime.cancel(timeoutHandle);
+      reject(error);
+      return;
+    }
+
+    dispatchedQuery.then(
+      (result) => {
+        if (completed) return;
+        completed = true;
+        runtime.cancel(timeoutHandle);
+        resolve(result);
+      },
+      (error: Error) => {
+        if (completed) return;
+        completed = true;
+        runtime.cancel(timeoutHandle);
+        reject(error);
+      },
+    );
+  });
+};
+
+const beginTransactionBeforeDeadline = async (
+  lease: ClientLease,
+  deadline: SqlExecutionDeadline,
+  runtime: DeadlineRuntime,
+  beginSql: string,
+): Promise<void> => {
+  const remainingMs = getRemainingSqlExecutionMs(deadline);
+  await executeWithDeadlineBackstop(
+    lease,
+    deadline,
+    runtime,
+    `${beginSql}; SET LOCAL statement_timeout = ${String(remainingMs)}; SET LOCAL transaction_timeout = ${String(remainingMs)}`,
+    [],
+    remainingMs,
+    ignoreDispatch,
+  );
+};
+
+const queryBeforeDeadline = async (
+  lease: ClientLease,
+  deadline: SqlExecutionDeadline,
+  runtime: DeadlineRuntime,
+  text: string,
+  params: ReadonlyArray<unknown>,
+  statementTimeoutCapMs: number,
+  onDispatch: () => void,
+): Promise<pg.QueryResult> => {
+  const serverTimeoutMs = Math.min(
+    statementTimeoutCapMs,
+    getRemainingSqlExecutionMs(deadline),
+  );
+  await executeWithDeadlineBackstop(
+    lease,
+    deadline,
+    runtime,
+    `SET LOCAL statement_timeout = ${String(serverTimeoutMs)}`,
+    [],
+    serverTimeoutMs,
+    ignoreDispatch,
+  );
+  // Recompute the hard bound after the SET LOCAL round trip. The server-side
+  // transaction timeout enforces the absolute budget across that round trip,
+  // while this statement timeout caps the individual command.
+  return executeWithDeadlineBackstop(
+    lease,
+    deadline,
+    runtime,
+    text,
+    params,
+    statementTimeoutCapMs,
+    onDispatch,
+  );
+};
+
+type TransactionRollbackResult =
+  | Readonly<{ outcome: "rolled_back"; cleanupError: undefined }>
+  | Readonly<{ outcome: "unknown"; cleanupError: Error | undefined }>;
+
+const rollbackWithinCleanupAllowance = async (
+  lease: ClientLease,
+  runtime: DeadlineRuntime,
+): Promise<TransactionRollbackResult> => {
+  if (lease.isReleased()) {
+    return { outcome: "unknown", cleanupError: undefined };
+  }
+
+  const cleanupDeadline = createSqlExecutionDeadline(
+    SQL_TRANSACTION_CLEANUP_TIMEOUT_MS,
+    runtime.now,
+  );
+  try {
+    await executeWithDeadlineBackstop(
+      lease,
+      cleanupDeadline,
+      runtime,
+      "ROLLBACK",
+      [],
+      SQL_TRANSACTION_CLEANUP_TIMEOUT_MS,
+      ignoreDispatch,
+    );
+    return { outcome: "rolled_back", cleanupError: undefined };
+  } catch (cleanupError) {
+    const errorToRaise = cleanupError instanceof Error
+      ? cleanupError
+      : new Error("PostgreSQL rollback cleanup failed");
+    lease.discard(errorToRaise);
+    return { outcome: "unknown", cleanupError: errorToRaise };
+  }
+};
+
+const rethrowAfterTransactionFailure = async (
+  lease: ClientLease,
+  runtime: DeadlineRuntime,
+  error: unknown,
+): Promise<never> => {
+  const rollback = await rollbackWithinCleanupAllowance(lease, runtime);
+  if (rollback.outcome === "rolled_back") {
+    throw error;
+  }
+  throw new SqlTransactionOutcomeUnknownError(
+    "transaction",
+    error,
+    rollback.outcome,
+    rollback.cleanupError,
+  );
+};
+
+export const withDeadlineTransactionUsingPool = async <T>(
+  pool: DeadlinePool,
+  deadline: SqlExecutionDeadline,
+  beginSql: string,
+  callback: (transaction: DeadlineTransaction) => Promise<T>,
+  runtime: DeadlineRuntime,
+): Promise<T> => {
+  const lease = await acquirePoolClientBeforeDeadline(pool, deadline, runtime);
+
+  try {
+    const transaction: DeadlineTransaction = {
+      query: (text, params, statementTimeoutCapMs) => queryBeforeDeadline(
+        lease,
+        deadline,
+        runtime,
+        text,
+        params,
+        statementTimeoutCapMs,
+        ignoreDispatch,
+      ),
+      queryWithDispatchMarker: (
+        text,
+        params,
+        statementTimeoutCapMs,
+        onDispatch,
+      ) => queryBeforeDeadline(
+        lease,
+        deadline,
+        runtime,
+        text,
+        params,
+        statementTimeoutCapMs,
+        onDispatch,
+      ),
+    };
+
+    let result: T;
+    try {
+      await beginTransactionBeforeDeadline(lease, deadline, runtime, beginSql);
+      result = await callback(transaction);
+      await transaction.query("RESET ROLE", [], deadline.timeoutMs);
+    } catch (error) {
+      await rethrowAfterTransactionFailure(lease, runtime, error);
+    }
+
+    try {
+      await transaction.query("COMMIT", [], deadline.timeoutMs);
+    } catch (error) {
+      const rollback = await rollbackWithinCleanupAllowance(lease, runtime);
+      throw new SqlTransactionOutcomeUnknownError(
+        "commit",
+        error,
+        rollback.outcome,
+        rollback.cleanupError,
+      );
+    }
+
+    return result;
+  } finally {
+    lease.release();
+  }
+};
+
+export const withReadOnlyDeadlineTransactionUsingPool = async <T>(
+  pool: DeadlinePool,
+  deadline: SqlExecutionDeadline,
+  beginSql: ReadOnlyTransactionStart,
+  callback: (transaction: DeadlineTransaction) => Promise<T>,
+  runtime: DeadlineRuntime,
+): Promise<T> => {
+  try {
+    return await withDeadlineTransactionUsingPool(
+      pool,
+      deadline,
+      beginSql,
+      callback,
+      runtime,
+    );
+  } catch (error) {
+    const deadlineError = getReadOnlyTransactionDeadlineError(error);
+    if (deadlineError !== null) {
+      throw deadlineError;
+    }
+    throw error;
+  }
+};

--- a/apps/sql-api/src/dbPool.test.ts
+++ b/apps/sql-api/src/dbPool.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import {
+  createSqlExecutionDeadline,
+  SqlExecutionDeadlineError,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import type {
+  DeadlineRuntime,
+  DeadlineTimerHandle,
+} from "./dbDeadline.js";
+import {
+  createDatabasePoolProvider,
+  POSTGRES_CONNECTION_TIMEOUT_MS,
+  waitForPoolBeforeDeadline,
+} from "./dbPool.js";
+
+type ScheduledTask = {
+  callback: () => void;
+  delayMs: number;
+  cancelled: boolean;
+};
+
+const createManualRuntime = (
+  readTimeMs: () => number,
+): Readonly<{
+  runtime: DeadlineRuntime;
+  tasks: Array<ScheduledTask>;
+}> => {
+  const tasks: Array<ScheduledTask> = [];
+  return {
+    tasks,
+    runtime: {
+      now: readTimeMs,
+      schedule: (callback, delayMs): DeadlineTimerHandle => {
+        const task: ScheduledTask = { callback, delayMs, cancelled: false };
+        tasks.push(task);
+        return task;
+      },
+      cancel: (handle): void => {
+        (handle as ScheduledTask).cancelled = true;
+      },
+    },
+  };
+};
+
+const createPool = (): pg.Pool => ({}) as pg.Pool;
+
+test("pool initialization is shared and configures bounded PostgreSQL connection establishment", async (): Promise<void> => {
+  let resolveDatabaseUrl: ((databaseUrl: string) => void) | undefined;
+  let databaseUrlRequestCount = 0;
+  const poolConfigs: Array<pg.PoolConfig> = [];
+  const expectedPool = createPool();
+  const provider = createDatabasePoolProvider({
+    createPool: (config) => {
+      poolConfigs.push(config);
+      return expectedPool;
+    },
+    getDatabaseUrl: () => {
+      databaseUrlRequestCount += 1;
+      return new Promise<string>((resolve) => {
+        resolveDatabaseUrl = resolve;
+      });
+    },
+    useTls: () => true,
+  });
+
+  const first = provider.getPool();
+  const second = provider.getPool();
+  assert.equal(first, second);
+  assert.equal(databaseUrlRequestCount, 1);
+  assert.ok(resolveDatabaseUrl !== undefined);
+  resolveDatabaseUrl("postgresql://database.example.internal/expense_tracker");
+
+  assert.equal(await first, expectedPool);
+  assert.equal(await second, expectedPool);
+  assert.equal(poolConfigs.length, 1);
+  assert.equal(poolConfigs[0]?.connectionTimeoutMillis, POSTGRES_CONNECTION_TIMEOUT_MS);
+  assert.equal(poolConfigs[0]?.ssl, true);
+});
+
+test("pool initialization clears failed shared state without creating a pool", async (): Promise<void> => {
+  let databaseUrlRequestCount = 0;
+  let poolCreationCount = 0;
+  const expectedPool = createPool();
+  const provider = createDatabasePoolProvider({
+    createPool: () => {
+      poolCreationCount += 1;
+      return expectedPool;
+    },
+    getDatabaseUrl: async () => {
+      databaseUrlRequestCount += 1;
+      if (databaseUrlRequestCount === 1) {
+        throw new Error("database URL unavailable");
+      }
+      return "postgresql://database.example.internal/expense_tracker";
+    },
+    useTls: () => false,
+  });
+
+  await assert.rejects(provider.getPool(), /database URL unavailable/u);
+  assert.equal(await provider.getPool(), expectedPool);
+  assert.equal(databaseUrlRequestCount, 2);
+  assert.equal(poolCreationCount, 1);
+});
+
+test("a short first SQL caller does not shorten shared pool initialization for a longer caller", async (): Promise<void> => {
+  let resolveDatabaseUrl: ((databaseUrl: string) => void) | undefined;
+  const initializationTimeouts: Array<number> = [];
+  const expectedPool = createPool();
+  const provider = createDatabasePoolProvider({
+    createPool: () => expectedPool,
+    getDatabaseUrl: (timeoutMs) => new Promise<string>((resolve) => {
+      initializationTimeouts.push(timeoutMs);
+      resolveDatabaseUrl = resolve;
+    }),
+    useTls: () => false,
+  });
+  const { runtime, tasks } = createManualRuntime(() => 10_000);
+  const shortDeadline = createSqlExecutionDeadline(1_000, () => 10_000);
+  const longDeadline = createSqlExecutionDeadline(10_000, () => 10_000);
+
+  const shortWait = waitForPoolBeforeDeadline(provider, shortDeadline, runtime);
+  const longWait = waitForPoolBeforeDeadline(provider, longDeadline, runtime);
+  const rejected = assert.rejects(
+    shortWait,
+    (error: unknown) => error instanceof SqlExecutionDeadlineError && error.timeoutMs === 1_000,
+  );
+  const timeoutTask = tasks[0];
+  assert.ok(timeoutTask !== undefined);
+  assert.equal(timeoutTask.delayMs, 1_000);
+  assert.equal(tasks[1]?.delayMs, 10_000);
+  assert.deepEqual(initializationTimeouts, [5_000]);
+  timeoutTask.callback();
+  await rejected;
+
+  assert.ok(resolveDatabaseUrl !== undefined);
+  resolveDatabaseUrl("postgresql://database.example.internal/expense_tracker");
+  assert.equal(await longWait, expectedPool);
+  assert.equal(await provider.getPool(), expectedPool);
+});
+
+test("a SQL caller always gives shared pool initialization its fixed five-second budget", async (): Promise<void> => {
+  let receivedInitializationTimeoutMs = 0;
+  const expectedPool = createPool();
+  const provider = createDatabasePoolProvider({
+    createPool: () => expectedPool,
+    getDatabaseUrl: async (timeoutMs) => {
+      receivedInitializationTimeoutMs = timeoutMs;
+      return "postgresql://database.example.internal/expense_tracker";
+    },
+    useTls: () => false,
+  });
+  const { runtime } = createManualRuntime(() => 12_000);
+  const deadline = createSqlExecutionDeadline(3_000, () => 12_000);
+
+  assert.equal(await waitForPoolBeforeDeadline(provider, deadline, runtime), expectedPool);
+  assert.equal(receivedInitializationTimeoutMs, 5_000);
+});

--- a/apps/sql-api/src/dbPool.ts
+++ b/apps/sql-api/src/dbPool.ts
@@ -1,0 +1,114 @@
+import pg from "pg";
+import { SQL_API_DB_POOL_MAX_CONNECTIONS } from "@expense-budget-tracker/agent-shared";
+import {
+  getRemainingSqlExecutionMs,
+  SqlExecutionDeadlineError,
+  type SqlExecutionDeadline,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import {
+  DATABASE_SECRET_TIMEOUT_MS,
+  getDatabaseUrl,
+} from "./config.js";
+import type { DeadlineRuntime } from "./dbDeadline.js";
+
+export const POSTGRES_CONNECTION_TIMEOUT_MS = 5_000;
+
+export type DatabasePoolProvider = Readonly<{
+  getPool: () => Promise<pg.Pool>;
+}>;
+
+type DatabasePoolProviderDependencies = Readonly<{
+  createPool: (config: pg.PoolConfig) => pg.Pool;
+  getDatabaseUrl: (timeoutMs: number) => Promise<string>;
+  useTls: () => boolean;
+}>;
+
+export const createDatabasePoolProvider = (
+  dependencies: DatabasePoolProviderDependencies,
+): DatabasePoolProvider => {
+  let initializedPool: pg.Pool | undefined;
+  let initialization: Promise<pg.Pool> | undefined;
+
+  const getPool = (): Promise<pg.Pool> => {
+    if (initializedPool !== undefined) {
+      return Promise.resolve(initializedPool);
+    }
+    if (initialization !== undefined) {
+      return initialization;
+    }
+
+    const startedInitialization = dependencies.getDatabaseUrl(DATABASE_SECRET_TIMEOUT_MS).then(
+      (connectionString): pg.Pool => dependencies.createPool({
+        connectionString,
+        ssl: dependencies.useTls(),
+        max: SQL_API_DB_POOL_MAX_CONNECTIONS,
+        connectionTimeoutMillis: POSTGRES_CONNECTION_TIMEOUT_MS,
+      }),
+    );
+    initialization = startedInitialization;
+    void startedInitialization.then(
+      (createdPool) => {
+        initializedPool = createdPool;
+        if (initialization === startedInitialization) {
+          initialization = undefined;
+        }
+      },
+      () => {
+        if (initialization === startedInitialization) {
+          initialization = undefined;
+        }
+      },
+    );
+    return startedInitialization;
+  };
+
+  return { getPool };
+};
+
+export const waitForPoolBeforeDeadline = (
+  provider: DatabasePoolProvider,
+  deadline: SqlExecutionDeadline,
+  runtime: DeadlineRuntime,
+): Promise<pg.Pool> => {
+  const remainingMs = getRemainingSqlExecutionMs(deadline);
+  const initialization = provider.getPool();
+
+  return new Promise<pg.Pool>((resolve, reject) => {
+    let completed = false;
+    const timeoutHandle = runtime.schedule(() => {
+      if (completed) return;
+      completed = true;
+      reject(new SqlExecutionDeadlineError(deadline.timeoutMs));
+    }, remainingMs);
+
+    initialization.then(
+      (databasePool) => {
+        if (completed) return;
+        completed = true;
+        runtime.cancel(timeoutHandle);
+        try {
+          getRemainingSqlExecutionMs(deadline);
+          resolve(databasePool);
+        } catch (error) {
+          reject(error);
+        }
+      },
+      (error: Error) => {
+        if (completed) return;
+        completed = true;
+        runtime.cancel(timeoutHandle);
+        reject(error);
+      },
+    );
+  });
+};
+
+export const databasePoolProvider = createDatabasePoolProvider({
+  // RDS certificates require the bundled Amazon CA configured by the Lambda.
+  createPool: (config) => new pg.Pool(config),
+  getDatabaseUrl,
+  useTls: () => typeof process.env.DB_SECRET_ARN === "string" && process.env.DB_SECRET_ARN.length > 0,
+});
+
+export const getPool = (): Promise<pg.Pool> =>
+  databasePoolProvider.getPool();

--- a/apps/sql-api/src/machineApi.ts
+++ b/apps/sql-api/src/machineApi.ts
@@ -3,6 +3,8 @@ import { AGENT_API_KEY_ENV_VAR_NAME, buildErrorEnvelope } from "@expense-budget-
 import {
   ensureTrustedIdentityProvisioned,
   queryAsTrustedIdentity,
+  queryAsTrustedIdentityBeforeDeadline,
+  resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline,
   withReadOnlyRestrictedTrustedIdentityContext,
   withRestrictedTrustedIdentityContext,
 } from "./db.js";
@@ -28,6 +30,8 @@ export const createMachineApiHandler = (
   const dependencies: MachineApiDependencies = {
     ensureTrustedIdentityProvisioned,
     queryAsTrustedIdentity,
+    queryAsTrustedIdentityBeforeDeadline,
+    resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline,
     withReadOnlyRestrictedTrustedIdentityContext,
     withRestrictedTrustedIdentityContext,
     ...overrides,

--- a/apps/sql-api/src/machineApi/request.ts
+++ b/apps/sql-api/src/machineApi/request.ts
@@ -29,6 +29,18 @@ export const getAuthBaseUrl = (event: APIGatewayProxyEvent): string => {
   return trimTrailingSlash(getApiBaseUrl(event).replace("//api.", "//auth.").replace(/\/v1$/, ""));
 };
 
+export const getMcpUrl = (event: APIGatewayProxyEvent): string => {
+  const authUrl = new URL(getAuthBaseUrl(event));
+  if (!authUrl.hostname.startsWith("auth.")) {
+    throw new Error(`Cannot derive MCP URL from auth host ${authUrl.hostname}`);
+  }
+  authUrl.hostname = `mcp.${authUrl.hostname.slice("auth.".length)}`;
+  authUrl.pathname = "/mcp";
+  authUrl.search = "";
+  authUrl.hash = "";
+  return authUrl.toString();
+};
+
 export const buildDiscoveryEnvelope = (event: APIGatewayProxyEvent): Readonly<Record<string, unknown>> => {
   const authBaseUrl = getAuthBaseUrl(event);
 
@@ -36,6 +48,7 @@ export const buildDiscoveryEnvelope = (event: APIGatewayProxyEvent): Readonly<Re
     apiBaseUrl: getApiBaseUrl(event),
     authBaseUrl,
     bootstrapUrl: `${authBaseUrl}/api/agent/send-code`,
+    mcpUrl: getMcpUrl(event),
   });
 };
 

--- a/apps/sql-api/src/machineApi/routeHandlers.test.ts
+++ b/apps/sql-api/src/machineApi/routeHandlers.test.ts
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import {
+  createSqlExecutionDeadline,
+  SQL_STATEMENT_TIMEOUT_MS,
+  SqlExecutionDeadlineError,
+  type SqlExecutionDeadline,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import { SqlTransactionOutcomeUnknownError } from "../dbDeadline.js";
+import type { RestrictedQueryFn } from "../db.js";
 import { createMachineApiHandler } from "../machineApi.js";
 import {
   handleMeRouteWithResolver,
@@ -7,13 +15,20 @@ import {
   handleSqlQueryRouteWithWorkspaceResolver,
   handleSqlRouteWithWorkspaceResolver,
 } from "./routeHandlers.js";
-import { createAuthenticatedEvent, createEvent } from "../handlerTestUtils.js";
+import { createAuthenticatedEvent, createEvent, createQueryResult } from "../handlerTestUtils.js";
 import type { MachineApiDependencies, MachineRouteContext } from "./types.js";
+import { resolveSqlWorkspaceId } from "./workspaceService.js";
 
 const createDependencies = (): MachineApiDependencies => ({
   ensureTrustedIdentityProvisioned: async () => undefined,
   queryAsTrustedIdentity: async () => {
     throw new Error("queryAsTrustedIdentity should not be called");
+  },
+  queryAsTrustedIdentityBeforeDeadline: async () => {
+    throw new Error("queryAsTrustedIdentityBeforeDeadline should not be called");
+  },
+  resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline: async () => {
+    throw new Error("resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline should not be called");
   },
   withReadOnlyRestrictedTrustedIdentityContext: async () => {
     throw new Error("withReadOnlyRestrictedTrustedIdentityContext should not be called");
@@ -238,6 +253,123 @@ test("handleSqlExecuteRoute and legacy route accept writes before workspace reso
   assert.equal(workspaceResolutionCount, 2);
 });
 
+test("handleSqlExecuteRoute rejects readonly SQL with query guidance before workspace resolution", async (): Promise<void> => {
+  let workspaceResolutionCount = 0;
+  const context: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({ sql: "SELECT account_id FROM accounts" }),
+      httpMethod: "POST",
+      path: "/v1/sql/execute",
+      resource: "/sql/execute",
+    }),
+  };
+  const resolveWorkspaceId = async (): Promise<string> => {
+    workspaceResolutionCount += 1;
+    return "workspace-1";
+  };
+
+  for (const sql of [
+    "SELECT account_id FROM accounts",
+    "WITH selected AS (SELECT account_id FROM accounts) SELECT account_id FROM selected",
+  ]) {
+    const response = await handleSqlExecuteRouteWithWorkspaceResolver(
+      {
+        ...context,
+        event: { ...context.event, body: JSON.stringify({ sql }) },
+      },
+      resolveWorkspaceId,
+    );
+    const payload = JSON.parse(response.body) as {
+      error: Readonly<{ code: string }>;
+      instructions: string;
+    };
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(payload.error.code, "mutation_sql_required");
+    assert.match(payload.instructions, /\/v1\/sql\/query/u);
+  }
+  assert.equal(workspaceResolutionCount, 0);
+});
+
+test("machine SQL routes start the total deadline before workspace resolution", async (): Promise<void> => {
+  const deadlines: Array<SqlExecutionDeadline> = [];
+  const queryContext: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({ sql: "SELECT account_id FROM accounts" }),
+      httpMethod: "POST",
+      path: "/v1/sql/query",
+      resource: "/sql/query",
+    }),
+  };
+  const executeContext: MachineRouteContext = {
+    ...queryContext,
+    event: {
+      ...queryContext.event,
+      body: JSON.stringify({
+        sql: "UPDATE account_metadata SET liquidity = 'low' WHERE account_id = 'a-main-usd'",
+      }),
+      path: "/v1/sql/execute",
+      resource: "/sql/execute",
+    },
+  };
+  const resolveWorkspaceId = async (
+    _dependencies: MachineApiDependencies,
+    _authenticated: MachineRouteContext["authenticated"],
+    _headerWorkspaceId: string,
+    deadline: SqlExecutionDeadline,
+  ): Promise<null> => {
+    deadlines.push(deadline);
+    return null;
+  };
+
+  await handleSqlQueryRouteWithWorkspaceResolver(queryContext, resolveWorkspaceId);
+  await handleSqlExecuteRouteWithWorkspaceResolver(executeContext, resolveWorkspaceId);
+  await handleSqlRouteWithWorkspaceResolver(queryContext, resolveWorkspaceId);
+
+  assert.equal(deadlines.length, 3);
+  assert.deepEqual(
+    deadlines.map((deadline) => deadline.timeoutMs),
+    [25_000, 25_000, 25_000],
+  );
+});
+
+test("machine SQL workspace resolution uses only the same bounded provisioning path", async (): Promise<void> => {
+  const context = createContext();
+  const deadline = createSqlExecutionDeadline(SQL_STATEMENT_TIMEOUT_MS, Date.now);
+  const provisioningDeadlines: Array<SqlExecutionDeadline> = [];
+  const queryDeadlines: Array<SqlExecutionDeadline> = [];
+  const dependencies: MachineApiDependencies = {
+    ...createDependencies(),
+    resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline: async (_identity, receivedDeadline) => {
+      provisioningDeadlines.push(receivedDeadline);
+      return { workspaceId: "workspace-context", created: false };
+    },
+    queryAsTrustedIdentityBeforeDeadline: async (
+      _identity,
+      _workspaceId,
+      _text,
+      _params,
+      receivedDeadline,
+    ) => {
+      queryDeadlines.push(receivedDeadline);
+      return createQueryResult([{ selected_workspace_id: "workspace-selected" }]);
+    },
+  };
+
+  const workspaceId = await resolveSqlWorkspaceId(
+    dependencies,
+    context.authenticated,
+    "",
+    deadline,
+  );
+
+  assert.equal(workspaceId, "workspace-selected");
+  assert.deepEqual(provisioningDeadlines, [deadline]);
+  assert.deepEqual(queryDeadlines, [deadline]);
+});
+
 test("new SQL routes reject batches while legacy SQL retains atomic script validation", async (): Promise<void> => {
   let workspaceResolutionCount = 0;
   const resolveWorkspaceId = async (): Promise<null> => {
@@ -322,4 +454,112 @@ test("SQL query, execute, and legacy routes reject nested WITH MERGE before work
     assert.equal(payload.error.code, "unsupported_statement");
   }
   assert.equal(workspaceResolutionCount, 0);
+});
+
+test("mutating SQL routes require state verification after an ambiguous deadline", async (): Promise<void> => {
+  const context: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({
+        sql: "UPDATE account_metadata SET liquidity = 'low' WHERE account_id = 'a-main-usd'",
+      }),
+      httpMethod: "POST",
+      path: "/v1/sql/execute",
+      resource: "/sql/execute",
+    }),
+    dependencies: {
+      ...createDependencies(),
+      resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline: async () => ({
+        workspaceId: "workspace-1",
+        created: false,
+      }),
+      queryAsTrustedIdentityBeforeDeadline: async () => createQueryResult([{
+        workspace_id: "workspace-1",
+        name: "Personal",
+      }]),
+      withRestrictedTrustedIdentityContext: async <T>(
+        _identity: MachineRouteContext["authenticated"]["identity"],
+        _workspaceId: string,
+        _deadline: SqlExecutionDeadline,
+        callback: (queryFn: RestrictedQueryFn) => Promise<T>,
+      ): Promise<T> => callback(async (_sql, _params, _statementTimeoutMs, onDispatch) => {
+        onDispatch();
+        throw new SqlTransactionOutcomeUnknownError(
+          "transaction",
+          new SqlExecutionDeadlineError(SQL_STATEMENT_TIMEOUT_MS),
+          "unknown",
+          undefined,
+        );
+      }),
+    },
+  };
+  const resolveWorkspaceId = async (): Promise<string> => "workspace-1";
+
+  for (const handleRoute of [
+    handleSqlExecuteRouteWithWorkspaceResolver,
+    handleSqlRouteWithWorkspaceResolver,
+  ] as const) {
+    const response = await handleRoute(context, resolveWorkspaceId);
+    const payload = JSON.parse(response.body) as {
+      data: Readonly<{ outcome: string; retryable: boolean }>;
+      error: Readonly<{ code: string; message: string }>;
+      instructions: string;
+    };
+
+    assert.equal(response.statusCode, 500);
+    assert.deepEqual(payload.data, { outcome: "unknown", retryable: false });
+    assert.deepEqual(payload.error, {
+      code: "sql_mutation_outcome_unknown",
+      message: "The SQL mutation transaction outcome is unknown",
+    });
+    assert.match(payload.instructions, /Do not blindly retry/u);
+    assert.match(payload.instructions, /\/v1\/sql\/query/u);
+  }
+});
+
+test("mutating SQL routes keep pre-dispatch deadline failures retryable", async (): Promise<void> => {
+  const context: MachineRouteContext = {
+    ...createContext(),
+    event: createAuthenticatedEvent({
+      body: JSON.stringify({
+        sql: "UPDATE account_metadata SET liquidity = 'low' WHERE account_id = 'a-main-usd'",
+      }),
+      httpMethod: "POST",
+      path: "/v1/sql/execute",
+      resource: "/sql/execute",
+    }),
+    dependencies: {
+      ...createDependencies(),
+      resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline: async () => ({
+        workspaceId: "workspace-1",
+        created: false,
+      }),
+      queryAsTrustedIdentityBeforeDeadline: async () => createQueryResult([{
+        workspace_id: "workspace-1",
+        name: "Personal",
+      }]),
+      withRestrictedTrustedIdentityContext: async <T>(): Promise<T> => {
+        throw new SqlExecutionDeadlineError(SQL_STATEMENT_TIMEOUT_MS);
+      },
+    },
+  };
+  const resolveWorkspaceId = async (): Promise<string> => "workspace-1";
+
+  for (const handleRoute of [
+    handleSqlExecuteRouteWithWorkspaceResolver,
+    handleSqlRouteWithWorkspaceResolver,
+  ] as const) {
+    const response = await handleRoute(context, resolveWorkspaceId);
+    const payload = JSON.parse(response.body) as {
+      data: Readonly<{ retryable: boolean }>;
+      error: Readonly<{ code: string }>;
+      instructions: string;
+    };
+
+    assert.equal(response.statusCode, 500);
+    assert.deepEqual(payload.data, { retryable: true });
+    assert.equal(payload.error.code, "agent_sql_failed");
+    assert.match(payload.instructions, /Retry SQL/u);
+    assert.doesNotMatch(payload.instructions, /Verify current state/u);
+  }
 });

--- a/apps/sql-api/src/machineApi/routeHandlers.ts
+++ b/apps/sql-api/src/machineApi/routeHandlers.ts
@@ -1,23 +1,25 @@
 import type { APIGatewayProxyResult } from "aws-lambda";
 import { buildSourceDiscoveryResponse } from "@expense-budget-tracker/agent-shared/discovery";
 import {
-  RUN_SQL_WITH_WORKSPACE_INPUT,
   buildCreateWorkspaceAction,
   buildErrorEnvelope,
   buildListWorkspacesAction,
-  buildRunSqlAction,
+  buildRunSqlExecuteAction,
+  buildRunSqlQueryAction,
   buildSchemaAction,
   buildSelectWorkspaceAction,
   buildSuccessEnvelope,
 } from "@expense-budget-tracker/agent-shared";
 import {
+  createSqlExecutionDeadline,
   MAX_SQL_MUTATION_ROWS,
   MAX_SQL_ROWS,
   SQL_STATEMENT_TIMEOUT_MS,
   SqlPolicyError,
   validateExpenseSql,
-  validateSingleExpenseSql,
+  validateSingleMutationExpenseSql,
   validateSingleReadOnlyExpenseSql,
+  type SqlExecutionDeadline,
   type ValidatedExpenseSql,
   type ValidatedReadOnlyExpenseSql,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
@@ -25,7 +27,14 @@ import { resolveOrCreateWorkspaceForTrustedIdentity } from "../db.js";
 import { buildDiscoveryEnvelope, getApiBaseUrl, readJsonBody } from "./request.js";
 import { buildRetryableErrorResponse, json } from "./responses.js";
 import { ALLOWED_RELATION_NAMES, loadAllowedSchema } from "./schemaService.js";
-import { getSqlPolicyInstructions, getUserSqlExecutionMessage, isUserSqlExecutionError, runReadOnlySql, runSql } from "./sqlService.js";
+import {
+  getSqlPolicyInstructions,
+  getUserSqlExecutionMessage,
+  isAmbiguousSqlMutationOutcomeError,
+  isUserSqlExecutionError,
+  runReadOnlySql,
+  runSql,
+} from "./sqlService.js";
 import type { AuthenticatedContext, MachineApiDependencies, MachineRouteContext } from "./types.js";
 import { createWorkspace, getWorkspace, listWorkspaces, persistSelectedWorkspace, resolveSqlWorkspaceId } from "./workspaceService.js";
 
@@ -100,9 +109,10 @@ export const handleSchemaRoute = async (
           },
         },
         [
-          buildRunSqlAction({ baseUrl: context.apiBaseUrl, path: "/sql" }, RUN_SQL_WITH_WORKSPACE_INPUT),
+          buildRunSqlQueryAction({ baseUrl: context.apiBaseUrl, path: "/sql/query" }),
+          buildRunSqlExecuteAction({ baseUrl: context.apiBaseUrl, path: "/sql/execute" }),
         ],
-        "Schema includes only relations supported by /sql and may include optional hints about constraints or write semantics. SQL supports only SUM, COUNT, MIN, MAX, AVG, and COALESCE function calls. Select a workspace once, then run SQL.",
+        "Schema includes only relations supported by restricted SQL and may include optional hints about constraints or write semantics. Prefer /sql/query for reads and /sql/execute for one explicitly approved write. Legacy /sql remains available only for compatibility and atomic multi-statement scripts. SQL supports only SUM, COUNT, MIN, MAX, AVG, and COALESCE function calls. Select a workspace once, then run SQL.",
       ),
     );
   } catch (error) {
@@ -243,9 +253,10 @@ export const handleSelectWorkspaceRoute = async (
           },
         },
         [
-          buildRunSqlAction({ baseUrl: context.apiBaseUrl, path: "/sql" }, RUN_SQL_WITH_WORKSPACE_INPUT),
+          buildRunSqlQueryAction({ baseUrl: context.apiBaseUrl, path: "/sql/query" }),
+          buildRunSqlExecuteAction({ baseUrl: context.apiBaseUrl, path: "/sql/execute" }),
         ],
-        "Workspace saved for this API key. /sql can now omit X-Workspace-Id; send the header only to override.",
+        "Workspace saved for this API key. /sql/query and /sql/execute can now omit X-Workspace-Id; send the header only to override. Legacy /sql remains available only for compatibility and atomic multi-statement scripts.",
       ),
     );
   } catch (error) {
@@ -279,6 +290,7 @@ type SqlRunner<TValidated extends ValidatedExpenseSql> = (
   authenticated: AuthenticatedContext,
   workspaceId: string,
   validated: TValidated,
+  executionDeadline: SqlExecutionDeadline,
 ) => ReturnType<typeof runSql>;
 type SqlRouteText = Readonly<{
   missingSql: string;
@@ -328,10 +340,16 @@ const handleValidatedSqlRouteWithWorkspaceResolver = async <TValidated extends V
   }
 
   const headerWorkspaceId = (context.event.headers["X-Workspace-Id"] ?? context.event.headers["x-workspace-id"] ?? "").trim();
+  const executionDeadline = createSqlExecutionDeadline(SQL_STATEMENT_TIMEOUT_MS, Date.now);
 
   let workspaceId: string | null;
   try {
-    workspaceId = await resolveWorkspaceId(context.dependencies, context.authenticated, headerWorkspaceId);
+    workspaceId = await resolveWorkspaceId(
+      context.dependencies,
+      context.authenticated,
+      headerWorkspaceId,
+      executionDeadline,
+    );
   } catch (error) {
     return buildRetryableErrorResponse(
       "agent_sql_failed",
@@ -344,7 +362,7 @@ const handleValidatedSqlRouteWithWorkspaceResolver = async <TValidated extends V
   if (workspaceId === null || workspaceId === "") {
     return json(
       400,
-        buildErrorEnvelope(
+      buildErrorEnvelope(
         { field: "X-Workspace-Id", expected: "workspaceId string" },
         [],
         "Send X-Workspace-Id, or call /workspaces/{workspaceId}/select once to save the active workspace for this API key.",
@@ -360,6 +378,7 @@ const handleValidatedSqlRouteWithWorkspaceResolver = async <TValidated extends V
       context.authenticated,
       workspaceId,
       validated,
+      executionDeadline,
     );
     if (response === null) {
       return json(
@@ -390,6 +409,19 @@ const handleValidatedSqlRouteWithWorkspaceResolver = async <TValidated extends V
           "Review SQL syntax, relation names, and workspace ID, then retry.",
           "sql_execution_failed",
           getUserSqlExecutionMessage(error),
+        ),
+      );
+    }
+
+    if (isAmbiguousSqlMutationOutcomeError(error)) {
+      return json(
+        500,
+        buildErrorEnvelope(
+          { outcome: "unknown", retryable: false },
+          [],
+          `Do not blindly retry this mutation. Verify current state through ${context.apiBaseUrl}/sql/query before deciding whether to retry.`,
+          "sql_mutation_outcome_unknown",
+          error.message,
         ),
       );
     }
@@ -425,11 +457,11 @@ export const handleSqlExecuteRouteWithWorkspaceResolver = async (
   handleValidatedSqlRouteWithWorkspaceResolver(
     context,
     resolveWorkspaceId,
-    validateSingleExpenseSql,
+    validateSingleMutationExpenseSql,
     runSql,
     {
-      missingSql: "Send exactly one non-empty SELECT, WITH, INSERT, UPDATE, or DELETE sql statement.",
-      success: `Workspace context is required for SQL. Use X-Workspace-Id to override the saved workspace for this API key. This endpoint accepts exactly one supported statement. Returned rows are capped at ${MAX_SQL_ROWS} per request with returnedRowCount, totalRowCount, and truncated metadata; mutations are limited to ${MAX_SQL_MUTATION_ROWS} affected rows.`,
+      missingSql: "Send exactly one non-empty INSERT, UPDATE, or DELETE mutation.",
+      success: `Workspace context is required for SQL. Use X-Workspace-Id to override the saved workspace for this API key. This endpoint accepts exactly one approved INSERT, UPDATE, or DELETE mutation. Returned rows are capped at ${MAX_SQL_ROWS} per request with returnedRowCount, totalRowCount, and truncated metadata; mutations are limited to ${MAX_SQL_MUTATION_ROWS} affected rows.`,
     },
   );
 

--- a/apps/sql-api/src/machineApi/schemaService.test.ts
+++ b/apps/sql-api/src/machineApi/schemaService.test.ts
@@ -30,6 +30,12 @@ test("loadAllowedSchema resolves a real workspace context before querying", asyn
       queryWorkspaceId = workspaceId;
       return createQueryResult([]);
     },
+    queryAsTrustedIdentityBeforeDeadline: async () => {
+      throw new Error("queryAsTrustedIdentityBeforeDeadline should not be called");
+    },
+    resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline: async () => {
+      throw new Error("resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline should not be called");
+    },
     withReadOnlyRestrictedTrustedIdentityContext: async () => {
       throw new Error("withReadOnlyRestrictedTrustedIdentityContext should not be called");
     },

--- a/apps/sql-api/src/machineApi/sqlService.test.ts
+++ b/apps/sql-api/src/machineApi/sqlService.test.ts
@@ -1,10 +1,24 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { QueryResult } from "pg";
-import { SqlPolicyError } from "@expense-budget-tracker/agent-shared/sql-policy";
+import type { PoolClient, QueryResult } from "pg";
+import {
+  createSqlExecutionDeadline,
+  SQL_STATEMENT_TIMEOUT_MS,
+  SqlExecutionDeadlineError,
+  SqlPolicyError,
+  type SqlExecutionDeadline,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import type { RestrictedQueryFn } from "../db.js";
+import {
+  SqlTransactionOutcomeUnknownError,
+  systemDeadlineRuntime,
+  type DeadlinePool,
+  withDeadlineTransactionUsingPool,
+} from "../dbDeadline.js";
 import { createQueryResult } from "../handlerTestUtils.js";
 import {
   getUserSqlExecutionMessage,
+  isAmbiguousSqlMutationOutcomeError,
   isUserSqlExecutionError,
   runReadOnlySqlWithWorkspaceGetter,
   runSqlWithWorkspaceGetter,
@@ -35,12 +49,19 @@ const createDependencies = (
   ensureTrustedIdentityProvisioned: overrides.ensureTrustedIdentityProvisioned ?? (async () => undefined),
   queryAsTrustedIdentity: overrides.queryAsTrustedIdentity ?? (async () =>
     createQueryResult([{ workspace_id: "user-1", name: "Personal" }])),
+  queryAsTrustedIdentityBeforeDeadline: overrides.queryAsTrustedIdentityBeforeDeadline ?? (async () =>
+    createQueryResult([{ workspace_id: "user-1", name: "Personal" }])),
+  resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline:
+    overrides.resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline ?? (async () => ({
+      workspaceId: "user-1",
+      created: false,
+    })),
   withReadOnlyRestrictedTrustedIdentityContext:
     overrides.withReadOnlyRestrictedTrustedIdentityContext ?? (async <T>(
       _identity: AuthenticatedContext["identity"],
       _workspaceId: string,
-      _statementTimeoutMs: number,
-      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+      _deadline: SqlExecutionDeadline,
+      callback: (queryFn: RestrictedQueryFn) => Promise<T>,
     ): Promise<T> =>
       callback(async () =>
         ({
@@ -53,8 +74,8 @@ const createDependencies = (
   withRestrictedTrustedIdentityContext: overrides.withRestrictedTrustedIdentityContext ?? (async <T>(
     _identity: AuthenticatedContext["identity"],
     _workspaceId: string,
-    _statementTimeoutMs: number,
-    callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+    _deadline: SqlExecutionDeadline,
+    callback: (queryFn: RestrictedQueryFn) => Promise<T>,
   ): Promise<T> =>
     callback(async () =>
       ({
@@ -66,10 +87,43 @@ const createDependencies = (
       }) as QueryResult)),
 });
 
+const createTransactionalDependencies = (
+  client: PoolClient,
+): MachineApiDependencies => {
+  const pool: DeadlinePool = {
+    connect: (callback): void => callback(undefined, client),
+  };
+  return createDependencies({
+    withRestrictedTrustedIdentityContext: async <T>(
+      _identity: AuthenticatedContext["identity"],
+      _workspaceId: string,
+      deadline: SqlExecutionDeadline,
+      callback: (queryFn: RestrictedQueryFn) => Promise<T>,
+    ): Promise<T> => withDeadlineTransactionUsingPool(
+      pool,
+      deadline,
+      "BEGIN",
+      (transaction): Promise<T> => callback(
+        (text, params, statementTimeoutMs, onDispatch) =>
+          transaction.queryWithDispatchMarker(
+            text,
+            params,
+            statementTimeoutMs,
+            onDispatch,
+          ),
+      ),
+      systemDeadlineRuntime,
+    ),
+  });
+};
+
 const workspaceGetter = async (): Promise<WorkspaceSummary> => ({
   workspaceId: "user-1",
   name: "Personal",
 });
+
+const createExecutionDeadline = (): SqlExecutionDeadline =>
+  createSqlExecutionDeadline(SQL_STATEMENT_TIMEOUT_MS, Date.now);
 
 test("runSql rejects function-only SQL before executing restricted queries", async (): Promise<void> => {
   let restrictedContextCalled = false;
@@ -86,6 +140,7 @@ test("runSql rejects function-only SQL before executing restricted queries", asy
       createAuthenticatedContext(),
       "user-1",
       "SELECT delete_workspace_for_current_user('user-1')",
+      createExecutionDeadline(),
       workspaceGetter,
     ),
     (error: unknown) => error instanceof SqlPolicyError && error.code === "function_calls_not_allowed",
@@ -110,6 +165,7 @@ test("runSql rejects data-modifying CTEs before workspace or restricted database
       createAuthenticatedContext(),
       "user-1",
       "WITH deleted_rates AS (DELETE FROM fx_rates_raw WHERE base_currency = 'EUR' RETURNING *) SELECT * FROM deleted_rates",
+      createExecutionDeadline(),
       async (): Promise<WorkspaceSummary> => {
         workspaceGetterCalled = true;
         return workspaceGetter();
@@ -140,6 +196,7 @@ test("runSql rejects community public share relations before executing restricte
       createAuthenticatedContext(),
       "user-1",
       "SELECT * FROM community.monthly_category_shares",
+      createExecutionDeadline(),
       workspaceGetter,
     ),
     (error: unknown) => error instanceof SqlPolicyError && error.code === "relation_not_allowed",
@@ -151,6 +208,7 @@ test("runSql rejects community public share relations before executing restricte
       createAuthenticatedContext(),
       "user-1",
       "SELECT * FROM community.read_public_monthly_category_share('token', '2025-01-01', '2025-12-01')",
+      createExecutionDeadline(),
       workspaceGetter,
     ),
     (error: unknown) => error instanceof SqlPolicyError && error.code === "function_calls_not_allowed",
@@ -161,19 +219,26 @@ test("runSql rejects community public share relations before executing restricte
 
 test("runSql executes every statement in one restricted transaction", async (): Promise<void> => {
   let restrictedContextCount = 0;
+  let receivedStatementTimeoutMs: number | undefined;
+  let workspaceDeadline: SqlExecutionDeadline | undefined;
+  let restrictedDeadline: SqlExecutionDeadline | undefined;
   const executedSql: Array<string> = [];
   const executedParams: Array<ReadonlyArray<unknown>> = [];
+  const executedStatementTimeouts: Array<number> = [];
   const dependencies = createDependencies({
     withRestrictedTrustedIdentityContext: async <T>(
       _identity: AuthenticatedContext["identity"],
       _workspaceId: string,
-      _statementTimeoutMs: number,
-      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+      deadline: SqlExecutionDeadline,
+      callback: (queryFn: RestrictedQueryFn) => Promise<T>,
     ): Promise<T> => {
       restrictedContextCount += 1;
-      return callback(async (sql, params) => {
+      restrictedDeadline = deadline;
+      receivedStatementTimeoutMs = deadline.timeoutMs;
+      return callback(async (sql, params, statementTimeoutMs) => {
         executedSql.push(sql);
         executedParams.push(params);
+        executedStatementTimeouts.push(statementTimeoutMs);
         if (sql.startsWith("DECLARE ") || sql.startsWith("CLOSE ")) {
           return ({
             command: sql.startsWith("DECLARE ") ? "DECLARE" : "CLOSE",
@@ -202,19 +267,27 @@ test("runSql executes every statement in one restricted transaction", async (): 
       });
     },
   });
+  const executionDeadline = createExecutionDeadline();
 
   const result = await runSqlWithWorkspaceGetter(
     dependencies,
     createAuthenticatedContext(),
     "user-1",
     "SELECT SUM(amount) AS balance FROM ledger_entries WHERE account_id = 'a-main-usd'; SELECT COUNT(*) FROM accounts",
-    workspaceGetter,
+    executionDeadline,
+    async (_dependencies, _identity, _workspaceId, deadline): Promise<WorkspaceSummary> => {
+      workspaceDeadline = deadline;
+      return workspaceGetter();
+    },
   );
   const workspace = (result?.workspace ?? null) as WorkspaceSummary | null;
   const statements = (result?.statements ?? []) as ReadonlyArray<Readonly<Record<string, unknown>>>;
   const statement = statements[0];
 
   assert.equal(restrictedContextCount, 1);
+  assert.equal(workspaceDeadline, executionDeadline);
+  assert.equal(restrictedDeadline, executionDeadline);
+  assert.equal(receivedStatementTimeoutMs, SQL_STATEMENT_TIMEOUT_MS);
   assert.deepEqual(executedSql, [
     "DECLARE api_sql_read_cursor_1 NO SCROLL CURSOR FOR SELECT SUM(amount) AS balance FROM ledger_entries WHERE account_id = 'a-main-usd'",
     "FETCH FORWARD 101 FROM api_sql_read_cursor_1",
@@ -226,6 +299,11 @@ test("runSql executes every statement in one restricted transaction", async (): 
     "CLOSE api_sql_read_cursor_2",
   ]);
   assert.deepEqual(executedParams, [[], [], [], [], [], [], [], []]);
+  assert.equal(executedStatementTimeouts.length, executedSql.length);
+  assert.equal(executedStatementTimeouts.every(
+    (statementTimeoutMs) => statementTimeoutMs > 0
+      && statementTimeoutMs <= SQL_STATEMENT_TIMEOUT_MS,
+  ), true);
   assert.equal(workspace?.workspaceId, "user-1");
   assert.equal(statements.length, 2);
   assert.equal(statement?.rowCount, 1);
@@ -241,8 +319,8 @@ test("runReadOnlySql bounds composed reads in PostgreSQL and preserves accurate 
     withReadOnlyRestrictedTrustedIdentityContext: async <T>(
       _identity: AuthenticatedContext["identity"],
       _workspaceId: string,
-      _statementTimeoutMs: number,
-      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+      _deadline: SqlExecutionDeadline,
+      callback: (queryFn: RestrictedQueryFn) => Promise<T>,
     ): Promise<T> => callback(async (querySql, params) => {
       executedSql.push(querySql);
       executedParams.push(params);
@@ -267,6 +345,7 @@ test("runReadOnlySql bounds composed reads in PostgreSQL and preserves accurate 
       }) as QueryResult;
     }),
   });
+
   const sql = "WITH account_rows AS (SELECT account_id FROM accounts) SELECT account_id FROM account_rows UNION SELECT account_id FROM accounts ORDER BY account_id OFFSET 1;";
 
   const result = await runReadOnlySqlWithWorkspaceGetter(
@@ -274,6 +353,7 @@ test("runReadOnlySql bounds composed reads in PostgreSQL and preserves accurate 
     createAuthenticatedContext(),
     "user-1",
     sql,
+    createExecutionDeadline(),
     workspaceGetter,
   );
   const statements = (result?.statements ?? []) as ReadonlyArray<Readonly<Record<string, unknown>>>;
@@ -301,8 +381,8 @@ test("runReadOnlySql uses only the read-only restricted transaction", async (): 
     withReadOnlyRestrictedTrustedIdentityContext: async <T>(
       _identity: AuthenticatedContext["identity"],
       _workspaceId: string,
-      _statementTimeoutMs: number,
-      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+      _deadline: SqlExecutionDeadline,
+      callback: (queryFn: RestrictedQueryFn) => Promise<T>,
     ): Promise<T> => {
       readOnlyContextCount += 1;
       return callback(async () => createQueryResult([{ account_id: "a-main-usd" }]));
@@ -318,6 +398,7 @@ test("runReadOnlySql uses only the read-only restricted transaction", async (): 
     createAuthenticatedContext(),
     "user-1",
     "SELECT account_id FROM accounts",
+    createExecutionDeadline(),
     workspaceGetter,
   );
 
@@ -325,18 +406,12 @@ test("runReadOnlySql uses only the read-only restricted transaction", async (): 
   assert.equal(writeContextCount, 0);
 });
 
-test("runSql raises mutation batch overflow from inside the single transaction callback", async (): Promise<void> => {
-  let restrictedContextCount = 0;
+test("runSql keeps a row-limit policy error definitive after successful rollback", async (): Promise<void> => {
   let statementCount = 0;
-  const dependencies = createDependencies({
-    withRestrictedTrustedIdentityContext: async <T>(
-      _identity: AuthenticatedContext["identity"],
-      _workspaceId: string,
-      _statementTimeoutMs: number,
-      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
-    ): Promise<T> => {
-      restrictedContextCount += 1;
-      return callback(async () => {
+  const releases: Array<Error | undefined> = [];
+  const client = {
+    query: async (text: string): Promise<QueryResult> => {
+      if (text.startsWith("UPDATE account_metadata") || text.startsWith("DELETE FROM budget_lines")) {
         statementCount += 1;
         return ({
           command: "UPDATE",
@@ -345,9 +420,14 @@ test("runSql raises mutation batch overflow from inside the single transaction c
           fields: [],
           rows: [],
         }) as QueryResult;
-      });
+      }
+      return createQueryResult([]);
     },
-  });
+    release: (error?: Error | boolean): void => {
+      releases.push(error instanceof Error ? error : undefined);
+    },
+  } as PoolClient;
+  const dependencies = createTransactionalDependencies(client);
 
   await assert.rejects(
     () => runSqlWithWorkspaceGetter(
@@ -355,15 +435,17 @@ test("runSql raises mutation batch overflow from inside the single transaction c
       createAuthenticatedContext(),
       "user-1",
       "UPDATE account_metadata SET liquidity = 'low'; DELETE FROM budget_lines",
+      createExecutionDeadline(),
       workspaceGetter,
     ),
     (error: unknown) =>
       error instanceof SqlPolicyError
-      && error.code === "mutation_request_row_limit_exceeded",
+      && error.code === "mutation_request_row_limit_exceeded"
+      && !isAmbiguousSqlMutationOutcomeError(error),
   );
 
-  assert.equal(restrictedContextCount, 1);
   assert.equal(statementCount, 2);
+  assert.deepEqual(releases, [undefined]);
 });
 
 test("runSql tags safe PostgreSQL errors only when validated user SQL is executing", async (): Promise<void> => {
@@ -375,8 +457,8 @@ test("runSql tags safe PostgreSQL errors only when validated user SQL is executi
     withRestrictedTrustedIdentityContext: async <T>(
       _identity: AuthenticatedContext["identity"],
       _workspaceId: string,
-      _statementTimeoutMs: number,
-      callback: (queryFn: (text: string, params: ReadonlyArray<unknown>) => Promise<QueryResult>) => Promise<T>,
+      _deadline: SqlExecutionDeadline,
+      callback: (queryFn: RestrictedQueryFn) => Promise<T>,
     ): Promise<T> => callback(async (): Promise<QueryResult> => {
       throw databaseError;
     }),
@@ -388,6 +470,7 @@ test("runSql tags safe PostgreSQL errors only when validated user SQL is executi
       createAuthenticatedContext(),
       "user-1",
       "SELECT amount FROM ledger_entries",
+      createExecutionDeadline(),
       workspaceGetter,
     ),
     (error: unknown) =>
@@ -407,6 +490,7 @@ test("runSql does not tag PostgreSQL errors from workspace lookup or transaction
       createAuthenticatedContext(),
       "user-1",
       "SELECT amount FROM ledger_entries",
+      createExecutionDeadline(),
       async (): Promise<WorkspaceSummary> => {
         throw workspaceError;
       },
@@ -429,8 +513,238 @@ test("runSql does not tag PostgreSQL errors from workspace lookup or transaction
       createAuthenticatedContext(),
       "user-1",
       "SELECT amount FROM ledger_entries",
+      createExecutionDeadline(),
       workspaceGetter,
     ),
     (error: unknown) => error === setupError && !isUserSqlExecutionError(error),
   );
+});
+
+test("runSql marks a deadline after mutating SQL dispatch as an ambiguous outcome", async (): Promise<void> => {
+  const deadlineError = new SqlExecutionDeadlineError(SQL_STATEMENT_TIMEOUT_MS);
+  const outcomeError = new SqlTransactionOutcomeUnknownError(
+    "transaction",
+    deadlineError,
+    "unknown",
+    undefined,
+  );
+  const dependencies = createDependencies({
+    withRestrictedTrustedIdentityContext: async <T>(
+      _identity: AuthenticatedContext["identity"],
+      _workspaceId: string,
+      _deadline: SqlExecutionDeadline,
+      callback: (queryFn: RestrictedQueryFn) => Promise<T>,
+    ): Promise<T> => callback(async (_sql, _params, _statementTimeoutMs, onDispatch) => {
+      onDispatch();
+      throw outcomeError;
+    }),
+  });
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "UPDATE account_metadata SET liquidity = 'low' WHERE account_id = 'a-main-usd'",
+      createExecutionDeadline(),
+      workspaceGetter,
+    ),
+    (error: unknown) =>
+      isAmbiguousSqlMutationOutcomeError(error)
+      && error.cause === outcomeError,
+  );
+});
+
+test("runSql keeps an operational statement failure definitive after successful rollback", async (): Promise<void> => {
+  const tlsError = Object.assign(
+    new Error("TLS socket closed without a PostgreSQL error response"),
+    { code: "UNRECOGNIZED_TLS_FAILURE" },
+  );
+  const releases: Array<Error | undefined> = [];
+  const client = {
+    query: async (text: string): Promise<QueryResult> => {
+      if (text.startsWith("UPDATE account_metadata")) throw tlsError;
+      return createQueryResult([]);
+    },
+    release: (error?: Error | boolean): void => {
+      releases.push(error instanceof Error ? error : undefined);
+    },
+  } as PoolClient;
+  const dependencies = createTransactionalDependencies(client);
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "UPDATE account_metadata SET liquidity = 'low' WHERE account_id = 'a-main-usd'",
+      createExecutionDeadline(),
+      workspaceGetter,
+    ),
+    (error: unknown) =>
+      error === tlsError
+      && !isAmbiguousSqlMutationOutcomeError(error),
+  );
+  assert.deepEqual(releases, [undefined]);
+});
+
+test("runSql keeps definitive user SQL rejection after mutation dispatch non-ambiguous", async (): Promise<void> => {
+  const constraintError = Object.assign(
+    new Error("duplicate key value violates unique constraint"),
+    { code: "23505" },
+  );
+  const dependencies = createDependencies({
+    withRestrictedTrustedIdentityContext: async <T>(
+      _identity: AuthenticatedContext["identity"],
+      _workspaceId: string,
+      _deadline: SqlExecutionDeadline,
+      callback: (queryFn: RestrictedQueryFn) => Promise<T>,
+    ): Promise<T> => callback(async (_sql, _params, _statementTimeoutMs, onDispatch) => {
+      onDispatch();
+      throw constraintError;
+    }),
+  });
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "INSERT INTO budget_lines (workspace_id) VALUES ('workspace-1')",
+      createExecutionDeadline(),
+      workspaceGetter,
+    ),
+    (error: unknown) =>
+      isUserSqlExecutionError(error)
+      && !isAmbiguousSqlMutationOutcomeError(error)
+      && getUserSqlExecutionMessage(error) === constraintError.message,
+  );
+});
+
+test("runSql treats a row-limit policy error with rollback failure as ambiguous", async (): Promise<void> => {
+  const rollbackError = new Error("PostgreSQL connection closed during rollback");
+  const releases: Array<Error | undefined> = [];
+  const client = {
+    query: async (text: string): Promise<QueryResult> => {
+      if (text === "ROLLBACK") throw rollbackError;
+      if (text.startsWith("UPDATE account_metadata") || text.startsWith("DELETE FROM budget_lines")) {
+        return ({
+          command: "UPDATE",
+          rowCount: 60,
+          oid: 0,
+          fields: [],
+          rows: [],
+        }) as QueryResult;
+      }
+      return createQueryResult([]);
+    },
+    release: (error?: Error | boolean): void => {
+      releases.push(error instanceof Error ? error : undefined);
+    },
+  } as PoolClient;
+  const dependencies = createTransactionalDependencies(client);
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "UPDATE account_metadata SET liquidity = 'low'; DELETE FROM budget_lines",
+      createExecutionDeadline(),
+      workspaceGetter,
+    ),
+    (error: unknown) => {
+      if (
+        !isAmbiguousSqlMutationOutcomeError(error)
+        || !(error.cause instanceof SqlTransactionOutcomeUnknownError)
+      ) {
+        return false;
+      }
+      return error.cause.failurePhase === "transaction"
+        && error.cause.originalError instanceof SqlPolicyError
+        && error.cause.originalError.code === "mutation_request_row_limit_exceeded"
+        && error.cause.rollbackOutcome === "unknown"
+        && error.cause.cleanupError === rollbackError;
+    },
+  );
+  assert.deepEqual(releases, [rollbackError]);
+});
+
+test("runSql leaves a pre-dispatch mutation deadline safely retryable", async (): Promise<void> => {
+  const deadlineError = new SqlExecutionDeadlineError(SQL_STATEMENT_TIMEOUT_MS);
+  const dependencies = createDependencies({
+    withRestrictedTrustedIdentityContext: async <T>(
+      _identity: AuthenticatedContext["identity"],
+      _workspaceId: string,
+      _deadline: SqlExecutionDeadline,
+      callback: (queryFn: RestrictedQueryFn) => Promise<T>,
+    ): Promise<T> => callback(async () => {
+      throw deadlineError;
+    }),
+  });
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "UPDATE account_metadata SET liquidity = 'low' WHERE account_id = 'a-main-usd'",
+      createExecutionDeadline(),
+      workspaceGetter,
+    ),
+    (error: unknown) =>
+      error === deadlineError
+      && !isAmbiguousSqlMutationOutcomeError(error),
+  );
+});
+
+test("runSql marks a commit failure after a mutating statement as ambiguous", async (): Promise<void> => {
+  const commitError = Object.assign(
+    new Error("Connection terminated unexpectedly"),
+    { code: "08006" },
+  );
+  const releases: Array<Error | undefined> = [];
+  const client = {
+    query: async (text: string): Promise<QueryResult> => {
+      if (text === "COMMIT") throw commitError;
+      if (text.startsWith("UPDATE account_metadata")) {
+        return ({
+          command: "UPDATE",
+          rowCount: 1,
+          oid: 0,
+          fields: [],
+          rows: [],
+        }) as QueryResult;
+      }
+      return createQueryResult([]);
+    },
+    release: (error?: Error | boolean): void => {
+      releases.push(error instanceof Error ? error : undefined);
+    },
+  } as PoolClient;
+  const dependencies = createTransactionalDependencies(client);
+
+  await assert.rejects(
+    () => runSqlWithWorkspaceGetter(
+      dependencies,
+      createAuthenticatedContext(),
+      "user-1",
+      "UPDATE account_metadata SET liquidity = 'low' WHERE account_id = 'a-main-usd'",
+      createExecutionDeadline(),
+      workspaceGetter,
+    ),
+    (error: unknown) => {
+      if (
+        !isAmbiguousSqlMutationOutcomeError(error)
+        || !(error.cause instanceof SqlTransactionOutcomeUnknownError)
+      ) {
+        return false;
+      }
+      return error.cause.failurePhase === "commit"
+        && error.cause.originalError === commitError
+        && error.cause.rollbackOutcome === "rolled_back"
+        && error.cause.cleanupError === undefined;
+    },
+  );
+  assert.deepEqual(releases, [undefined]);
 });

--- a/apps/sql-api/src/machineApi/sqlService.ts
+++ b/apps/sql-api/src/machineApi/sqlService.ts
@@ -1,17 +1,18 @@
 import {
-  executeValidatedExpenseSql,
+  executeValidatedExpenseSqlWithinDeadline,
   MAX_SQL_MUTATION_ROWS,
   MAX_SQL_ROWS,
-  SQL_STATEMENT_TIMEOUT_MS,
   SqlPolicyError,
   validateExpenseSql,
   validateReadOnlyExpenseSql,
   type AllowedRelationName,
+  type SqlExecutionDeadline,
   type ValidatedExpenseSql,
   type ValidatedReadOnlyExpenseSql,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
+import { SqlTransactionOutcomeUnknownError } from "../dbDeadline.js";
 import type { EntityHints, MachineApiDependencies, PgError, TrustedIdentityContext, WorkspaceSummary } from "./types.js";
-import { getWorkspace } from "./workspaceService.js";
+import { getWorkspaceBeforeDeadline } from "./workspaceService.js";
 
 const ENTITY_METADATA: Readonly<Record<AllowedRelationName, Readonly<{
   summary: string;
@@ -49,10 +50,17 @@ const ENTITY_METADATA: Readonly<Record<AllowedRelationName, Readonly<{
 
 const USER_SQL_ERROR_CLASSES: ReadonlySet<string> = new Set(["22", "23", "42"]);
 const DEFAULT_USER_SQL_EXECUTION_MESSAGE = "The SQL statement could not be executed";
+const AMBIGUOUS_SQL_MUTATION_OUTCOME_MESSAGE = "The SQL mutation transaction outcome is unknown";
 
 export class UserSqlExecutionError extends Error {
   constructor(message: string) {
     super(message);
+  }
+}
+
+export class AmbiguousSqlMutationOutcomeError extends Error {
+  constructor(cause: unknown) {
+    super(AMBIGUOUS_SQL_MUTATION_OUTCOME_MESSAGE, { cause });
   }
 }
 
@@ -112,6 +120,11 @@ const throwUserSqlExecutionError = (error: unknown): never => {
 export const isUserSqlExecutionError = (error: unknown): error is UserSqlExecutionError =>
   error instanceof UserSqlExecutionError;
 
+export const isAmbiguousSqlMutationOutcomeError = (
+  error: unknown,
+): error is AmbiguousSqlMutationOutcomeError =>
+  error instanceof AmbiguousSqlMutationOutcomeError;
+
 export const getUserSqlExecutionMessage = (error: unknown): string => {
   if (error instanceof UserSqlExecutionError && error.message !== "") {
     return error.message;
@@ -126,11 +139,13 @@ type MachineApiWorkspaceGetter = (
   dependencies: MachineApiDependencies,
   identity: TrustedIdentityContext["identity"],
   workspaceId: string,
+  deadline: SqlExecutionDeadline,
 ) => Promise<WorkspaceSummary | null>;
 
 export type ExistingWorkspaceGetter = (
   identity: TrustedIdentityContext["identity"],
   workspaceId: string,
+  deadline: SqlExecutionDeadline,
 ) => Promise<WorkspaceSummary | null>;
 
 type RestrictedContextRunner = MachineApiDependencies["withRestrictedTrustedIdentityContext"];
@@ -141,7 +156,7 @@ export const getSqlPolicyInstructions = (
 ): string => {
   if (error.code === "relation_not_allowed") {
     if (isSchemaExplorationAttempt(error.message)) {
-      return `System catalogs are not queryable via /sql. Use ${apiBaseUrl}/schema to inspect allowed relations, columns, and any agent hints, then query only those relations. Example: SELECT * FROM accounts LIMIT 0.`;
+      return `System catalogs are not queryable via restricted SQL. Use ${apiBaseUrl}/schema to inspect allowed relations, columns, and any agent hints, then query only those relations through ${apiBaseUrl}/sql/query. Example: SELECT * FROM accounts LIMIT 0.`;
     }
 
     return `Relation is not exposed by policy. Use ${apiBaseUrl}/schema to see allowed relations, columns, and any agent hints, then retry. Workspace context must be set via /workspaces/{workspaceId}/select or X-Workspace-Id.`;
@@ -156,11 +171,11 @@ export const getSqlPolicyInstructions = (
   }
 
   if (error.code === "unsupported_statement") {
-    return "Use only SELECT, WITH, INSERT, UPDATE, or DELETE. /sql/query and /sql/execute accept exactly one statement; legacy /sql accepts atomic multi-statement scripts. BEGIN/COMMIT/ROLLBACK and DDL are not allowed.";
+    return "Send exactly one SELECT or WITH...SELECT statement to /sql/query, or exactly one approved INSERT, UPDATE, or DELETE mutation to /sql/execute. Legacy /sql accepts atomic multi-statement scripts. BEGIN/COMMIT/ROLLBACK and DDL are not allowed.";
   }
 
   if (error.code === "single_statement_required") {
-    return "Send exactly one SQL statement to /sql/query or /sql/execute. Use legacy /sql only when an atomic multi-statement script is required.";
+    return "Send exactly one read-only statement to /sql/query or exactly one approved mutation to /sql/execute. Use legacy /sql only when an atomic multi-statement script is required.";
   }
 
   if (error.code === "sql_script_too_long" || error.code === "too_many_sql_statements") {
@@ -176,6 +191,10 @@ export const getSqlPolicyInstructions = (
 
   if (error.code === "read_only_sql_required") {
     return "Use /sql/query for exactly one SELECT or WITH...SELECT statement without data-modifying CTEs. Send one approved write statement to /sql/execute.";
+  }
+
+  if (error.code === "mutation_sql_required") {
+    return `Use ${apiBaseUrl}/sql/query for SELECT and WITH...SELECT. ${apiBaseUrl}/sql/execute accepts exactly one approved INSERT, UPDATE, or DELETE mutation.`;
   }
 
   if (error.code === "on_conflict_not_allowed") {
@@ -213,34 +232,69 @@ const executeSqlWithWorkspaceGetter = async (
   authenticated: TrustedIdentityContext,
   workspaceId: string,
   validated: ValidatedExpenseSql,
+  executionDeadline: SqlExecutionDeadline,
   workspaceGetter: ExistingWorkspaceGetter,
   runInRestrictedContext: RestrictedContextRunner,
 ): Promise<Readonly<Record<string, unknown>> | null> => {
-  const workspace = await workspaceGetter(authenticated.identity, workspaceId);
+  const workspace = await workspaceGetter(
+    authenticated.identity,
+    workspaceId,
+    executionDeadline,
+  );
   if (workspace === null) {
     return null;
   }
 
-  const result = await runInRestrictedContext(
-    authenticated.identity,
-    workspaceId,
-    SQL_STATEMENT_TIMEOUT_MS,
-    async (queryFn) => executeValidatedExpenseSql(
-      validated,
-      async (request) => {
-        try {
-          const queryResult = await queryFn(request.sql, request.params);
-          return {
-            command: queryResult.command,
-            rows: queryResult.rows as ReadonlyArray<Readonly<Record<string, unknown>>>,
-            rowCount: queryResult.rowCount,
-          };
-        } catch (error) {
-          throwUserSqlExecutionError(error);
-        }
-      },
-    ),
+  const mutatingSql: ReadonlySet<string> = new Set(
+    validated.statements
+      .filter((statement) => statement.isMutating)
+      .map((statement) => statement.sql),
   );
+  let mutationExecutionStarted = false;
+  let result: Awaited<ReturnType<typeof executeValidatedExpenseSqlWithinDeadline>>;
+  try {
+    result = await runInRestrictedContext(
+      authenticated.identity,
+      workspaceId,
+      executionDeadline,
+      async (queryFn) => {
+        const executed = await executeValidatedExpenseSqlWithinDeadline(
+          validated,
+          executionDeadline,
+          async (request, remainingStatementTimeoutMs) => {
+            try {
+              const queryResult = await queryFn(
+                request.sql,
+                request.params,
+                remainingStatementTimeoutMs,
+                () => {
+                  if (mutatingSql.has(request.sql)) {
+                    mutationExecutionStarted = true;
+                  }
+                },
+              );
+              return {
+                command: queryResult.command,
+                rows: queryResult.rows as ReadonlyArray<Readonly<Record<string, unknown>>>,
+                rowCount: queryResult.rowCount,
+              };
+            } catch (error) {
+              throwUserSqlExecutionError(error);
+            }
+          },
+        );
+        return executed;
+      },
+    );
+  } catch (error) {
+    if (error instanceof SqlTransactionOutcomeUnknownError) {
+      if (!mutationExecutionStarted) {
+        throw error.originalError;
+      }
+      throw new AmbiguousSqlMutationOutcomeError(error);
+    }
+    throw error;
+  }
 
   return {
     statements: result.statements.map((statement) => {
@@ -260,7 +314,7 @@ const executeSqlWithWorkspaceGetter = async (
     workspace,
     limits: {
       maxRows: MAX_SQL_ROWS,
-      statementTimeoutMs: SQL_STATEMENT_TIMEOUT_MS,
+      statementTimeoutMs: executionDeadline.timeoutMs,
     },
   };
 };
@@ -270,16 +324,19 @@ export const runSqlWithWorkspaceGetter = async (
   authenticated: TrustedIdentityContext,
   workspaceId: string,
   sql: string,
+  executionDeadline: SqlExecutionDeadline,
   workspaceGetter: MachineApiWorkspaceGetter,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
   executeSqlWithWorkspaceGetter(
     authenticated,
     workspaceId,
     validateExpenseSql(sql),
-    (identity, resolvedWorkspaceId) => workspaceGetter(
+    executionDeadline,
+    (identity, resolvedWorkspaceId, deadline) => workspaceGetter(
       dependencies,
       identity,
       resolvedWorkspaceId,
+      deadline,
     ),
     dependencies.withRestrictedTrustedIdentityContext,
   );
@@ -289,16 +346,19 @@ export const runReadOnlySqlWithWorkspaceGetter = async (
   authenticated: TrustedIdentityContext,
   workspaceId: string,
   sql: string,
+  executionDeadline: SqlExecutionDeadline,
   workspaceGetter: MachineApiWorkspaceGetter,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
   executeSqlWithWorkspaceGetter(
     authenticated,
     workspaceId,
     validateReadOnlyExpenseSql(sql),
-    (identity, resolvedWorkspaceId) => workspaceGetter(
+    executionDeadline,
+    (identity, resolvedWorkspaceId, deadline) => workspaceGetter(
       dependencies,
       identity,
       resolvedWorkspaceId,
+      deadline,
     ),
     dependencies.withReadOnlyRestrictedTrustedIdentityContext,
   );
@@ -307,6 +367,7 @@ export const runSqlWithServices = async (
   authenticated: TrustedIdentityContext,
   workspaceId: string,
   validated: ValidatedExpenseSql,
+  executionDeadline: SqlExecutionDeadline,
   workspaceGetter: ExistingWorkspaceGetter,
   runInRestrictedContext: RestrictedContextRunner,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
@@ -314,6 +375,7 @@ export const runSqlWithServices = async (
     authenticated,
     workspaceId,
     validated,
+    executionDeadline,
     workspaceGetter,
     runInRestrictedContext,
   );
@@ -322,6 +384,7 @@ export const runReadOnlySqlWithServices = async (
   authenticated: TrustedIdentityContext,
   workspaceId: string,
   validated: ValidatedReadOnlyExpenseSql,
+  executionDeadline: SqlExecutionDeadline,
   workspaceGetter: ExistingWorkspaceGetter,
   runInReadOnlyRestrictedContext: RestrictedContextRunner,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
@@ -329,6 +392,7 @@ export const runReadOnlySqlWithServices = async (
     authenticated,
     workspaceId,
     validated,
+    executionDeadline,
     workspaceGetter,
     runInReadOnlyRestrictedContext,
   );
@@ -338,15 +402,18 @@ export const runSql = async (
   authenticated: TrustedIdentityContext,
   workspaceId: string,
   validated: ValidatedExpenseSql,
+  executionDeadline: SqlExecutionDeadline,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
   executeSqlWithWorkspaceGetter(
     authenticated,
     workspaceId,
     validated,
-    (identity, resolvedWorkspaceId) => getWorkspace(
+    executionDeadline,
+    (identity, resolvedWorkspaceId, deadline) => getWorkspaceBeforeDeadline(
       dependencies,
       identity,
       resolvedWorkspaceId,
+      deadline,
     ),
     dependencies.withRestrictedTrustedIdentityContext,
   );
@@ -356,15 +423,18 @@ export const runReadOnlySql = async (
   authenticated: TrustedIdentityContext,
   workspaceId: string,
   validated: ValidatedReadOnlyExpenseSql,
+  executionDeadline: SqlExecutionDeadline,
 ): Promise<Readonly<Record<string, unknown>> | null> =>
   executeSqlWithWorkspaceGetter(
     authenticated,
     workspaceId,
     validated,
-    (identity, resolvedWorkspaceId) => getWorkspace(
+    executionDeadline,
+    (identity, resolvedWorkspaceId, deadline) => getWorkspaceBeforeDeadline(
       dependencies,
       identity,
       resolvedWorkspaceId,
+      deadline,
     ),
     dependencies.withReadOnlyRestrictedTrustedIdentityContext,
   );

--- a/apps/sql-api/src/machineApi/types.ts
+++ b/apps/sql-api/src/machineApi/types.ts
@@ -4,6 +4,8 @@ import type { AllowedRelationName } from "@expense-budget-tracker/agent-shared/s
 import {
   ensureTrustedIdentityProvisioned,
   queryAsTrustedIdentity,
+  queryAsTrustedIdentityBeforeDeadline,
+  resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline,
   type UserIdentity,
   withReadOnlyRestrictedTrustedIdentityContext,
   withRestrictedTrustedIdentityContext,
@@ -23,6 +25,8 @@ export type AuthenticatedContext = TrustedIdentityContext & Readonly<{
 export type MachineApiDependencies = Readonly<{
   ensureTrustedIdentityProvisioned: typeof ensureTrustedIdentityProvisioned;
   queryAsTrustedIdentity: typeof queryAsTrustedIdentity;
+  queryAsTrustedIdentityBeforeDeadline: typeof queryAsTrustedIdentityBeforeDeadline;
+  resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline: typeof resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline;
   withReadOnlyRestrictedTrustedIdentityContext: typeof withReadOnlyRestrictedTrustedIdentityContext;
   withRestrictedTrustedIdentityContext: typeof withRestrictedTrustedIdentityContext;
 }>;

--- a/apps/sql-api/src/machineApi/workspaceService.ts
+++ b/apps/sql-api/src/machineApi/workspaceService.ts
@@ -1,4 +1,9 @@
-import { resolveOrCreateWorkspaceForTrustedIdentity, type QueryFn, type UserIdentity } from "../db.js";
+import type { SqlExecutionDeadline } from "@expense-budget-tracker/agent-shared/sql-policy";
+import {
+  resolveOrCreateWorkspaceForTrustedIdentity,
+  type QueryFn,
+  type UserIdentity,
+} from "../db.js";
 import type { AuthenticatedContext, MachineApiDependencies, WorkspaceSummary } from "./types.js";
 
 const WORKSPACES_SQL = `SELECT w.workspace_id, w.name
@@ -118,6 +123,29 @@ export const getWorkspace = async (
   );
 };
 
+export const getWorkspaceBeforeDeadline = async (
+  dependencies: MachineApiDependencies,
+  identity: UserIdentity,
+  workspaceId: string,
+  deadline: SqlExecutionDeadline,
+): Promise<WorkspaceSummary | null> => {
+  const contextWorkspace = await dependencies.resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline(
+    identity,
+    deadline,
+  );
+  return getWorkspaceWithQuery(
+    (text, params) => dependencies.queryAsTrustedIdentityBeforeDeadline(
+      identity,
+      contextWorkspace.workspaceId,
+      text,
+      params,
+      deadline,
+    ),
+    identity,
+    workspaceId,
+  );
+};
+
 export const persistSelectedWorkspace = async (
   dependencies: MachineApiDependencies,
   authenticated: AuthenticatedContext,
@@ -136,22 +164,68 @@ export const persistSelectedWorkspace = async (
   }
 };
 
-const getSelectedWorkspace = async (
+const listWorkspacesBeforeDeadline = async (
+  dependencies: MachineApiDependencies,
+  identity: UserIdentity,
+  deadline: SqlExecutionDeadline,
+): Promise<ReadonlyArray<WorkspaceSummary>> => {
+  const contextWorkspace = await dependencies.resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline(
+    identity,
+    deadline,
+  );
+  return listWorkspacesWithQuery(
+    (text, params) => dependencies.queryAsTrustedIdentityBeforeDeadline(
+      identity,
+      contextWorkspace.workspaceId,
+      text,
+      params,
+      deadline,
+    ),
+    identity,
+  );
+};
+
+const persistSelectedWorkspaceBeforeDeadline = async (
   dependencies: MachineApiDependencies,
   authenticated: AuthenticatedContext,
+  workspaceId: string,
+  deadline: SqlExecutionDeadline,
+): Promise<void> => {
+  const contextWorkspace = await dependencies.resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline(
+    authenticated.identity,
+    deadline,
+  );
+  const result = await dependencies.queryAsTrustedIdentityBeforeDeadline(
+    authenticated.identity,
+    contextWorkspace.workspaceId,
+    AGENT_CONNECTION_UPDATE_SQL,
+    [workspaceId, authenticated.connectionId, authenticated.identity.userId],
+    deadline,
+  );
+  if (result.rows.length !== 1) {
+    throw new Error(`Failed to persist selected workspace for connection ${authenticated.connectionId}`);
+  }
+};
+
+const getSelectedWorkspaceBeforeDeadline = async (
+  dependencies: MachineApiDependencies,
+  authenticated: AuthenticatedContext,
+  deadline: SqlExecutionDeadline,
 ): Promise<string | null> => {
-  const contextWorkspace = await resolveOrCreateWorkspaceForTrustedIdentity(authenticated.identity);
-  const result = await dependencies.queryAsTrustedIdentity(
+  const contextWorkspace = await dependencies.resolveOrCreateWorkspaceForTrustedIdentityBeforeDeadline(
+    authenticated.identity,
+    deadline,
+  );
+  const result = await dependencies.queryAsTrustedIdentityBeforeDeadline(
     authenticated.identity,
     contextWorkspace.workspaceId,
     AGENT_CONNECTION_SELECT_SQL,
     [authenticated.connectionId, authenticated.identity.userId],
+    deadline,
   );
-
   if (result.rows.length === 0) {
     return null;
   }
-
   const row = result.rows[0] as { selected_workspace_id: string | null };
   return row.selected_workspace_id;
 };
@@ -160,17 +234,26 @@ export const resolveSqlWorkspaceId = async (
   dependencies: MachineApiDependencies,
   authenticated: AuthenticatedContext,
   headerWorkspaceId: string,
+  deadline: SqlExecutionDeadline,
 ): Promise<string | null> => {
   if (headerWorkspaceId !== "") {
     return headerWorkspaceId;
   }
 
-  const savedWorkspaceId = await getSelectedWorkspace(dependencies, authenticated);
+  const savedWorkspaceId = await getSelectedWorkspaceBeforeDeadline(
+    dependencies,
+    authenticated,
+    deadline,
+  );
   if (savedWorkspaceId !== null && savedWorkspaceId !== "") {
     return savedWorkspaceId;
   }
 
-  const workspaces = await listWorkspaces(dependencies, authenticated.identity);
+  const workspaces = await listWorkspacesBeforeDeadline(
+    dependencies,
+    authenticated.identity,
+    deadline,
+  );
   if (workspaces.length !== 1) {
     return null;
   }
@@ -180,6 +263,11 @@ export const resolveSqlWorkspaceId = async (
     throw new Error("Expected exactly one workspace, but none were found");
   }
 
-  await persistSelectedWorkspace(dependencies, authenticated, onlyWorkspace.workspaceId);
+  await persistSelectedWorkspaceBeforeDeadline(
+    dependencies,
+    authenticated,
+    onlyWorkspace.workspaceId,
+    deadline,
+  );
   return onlyWorkspace.workspaceId;
 };

--- a/apps/sql-api/src/mcp-handler.test.ts
+++ b/apps/sql-api/src/mcp-handler.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { APIGatewayProxyEventV2 } from "aws-lambda";
+import {
+  MCP_SQL_STATEMENT_TIMEOUT_MS,
+  SqlExecutionDeadlineError,
+  type SqlExecutionDeadline,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
+import { SqlTransactionOutcomeUnknownError } from "./dbDeadline.js";
 import type { UserIdentity } from "./db.js";
 import { createQueryResult } from "./handlerTestUtils.js";
 import {
@@ -12,6 +19,10 @@ import { createMcpServer } from "./mcp/server.js";
 import type { SqlApiLogEvent } from "./logger.js";
 import {
   createMcpApp,
+  createMcpHandler,
+  createMcpRequestFromHttpApiV2Event,
+  createHttpApiV2ResultFromMcpResponse,
+  McpHttpApiV2EventError,
   type McpHandlerDependencies,
 } from "./mcp-handler.js";
 
@@ -51,6 +62,7 @@ const createDependencies = (
   log: (event) => {
     logEvents.push(event);
   },
+  now: Date.now,
 });
 
 const authenticatedHeaders = (): Readonly<Record<string, string>> => ({
@@ -78,31 +90,194 @@ const initializeRequest = (): Request => new Request(RESOURCE, {
   }),
 });
 
-test("MCP handler serves health and both protected-resource metadata locations", async (): Promise<void> => {
+const createHttpApiV2Event = (
+  method: "GET" | "POST" | "DELETE",
+  path: string,
+  headers: Readonly<Record<string, string>>,
+  rawQueryString: string,
+  body: string | undefined,
+  isBase64Encoded: boolean,
+  cookies: Array<string> | undefined,
+): APIGatewayProxyEventV2 => ({
+  version: "2.0",
+  routeKey: `${method} ${path}`,
+  rawPath: path,
+  rawQueryString,
+  ...(cookies === undefined ? {} : { cookies }),
+  headers: { ...headers },
+  requestContext: {
+    accountId: "123456789012",
+    apiId: "mcp-http-api",
+    domainName: CONFIG.canonicalHost,
+    domainPrefix: "mcp",
+    http: {
+      method,
+      path,
+      protocol: "HTTP/1.1",
+      sourceIp: "203.0.113.10",
+      userAgent: "mcp-handler-test",
+    },
+    requestId: "request-1",
+    routeKey: `${method} ${path}`,
+    stage: "$default",
+    time: "14/Aug/2026:12:00:00 +0000",
+    timeEpoch: 1_776_165_600_000,
+  },
+  ...(body === undefined ? {} : { body }),
+  isBase64Encoded,
+});
+
+test("MCP HTTP API v2 adapter preserves raw path, query, cookies, and base64 request bodies", async (): Promise<void> => {
+  const event = createHttpApiV2Event(
+    "POST",
+    "/mcp",
+    {
+      host: CONFIG.canonicalHost,
+      "content-type": "application/json",
+      "x-forwarded-for": "203.0.113.10",
+    },
+    "workspace=one%20two&workspace=three",
+    Buffer.from('{"jsonrpc":"2.0"}', "utf8").toString("base64"),
+    true,
+    ["first=one", "second=two"],
+  );
+
+  const request = createMcpRequestFromHttpApiV2Event(event);
+
+  assert.equal(request.method, "POST");
+  assert.equal(
+    request.url,
+    "https://mcp.example.com/mcp?workspace=one%20two&workspace=three",
+  );
+  assert.equal(request.headers.get("cookie"), "first=one; second=two");
+  assert.equal(request.headers.get("x-forwarded-for"), "203.0.113.10");
+  assert.equal(await request.text(), '{"jsonrpc":"2.0"}');
+});
+
+test("MCP HTTP API v2 adapter rejects non-v2 and inconsistent route events", (): void => {
+  const event = createHttpApiV2Event(
+    "GET",
+    "/mcp",
+    { host: CONFIG.canonicalHost },
+    "",
+    undefined,
+    false,
+    undefined,
+  );
+
+  assert.throws(
+    () => createMcpRequestFromHttpApiV2Event({ ...event, version: "1.0" }),
+    McpHttpApiV2EventError,
+  );
+  assert.throws(
+    () => createMcpRequestFromHttpApiV2Event({ ...event, routeKey: "GET /other" }),
+    McpHttpApiV2EventError,
+  );
+});
+
+test("MCP HTTP API v2 adapter emits structured status, headers, cookies, and buffered body", async (): Promise<void> => {
+  const headers = new Headers({ "content-type": "application/json", "x-request-id": "request-1" });
+  headers.append("set-cookie", "first=one; Secure");
+  headers.append("set-cookie", "second=two; Secure");
+  const response = new Response('{"error":"invalid_token"}', { status: 401, headers });
+
+  const result = await createHttpApiV2ResultFromMcpResponse(response);
+
+  assert.equal(result.statusCode, 401);
+  assert.deepEqual(result.headers, {
+    "content-type": "application/json",
+    "x-request-id": "request-1",
+  });
+  assert.deepEqual(result.cookies, ["first=one; Secure", "second=two; Secure"]);
+  assert.equal(result.body, '{"error":"invalid_token"}');
+  assert.equal(result.isBase64Encoded, false);
+});
+
+test("MCP Lambda handler consumes HTTP API v2 metadata events without REST aliases", async (): Promise<void> => {
+  const handler = createMcpHandler(createDependencies(async () => CONNECTION, []));
+  const metadata = await handler(createHttpApiV2Event(
+    "GET",
+    "/.well-known/oauth-protected-resource/mcp",
+    { host: CONFIG.canonicalHost },
+    "",
+    undefined,
+    false,
+    undefined,
+  ));
+
+  assert.equal(metadata.statusCode, 200);
+  assert.deepEqual(JSON.parse(metadata.body ?? ""), {
+    resource: RESOURCE,
+    authorization_servers: [CONFIG.issuer],
+    bearer_methods_supported: ["header"],
+    scopes_supported: ["expenses:read", "expenses:write"],
+  });
+});
+
+test("MCP Lambda preserves OAuth challenge headers in an HTTP API v2 response", async (): Promise<void> => {
+  const handler = createMcpHandler(createDependencies(async () => CONNECTION, []));
+  const response = await handler(createHttpApiV2Event(
+    "POST",
+    "/mcp",
+    { host: CONFIG.canonicalHost },
+    "",
+    undefined,
+    false,
+    undefined,
+  ));
+
+  assert.equal(response.statusCode, 401);
+  assert.equal(response.headers?.["www-authenticate"], `Bearer resource_metadata="${METADATA_URL}"`);
+  assert.equal(response.isBase64Encoded, false);
+});
+
+test("MCP Lambda starts one absolute deadline at HTTP API request entry before OAuth", async (): Promise<void> => {
+  const steps: Array<string> = [];
+  let authenticationDeadline: SqlExecutionDeadline | undefined;
+  const dependencies = createDependencies(async (_token, _resource, deadline) => {
+    steps.push("authenticate");
+    authenticationDeadline = deadline;
+    throw new McpAuthenticationError();
+  }, []);
+  const handler = createMcpHandler({
+    ...dependencies,
+    now: () => {
+      steps.push("deadline");
+      return 10_000;
+    },
+  });
+
+  const response = await handler(createHttpApiV2Event(
+    "POST",
+    "/mcp",
+    authenticatedHeaders(),
+    "",
+    undefined,
+    false,
+    undefined,
+  ));
+
+  assert.equal(response.statusCode, 401);
+  assert.deepEqual(steps, ["deadline", "authenticate"]);
+  assert.equal(authenticationDeadline?.expiresAtMs, 10_000 + MCP_SQL_STATEMENT_TIMEOUT_MS);
+});
+
+test("MCP handler serves only the pathful protected-resource metadata location", async (): Promise<void> => {
   const logEvents: Array<SqlApiLogEvent> = [];
   const app = createMcpApp(createDependencies(async () => CONNECTION, logEvents));
 
-  const health = await app.request("https://mcp.example.com/health");
-  assert.equal(health.status, 200);
-  assert.deepEqual(await health.json(), { status: "ok" });
-
-  for (const path of [
-    "/.well-known/oauth-protected-resource/mcp",
-    "/.well-known/oauth-protected-resource",
-  ]) {
-    const response = await app.request(`https://mcp.example.com${path}`);
-    assert.equal(response.status, 200, path);
-    assert.deepEqual(await response.json(), {
-      resource: RESOURCE,
-      authorization_servers: [CONFIG.issuer],
-      bearer_methods_supported: ["header"],
-      scopes_supported: ["expenses:read", "expenses:write"],
-    });
-  }
+  const response = await app.request(METADATA_URL);
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    resource: RESOURCE,
+    authorization_servers: [CONFIG.issuer],
+    bearer_methods_supported: ["header"],
+    scopes_supported: ["expenses:read", "expenses:write"],
+  });
   assert.deepEqual(logEvents, []);
 });
 
-test("MCP handler does not serve any /v1 route aliases", async (): Promise<void> => {
+test("MCP handler does not serve removed, unknown, or /v1 routes", async (): Promise<void> => {
   let authenticationCalls = 0;
   const app = createMcpApp(createDependencies(async () => {
     authenticationCalls += 1;
@@ -110,6 +285,9 @@ test("MCP handler does not serve any /v1 route aliases", async (): Promise<void>
   }, []));
 
   for (const path of [
+    "/health",
+    "/.well-known/oauth-protected-resource",
+    "/unknown",
     "/v1/health",
     "/v1/.well-known/oauth-protected-resource/mcp",
     "/v1/.well-known/oauth-protected-resource",
@@ -170,11 +348,12 @@ test("MCP handler maps current identity trust failures to the generic Bearer cha
     cognitoEnabled: false,
   };
   const app = createMcpApp(createDependencies(
-    (token, resource) => authenticateMcpAccessTokenWithDependencies(
+    (token, resource, deadline) => authenticateMcpAccessTokenWithDependencies(
       token,
       resource,
+      deadline,
       {
-        query: async () => createQueryResult([{
+        queryBeforeDeadline: async () => createQueryResult([{
           connection_id: CONNECTION.connectionId,
           user_id: CONNECTION.identity.userId,
           client_id: CONNECTION.clientId,
@@ -182,7 +361,7 @@ test("MCP handler maps current identity trust failures to the generic Bearer cha
           scopes: CONNECTION.scopes,
           expires_at: new Date("2026-08-14T13:00:00.000Z"),
         }]),
-        loadTrustedUserIdentity: async () => disabledIdentity,
+        loadTrustedUserIdentityBeforeDeadline: async () => disabledIdentity,
         now: () => new Date("2026-08-14T12:00:00.000Z"),
       },
     ),
@@ -204,14 +383,39 @@ test("MCP handler maps current identity trust failures to the generic Bearer cha
   assert.deepEqual(logEvents, []);
 });
 
+test("MCP handler maps a readonly authentication transaction deadline to retryable 504", async (): Promise<void> => {
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const app = createMcpApp(createDependencies(async () => {
+    throw new SqlTransactionOutcomeUnknownError(
+      "commit",
+      new SqlExecutionDeadlineError(MCP_SQL_STATEMENT_TIMEOUT_MS),
+      "unknown",
+      undefined,
+    );
+  }, logEvents));
+
+  const response = await app.request(RESOURCE, {
+    method: "POST",
+    headers: authenticatedHeaders(),
+  });
+
+  assert.equal(response.status, 504);
+  assert.deepEqual(await response.json(), {
+    error: "request_deadline_exceeded",
+    error_description: "The MCP request exceeded its 20-second total execution deadline. Retry the request.",
+  });
+  assert.deepEqual(logEvents, []);
+});
+
 test("MCP handler maps invalid scope snapshots to the generic Bearer challenge", async (): Promise<void> => {
   const logEvents: Array<SqlApiLogEvent> = [];
   const app = createMcpApp(createDependencies(
-    (token, resource) => authenticateMcpAccessTokenWithDependencies(
+    (token, resource, deadline) => authenticateMcpAccessTokenWithDependencies(
       token,
       resource,
+      deadline,
       {
-        query: async () => createQueryResult([{
+        queryBeforeDeadline: async () => createQueryResult([{
           connection_id: CONNECTION.connectionId,
           user_id: CONNECTION.identity.userId,
           client_id: CONNECTION.clientId,
@@ -219,7 +423,7 @@ test("MCP handler maps invalid scope snapshots to the generic Bearer challenge",
           scopes: ["expenses:write", "expenses:read"],
           expires_at: new Date("2026-08-14T13:00:00.000Z"),
         }]),
-        loadTrustedUserIdentity: async () => CONNECTION.identity,
+        loadTrustedUserIdentityBeforeDeadline: async () => CONNECTION.identity,
         now: () => new Date("2026-08-14T12:00:00.000Z"),
       },
     ),
@@ -245,11 +449,12 @@ test("MCP handler maps invalid scope snapshots to the generic Bearer challenge",
 test("MCP handler keeps unrelated access-token row corruption as an internal error", async (): Promise<void> => {
   const logEvents: Array<SqlApiLogEvent> = [];
   const app = createMcpApp(createDependencies(
-    (token, resource) => authenticateMcpAccessTokenWithDependencies(
+    (token, resource, deadline) => authenticateMcpAccessTokenWithDependencies(
       token,
       resource,
+      deadline,
       {
-        query: async () => createQueryResult([{
+        queryBeforeDeadline: async () => createQueryResult([{
           connection_id: CONNECTION.connectionId,
           user_id: CONNECTION.identity.userId,
           client_id: 42,
@@ -257,7 +462,7 @@ test("MCP handler keeps unrelated access-token row corruption as an internal err
           scopes: CONNECTION.scopes,
           expires_at: new Date("2026-08-14T13:00:00.000Z"),
         }]),
-        loadTrustedUserIdentity: async () => CONNECTION.identity,
+        loadTrustedUserIdentityBeforeDeadline: async () => CONNECTION.identity,
         now: () => new Date("2026-08-14T12:00:00.000Z"),
       },
     ),
@@ -304,31 +509,44 @@ test("MCP handler rejects non-canonical Host and Origin before authentication", 
   assert.equal(authenticationCalls, 0);
 });
 
-test("MCP handler returns 405 for authenticated GET and DELETE requests", async (): Promise<void> => {
-  const app = createMcpApp(createDependencies(async () => CONNECTION, []));
+test("MCP handler preserves authenticated GET protocol behavior without exposing other methods", async (): Promise<void> => {
+  let authenticationCalls = 0;
+  const app = createMcpApp(createDependencies(async () => {
+    authenticationCalls += 1;
+    return CONNECTION;
+  }, []));
 
-  for (const method of ["GET", "DELETE"]) {
-    const response = await app.request(RESOURCE, {
-      method,
-      headers: authenticatedHeaders(),
-    });
-    assert.equal(response.status, 405, method);
-    assert.equal(response.headers.get("allow"), "POST", method);
-  }
+  const get = await app.request(RESOURCE, {
+    method: "GET",
+    headers: authenticatedHeaders(),
+  });
+  assert.equal(get.status, 405);
+  assert.equal(get.headers.get("allow"), "POST");
+
+  const deleted = await app.request(RESOURCE, {
+    method: "DELETE",
+    headers: authenticatedHeaders(),
+  });
+  assert.equal(deleted.status, 404);
+  assert.equal(authenticationCalls, 1);
 });
 
 test("MCP handler uses stateless JSON transport with no session identifier", async (): Promise<void> => {
   let serverCreations = 0;
-  const dependencies = createDependencies(async (token, resource) => {
+  const authenticationDeadlines: Array<SqlExecutionDeadline> = [];
+  const serverDeadlines: Array<SqlExecutionDeadline> = [];
+  const dependencies = createDependencies(async (token, resource, deadline) => {
     assert.equal(token, ACCESS_TOKEN);
     assert.equal(resource, RESOURCE);
+    authenticationDeadlines.push(deadline);
     return CONNECTION;
   }, []);
   const app = createMcpApp({
     ...dependencies,
-    createMcpServer: (connection) => {
+    createMcpServer: (connection, deadline) => {
       serverCreations += 1;
-      return createMcpServer(connection);
+      serverDeadlines.push(deadline);
+      return createMcpServer(connection, deadline);
     },
   });
 
@@ -342,6 +560,12 @@ test("MCP handler uses stateless JSON transport with no session identifier", asy
     assert.equal(body["id"], 1);
   }
   assert.equal(serverCreations, 2);
+  assert.equal(serverDeadlines[0], authenticationDeadlines[0]);
+  assert.equal(serverDeadlines[1], authenticationDeadlines[1]);
+  assert.deepEqual(
+    authenticationDeadlines.map((deadline) => deadline.timeoutMs),
+    [MCP_SQL_STATEMENT_TIMEOUT_MS, MCP_SQL_STATEMENT_TIMEOUT_MS],
+  );
 });
 
 test("MCP handler sanitizes and structurally logs unexpected authentication failures", async (): Promise<void> => {

--- a/apps/sql-api/src/mcp-handler.ts
+++ b/apps/sql-api/src/mcp-handler.ts
@@ -1,11 +1,20 @@
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import { handle } from "hono/aws-lambda";
+import type {
+  APIGatewayProxyEventV2,
+  APIGatewayProxyStructuredResultV2,
+} from "aws-lambda";
+import {
+  createSqlExecutionDeadline,
+  MCP_SQL_STATEMENT_TIMEOUT_MS,
+  type SqlExecutionDeadline,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
 import { type Context, Hono } from "hono";
 import {
   authenticateMcpAccessToken,
   McpAuthenticationError,
   type AuthenticatedMcpAccessToken,
 } from "./mcp/auth.js";
+import { getReadOnlyTransactionDeadlineError } from "./dbDeadline.js";
 import { getMcpRuntimeConfig, type McpRuntimeConfig } from "./mcp/config.js";
 import {
   buildBearerChallenge,
@@ -16,18 +25,31 @@ import { getSafeErrorType, log } from "./logger.js";
 
 const BEARER_AUTHORIZATION_PATTERN = /^[Bb][Ee][Aa][Rr][Ee][Rr]\s+(ebt_at_[A-Za-z0-9_-]{43})$/u;
 
+export class McpHttpApiV2EventError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpHttpApiV2EventError";
+  }
+}
+
 export type McpHandlerDependencies = Readonly<{
   authenticateMcpAccessToken: typeof authenticateMcpAccessToken;
   createMcpServer: typeof createMcpServer;
   getMcpRuntimeConfig: typeof getMcpRuntimeConfig;
   log: typeof log;
+  now: () => number;
 }>;
+
+export type McpHttpApiV2Handler = (
+  event: APIGatewayProxyEventV2,
+) => Promise<APIGatewayProxyStructuredResultV2>;
 
 const defaultDependencies: McpHandlerDependencies = {
   authenticateMcpAccessToken,
   createMcpServer,
   getMcpRuntimeConfig,
   log,
+  now: Date.now,
 };
 
 const extractBearerAccessToken = (authorization: string | undefined): string | null => {
@@ -62,13 +84,91 @@ const validateCanonicalRequestSource = (
   return origin === null || origin === config.resourceOrigin;
 };
 
+const buildHttpApiV2RequestUrl = (event: APIGatewayProxyEventV2): string => {
+  if (event.version !== "2.0") {
+    throw new McpHttpApiV2EventError("MCP Lambda requires an API Gateway HTTP API payload version 2.0 event.");
+  }
+  if (!event.rawPath.startsWith("/")) {
+    throw new McpHttpApiV2EventError("MCP HTTP API event rawPath must start with '/'.");
+  }
+
+  const method = event.requestContext.http.method;
+  const expectedRouteKey = `${method} ${event.rawPath}`;
+  if (event.routeKey !== expectedRouteKey) {
+    throw new McpHttpApiV2EventError(
+      `MCP HTTP API event routeKey must be '${expectedRouteKey}'.`,
+    );
+  }
+  if (event.requestContext.http.path !== event.rawPath) {
+    throw new McpHttpApiV2EventError("MCP HTTP API event requestContext.http.path must match rawPath.");
+  }
+
+  const host = event.headers.host;
+  if (host === undefined || host.trim() === "") {
+    throw new McpHttpApiV2EventError("MCP HTTP API event is missing the required Host header.");
+  }
+  const querySuffix = event.rawQueryString === "" ? "" : `?${event.rawQueryString}`;
+  return new URL(`${event.rawPath}${querySuffix}`, `https://${host}`).toString();
+};
+
+export const createMcpRequestFromHttpApiV2Event = (
+  event: APIGatewayProxyEventV2,
+): Request => {
+  const url = buildHttpApiV2RequestUrl(event);
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(event.headers)) {
+    if (value !== undefined) {
+      headers.append(name, value);
+    }
+  }
+  if (event.cookies !== undefined) {
+    if (headers.has("cookie")) {
+      throw new McpHttpApiV2EventError("MCP HTTP API event must not duplicate cookies in headers and cookies.");
+    }
+    headers.set("cookie", event.cookies.join("; "));
+  }
+
+  const method = event.requestContext.http.method;
+  if ((method === "GET" || method === "HEAD") && event.body !== undefined) {
+    throw new McpHttpApiV2EventError(`MCP HTTP API ${method} event must not include a request body.`);
+  }
+  const body = event.body === undefined
+    ? undefined
+    : event.isBase64Encoded
+      ? Buffer.from(event.body, "base64")
+      : event.body;
+
+  return new Request(url, { method, headers, body });
+};
+
+export const createHttpApiV2ResultFromMcpResponse = async (
+  response: Response,
+): Promise<APIGatewayProxyStructuredResultV2> => {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, name) => {
+    if (name !== "set-cookie") {
+      headers[name] = value;
+    }
+  });
+  const cookies = response.headers.getSetCookie();
+
+  return {
+    statusCode: response.status,
+    headers,
+    ...(cookies.length === 0 ? {} : { cookies }),
+    body: await response.text(),
+    isBase64Encoded: false,
+  };
+};
+
 const handleMcpTransportRequest = async (
   request: Request,
   connection: AuthenticatedMcpAccessToken,
   config: McpRuntimeConfig,
+  deadline: SqlExecutionDeadline,
   dependencies: McpHandlerDependencies,
 ): Promise<Response> => {
-  const server = dependencies.createMcpServer(connection);
+  const server = dependencies.createMcpServer(connection, deadline);
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,
@@ -86,17 +186,19 @@ const handleMcpTransportRequest = async (
   }
 };
 
-const buildMcpRoutes = (app: Hono, dependencies: McpHandlerDependencies): Hono => {
-  app.get("/health", (context) => context.json({ status: "ok" }));
-
+const buildMcpRoutes = (
+  app: Hono,
+  dependencies: McpHandlerDependencies,
+  createRequestDeadline: () => SqlExecutionDeadline,
+): Hono => {
   const protectedResourceMetadata = (context: Context): Response => {
     const config = dependencies.getMcpRuntimeConfig();
     return context.json(buildProtectedResourceMetadata(config));
   };
   app.get("/.well-known/oauth-protected-resource/mcp", protectedResourceMetadata);
-  app.get("/.well-known/oauth-protected-resource", protectedResourceMetadata);
 
-  app.all("/mcp", async (context): Promise<Response> => {
+  app.on(["GET", "POST"], "/mcp", async (context): Promise<Response> => {
+    const deadline = createRequestDeadline();
     const config = dependencies.getMcpRuntimeConfig();
     if (!validateCanonicalRequestSource(context.req.raw, config)) {
       return context.json(
@@ -115,10 +217,24 @@ const buildMcpRoutes = (app: Hono, dependencies: McpHandlerDependencies): Hono =
 
     let connection: AuthenticatedMcpAccessToken;
     try {
-      connection = await dependencies.authenticateMcpAccessToken(token, config.resource);
+      connection = await dependencies.authenticateMcpAccessToken(
+        token,
+        config.resource,
+        deadline,
+      );
     } catch (error) {
       if (error instanceof McpAuthenticationError) {
         return buildBearerChallengeResponse(context, config);
+      }
+      const deadlineError = getReadOnlyTransactionDeadlineError(error);
+      if (deadlineError !== null) {
+        return context.json(
+          {
+            error: "request_deadline_exceeded",
+            error_description: "The MCP request exceeded its 20-second total execution deadline. Retry the request.",
+          },
+          504,
+        );
       }
       dependencies.log({
         domain: "sql_api",
@@ -144,15 +260,24 @@ const buildMcpRoutes = (app: Hono, dependencies: McpHandlerDependencies): Hono =
       );
     }
 
-    return handleMcpTransportRequest(context.req.raw, connection, config, dependencies);
+    return handleMcpTransportRequest(
+      context.req.raw,
+      connection,
+      config,
+      deadline,
+      dependencies,
+    );
   });
 
   return app;
 };
 
-export const createMcpApp = (dependencies: McpHandlerDependencies): Hono => {
+const createMcpAppWithDeadlineFactory = (
+  dependencies: McpHandlerDependencies,
+  createRequestDeadline: () => SqlExecutionDeadline,
+): Hono => {
   const app = new Hono();
-  app.route("/", buildMcpRoutes(new Hono(), dependencies));
+  app.route("/", buildMcpRoutes(new Hono(), dependencies, createRequestDeadline));
   app.onError((error, context) => {
     dependencies.log({
       domain: "sql_api",
@@ -169,7 +294,21 @@ export const createMcpApp = (dependencies: McpHandlerDependencies): Hono => {
   return app;
 };
 
-export const createMcpHandler = (dependencies: McpHandlerDependencies) =>
-  handle(createMcpApp(dependencies));
+export const createMcpApp = (dependencies: McpHandlerDependencies): Hono =>
+  createMcpAppWithDeadlineFactory(
+    dependencies,
+    () => createSqlExecutionDeadline(MCP_SQL_STATEMENT_TIMEOUT_MS, dependencies.now),
+  );
+
+export const createMcpHandler = (
+  dependencies: McpHandlerDependencies,
+): McpHttpApiV2Handler =>
+  async (event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> => {
+    const deadline = createSqlExecutionDeadline(MCP_SQL_STATEMENT_TIMEOUT_MS, dependencies.now);
+    const request = createMcpRequestFromHttpApiV2Event(event);
+    const app = createMcpAppWithDeadlineFactory(dependencies, () => deadline);
+    const response = await app.fetch(request);
+    return createHttpApiV2ResultFromMcpResponse(response);
+  };
 
 export const handler = createMcpHandler(defaultDependencies);

--- a/apps/sql-api/src/mcp/auth.test.ts
+++ b/apps/sql-api/src/mcp/auth.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
-import { createQueryResult } from "../handlerTestUtils.js";
+import {
+  createSqlExecutionDeadline,
+  MCP_SQL_STATEMENT_TIMEOUT_MS,
+  type SqlExecutionDeadline,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
 import type { UserIdentity } from "../db.js";
+import { createQueryResult } from "../handlerTestUtils.js";
 import {
   authenticateMcpAccessTokenWithDependencies,
   McpAuthenticationError,
@@ -23,19 +28,25 @@ const IDENTITY: UserIdentity = {
 type AuthCalls = {
   queries: Array<Readonly<{ text: string; params: ReadonlyArray<unknown> }>>;
   loadedUserIds: Array<string>;
+  deadlines: Array<SqlExecutionDeadline>;
 };
+
+const createDeadline = (): SqlExecutionDeadline =>
+  createSqlExecutionDeadline(MCP_SQL_STATEMENT_TIMEOUT_MS, () => 10_000);
 
 const createDependencies = (
   rows: ReadonlyArray<unknown>,
   identity: UserIdentity | null,
   calls: AuthCalls,
 ): McpAuthDependencies => ({
-  query: async (text, params) => {
+  queryBeforeDeadline: async (text, params, deadline) => {
     calls.queries.push({ text, params });
+    calls.deadlines.push(deadline);
     return createQueryResult(rows);
   },
-  loadTrustedUserIdentity: async (userId) => {
+  loadTrustedUserIdentityBeforeDeadline: async (userId, deadline) => {
     calls.loadedUserIds.push(userId);
+    calls.deadlines.push(deadline);
     return identity;
   },
   now: () => NOW,
@@ -52,10 +63,12 @@ const validRow = (overrides: Readonly<Record<string, unknown>>): Readonly<Record
 });
 
 test("MCP auth hashes the entire opaque access token and loads the existing user identity", async (): Promise<void> => {
-  const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+  const calls: AuthCalls = { queries: [], loadedUserIds: [], deadlines: [] };
+  const deadline = createDeadline();
   const result = await authenticateMcpAccessTokenWithDependencies(
     ACCESS_TOKEN,
     RESOURCE,
+    deadline,
     createDependencies([validRow({})], IDENTITY, calls),
   );
 
@@ -65,6 +78,8 @@ test("MCP auth hashes the entire opaque access token and loads the existing user
     createHash("sha256").update(ACCESS_TOKEN).digest("hex"),
   ]);
   assert.deepEqual(calls.loadedUserIds, [IDENTITY.userId]);
+  assert.equal(calls.deadlines.length, 2);
+  assert.equal(calls.deadlines.every((received) => received === deadline), true);
   assert.deepEqual(result, {
     connectionId: "connection-1",
     clientId: "ebt_cl_client",
@@ -75,10 +90,11 @@ test("MCP auth hashes the entire opaque access token and loads the existing user
 });
 
 test("MCP auth accepts the canonical read-only scope snapshot", async (): Promise<void> => {
-  const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+  const calls: AuthCalls = { queries: [], loadedUserIds: [], deadlines: [] };
   const result = await authenticateMcpAccessTokenWithDependencies(
     ACCESS_TOKEN,
     RESOURCE,
+    createDeadline(),
     createDependencies(
       [validRow({ scopes: ["expenses:read"] })],
       IDENTITY,
@@ -96,11 +112,12 @@ test("MCP auth rejects non-OAuth credentials before database access", async (): 
     `EBT_AT_${"A".repeat(43)}`,
     `ebt_at_${"A".repeat(42)}`,
   ]) {
-    const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+    const calls: AuthCalls = { queries: [], loadedUserIds: [], deadlines: [] };
     await assert.rejects(
       () => authenticateMcpAccessTokenWithDependencies(
         token,
         RESOURCE,
+        createDeadline(),
         createDependencies([], IDENTITY, calls),
       ),
       (error: unknown) => error instanceof McpAuthenticationError,
@@ -115,11 +132,12 @@ test("MCP auth rejects missing, expired, and wrong-resource access-token grants"
     [validRow({ expires_at: NOW })],
     [validRow({ resource: "https://mcp.other.example/mcp" })],
   ]) {
-    const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+    const calls: AuthCalls = { queries: [], loadedUserIds: [], deadlines: [] };
     await assert.rejects(
       () => authenticateMcpAccessTokenWithDependencies(
         ACCESS_TOKEN,
         RESOURCE,
+        createDeadline(),
         createDependencies(rows, IDENTITY, calls),
       ),
       (error: unknown) => error instanceof McpAuthenticationError,
@@ -136,11 +154,12 @@ test("MCP auth rejects invalid scope snapshots", async (): Promise<void> => {
   ];
 
   for (const scopes of invalidSnapshots) {
-    const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+    const calls: AuthCalls = { queries: [], loadedUserIds: [], deadlines: [] };
     await assert.rejects(
       () => authenticateMcpAccessTokenWithDependencies(
         ACCESS_TOKEN,
         RESOURCE,
+        createDeadline(),
         createDependencies([validRow({ scopes })], IDENTITY, calls),
       ),
       (error: unknown) =>
@@ -153,11 +172,12 @@ test("MCP auth rejects invalid scope snapshots", async (): Promise<void> => {
 });
 
 test("MCP auth preserves unrelated database row corruption as an internal error", async (): Promise<void> => {
-  const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+  const calls: AuthCalls = { queries: [], loadedUserIds: [], deadlines: [] };
   await assert.rejects(
     () => authenticateMcpAccessTokenWithDependencies(
       ACCESS_TOKEN,
       RESOURCE,
+      createDeadline(),
       createDependencies([validRow({ client_id: 42 })], IDENTITY, calls),
     ),
     (error: unknown) =>
@@ -192,11 +212,12 @@ test("MCP auth rejects absent and currently untrusted user identities as invalid
   ];
 
   for (const testCase of cases) {
-    const calls: AuthCalls = { queries: [], loadedUserIds: [] };
+    const calls: AuthCalls = { queries: [], loadedUserIds: [], deadlines: [] };
     await assert.rejects(
       () => authenticateMcpAccessTokenWithDependencies(
         ACCESS_TOKEN,
         RESOURCE,
+        createDeadline(),
         createDependencies([validRow({})], testCase.identity, calls),
       ),
       (error: unknown) =>

--- a/apps/sql-api/src/mcp/auth.ts
+++ b/apps/sql-api/src/mcp/auth.ts
@@ -1,9 +1,9 @@
 import { createHash } from "node:crypto";
+import type { SqlExecutionDeadline } from "@expense-budget-tracker/agent-shared/sql-policy";
 import { z } from "zod";
 import {
-  loadTrustedUserIdentity,
-  query,
-  type QueryFn,
+  loadTrustedUserIdentityBeforeDeadline,
+  queryBeforeDeadline,
   type UserIdentity,
 } from "../db.js";
 import type { McpScope } from "./config.js";
@@ -34,14 +34,14 @@ export class McpAuthenticationError extends Error {
 }
 
 export type McpAuthDependencies = Readonly<{
-  query: QueryFn;
-  loadTrustedUserIdentity: (userId: string) => Promise<UserIdentity | null>;
+  queryBeforeDeadline: typeof queryBeforeDeadline;
+  loadTrustedUserIdentityBeforeDeadline: typeof loadTrustedUserIdentityBeforeDeadline;
   now: () => Date;
 }>;
 
 const defaultDependencies: McpAuthDependencies = {
-  query,
-  loadTrustedUserIdentity,
+  queryBeforeDeadline,
+  loadTrustedUserIdentityBeforeDeadline,
   now: () => new Date(),
 };
 
@@ -75,16 +75,18 @@ const readCanonicalScopeSnapshot = (
 export const authenticateMcpAccessTokenWithDependencies = async (
   token: string,
   expectedResource: string,
+  deadline: SqlExecutionDeadline,
   dependencies: McpAuthDependencies,
 ): Promise<AuthenticatedMcpAccessToken> => {
   if (!ACCESS_TOKEN_PATTERN.test(token)) {
     throw new McpAuthenticationError();
   }
 
-  const result = await dependencies.query(
+  const result = await dependencies.queryBeforeDeadline(
     `SELECT connection_id, user_id, client_id, resource, scopes, expires_at
      FROM auth.validate_oauth_access_token($1)`,
     [hashAccessToken(token)],
+    deadline,
   );
   if (result.rows.length !== 1) {
     throw new McpAuthenticationError();
@@ -103,7 +105,10 @@ export const authenticateMcpAccessTokenWithDependencies = async (
     throw new McpAuthenticationError();
   }
 
-  const identity = await dependencies.loadTrustedUserIdentity(row.user_id);
+  const identity = await dependencies.loadTrustedUserIdentityBeforeDeadline(
+    row.user_id,
+    deadline,
+  );
   if (
     identity === null
     || identity.userId !== row.user_id
@@ -126,5 +131,11 @@ export const authenticateMcpAccessTokenWithDependencies = async (
 export const authenticateMcpAccessToken = (
   token: string,
   expectedResource: string,
+  deadline: SqlExecutionDeadline,
 ): Promise<AuthenticatedMcpAccessToken> =>
-  authenticateMcpAccessTokenWithDependencies(token, expectedResource, defaultDependencies);
+  authenticateMcpAccessTokenWithDependencies(
+    token,
+    expectedResource,
+    deadline,
+    defaultDependencies,
+  );

--- a/apps/sql-api/src/mcp/dataService.test.ts
+++ b/apps/sql-api/src/mcp/dataService.test.ts
@@ -2,10 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { QueryResult } from "pg";
 import {
+  createSqlExecutionDeadline,
+  MCP_SQL_STATEMENT_TIMEOUT_MS,
+  type SqlExecutionDeadline,
   validateSingleExpenseSql,
   validateSingleReadOnlyExpenseSql,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
-import type { QueryFn, UserIdentity } from "../db.js";
+import type { RestrictedQueryFn, UserIdentity } from "../db.js";
 import { createQueryResult } from "../handlerTestUtils.js";
 import {
   createMcpDataServices,
@@ -35,6 +38,14 @@ type DataCalls = {
   }>>;
   readContextWorkspaceIds: Array<string>;
   writeContextWorkspaceIds: Array<string>;
+  readStatementTimeouts: Array<number>;
+  writeStatementTimeouts: Array<number>;
+  readCommandTimeouts: Array<number>;
+  writeCommandTimeouts: Array<number>;
+  sqlLookupDeadlines: Array<SqlExecutionDeadline>;
+  workspaceQueryDeadlines: Array<SqlExecutionDeadline>;
+  readContextDeadlines: Array<SqlExecutionDeadline>;
+  writeContextDeadlines: Array<SqlExecutionDeadline>;
 };
 
 const createCalls = (): DataCalls => ({
@@ -42,6 +53,14 @@ const createCalls = (): DataCalls => ({
   workspaceQueries: [],
   readContextWorkspaceIds: [],
   writeContextWorkspaceIds: [],
+  readStatementTimeouts: [],
+  writeStatementTimeouts: [],
+  readCommandTimeouts: [],
+  writeCommandTimeouts: [],
+  sqlLookupDeadlines: [],
+  workspaceQueryDeadlines: [],
+  readContextDeadlines: [],
+  writeContextDeadlines: [],
 });
 
 const createRestrictedQueryResult = (sql: string): QueryResult => {
@@ -80,36 +99,59 @@ const createDependencies = (
   workspaceRows: ReadonlyArray<unknown>,
   calls: DataCalls,
 ): McpDataDependencies => ({
-  queryAsExistingTrustedIdentity: async (identity, text, params) => {
+  queryAsExistingTrustedIdentityBeforeDeadline: async (
+    identity,
+    text,
+    params,
+    deadline,
+  ) => {
     calls.userQueries.push({ userId: identity.userId, text, params });
+    calls.sqlLookupDeadlines.push(deadline);
     return createQueryResult(userRows);
   },
-  queryAsExistingTrustedWorkspace: async (identity, workspaceId, text, params) => {
+  queryAsExistingTrustedWorkspaceBeforeDeadline: async (
+    identity,
+    workspaceId,
+    text,
+    params,
+    deadline,
+  ) => {
     calls.workspaceQueries.push({
       userId: identity.userId,
       workspaceId,
       text,
       params,
     });
+    calls.workspaceQueryDeadlines.push(deadline);
     return createQueryResult(workspaceRows);
   },
   withNonProvisioningReadOnlyRestrictedTrustedIdentityContext: async <T>(
     _identity: UserIdentity,
     workspaceId: string,
-    _statementTimeoutMs: number,
-    callback: (queryFn: QueryFn) => Promise<T>,
+    deadline: SqlExecutionDeadline,
+    callback: (queryFn: RestrictedQueryFn) => Promise<T>,
   ): Promise<T> => {
     calls.readContextWorkspaceIds.push(workspaceId);
-    return callback(async (text): Promise<QueryResult> => createRestrictedQueryResult(text));
+    calls.readContextDeadlines.push(deadline);
+    calls.readStatementTimeouts.push(deadline.timeoutMs);
+    return callback(async (text, _params, statementTimeoutMs): Promise<QueryResult> => {
+      calls.readCommandTimeouts.push(statementTimeoutMs);
+      return createRestrictedQueryResult(text);
+    });
   },
   withRestrictedTrustedIdentityContext: async <T>(
     _identity: UserIdentity,
     workspaceId: string,
-    _statementTimeoutMs: number,
-    callback: (queryFn: QueryFn) => Promise<T>,
+    deadline: SqlExecutionDeadline,
+    callback: (queryFn: RestrictedQueryFn) => Promise<T>,
   ): Promise<T> => {
     calls.writeContextWorkspaceIds.push(workspaceId);
-    return callback(async (text): Promise<QueryResult> => createRestrictedQueryResult(text));
+    calls.writeContextDeadlines.push(deadline);
+    calls.writeStatementTimeouts.push(deadline.timeoutMs);
+    return callback(async (text, _params, statementTimeoutMs): Promise<QueryResult> => {
+      calls.writeCommandTimeouts.push(statementTimeoutMs);
+      return createRestrictedQueryResult(text);
+    });
   },
 });
 
@@ -117,11 +159,16 @@ test("MCP data services preserve zero workspaces without provisioning or write c
   const calls = createCalls();
   const services = createMcpDataServices(createDependencies([], [], calls));
 
-  const workspaces = await services.listWorkspaces(IDENTITY);
+  const executionDeadline = createSqlExecutionDeadline(
+    MCP_SQL_STATEMENT_TIMEOUT_MS,
+    Date.now,
+  );
+  const workspaces = await services.listWorkspaces(IDENTITY, executionDeadline);
   const queryResult = await services.runReadOnlySql(
     { identity: IDENTITY },
     WORKSPACE_ID,
     validateSingleReadOnlyExpenseSql("SELECT account_id FROM accounts"),
+    executionDeadline,
   );
 
   assert.deepEqual(workspaces, []);
@@ -132,6 +179,7 @@ test("MCP data services preserve zero workspaces without provisioning or write c
     assert.doesNotMatch(query.text, /\b(?:INSERT|UPDATE|DELETE)\b|ensure_/iu);
   }
   assert.deepEqual(calls.workspaceQueries, []);
+  assert.deepEqual(calls.sqlLookupDeadlines, [executionDeadline, executionDeadline]);
   assert.deepEqual(calls.readContextWorkspaceIds, []);
   assert.deepEqual(calls.writeContextWorkspaceIds, []);
 });
@@ -139,8 +187,9 @@ test("MCP data services preserve zero workspaces without provisioning or write c
 test("MCP workspace lookup requires exact existing user membership", async (): Promise<void> => {
   const calls = createCalls();
   const services = createMcpDataServices(createDependencies([], [], calls));
+  const deadline = createSqlExecutionDeadline(MCP_SQL_STATEMENT_TIMEOUT_MS, Date.now);
 
-  const workspace = await services.getWorkspace(IDENTITY, WORKSPACE_ID);
+  const workspace = await services.getWorkspace(IDENTITY, WORKSPACE_ID, deadline);
 
   assert.equal(workspace, null);
   assert.equal(calls.userQueries.length, 1);
@@ -148,19 +197,22 @@ test("MCP workspace lookup requires exact existing user membership", async (): P
   assert.match(calls.userQueries[0]?.text ?? "", /JOIN workspace_members/u);
   assert.deepEqual(calls.readContextWorkspaceIds, []);
   assert.deepEqual(calls.writeContextWorkspaceIds, []);
+  assert.deepEqual(calls.sqlLookupDeadlines, [deadline]);
 });
 
 test("MCP schema reads use only the existing workspace read context", async (): Promise<void> => {
   const calls = createCalls();
   const services = createMcpDataServices(createDependencies([], [], calls));
+  const deadline = createSqlExecutionDeadline(MCP_SQL_STATEMENT_TIMEOUT_MS, Date.now);
 
-  await services.loadAllowedSchemaForWorkspace(IDENTITY, WORKSPACE_ID);
+  await services.loadAllowedSchemaForWorkspace(IDENTITY, WORKSPACE_ID, deadline);
 
   assert.deepEqual(calls.userQueries, []);
   assert.equal(calls.workspaceQueries.length, 1);
   assert.equal(calls.workspaceQueries[0]?.userId, IDENTITY.userId);
   assert.equal(calls.workspaceQueries[0]?.workspaceId, WORKSPACE_ID);
   assert.match(calls.workspaceQueries[0]?.text ?? "", /FROM information_schema[.]columns/u);
+  assert.deepEqual(calls.workspaceQueryDeadlines, [deadline]);
   assert.deepEqual(calls.readContextWorkspaceIds, []);
   assert.deepEqual(calls.writeContextWorkspaceIds, []);
 });
@@ -172,20 +224,38 @@ test("MCP SQL routes reads through the non-provisioning reader and writes throug
     [],
     calls,
   ));
+  const readDeadline = createSqlExecutionDeadline(MCP_SQL_STATEMENT_TIMEOUT_MS, Date.now);
+  const writeDeadline = createSqlExecutionDeadline(MCP_SQL_STATEMENT_TIMEOUT_MS, Date.now);
 
   await services.runReadOnlySql(
     { identity: IDENTITY },
     WORKSPACE_ID,
     validateSingleReadOnlyExpenseSql("SELECT account_id FROM accounts"),
+    readDeadline,
   );
   await services.runSql(
     { identity: IDENTITY },
     WORKSPACE_ID,
     validateSingleExpenseSql("DELETE FROM budget_lines WHERE category = 'Food'"),
+    writeDeadline,
   );
 
   assert.deepEqual(calls.readContextWorkspaceIds, [WORKSPACE_ID]);
   assert.deepEqual(calls.writeContextWorkspaceIds, [WORKSPACE_ID]);
+  assert.deepEqual(calls.readStatementTimeouts, [MCP_SQL_STATEMENT_TIMEOUT_MS]);
+  assert.deepEqual(calls.writeStatementTimeouts, [MCP_SQL_STATEMENT_TIMEOUT_MS]);
+  assert.deepEqual(calls.sqlLookupDeadlines, [readDeadline, writeDeadline]);
+  assert.deepEqual(calls.readContextDeadlines, [readDeadline]);
+  assert.deepEqual(calls.writeContextDeadlines, [writeDeadline]);
+  assert.equal(calls.readCommandTimeouts.length, 4);
+  assert.equal(calls.writeCommandTimeouts.length, 1);
+  assert.equal([
+    ...calls.readCommandTimeouts,
+    ...calls.writeCommandTimeouts,
+  ].every(
+    (statementTimeoutMs) => statementTimeoutMs > 0
+      && statementTimeoutMs <= MCP_SQL_STATEMENT_TIMEOUT_MS,
+  ), true);
   assert.equal(calls.userQueries.length, 2);
   assert.deepEqual(calls.userQueries.map((query) => query.params), [
     [WORKSPACE_ID, IDENTITY.userId],

--- a/apps/sql-api/src/mcp/dataService.ts
+++ b/apps/sql-api/src/mcp/dataService.ts
@@ -1,10 +1,11 @@
 import type {
+  SqlExecutionDeadline,
   ValidatedExpenseSql,
   ValidatedReadOnlyExpenseSql,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
 import {
-  queryAsExistingTrustedIdentity,
-  queryAsExistingTrustedWorkspace,
+  queryAsExistingTrustedIdentityBeforeDeadline,
+  queryAsExistingTrustedWorkspaceBeforeDeadline,
   type UserIdentity,
   withNonProvisioningReadOnlyRestrictedTrustedIdentityContext,
   withRestrictedTrustedIdentityContext,
@@ -25,43 +26,70 @@ import {
 } from "../machineApi/workspaceService.js";
 
 export type McpDataDependencies = Readonly<{
-  queryAsExistingTrustedIdentity: typeof queryAsExistingTrustedIdentity;
-  queryAsExistingTrustedWorkspace: typeof queryAsExistingTrustedWorkspace;
+  queryAsExistingTrustedIdentityBeforeDeadline: typeof queryAsExistingTrustedIdentityBeforeDeadline;
+  queryAsExistingTrustedWorkspaceBeforeDeadline: typeof queryAsExistingTrustedWorkspaceBeforeDeadline;
   withNonProvisioningReadOnlyRestrictedTrustedIdentityContext: typeof withNonProvisioningReadOnlyRestrictedTrustedIdentityContext;
   withRestrictedTrustedIdentityContext: typeof withRestrictedTrustedIdentityContext;
 }>;
 
 export type McpDataServices = Readonly<{
-  listWorkspaces: (identity: UserIdentity) => Promise<ReadonlyArray<WorkspaceSummary>>;
-  getWorkspace: (identity: UserIdentity, workspaceId: string) => Promise<WorkspaceSummary | null>;
-  loadAllowedSchemaForWorkspace: (identity: UserIdentity, workspaceId: string) => Promise<ReadonlyArray<SchemaRelation>>;
+  listWorkspaces: (
+    identity: UserIdentity,
+    deadline: SqlExecutionDeadline,
+  ) => Promise<ReadonlyArray<WorkspaceSummary>>;
+  getWorkspace: (
+    identity: UserIdentity,
+    workspaceId: string,
+    deadline: SqlExecutionDeadline,
+  ) => Promise<WorkspaceSummary | null>;
+  loadAllowedSchemaForWorkspace: (
+    identity: UserIdentity,
+    workspaceId: string,
+    deadline: SqlExecutionDeadline,
+  ) => Promise<ReadonlyArray<SchemaRelation>>;
   runReadOnlySql: (
     authenticated: TrustedIdentityContext,
     workspaceId: string,
     validated: ValidatedReadOnlyExpenseSql,
+    deadline: SqlExecutionDeadline,
   ) => Promise<Readonly<Record<string, unknown>> | null>;
   runSql: (
     authenticated: TrustedIdentityContext,
     workspaceId: string,
     validated: ValidatedExpenseSql,
+    deadline: SqlExecutionDeadline,
   ) => Promise<Readonly<Record<string, unknown>> | null>;
 }>;
 
 export const createMcpDataServices = (
   dependencies: McpDataDependencies,
 ): McpDataServices => {
-  const listWorkspaces = (identity: UserIdentity): Promise<ReadonlyArray<WorkspaceSummary>> =>
+  const listWorkspaces = (
+    identity: UserIdentity,
+    deadline: SqlExecutionDeadline,
+  ): Promise<ReadonlyArray<WorkspaceSummary>> =>
     listWorkspacesWithQuery(
-      (text, params) => dependencies.queryAsExistingTrustedIdentity(identity, text, params),
+      (text, params) => dependencies.queryAsExistingTrustedIdentityBeforeDeadline(
+        identity,
+        text,
+        params,
+        deadline,
+      ),
       identity,
     );
 
   const getWorkspace = (
     identity: UserIdentity,
     workspaceId: string,
+    deadline: SqlExecutionDeadline,
   ): Promise<WorkspaceSummary | null> =>
     getWorkspaceWithQuery(
-      (text, params) => dependencies.queryAsExistingTrustedIdentity(identity, text, params),
+      (text, params) => dependencies.queryAsExistingTrustedIdentityBeforeDeadline(
+        identity,
+        text,
+        params,
+        deadline,
+      ),
       identity,
       workspaceId,
     );
@@ -69,13 +97,15 @@ export const createMcpDataServices = (
   const loadAllowedSchemaForWorkspace = (
     identity: UserIdentity,
     workspaceId: string,
+    deadline: SqlExecutionDeadline,
   ): Promise<ReadonlyArray<SchemaRelation>> =>
     loadAllowedSchemaWithQuery(
-      (text, params) => dependencies.queryAsExistingTrustedWorkspace(
+      (text, params) => dependencies.queryAsExistingTrustedWorkspaceBeforeDeadline(
         identity,
         workspaceId,
         text,
         params,
+        deadline,
       ),
     );
 
@@ -83,11 +113,13 @@ export const createMcpDataServices = (
     authenticated: TrustedIdentityContext,
     workspaceId: string,
     validated: ValidatedReadOnlyExpenseSql,
+    deadline: SqlExecutionDeadline,
   ): Promise<Readonly<Record<string, unknown>> | null> =>
     runReadOnlySqlWithServices(
       authenticated,
       workspaceId,
       validated,
+      deadline,
       getWorkspace,
       dependencies.withNonProvisioningReadOnlyRestrictedTrustedIdentityContext,
     );
@@ -96,11 +128,13 @@ export const createMcpDataServices = (
     authenticated: TrustedIdentityContext,
     workspaceId: string,
     validated: ValidatedExpenseSql,
+    deadline: SqlExecutionDeadline,
   ): Promise<Readonly<Record<string, unknown>> | null> =>
     runSqlWithServices(
       authenticated,
       workspaceId,
       validated,
+      deadline,
       getWorkspace,
       dependencies.withRestrictedTrustedIdentityContext,
     );
@@ -115,8 +149,8 @@ export const createMcpDataServices = (
 };
 
 export const mcpDataServices = createMcpDataServices({
-  queryAsExistingTrustedIdentity,
-  queryAsExistingTrustedWorkspace,
+  queryAsExistingTrustedIdentityBeforeDeadline,
+  queryAsExistingTrustedWorkspaceBeforeDeadline,
   withNonProvisioningReadOnlyRestrictedTrustedIdentityContext,
   withRestrictedTrustedIdentityContext,
 });

--- a/apps/sql-api/src/mcp/results.test.ts
+++ b/apps/sql-api/src/mcp/results.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { SqlExecutionDeadlineError } from "@expense-budget-tracker/agent-shared/sql-policy";
 import type { SqlApiLogEvent } from "../logger.js";
-import { UserSqlExecutionError } from "../machineApi/sqlService.js";
+import {
+  AmbiguousSqlMutationOutcomeError,
+  UserSqlExecutionError,
+} from "../machineApi/sqlService.js";
 import { buildMcpToolErrorResultWithDependencies } from "./results.js";
 
 type JsonObject = Readonly<Record<string, unknown>>;
@@ -40,6 +44,36 @@ test("MCP error results preserve actionable user SQL errors", (): void => {
   assert.equal(error["code"], "sql_execution_failed");
   assert.equal(error["message"], "column amountt does not exist");
   assert.deepEqual(logEvents, []);
+});
+
+test("MCP error results expose an actionable total request deadline without logging it as unexpected", (): void => {
+  const logEvents: Array<SqlApiLogEvent> = [];
+  const payload = readResultPayload(buildMcpToolErrorResultWithDependencies(
+    new SqlExecutionDeadlineError(20_000),
+    "sql_query",
+    { log: (event) => logEvents.push(event) },
+  ));
+  const error = payload["error"] as JsonObject;
+
+  assert.equal(error["code"], "request_deadline_exceeded");
+  assert.deepEqual(error["details"], { timeoutMs: 20_000, retryable: true });
+  assert.match(payload["instructions"] as string, /safe to retry/u);
+  assert.deepEqual(logEvents, []);
+});
+
+test("bare sql_execute deadline errors are explicitly safe to retry", (): void => {
+  const payload = readResultPayload(buildMcpToolErrorResultWithDependencies(
+    new SqlExecutionDeadlineError(20_000),
+    "sql_execute",
+    { log: () => undefined },
+  ));
+  const error = payload["error"] as JsonObject;
+
+  assert.equal(error["code"], "request_deadline_exceeded");
+  assert.deepEqual(error["details"], { timeoutMs: 20_000, retryable: true });
+  assert.match(payload["instructions"] as string, /Retry sql_execute/u);
+  assert.match(payload["instructions"] as string, /before the mutation was dispatched/u);
+  assert.doesNotMatch(payload["instructions"] as string, /verify whether it applied/u);
 });
 
 test("MCP error results sanitize untagged PostgreSQL failures", (): void => {
@@ -88,7 +122,7 @@ test("MCP error results sanitize and structurally log unexpected failures", (): 
   }]);
 });
 
-test("unexpected sql_execute errors warn against blind mutation retries", (): void => {
+test("only explicitly ambiguous sql_execute errors require state verification", (): void => {
   const databaseError = Object.assign(
     new Error("duplicate key value exposes internal_constraint"),
     { code: "23505" },
@@ -105,6 +139,20 @@ test("unexpected sql_execute errors warn against blind mutation retries", (): vo
   assert.equal(error["code"], "internal_error");
   assert.equal(serialized.includes("internal_constraint"), false);
   assert.equal(typeof instructions, "string");
-  assert.match(instructions as string, /Do not blindly retry/u);
-  assert.match(instructions as string, /Use sql_query to verify/u);
+  assert.match(instructions as string, /Retry sql_execute once/u);
+  assert.doesNotMatch(instructions as string, /Use sql_query to verify/u);
+});
+
+test("ambiguous sql_execute outcomes remain non-retryable until state is verified", (): void => {
+  const payload = readResultPayload(buildMcpToolErrorResultWithDependencies(
+    new AmbiguousSqlMutationOutcomeError(new SqlExecutionDeadlineError(20_000)),
+    "sql_execute",
+    { log: () => undefined },
+  ));
+  const error = payload["error"] as JsonObject;
+
+  assert.equal(error["code"], "sql_mutation_outcome_unknown");
+  assert.deepEqual(error["details"], { outcome: "unknown", retryable: false });
+  assert.match(payload["instructions"] as string, /Do not blindly retry/u);
+  assert.match(payload["instructions"] as string, /Use sql_query to verify/u);
 });

--- a/apps/sql-api/src/mcp/results.ts
+++ b/apps/sql-api/src/mcp/results.ts
@@ -1,7 +1,11 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { SqlPolicyError } from "@expense-budget-tracker/agent-shared/sql-policy";
+import {
+  SqlExecutionDeadlineError,
+  SqlPolicyError,
+} from "@expense-budget-tracker/agent-shared/sql-policy";
 import { getSafeErrorType, log } from "../logger.js";
 import {
+  isAmbiguousSqlMutationOutcomeError,
   getUserSqlExecutionMessage,
   isUserSqlExecutionError,
 } from "../machineApi/sqlService.js";
@@ -52,6 +56,9 @@ const getSqlPolicyInstructions = (error: SqlPolicyError, toolName: string): stri
   if (error.code === "read_only_sql_required") {
     return "Send reads to sql_query and approved INSERT, UPDATE, or DELETE statements to sql_execute.";
   }
+  if (error.code === "mutation_sql_required") {
+    return "Send SELECT and WITH...SELECT statements to sql_query. Call sql_execute only with an approved INSERT, UPDATE, or DELETE mutation.";
+  }
   if (
     error.code === "mutation_statement_row_limit_exceeded"
     || error.code === "mutation_request_row_limit_exceeded"
@@ -83,9 +90,15 @@ const buildMcpErrorContent = (
 });
 
 const getUnexpectedErrorInstructions = (toolName: string): string =>
+  `Retry ${toolName} once. If it fails again, stop and report the server error.`;
+
+const getDeadlineInstructions = (toolName: string): string =>
   toolName === "sql_execute"
-    ? "Do not blindly retry the mutation. Use sql_query to verify whether it applied, and retry sql_execute only if the change is confirmed absent."
-    : `Retry ${toolName} once. If it fails again, stop and report the server error.`;
+    ? "Retry sql_execute. The deadline expired before the mutation was dispatched, so no mutation was applied."
+    : `Retry ${toolName}. This deadline failure is safe to retry because it cannot have applied a mutation.`;
+
+const getAmbiguousMutationInstructions = (): string =>
+  "Do not blindly retry the mutation. Use sql_query to verify whether it applied, and retry sql_execute only if the change is confirmed absent.";
 
 export const buildMcpToolErrorResultWithDependencies = (
   error: unknown,
@@ -102,6 +115,24 @@ export const buildMcpToolErrorResultWithDependencies = (
       error.message,
       getSqlPolicyInstructions(error, toolName),
       {},
+    );
+  }
+
+  if (error instanceof SqlExecutionDeadlineError) {
+    return buildMcpErrorContent(
+      "request_deadline_exceeded",
+      `The MCP request exceeded its ${String(error.timeoutMs)} ms total execution deadline`,
+      getDeadlineInstructions(toolName),
+      { timeoutMs: error.timeoutMs, retryable: true },
+    );
+  }
+
+  if (isAmbiguousSqlMutationOutcomeError(error)) {
+    return buildMcpErrorContent(
+      "sql_mutation_outcome_unknown",
+      error.message,
+      getAmbiguousMutationInstructions(),
+      { outcome: "unknown", retryable: false },
     );
   }
 

--- a/apps/sql-api/src/mcp/server.test.ts
+++ b/apps/sql-api/src/mcp/server.test.ts
@@ -3,9 +3,14 @@ import test from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
-  validateSingleExpenseSql,
+  createSqlExecutionDeadline,
+  MCP_SQL_STATEMENT_TIMEOUT_MS,
+  SqlExecutionDeadlineError,
+  type SqlExecutionDeadline,
+  validateSingleMutationExpenseSql,
   validateSingleReadOnlyExpenseSql,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
+import { SqlTransactionOutcomeUnknownError } from "../dbDeadline.js";
 import type { AuthenticatedMcpAccessToken } from "./auth.js";
 import {
   createMcpServerWithDependencies,
@@ -21,6 +26,10 @@ type ToolCalls = {
   schemaWorkspaceIds: Array<string>;
   queriedWorkspaceIds: Array<string>;
   executedWorkspaceIds: Array<string>;
+  workspaceDeadlines: Array<SqlExecutionDeadline>;
+  schemaDeadlines: Array<SqlExecutionDeadline>;
+  queryDeadlines: Array<SqlExecutionDeadline>;
+  executeDeadlines: Array<SqlExecutionDeadline>;
 };
 
 type JsonObject = Readonly<Record<string, unknown>>;
@@ -69,8 +78,9 @@ const createDependencies = (
   workspaceIds: ReadonlyArray<string>,
   calls: ToolCalls,
 ): McpServerDependencies => ({
-  listWorkspaces: async (identity) => {
+  listWorkspaces: async (identity, deadline) => {
     calls.listedUserIds.push(identity.userId);
+    calls.workspaceDeadlines.push(deadline);
     return workspaceIds.map((workspaceId) => ({
       workspaceId,
       name: workspaceId === PERSONAL_WORKSPACE_ID ? "Personal" : "Business",
@@ -86,21 +96,24 @@ const createDependencies = (
       name: workspaceId === PERSONAL_WORKSPACE_ID ? "Personal" : "Business",
     };
   },
-  loadAllowedSchemaForWorkspace: async (_identity, workspaceId) => {
+  loadAllowedSchemaForWorkspace: async (_identity, workspaceId, deadline) => {
     calls.schemaWorkspaceIds.push(workspaceId);
+    calls.schemaDeadlines.push(deadline);
     return [];
   },
   validateSingleReadOnlyExpenseSql,
-  validateSingleExpenseSql,
-  runReadOnlySql: async (_authenticated, workspaceId, validated) => {
+  validateSingleMutationExpenseSql,
+  runReadOnlySql: async (_authenticated, workspaceId, validated, deadline) => {
     calls.queriedWorkspaceIds.push(workspaceId);
+    calls.queryDeadlines.push(deadline);
     return {
       statements: [{ sql: validated.sql, rows: [{ amount: "10.00" }] }],
       workspace: { workspaceId, name: "Personal" },
     };
   },
-  runSql: async (_authenticated, workspaceId, validated) => {
+  runSql: async (_authenticated, workspaceId, validated, deadline) => {
     calls.executedWorkspaceIds.push(workspaceId);
+    calls.executeDeadlines.push(deadline);
     return {
       statements: [{ sql: validated.sql, command: "INSERT", rowCount: 1 }],
       workspace: { workspaceId, name: "Personal" },
@@ -114,6 +127,10 @@ const createCalls = (): ToolCalls => ({
   schemaWorkspaceIds: [],
   queriedWorkspaceIds: [],
   executedWorkspaceIds: [],
+  workspaceDeadlines: [],
+  schemaDeadlines: [],
+  queryDeadlines: [],
+  executeDeadlines: [],
 });
 
 const withClient = async (
@@ -121,7 +138,8 @@ const withClient = async (
   dependencies: McpServerDependencies,
   callback: (client: Client) => Promise<void>,
 ): Promise<void> => {
-  const server = createMcpServerWithDependencies(connection, dependencies);
+  const deadline = createSqlExecutionDeadline(MCP_SQL_STATEMENT_TIMEOUT_MS, () => 10_000);
+  const server = createMcpServerWithDependencies(connection, deadline, dependencies);
   const client = new Client({ name: "mcp-server-test", version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await server.connect(serverTransport);
@@ -196,6 +214,18 @@ test("MCP server registers four annotated tools and routes explicit workspaces",
   assert.deepEqual(calls.schemaWorkspaceIds, [BUSINESS_WORKSPACE_ID]);
   assert.deepEqual(calls.queriedWorkspaceIds, [PERSONAL_WORKSPACE_ID]);
   assert.deepEqual(calls.executedWorkspaceIds, [BUSINESS_WORKSPACE_ID]);
+  assert.equal(calls.workspaceDeadlines.length, 4);
+  assert.equal(calls.schemaDeadlines[0], calls.workspaceDeadlines[1]);
+  assert.equal(calls.queryDeadlines[0], calls.workspaceDeadlines[2]);
+  assert.equal(calls.executeDeadlines[0], calls.workspaceDeadlines[3]);
+  assert.deepEqual(
+    calls.workspaceDeadlines.map((deadline) => deadline.timeoutMs),
+    Array.from({ length: 4 }, () => MCP_SQL_STATEMENT_TIMEOUT_MS),
+  );
+  assert.equal(
+    calls.workspaceDeadlines.every((deadline) => deadline === calls.workspaceDeadlines[0]),
+    true,
+  );
 });
 
 test("MCP tools require explicit workspace membership when selection is ambiguous", async (): Promise<void> => {
@@ -221,6 +251,10 @@ test("MCP tools require explicit workspace membership when selection is ambiguou
   );
   assert.deepEqual(calls.schemaWorkspaceIds, []);
   assert.deepEqual(calls.queriedWorkspaceIds, []);
+  assert.deepEqual(
+    calls.workspaceDeadlines.map((deadline) => deadline.timeoutMs),
+    [MCP_SQL_STATEMENT_TIMEOUT_MS, MCP_SQL_STATEMENT_TIMEOUT_MS],
+  );
 });
 
 test("MCP read tools preserve an empty workspace list without provisioning state", async (): Promise<void> => {
@@ -252,6 +286,14 @@ test("MCP read tools preserve an empty workspace list without provisioning state
   assert.deepEqual(calls.schemaWorkspaceIds, []);
   assert.deepEqual(calls.queriedWorkspaceIds, []);
   assert.deepEqual(calls.executedWorkspaceIds, []);
+  assert.deepEqual(
+    calls.workspaceDeadlines.map((deadline) => deadline.timeoutMs),
+    [
+      MCP_SQL_STATEMENT_TIMEOUT_MS,
+      MCP_SQL_STATEMENT_TIMEOUT_MS,
+      MCP_SQL_STATEMENT_TIMEOUT_MS,
+    ],
+  );
 });
 
 test("MCP tools enforce read and write scopes before service execution", async (): Promise<void> => {
@@ -300,6 +342,62 @@ test("sql_query preserves read-only policy errors without calling the SQL runner
     },
   );
   assert.deepEqual(calls.queriedWorkspaceIds, []);
+  assert.deepEqual(calls.workspaceDeadlines, []);
+});
+
+test("readonly MCP tools unwrap transaction deadline uncertainty as request deadlines", async (): Promise<void> => {
+  const calls = createCalls();
+  const dependencies: McpServerDependencies = {
+    ...createDependencies([PERSONAL_WORKSPACE_ID], calls),
+    listWorkspaces: async () => {
+      throw new SqlTransactionOutcomeUnknownError(
+        "commit",
+        new SqlExecutionDeadlineError(MCP_SQL_STATEMENT_TIMEOUT_MS),
+        "unknown",
+        undefined,
+      );
+    },
+  };
+
+  await withClient(
+    createConnection(["expenses:read"]),
+    dependencies,
+    async (client): Promise<void> => {
+      const result = await client.callTool({ name: "list_workspaces", arguments: {} });
+      const payload = parseToolPayload(result);
+      const error = payload["error"];
+      assert.ok(isJsonObject(error));
+      assert.equal(result.isError, true);
+      assert.equal(error["code"], "request_deadline_exceeded");
+      assert.deepEqual(error["details"], { timeoutMs: 20_000, retryable: true });
+    },
+  );
+});
+
+test("sql_execute rejects readonly SQL before workspace resolution or execution", async (): Promise<void> => {
+  const calls = createCalls();
+  await withClient(
+    createConnection(["expenses:write"]),
+    createDependencies([PERSONAL_WORKSPACE_ID], calls),
+    async (client): Promise<void> => {
+      for (const sql of [
+        "SELECT account_id FROM accounts",
+        "WITH target AS (SELECT account_id FROM accounts) SELECT account_id FROM target",
+      ]) {
+        const result = await client.callTool({
+          name: "sql_execute",
+          arguments: { sql },
+        });
+        const payload = parseToolPayload(result);
+        assert.equal(result.isError, true);
+        assert.equal(readErrorCode(payload), "mutation_sql_required");
+        assert.match(payload["instructions"] as string, /sql_query/u);
+      }
+    },
+  );
+
+  assert.deepEqual(calls.executedWorkspaceIds, []);
+  assert.deepEqual(calls.workspaceDeadlines, []);
 });
 
 test("MCP SQL tools reject multi-statement input before either runner is called", async (): Promise<void> => {
@@ -330,4 +428,5 @@ test("MCP SQL tools reject multi-statement input before either runner is called"
 
   assert.deepEqual(calls.queriedWorkspaceIds, []);
   assert.deepEqual(calls.executedWorkspaceIds, []);
+  assert.deepEqual(calls.workspaceDeadlines, []);
 });

--- a/apps/sql-api/src/mcp/server.ts
+++ b/apps/sql-api/src/mcp/server.ts
@@ -2,11 +2,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
   MAX_SQL_ROWS,
-  SQL_STATEMENT_TIMEOUT_MS,
-  validateSingleExpenseSql,
+  MCP_SQL_STATEMENT_TIMEOUT_MS,
+  validateSingleMutationExpenseSql,
   validateSingleReadOnlyExpenseSql,
+  type SqlExecutionDeadline,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
 import { z } from "zod";
+import { getReadOnlyTransactionDeadlineError } from "../dbDeadline.js";
 import type { WorkspaceSummary } from "../machineApi/types.js";
 import type { AuthenticatedMcpAccessToken } from "./auth.js";
 import type { McpScope } from "./config.js";
@@ -18,11 +20,15 @@ import {
 } from "./results.js";
 
 const SERVER_NAME = "expense-budget-tracker";
-const SERVER_VERSION = "v1";
+const SERVER_VERSION = "1.2.0";
 const LIST_WORKSPACES_TOOL_NAME = "list_workspaces";
 const GET_SCHEMA_TOOL_NAME = "get_schema";
 const SQL_QUERY_TOOL_NAME = "sql_query";
 const SQL_EXECUTE_TOOL_NAME = "sql_execute";
+type ReadOnlyMcpToolName =
+  | typeof LIST_WORKSPACES_TOOL_NAME
+  | typeof GET_SCHEMA_TOOL_NAME
+  | typeof SQL_QUERY_TOOL_NAME;
 
 const workspaceIdSchema = z.string().trim().min(1).optional().describe(
   "Optional workspaceId returned by list_workspaces. Omit only when exactly one workspace is available.",
@@ -30,13 +36,13 @@ const workspaceIdSchema = z.string().trim().min(1).optional().describe(
 
 export type McpServerDependencies = McpDataServices & Readonly<{
   validateSingleReadOnlyExpenseSql: typeof validateSingleReadOnlyExpenseSql;
-  validateSingleExpenseSql: typeof validateSingleExpenseSql;
+  validateSingleMutationExpenseSql: typeof validateSingleMutationExpenseSql;
 }>;
 
 const defaultDependencies: McpServerDependencies = {
   ...mcpDataServices,
   validateSingleReadOnlyExpenseSql,
-  validateSingleExpenseSql,
+  validateSingleMutationExpenseSql,
 };
 
 const requireScope = (
@@ -53,12 +59,10 @@ const requireScope = (
   }
 };
 
-const resolveWorkspace = async (
-  connection: AuthenticatedMcpAccessToken,
+const selectWorkspace = (
+  workspaces: ReadonlyArray<WorkspaceSummary>,
   requestedWorkspaceId: string | undefined,
-  dependencies: McpServerDependencies,
-): Promise<WorkspaceSummary> => {
-  const workspaces = await dependencies.listWorkspaces(connection.identity);
+): WorkspaceSummary => {
   if (requestedWorkspaceId !== undefined) {
     const requestedWorkspace = workspaces.find(
       (workspace) => workspace.workspaceId === requestedWorkspaceId,
@@ -99,6 +103,16 @@ const resolveWorkspace = async (
   return onlyWorkspace;
 };
 
+const resolveWorkspace = async (
+  connection: AuthenticatedMcpAccessToken,
+  requestedWorkspaceId: string | undefined,
+  dependencies: McpServerDependencies,
+  deadline: SqlExecutionDeadline,
+): Promise<WorkspaceSummary> => selectWorkspace(
+  await dependencies.listWorkspaces(connection.identity, deadline),
+  requestedWorkspaceId,
+);
+
 const requireSqlResult = (
   result: Readonly<Record<string, unknown>> | null,
   workspaceId: string,
@@ -114,6 +128,14 @@ const requireSqlResult = (
   return result;
 };
 
+const buildReadOnlyMcpToolErrorResult = (
+  error: unknown,
+  toolName: ReadOnlyMcpToolName,
+): CallToolResult => buildMcpToolErrorResult(
+  getReadOnlyTransactionDeadlineError(error) ?? error,
+  toolName,
+);
+
 const getWorkspaceListInstructions = (workspaceCount: number): string => {
   if (workspaceCount === 0) {
     return "No workspaces are available. Create one in Expense Budget Tracker or ask a workspace owner to add you, then call list_workspaces again.";
@@ -126,6 +148,7 @@ const getWorkspaceListInstructions = (workspaceCount: number): string => {
 
 export const createMcpServerWithDependencies = (
   connection: AuthenticatedMcpAccessToken,
+  deadline: SqlExecutionDeadline,
   dependencies: McpServerDependencies,
 ): McpServer => {
   const server = new McpServer(
@@ -155,13 +178,13 @@ export const createMcpServerWithDependencies = (
     async (): Promise<CallToolResult> => {
       try {
         requireScope(connection, "expenses:read");
-        const workspaces = await dependencies.listWorkspaces(connection.identity);
+        const workspaces = await dependencies.listWorkspaces(connection.identity, deadline);
         return buildMcpSuccessResult(
           { workspaces },
           getWorkspaceListInstructions(workspaces.length),
         );
       } catch (error) {
-        return buildMcpToolErrorResult(error, LIST_WORKSPACES_TOOL_NAME);
+        return buildReadOnlyMcpToolErrorResult(error, LIST_WORKSPACES_TOOL_NAME);
       }
     },
   );
@@ -182,10 +205,16 @@ export const createMcpServerWithDependencies = (
     async ({ workspaceId }): Promise<CallToolResult> => {
       try {
         requireScope(connection, "expenses:read");
-        const workspace = await resolveWorkspace(connection, workspaceId, dependencies);
+        const workspace = await resolveWorkspace(
+          connection,
+          workspaceId,
+          dependencies,
+          deadline,
+        );
         const relations = await dependencies.loadAllowedSchemaForWorkspace(
           connection.identity,
           workspace.workspaceId,
+          deadline,
         );
         return buildMcpSuccessResult(
           {
@@ -193,13 +222,13 @@ export const createMcpServerWithDependencies = (
             relations,
             limits: {
               maxRows: MAX_SQL_ROWS,
-              statementTimeoutMs: SQL_STATEMENT_TIMEOUT_MS,
+              statementTimeoutMs: MCP_SQL_STATEMENT_TIMEOUT_MS,
             },
           },
           "Use only the returned relations and columns. Send reads to sql_query and approved mutations to sql_execute.",
         );
       } catch (error) {
-        return buildMcpToolErrorResult(error, GET_SCHEMA_TOOL_NAME);
+        return buildReadOnlyMcpToolErrorResult(error, GET_SCHEMA_TOOL_NAME);
       }
     },
   );
@@ -223,19 +252,25 @@ export const createMcpServerWithDependencies = (
     async ({ sql, workspaceId }): Promise<CallToolResult> => {
       try {
         requireScope(connection, "expenses:read");
-        const workspace = await resolveWorkspace(connection, workspaceId, dependencies);
         const validated = dependencies.validateSingleReadOnlyExpenseSql(sql);
+        const workspace = await resolveWorkspace(
+          connection,
+          workspaceId,
+          dependencies,
+          deadline,
+        );
         const result = await dependencies.runReadOnlySql(
           { identity: connection.identity },
           workspace.workspaceId,
           validated,
+          deadline,
         );
         return buildMcpSuccessResult(
           requireSqlResult(result, workspace.workspaceId),
           "Use the returned rows and truncation metadata to answer the request. Narrow and retry if truncated data is insufficient.",
         );
       } catch (error) {
-        return buildMcpToolErrorResult(error, SQL_QUERY_TOOL_NAME);
+        return buildReadOnlyMcpToolErrorResult(error, SQL_QUERY_TOOL_NAME);
       }
     },
   );
@@ -259,12 +294,18 @@ export const createMcpServerWithDependencies = (
     async ({ sql, workspaceId }): Promise<CallToolResult> => {
       try {
         requireScope(connection, "expenses:write");
-        const workspace = await resolveWorkspace(connection, workspaceId, dependencies);
-        const validated = dependencies.validateSingleExpenseSql(sql);
+        const validated = dependencies.validateSingleMutationExpenseSql(sql);
+        const workspace = await resolveWorkspace(
+          connection,
+          workspaceId,
+          dependencies,
+          deadline,
+        );
         const result = await dependencies.runSql(
           { identity: connection.identity },
           workspace.workspaceId,
           validated,
+          deadline,
         );
         return buildMcpSuccessResult(
           requireSqlResult(result, workspace.workspaceId),
@@ -281,4 +322,5 @@ export const createMcpServerWithDependencies = (
 
 export const createMcpServer = (
   connection: AuthenticatedMcpAccessToken,
-): McpServer => createMcpServerWithDependencies(connection, defaultDependencies);
+  deadline: SqlExecutionDeadline,
+): McpServer => createMcpServerWithDependencies(connection, deadline, defaultDependencies);

--- a/apps/web/src/server/agent/discovery.ts
+++ b/apps/web/src/server/agent/discovery.ts
@@ -31,10 +31,14 @@ const getAuthBaseUrl = (request: Request): string => {
 export const buildAgentDiscoveryEnvelope = (request: Request): AgentEnvelope => {
   const apiBaseUrl = getApiBaseUrl(request);
   const authBaseUrl = getAuthBaseUrl(request);
+  const mcpUrl = new URL(apiBaseUrl);
+  mcpUrl.hostname = mcpUrl.hostname.replace(/^api\./u, "mcp.");
+  mcpUrl.pathname = "/mcp";
 
   return buildSharedAgentDiscoveryEnvelope({
     apiBaseUrl,
     authBaseUrl,
     bootstrapUrl: `${authBaseUrl}/api/agent/send-code`,
+    mcpUrl: mcpUrl.toString(),
   });
 };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@
 Four components, one database:
 
 1. **web** (`apps/web/`) — Next.js 16 app. Serves the UI and exposes API routes for transactions, balances, budget, and FX data. All SQL runs against Postgres via a shared `pg.Pool` with per-request RLS context.
-2. **sql-api** (`apps/sql-api/`) — Two AWS Lambdas behind API Gateway (REST API) for machine clients. Lambda Authorizer validates `ApiKey` agent tokens; the handler serves discovery, workspace setup, and SQL with the same v1 machine surface. Separate from the web stack — no ALB involved.
+2. **sql-api** (`apps/sql-api/`) — Three AWS Lambdas: the `ApiKey` authorizer and v1 machine handler use the existing API Gateway REST API, while the dedicated OAuth-authenticated MCP handler uses a separate API Gateway HTTP API v2 at `mcp.*`. Separate from the web stack — no ALB involved.
 3. **worker** (`apps/worker/`) — TypeScript process that fetches daily raw exchange rates from ECB, CBR, NBS, NBU, and USDT, stores them in `fx_rates_raw`, and rebuilds query-ready all-pairs daily rates in `fx_rates_daily`. Runs on a schedule (local Docker) or as a Lambda (AWS).
 4. **Postgres** — single source of truth with workspace-scoped RLS and derived reporting views.
 
@@ -99,10 +99,13 @@ Machine clients (LLM agents, scripts, dashboards) use a separate path from the b
 
 ```
 Machine: Cloudflare → API Gateway (REST API) → Lambda Authorizer → SQL Lambda → RDS
+MCP: Cloudflare → dedicated API Gateway (HTTP API v2) → MCP Lambda → RDS
 Browser: Cloudflare → ALB → ECS (Next.js, Cognito Email OTP) → RDS
 ```
 
-The SQL API runs on API Gateway (REST API) with its own domain (`api.example.com`), fully separate from the ALB. This provides per-key rate limiting via Usage Plans (10 req/s, 10k req/day per key), auth at the gateway (Lambda Authorizer with 5-min cache), CloudWatch metrics per endpoint, and a clean boundary for future machine-facing services.
+The SQL API runs on API Gateway (REST API) with its own domain (`api.example.com`), fully separate from the ALB. This provides per-key rate limiting via Usage Plans (10 req/s, 10k req/day per key), auth at the gateway (the Lambda Authorizer runs on every request), CloudWatch metrics per endpoint, and a clean boundary for future machine-facing services. Revoked API keys take effect immediately.
+
+The stateless MCP transport runs independently at `https://mcp.example.com/mcp` on an HTTP API v2 exposing only `GET /mcp`, `POST /mcp`, and the pathful protected-resource metadata route `GET /.well-known/oauth-protected-resource/mcp`. Its default `execute-api` endpoint is disabled, so Cloudflare and the root-mapped regional custom domain are the only public ingress. The stage permits a burst of three and then 0.08 requests/second; over the 20-second application deadline plus five seconds of response/cleanup headroom, at most five accepted requests occupy the five reserved Lambda executions. OAuth remains on the existing `auth.*` ECS service behind the ALB.
 
 ### SQL Query API
 
@@ -113,7 +116,7 @@ curl / LLM agent
 GET https://api.example.com/v1/
 Authorization: none
 ...
-POST https://api.example.com/v1/sql
+POST https://api.example.com/v1/sql/query
 Authorization: ApiKey ebta_...
 X-Workspace-Id: workspace-id
       │
@@ -127,7 +130,7 @@ SQL Lambda (sets RLS context, executes query)
 Postgres (same app role + RLS as web app)
 ```
 
-Agents start from `GET /v1/`, complete email OTP on `auth.*`, store the returned ApiKey, load `/v1/me`, list or create `/v1/workspaces`, optionally inspect `/v1/schema`, select a workspace via `/v1/workspaces/{workspaceId}/select`, and send SQL to `/v1/sql`. `X-Workspace-Id` remains supported for explicit overrides, but is optional after a workspace is selected for that API key. The SQL execution path uses the same `app` role and RLS enforcement as the web application — `SET LOCAL app.user_id` and `app.workspace_id` per transaction.
+Agents start from `GET /v1/`, complete email OTP on `auth.*`, store the returned ApiKey, load `/v1/me`, list or create `/v1/workspaces`, optionally inspect `/v1/schema`, select a workspace via `/v1/workspaces/{workspaceId}/select`, and use `/v1/sql/query` for readonly statements or `/v1/sql/execute` for one approved mutation. `/v1/sql` remains compatibility-only for atomic multi-statement scripts. `X-Workspace-Id` works on all three endpoints for explicit overrides, but is optional after a workspace is selected for that API key. The SQL execution path uses the same `app` role and RLS enforcement as the web application — `SET LOCAL app.user_id` and `app.workspace_id` per transaction.
 
 ### Security
 
@@ -136,19 +139,25 @@ Agents start from `GET /v1/`, complete email OTP on `auth.*`, store the returned
 | Key storage | SHA-256 hash only, plaintext never stored |
 | Workspace isolation | Same RLS via `SET LOCAL` as all other routes |
 | SQL injection / DDL | Keyword whitelist: only SELECT/WITH/INSERT/UPDATE/DELETE |
-| Resource exhaustion | `statement_timeout = 30s`, 100-row limit, per-key throttling (10 req/s, 10k/day via Usage Plans) |
-| Auth caching | 5-min TTL by Authorization header — repeated requests skip Lambda + DB |
+| Resource exhaustion | one 25-second total SQL request deadline, 100-row limit, per-key throttling (10 req/s, 10k/day via Usage Plans) |
+| Auth caching | Disabled (0-second TTL) — every request invokes the authorizer and revoked keys take effect immediately |
 | Stale keys | `last_used_at` tracking, manual revocation |
 | Member removal | Auto-revoke trigger deletes all keys for removed user |
 
 ### Usage
 
 ```bash
-curl -X POST https://api.example.com/v1/sql \
+curl -X POST https://api.example.com/v1/sql/query \
   -H "Authorization: ApiKey ebta_ABCD1234_0123456789ABCDEFGHJKMNPQRS" \
   -H "X-Workspace-Id: workspace-id" \
   -H "Content-Type: application/json" \
   -d '{"sql": "SELECT * FROM ledger_entries ORDER BY ts DESC LIMIT 10"}'
+
+curl -X POST https://api.example.com/v1/sql/execute \
+  -H "Authorization: ApiKey ebta_ABCD1234_0123456789ABCDEFGHJKMNPQRS" \
+  -H "X-Workspace-Id: workspace-id" \
+  -H "Content-Type: application/json" \
+  -d '{"sql": "DELETE FROM budget_lines WHERE planned_value = 0"}'
 ```
 
 `X-Workspace-Id` is optional if the same API key has already called `POST /v1/workspaces/{workspaceId}/select`. If no workspace is saved and exactly one workspace exists for the user, the API auto-saves and uses that workspace for the key.

--- a/docs/resend-setup.md
+++ b/docs/resend-setup.md
@@ -14,17 +14,22 @@ Use a dedicated `mail` subdomain for transactional auth traffic.
 
 ## Prerequisites
 
-Keep these values in root `.env` or export them in the current shell:
+Keep these values in the root `.env`:
 
 - `AWS_REGION`
 - `AWS_PROFILE`
 - `RESEND_ADMIN_API_KEY`
+
+Keep the Cloudflare values only in the gitignored `scripts/cloudflare/.env`:
+
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ZONE_ID`
 
 `RESEND_ADMIN_API_KEY` is local-only. It creates the Resend domain and the separate domain-scoped send-only runtime key. The runtime key is written directly to AWS Secrets Manager and is not printed.
 
 `CLOUDFLARE_ZONE_ID` must belong to the exact domain passed through `--domain` or `DOMAIN_NAME`. The setup script verifies the zone before creating the Resend domain or writing DNS records.
+
+Do not source either env file into the long-lived parent shell. The setup scripts load them inside their own subprocesses, so production credentials disappear when each command exits.
 
 ## One-time setup
 

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -11,11 +11,11 @@ Deploy expense-budget-tracker to a dedicated AWS account using AWS CDK. DNS and 
 | RDS t4g.micro (24/7) | ~$12/month | Managed Postgres with automated backups, private subnet isolation |
 | NAT instance t4g.micro | ~$6/month | Outbound internet for ECS (ECR pulls) and Lambda in private subnet |
 | ALB | ~$16/month | HTTPS termination with Origin Certificate, health checks |
-| S3, CloudWatch, WAF, Lambda | ~$3/month | Access logs (S3), container and alarm monitoring (CloudWatch), rate limiting and SQLi/XSS protection (WAF), daily FX rate fetching (Lambda) |
-| API Gateway (REST API) + Lambda | ~$0/month | SQL API for machine clients with per-key rate limiting; REST API pricing ($3.50/M requests) is negligible at low volume |
-| **Total** | **~$10/year + ~$50/month** | |
+| S3, CloudWatch, WAF, Lambda | ~$3/month | Access logs, alarms, SQLi/XSS protection, and scheduled FX rates |
+| API Gateway + Lambda | ~$0/month | REST API for machine SQL and a separate HTTP API v2 for MCP; negligible at low volume |
+| **AWS total** | **~$10/year + ~$50/month** | Cloudflare subscription is separate |
 
-Cloudflare (DNS, CDN, DDoS, edge SSL) is free. All prices are approximate for `eu-central-1` and may vary.
+Cloudflare provides free DNS, CDN, DDoS protection, and edge SSL. The exact host + method + path predicate used for anonymous OAuth registration rate limiting requires Cloudflare Business or higher and is not included in this AWS estimate. All prices are approximate for `eu-central-1` and may vary.
 
 ## Prerequisites
 
@@ -46,6 +46,10 @@ Browser → Cloudflare (CDN + DDoS + edge SSL) → ALB (Origin Cert) → ECS Far
 Machine → Cloudflare → API Gateway (REST API) → Lambda Authorizer → Machine API Lambda → RDS
                          │
                          └─ api.* ──────────▶ GET /v1/ + authenticated /v1/* (ApiKey auth)
+
+MCP client → Cloudflare → API Gateway (HTTP API v2) → MCP Lambda → RDS
+                          │
+                          └─ mcp.* ──────────▶ POST /mcp (OAuth Bearer auth)
 ```
 
 **Cloudflare** handles domain registration, DNS, CDN caching, DDoS protection, and edge TLS.
@@ -64,8 +68,11 @@ Machine → Cloudflare → API Gateway (REST API) → Lambda Authorizer → Mach
 - **Cognito User Pool** (Essentials tier) — passwordless Email OTP auth with a CustomEmailSender Lambda through Resend, managed by the app directly (no Hosted UI)
 - **AWS WAF** on ALB — SQLi/XSS protection, common threat rules (rate limiting handled by Cloudflare)
 - **Lambda** (Node.js 24) for daily FX rate fetching + EventBridge schedule at 08:00 UTC, and Cognito custom email delivery through Resend
-- **API Gateway** (REST API) + two Lambdas (authorizer + SQL executor) for machine client SQL API; per-key rate limiting via Usage Plans, no auth cache (revoked keys stop working on the next request)
-- **CloudWatch Alarms + SNS** — alerts on ALB 5xx, API Gateway 5xx, ECS CPU/memory, ECS scale-out, DB connections, DB storage, Lambda errors
+- **API Gateway** — one REST API with authorizer + executor Lambdas for ApiKey machine SQL, plus an independent HTTP API v2 and Lambda for stateless Streamable HTTP MCP at `/mcp`; the MCP default `execute-api` endpoint is disabled
+- **MCP capacity budget** — the HTTP API accepts a burst of 3 and then 0.08 requests/second; across the 20-second application deadline plus 5 seconds of response/cleanup headroom, that is at most 5 concurrent accepted requests. Five reserved Lambda executions × the explicit 10-connection SQL API pool ceiling reserve at most 50 of the t4g.micro's roughly 85 connections, leaving about 35 for web, auth, worker, and the machine SQL API
+- **Machine SQL timeout budget** — one 25-second total deadline for `/sql/query`, `/sql/execute`, and compatibility `/sql`, including transaction commit, with bounded cleanup and response headroom below the Regional REST API's 29-second integration timeout and the Lambda's 35-second timeout
+- **MCP timeout budget** — one 20-second total MCP SQL execution deadline across transaction setup and every cursor command, a 29-second HTTP API integration timeout, and a 35-second Lambda timeout
+- **CloudWatch Alarms + SNS** — alerts on ALB 5xx, API Gateway 5xx, ECS CPU/memory, ECS scale-out, DB connections, DB storage, Lambda errors, and unexpected MCP Lambda throttling outside its five-execution capacity envelope
 - **S3** — ALB access logs (90-day retention)
 - **CloudWatch Logs** — ECS web container logs `/expense-tracker/web` (30-day retention), migration logs `/expense-tracker/migrate`, Lambda logs (automatic)
 - **AWS Backup** — daily backup plan with 35-day retention for RDS
@@ -77,7 +84,10 @@ Machine → Cloudflare → API Gateway (REST API) → Lambda Authorizer → Mach
 - DNS CNAME `@` root domain (proxied) pointing to ALB — redirects to `app.*`
 - DNS CNAME `app.*` (proxied) pointing to ALB — authenticated app
 - Origin Certificate for ALB HTTPS (imported into ACM)
-- Cache bypass rule for `app.*` and root domain (fully dynamic app, no edge caching benefit)
+- Public ACM certificates for the regional `api.*` and `mcp.*` API Gateway domains
+- Proxied DNS CNAMEs for `api.*` and `mcp.*`
+- Cache bypass for root, `app.*`, `auth.*`, and `mcp.*`
+- Per-real-client-IP rate limiting for anonymous `POST auth.*/oauth/register`
 - Edge SSL, DDoS protection (automatic with proxied DNS)
 
 ## Step-by-step setup
@@ -136,7 +146,7 @@ aws sts get-caller-identity --profile expense-tracker
 
 ### 3. Register domain and set up Cloudflare
 
-Domain and DNS are managed by Cloudflare. Cloudflare provides free CDN, DDoS protection, and edge SSL on top of DNS. No Cloudflare CLI is needed — only the dashboard (for domain registration) and API calls via `curl` (for everything else).
+Domain and DNS are managed by Cloudflare. Cloudflare provides free CDN, DDoS protection, and edge SSL on top of DNS; the exact anonymous-registration rate-limit predicate requires Business or higher. No Cloudflare CLI is needed — only the dashboard (for domain registration and plan management) and API calls via `curl` (for everything else).
 
 #### 3a. Register domain (dashboard — one time)
 
@@ -152,49 +162,45 @@ Go to https://dash.cloudflare.com/profile/api-tokens → **Create Token**:
 
 - Template: **"Edit zone DNS"**
 - Zone Resources: Include → Specific zone → your domain
-- **Important:** click "+ Add more" and add three more permissions:
+- **Important:** click "+ Add more" and add four more permissions:
   - **Zone → SSL and Certificates → Edit** (for Origin Certificate creation)
   - **Zone → Zone Settings → Edit** (for setting SSL mode to Full Strict)
-  - **Zone → Cache Rules → Edit** (for disabling edge cache on the app subdomain)
+  - **Zone → Cache Rules → Edit** (for disabling edge cache on dynamic hosts)
+  - **Zone → WAF → Edit** (for the anonymous OAuth registration rate limit)
 
-The token needs all four permissions (DNS + SSL + Zone Settings + Cache Rules). Missing any will cause script failures.
+The token needs all five permissions (DNS + SSL + Zone Settings + Cache Rules + WAF). Missing any will cause script failures.
 
 Copy the token and save it in your password manager along with the Zone ID from step 3c.
 
 #### 3c. Verify token and find Zone ID (terminal)
 
-Set the API token:
+Verify the token and find the zone in one credential-isolated subshell. The production token and the helper's temporary curl config disappear when the block exits:
 
 ```bash
-export CLOUDFLARE_API_TOKEN="<paste-your-api-token-here>"
-```
+(
+  set -euo pipefail
+  export CLOUDFLARE_API_TOKEN="<paste-your-api-token-here>"
+  source scripts/cloudflare/cloudflare-api.sh
 
-Verify the token works:
+  cloudflare_api_request \
+    "verify Cloudflare API token" \
+    "GET" \
+    "/user/tokens/verify" \
+    "" | python3 -m json.tool
 
-```bash
-curl -s "https://api.cloudflare.com/client/v4/user/tokens/verify" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" | python3 -m json.tool
-```
-
-Expected: `"status": "active"`.
-
-Find your Zone ID (replace `yourdomain.com` with your domain):
-
-```bash
-curl -s "https://api.cloudflare.com/client/v4/zones?name=yourdomain.com" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  | python3 -c '
+  cloudflare_api_request \
+    "find Cloudflare zone yourdomain.com" \
+    "GET" \
+    "/zones?name=yourdomain.com" \
+    "" | python3 -c '
 import sys, json
 for z in json.load(sys.stdin)["result"]:
-    print(f"Zone: {z["name"]}  ID: {z["id"]}  Status: {z["status"]}")
+    print("Zone: {}  ID: {}  Status: {}".format(z["name"], z["id"], z["status"]))
 '
+)
 ```
 
-Copy the **Zone ID** from the output and set it:
-
-```bash
-export CLOUDFLARE_ZONE_ID="<zone-id-from-output>"
-```
+Expected: `"status": "active"`. Copy the **Zone ID** from the output for the next step. The helper also removes the token from the subshell's exported environment immediately, keeps it in a permission-restricted temporary curl config, retries bounded failures, and redacts diagnostics.
 
 #### 3c′. Save Cloudflare credentials for future use
 
@@ -211,24 +217,27 @@ CLOUDFLARE_API_TOKEN=<paste-your-api-token-here>
 CLOUDFLARE_ZONE_ID=<paste-your-zone-id-here>
 ```
 
-This file is gitignored. All subsequent steps can load it instead of re-exporting:
-
-```bash
-set -a; source scripts/cloudflare/.env; set +a
-```
+This file is gitignored. Every command below loads it only inside its own explicit subshell. Do not source it in the long-lived parent shell.
 
 #### 3d. Create Origin Certificate and import into ACM (terminal)
 
 ```bash
-set -a; source scripts/cloudflare/.env; set +a
-export AWS_PROFILE=expense-tracker
+(
+  set -euo pipefail
+  set -a
+  source scripts/cloudflare/.env
+  set +a
+  export AWS_PROFILE=expense-tracker
 
-bash scripts/cloudflare/setup-certificate.sh \
-  --domain yourdomain.com \
-  --region eu-central-1
+  bash scripts/cloudflare/setup-certificate.sh \
+    --domain yourdomain.com \
+    --region eu-central-1
+)
 ```
 
 The script creates a Cloudflare Origin Certificate (15-year, wildcard) via the API and imports it into AWS ACM. It prints the **certificate ARN** — you need this for step 5.
+
+If Cloudflare accepts the create request but does not return a conclusive response, the script stops without issuing another certificate and retains a mode-0600 private key and CSR. Follow its printed `--resume-dir` command after propagation; resume performs list-only public-key reconciliation and never sends another create request.
 
 > **Why Origin Certificate?** Cloudflare Origin Certificates are free, long-lived (15 years), and trusted by Cloudflare's edge servers. Since all traffic flows through Cloudflare proxy, browsers see Cloudflare's edge certificate (Universal SSL, free). The Origin Certificate secures the connection between Cloudflare and your ALB.
 
@@ -237,12 +246,17 @@ The script creates a Cloudflare Origin Certificate (15-year, wildcard) via the A
 The SQL API for machine clients (LLM agents, scripts) uses a custom domain (`api.yourdomain.com`). This requires a public ACM certificate in your deployment region. API Gateway custom domains do not accept Cloudflare Origin Certificates — only publicly trusted certificates.
 
 ```bash
-set -a; source scripts/cloudflare/.env; set +a
-export AWS_PROFILE=expense-tracker
+(
+  set -euo pipefail
+  set -a
+  source scripts/cloudflare/.env
+  set +a
+  export AWS_PROFILE=expense-tracker
 
-bash scripts/cloudflare/setup-api-domain.sh \
-  --domain yourdomain.com \
-  --region eu-central-1
+  bash scripts/cloudflare/setup-api-domain.sh \
+    --domain yourdomain.com \
+    --region eu-central-1
+)
 ```
 
 The script requests the certificate, validates it via Cloudflare DNS, and waits for it to be issued. It prints the **API certificate ARN** — you need this for step 5.
@@ -262,10 +276,16 @@ RESEND_ADMIN_API_KEY=re_...
 2. Configure and verify the Resend sending domain:
 
 ```bash
-set -a; source scripts/cloudflare/.env; set +a
-bash scripts/resend/setup-resend-domain.sh \
-  --domain yourdomain.com \
-  --subdomain mail
+(
+  set -euo pipefail
+  set -a
+  source scripts/cloudflare/.env
+  set +a
+
+  bash scripts/resend/setup-resend-domain.sh \
+    --domain yourdomain.com \
+    --subdomain mail
+)
 ```
 
 The script creates or reuses `mail.yourdomain.com`, writes the required DNS records to Cloudflare, skips the Resend verification call when the domain is already verified, and otherwise requests verification before polling briefly. If DNS is still propagating, it exits non-zero; wait and rerun this step before continuing.
@@ -309,11 +329,34 @@ Edit `cdk.context.local.json` with your values:
 | `domainName` | Your domain, e.g. `yourdomain.com` |
 | `certificateArn` | ACM certificate ARN from step 3d (Cloudflare Origin Cert) |
 | `apiCertificateArn` | ACM certificate ARN from step 3e (public cert for `api.yourdomain.com`) |
+| `mcpCertificateArn` | Leave empty until step 5a, then add the public ACM certificate ARN for `mcp.yourdomain.com` |
 | `resendApiKeySecretArn` | Secrets Manager ARN for `expense-tracker/resend-api-key` from step 4 |
 | `resendSenderEmail` | Cognito sender address from step 4, e.g. `no-reply@mail.yourdomain.com` |
 | `langfuseBaseUrl` | Langfuse base URL, defaults to `https://cloud.langfuse.com` |
 | `alertEmail` | Email for CloudWatch alarm notifications |
 | `githubRepo` | GitHub repo for CI/CD, e.g. `user/expense-budget-tracker` |
+
+#### 5a. Create the MCP domain certificate and complete the context (~5-30 min wait)
+
+The canonical MCP endpoint is `https://mcp.yourdomain.com/mcp`. After every existing context value above is complete, leave only `mcpCertificateArn` empty and run:
+
+```bash
+(
+  set -euo pipefail
+  set -a
+  source scripts/cloudflare/.env
+  set +a
+  export AWS_PROFILE=expense-tracker
+  export AWS_REGION=eu-central-1
+
+  bash scripts/cloudflare/setup-mcp-domain.sh \
+    --domain yourdomain.com
+)
+```
+
+The script requires `infra/aws/cdk.context.local.json`, verifies its account, region, and domain against the explicit AWS profile, caller identity, and Cloudflare zone, then requests or reuses the single suitable exact-name certificate. Add the printed ARN as `mcpCertificateArn` in the local context and store the same value as the GitHub Actions secret `CDK_MCP_CERTIFICATE_ARN` before promotion. Keep its DNS-only validation CNAME for ACM renewal.
+
+Rerunning the script reuses the single exact-domain certificate when it is `ISSUED` or `PENDING_VALIDATION`; it stops before DNS changes if multiple reusable exact-domain certificates make selection ambiguous.
 
 #### Custom public site (optional)
 
@@ -348,14 +391,39 @@ Because the default pipeline still updates the ECS service before optional migra
 After deploy completes, **create the DNS record** pointing to the ALB and configure SSL:
 
 ```bash
-set -a; source scripts/cloudflare/.env; set +a
+(
+  set -euo pipefail
+  set -a
+  source scripts/cloudflare/.env
+  set +a
+  export AWS_PROFILE=expense-tracker
+  export AWS_REGION=eu-central-1
 
-bash scripts/cloudflare/setup-dns.sh \
-  --stack-name ExpenseBudgetTracker \
-  --region eu-central-1
+  bash scripts/cloudflare/setup-dns.sh \
+    --stack-name ExpenseBudgetTracker \
+    --region eu-central-1
+)
 ```
 
-The script creates DNS CNAMEs for `app.*` and root domain (both proxied via Cloudflare), sets SSL/TLS to Full (Strict), and configures cache bypass.
+The script creates proxied CNAMEs for the ALB, `api.*`, and `mcp.*`; sets SSL/TLS to Full (Strict); bypasses cache for dynamic hosts; and rate-limits the exact anonymous `POST auth.*/oauth/register` endpoint by the real client IP visible at Cloudflare edge. The rate-limit rule requires Cloudflare Business or higher because it matches hostname and method in addition to path.
+
+Verify Cloudflare resources and their CloudFormation targets after DNS propagation:
+
+```bash
+(
+  set -euo pipefail
+  set -a
+  source scripts/cloudflare/.env
+  set +a
+  export AWS_PROFILE=expense-tracker
+  export AWS_REGION=eu-central-1
+
+  bash scripts/cloudflare/verify.sh \
+    --stack-name ExpenseBudgetTracker
+)
+```
+
+The canonical MCP transport is `https://mcp.yourdomain.com/mcp`, and its protected-resource metadata is available only at `https://mcp.yourdomain.com/.well-known/oauth-protected-resource/mcp`. The HTTP API's default `execute-api` endpoint is disabled; clients must use the root-mapped custom domain without a stage prefix.
 
 ### 7. Post-deploy
 
@@ -411,6 +479,7 @@ After first deploy:
    - `AWS_DEPLOY_ROLE_ARN` — the role ARN from step 1
    - `CDK_CERTIFICATE_ARN` — ACM certificate ARN (Cloudflare Origin Cert, from step 3d)
    - `CDK_API_CERTIFICATE_ARN` — ACM certificate ARN (public cert for API domain, from step 3e)
+   - `CDK_MCP_CERTIFICATE_ARN` — ACM certificate ARN (public cert for MCP domain, from step 5a)
 
    **Variables** (Settings → Secrets and variables → Actions → Variables):
    - `AWS_REGION` — target region (e.g. `eu-central-1`)
@@ -433,6 +502,9 @@ No AWS keys stored in GitHub — uses OIDC federation.
 
 - `domain.com` → ALB → 302 redirect to `app.domain.com` (no container, just an ALB rule)
 - `app.domain.com` → ALB → ECS Fargate web container (port 8080)
+- `auth.domain.com` → ALB → ECS Fargate auth container (port 8081)
+- `api.domain.com/v1/*` → SQL REST API → Lambda authorizer + machine API Lambda
+- `mcp.domain.com/mcp` → dedicated MCP HTTP API v2 → MCP Lambda
 To serve your own site on `domain.com`, point its DNS to your site's hosting (Vercel, etc.). The ALB redirect becomes irrelevant since traffic no longer reaches it.
 
 ## Auth flow
@@ -447,7 +519,7 @@ To serve your own site on `domain.com`, point its DNS to your site's hosting (Ve
 
 ## Monitoring
 
-- **Alarms**: ALB 5xx (>5 in 5min), API Gateway 5xx (>5 in 5min), ECS CPU (>80% for 15min), ECS memory (>80% for 15min), ECS scale-out (>1 task), DB connections (>80%), DB storage (<2GB), Lambda errors (FX fetcher, SQL API authorizer, SQL API executor, Cognito custom email sender)
+- **Alarms**: ALB 5xx, SQL and MCP API Gateway 5xx, WAF body/query re-blocks, ECS CPU/memory and scale-out, DB connections/storage, Lambda errors, and unexpected MCP Lambda throttling outside its five-execution capacity envelope
 - **Access logs**: S3 bucket with all HTTP requests, 90-day retention
 - **Container logs**: CloudWatch Logs `/expense-tracker/web` and `/expense-tracker/migrate`, 30-day retention
 - **Lambda logs**: CloudWatch Logs (automatic), searchable in console

--- a/infra/aws/cdk.context.local.example.json
+++ b/infra/aws/cdk.context.local.example.json
@@ -3,6 +3,7 @@
   "domainName": "example.com",
   "certificateArn": "arn:aws:acm:eu-central-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "apiCertificateArn": "arn:aws:acm:eu-central-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "mcpCertificateArn": "",
   "resendApiKeySecretArn": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:expense-tracker/resend-api-key-xxxxxx",
   "resendSenderEmail": "no-reply@mail.example.com",
   "langfuseBaseUrl": "https://cloud.langfuse.com",

--- a/infra/aws/lib/ingress.test.ts
+++ b/infra/aws/lib/ingress.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { IResolvable } from "aws-cdk-lib";
+import type * as wafv2 from "aws-cdk-lib/aws-wafv2";
+import {
+  MAX_OAUTH_AUTHORIZE_QUERY_BYTES,
+  MAX_OAUTH_LOGIN_QUERY_BYTES,
+} from "@expense-budget-tracker/agent-shared";
+import { buildIngressWafRules } from "./ingress";
+
+const getRule = (
+  rules: ReadonlyArray<wafv2.CfnWebACL.RuleProperty>,
+  name: string,
+): wafv2.CfnWebACL.RuleProperty => {
+  const rule = rules.find((candidate) => candidate.name === name);
+  if (rule === undefined) throw new Error(`Expected WAF rule ${name}`);
+  return rule;
+};
+
+const requireStatement = (
+  statement: IResolvable | wafv2.CfnWebACL.StatementProperty | undefined,
+): wafv2.CfnWebACL.StatementProperty => {
+  if (statement === undefined || "resolve" in statement) {
+    throw new Error("Expected an inline WAF statement");
+  }
+  return statement;
+};
+
+const requireStatements = (
+  statements:
+    | Array<IResolvable | wafv2.CfnWebACL.StatementProperty>
+    | IResolvable
+    | undefined,
+): ReadonlyArray<wafv2.CfnWebACL.StatementProperty> => {
+  if (!Array.isArray(statements)) {
+    throw new Error("Expected inline WAF statements");
+  }
+  return statements.map(requireStatement);
+};
+
+const requireRuleActionOverrides = (
+  overrides:
+    | Array<IResolvable | wafv2.CfnWebACL.RuleActionOverrideProperty>
+    | IResolvable
+    | undefined,
+): ReadonlyArray<wafv2.CfnWebACL.RuleActionOverrideProperty> => {
+  if (!Array.isArray(overrides)) {
+    throw new Error("Expected inline WAF rule action overrides");
+  }
+  return overrides.map((override) => {
+    if ("resolve" in override) {
+      throw new Error("Expected an inline WAF rule action override");
+    }
+    return override;
+  });
+};
+
+const assertBoundedGetRoute = (
+  statement: wafv2.CfnWebACL.StatementProperty,
+  host: string,
+  path: string,
+  maxBytes: number,
+): void => {
+  const statements = requireStatements(statement.andStatement?.statements);
+  assert.deepEqual(
+    statements.slice(0, 3).map((part) => part.byteMatchStatement?.searchString),
+    ["GET", host, path],
+  );
+  assert.equal(
+    statements[3]?.sizeConstraintStatement?.comparisonOperator,
+    "LE",
+  );
+  assert.equal(statements[3]?.sizeConstraintStatement?.size, maxBytes);
+  assert.deepEqual(
+    statements[3]?.sizeConstraintStatement?.fieldToMatch,
+    { queryString: {} },
+  );
+};
+
+test("WAF counts the managed query-size rule and re-blocks outside exact bounded auth GETs", (): void => {
+  const rules = buildIngressWafRules("app.example.com", "auth.example.com");
+  const managedRule = getRule(rules, "AWSManagedCommonRules");
+  const managedStatement = requireStatement(managedRule.statement);
+  const overrides = requireRuleActionOverrides(
+    managedStatement.managedRuleGroupStatement?.ruleActionOverrides,
+  );
+  assert.deepEqual(
+    overrides.map((override) => override.name),
+    ["CrossSiteScripting_BODY", "SizeRestrictions_BODY", "SizeRestrictions_QUERYSTRING"],
+  );
+
+  const queryRule = getRule(rules, "BlockUnexpectedQuerySizeMatches");
+  const queryStatement = requireStatement(queryRule.statement);
+  const reblockStatements = requireStatements(queryStatement.andStatement?.statements);
+  assert.equal(
+    reblockStatements[0]?.labelMatchStatement?.key,
+    "awswaf:managed:aws:core-rule-set:SizeRestrictions_QueryString",
+  );
+  const exception = requireStatement(reblockStatements[1]?.notStatement?.statement);
+  const allowedRoutes = requireStatements(exception.orStatement?.statements);
+  assert.equal(allowedRoutes.length, 2);
+  assertBoundedGetRoute(
+    allowedRoutes[0] ?? {},
+    "auth.example.com",
+    "/oauth/authorize",
+    MAX_OAUTH_AUTHORIZE_QUERY_BYTES,
+  );
+  assertBoundedGetRoute(
+    allowedRoutes[1] ?? {},
+    "auth.example.com",
+    "/login",
+    MAX_OAUTH_LOGIN_QUERY_BYTES,
+  );
+});

--- a/infra/aws/lib/ingress.ts
+++ b/infra/aws/lib/ingress.ts
@@ -6,6 +6,10 @@ import * as wafv2 from "aws-cdk-lib/aws-wafv2";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";
 import { Construct } from "constructs";
+import {
+  MAX_OAUTH_AUTHORIZE_QUERY_BYTES,
+  MAX_OAUTH_LOGIN_QUERY_BYTES,
+} from "@expense-budget-tracker/agent-shared";
 
 export interface IngressProps {
   vpc: ec2.Vpc;
@@ -90,6 +94,15 @@ const hasLabel = (label: string): wafv2.CfnWebACL.StatementProperty => ({
   },
 });
 
+const querySizeAtMost = (maxBytes: number): wafv2.CfnWebACL.StatementProperty => ({
+  sizeConstraintStatement: {
+    comparisonOperator: "LE",
+    fieldToMatch: { queryString: {} },
+    size: maxBytes,
+    textTransformations: [noneTextTransformation()],
+  },
+});
+
 const andStatement = (
   statements: ReadonlyArray<wafv2.CfnWebACL.StatementProperty>,
 ): wafv2.CfnWebACL.StatementProperty => ({
@@ -147,6 +160,111 @@ const postRequestToApp = (
     headerIs("origin", `https://${appDomain}`),
     headerStartsWith("content-type", contentTypePrefix),
   ]);
+
+export const buildIngressWafRules = (
+  appDomain: string,
+  authDomain: string,
+): ReadonlyArray<wafv2.CfnWebACL.RuleProperty> => {
+  const chatJsonRequest = postRequestToApp(appDomain, "/api/chat", "application/json");
+  const newChatJsonRequest = postRequestToApp(
+    appDomain,
+    "/api/chat/new",
+    "application/json",
+  );
+  const chatTranscriptionUploadRequest = postRequestToApp(
+    appDomain,
+    "/api/chat/transcriptions",
+    "multipart/form-data",
+  );
+  const boundedOAuthQueryRequest = orStatement([
+    andStatement([
+      methodIs("GET"),
+      headerIs("host", authDomain),
+      uriPathIs("/oauth/authorize"),
+      querySizeAtMost(MAX_OAUTH_AUTHORIZE_QUERY_BYTES),
+    ]),
+    andStatement([
+      methodIs("GET"),
+      headerIs("host", authDomain),
+      uriPathIs("/login"),
+      querySizeAtMost(MAX_OAUTH_LOGIN_QUERY_BYTES),
+    ]),
+  ]);
+
+  return [
+    {
+      name: "AWSManagedCommonRules",
+      priority: 0,
+      overrideAction: { none: {} },
+      statement: {
+        managedRuleGroupStatement: {
+          vendorName: "AWS",
+          name: "AWSManagedRulesCommonRuleSet",
+          ruleActionOverrides: [
+            {
+              name: "CrossSiteScripting_BODY",
+              actionToUse: { count: {} },
+            },
+            // SizeRestrictions_BODY blocks requests with body > 8 KB.
+            // Large app payloads are re-blocked below except for explicit upload routes.
+            {
+              name: "SizeRestrictions_BODY",
+              actionToUse: { count: {} },
+            },
+            // OAuth authorization queries can exceed the managed 2 KiB threshold.
+            // Exact bounded auth routes are allowed and all other matches are re-blocked.
+            {
+              name: "SizeRestrictions_QUERYSTRING",
+              actionToUse: { count: {} },
+            },
+          ],
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "expense-tracker-common-rules",
+      },
+    },
+    blockLabeledRequestUnless(
+      "BlockUnexpectedXssBodyMatches",
+      1,
+      "awswaf:managed:aws:core-rule-set:CrossSiteScripting_Body",
+      chatTranscriptionUploadRequest,
+      "expense-tracker-xss-body-reblock",
+    ),
+    blockLabeledRequestUnless(
+      "BlockUnexpectedBodySizeMatches",
+      2,
+      "awswaf:managed:aws:core-rule-set:SizeRestrictions_Body",
+      orStatement([chatJsonRequest, newChatJsonRequest, chatTranscriptionUploadRequest]),
+      "expense-tracker-size-body-reblock",
+    ),
+    blockLabeledRequestUnless(
+      "BlockUnexpectedQuerySizeMatches",
+      3,
+      "awswaf:managed:aws:core-rule-set:SizeRestrictions_QueryString",
+      boundedOAuthQueryRequest,
+      "expense-tracker-size-query-reblock",
+    ),
+    {
+      name: "AWSManagedKnownBadInputs",
+      priority: 4,
+      overrideAction: { none: {} },
+      statement: {
+        managedRuleGroupStatement: {
+          vendorName: "AWS",
+          name: "AWSManagedRulesKnownBadInputsRuleSet",
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "expense-tracker-bad-inputs",
+      },
+    },
+  ];
+};
 
 export function ingress(scope: Construct, props: IngressProps): IngressResult {
   // --- ALB ---
@@ -237,18 +355,6 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
   //
   // WAF is kept for managed rule sets (SQLi, XSS, known bad inputs) which inspect
   // request content and work correctly regardless of source IP.
-  const chatJsonRequest = postRequestToApp(props.appDomain, "/api/chat", "application/json");
-  const newChatJsonRequest = postRequestToApp(
-    props.appDomain,
-    "/api/chat/new",
-    "application/json",
-  );
-  const chatTranscriptionUploadRequest = postRequestToApp(
-    props.appDomain,
-    "/api/chat/transcriptions",
-    "multipart/form-data",
-  );
-
   const waf = new wafv2.CfnWebACL(scope, "Waf", {
     scope: "REGIONAL",
     defaultAction: { allow: {} },
@@ -257,66 +363,7 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
       cloudWatchMetricsEnabled: true,
       metricName: "expense-tracker-waf",
     },
-    rules: [
-      {
-        name: "AWSManagedCommonRules",
-        priority: 0,
-        overrideAction: { none: {} },
-        statement: {
-          managedRuleGroupStatement: {
-            vendorName: "AWS",
-            name: "AWSManagedRulesCommonRuleSet",
-            ruleActionOverrides: [
-              {
-                name: "CrossSiteScripting_BODY",
-                actionToUse: { count: {} },
-              },
-              // SizeRestrictions_BODY blocks requests with body > 8 KB.
-              // Large app payloads are re-blocked below except for explicit upload routes.
-              {
-                name: "SizeRestrictions_BODY",
-                actionToUse: { count: {} },
-              },
-            ],
-          },
-        },
-        visibilityConfig: {
-          sampledRequestsEnabled: true,
-          cloudWatchMetricsEnabled: true,
-          metricName: "expense-tracker-common-rules",
-        },
-      },
-      blockLabeledRequestUnless(
-        "BlockUnexpectedXssBodyMatches",
-        1,
-        "awswaf:managed:aws:core-rule-set:CrossSiteScripting_Body",
-        chatTranscriptionUploadRequest,
-        "expense-tracker-xss-body-reblock",
-      ),
-      blockLabeledRequestUnless(
-        "BlockUnexpectedBodySizeMatches",
-        2,
-        "awswaf:managed:aws:core-rule-set:SizeRestrictions_Body",
-        orStatement([chatJsonRequest, newChatJsonRequest, chatTranscriptionUploadRequest]),
-        "expense-tracker-size-body-reblock",
-      ),
-      {
-        name: "AWSManagedKnownBadInputs",
-        priority: 3,
-        overrideAction: { none: {} },
-        statement: {
-          managedRuleGroupStatement: {
-            vendorName: "AWS",
-            name: "AWSManagedRulesKnownBadInputsRuleSet",
-          },
-        },
-        visibilityConfig: {
-          sampledRequestsEnabled: true,
-          cloudWatchMetricsEnabled: true,
-          metricName: "expense-tracker-bad-inputs",
-        },
-      },
-    ],
+    rules: [...buildIngressWafRules(props.appDomain, props.authDomain)],
   });
   const webAclName = cdk.Fn.select(0, cdk.Fn.split("|", waf.ref));
 

--- a/infra/aws/lib/mcp-gateway.test.ts
+++ b/infra/aws/lib/mcp-gateway.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import * as cdk from "aws-cdk-lib";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
+import * as apigwv2_integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as logs from "aws-cdk-lib/aws-logs";
+import {
+  addMcpHttpApiRoutes,
+  buildRdsCaDownloadCommand,
+  createMcpHttpAccessLogFormat,
+  createMcpHttpApiCustomDomain,
+  MCP_CAPACITY_BUDGET,
+  MCP_TIMEOUT_BUDGET,
+} from "./mcp-gateway";
+
+type McpHttpApiTestResources = Readonly<{
+  stack: cdk.Stack;
+  httpApi: apigwv2.HttpApi;
+  httpStage: apigwv2.HttpStage;
+}>;
+
+const createMcpHttpApiTestResources = (): McpHttpApiTestResources => {
+  const stack = new cdk.Stack();
+  const httpApi = new apigwv2.HttpApi(stack, "McpHttpApi", {
+    apiName: "expense-tracker-mcp-http-api",
+    createDefaultStage: false,
+    disableExecuteApiEndpoint: true,
+  });
+  const fn = new lambda.Function(stack, "McpHandler", {
+    runtime: lambda.Runtime.NODEJS_24_X,
+    handler: "index.handler",
+    code: lambda.Code.fromInline("exports.handler = async () => ({ statusCode: 200, body: '{}' });"),
+  });
+  const integration = new apigwv2_integrations.HttpLambdaIntegration(
+    "McpHttpLambdaIntegration",
+    fn,
+    {
+      payloadFormatVersion: apigwv2.PayloadFormatVersion.VERSION_2_0,
+      timeout: cdk.Duration.seconds(MCP_TIMEOUT_BUDGET.integrationSeconds),
+    },
+  );
+  addMcpHttpApiRoutes(httpApi, integration);
+  const accessLogGroup = new logs.LogGroup(stack, "McpApiAccessLogGroup");
+  const httpStage = new apigwv2.HttpStage(stack, "McpHttpApiStage", {
+    httpApi,
+    stageName: "$default",
+    autoDeploy: true,
+    throttle: {
+      burstLimit: MCP_CAPACITY_BUDGET.throttlingBurstLimit,
+      rateLimit: MCP_CAPACITY_BUDGET.throttlingRateLimit,
+    },
+    detailedMetricsEnabled: true,
+    accessLogSettings: {
+      destination: new apigwv2.LogGroupLogDestination(accessLogGroup),
+      format: createMcpHttpAccessLogFormat(),
+    },
+  });
+  return { stack, httpApi, httpStage };
+};
+
+const synthesizeMcpHttpApiTemplate = (): Template => {
+  const resources = createMcpHttpApiTestResources();
+  return Template.fromStack(resources.stack);
+};
+
+const synthesizeMcpHttpApiDomainTemplate = (): Template => {
+  const resources = createMcpHttpApiTestResources();
+  const certificate = acm.Certificate.fromCertificateArn(
+    resources.stack,
+    "McpCertificate",
+    "arn:aws:acm:eu-central-1:123456789012:certificate/00000000-0000-0000-0000-000000000000",
+  );
+  createMcpHttpApiCustomDomain(
+    resources.stack,
+    "mcp.example.com",
+    certificate,
+    resources.httpApi,
+    resources.httpStage,
+  );
+  return Template.fromStack(resources.stack);
+};
+
+test("MCP token bucket fits reserved concurrency and the RDS connection budget", (): void => {
+  const reservedConnections = MCP_CAPACITY_BUDGET.reservedConcurrentExecutions
+    * MCP_CAPACITY_BUDGET.maxConnectionsPerExecutionEnvironment;
+  const remainingConnections = MCP_CAPACITY_BUDGET.approximateRdsMaxConnections
+    - reservedConnections;
+
+  assert.equal(MCP_CAPACITY_BUDGET.responseAndCleanupHeadroomSeconds, 5);
+  assert.equal(MCP_CAPACITY_BUDGET.maxAcceptedOccupancySeconds, 25);
+  assert.equal(MCP_CAPACITY_BUDGET.throttlingBurstLimit, 3);
+  assert.equal(MCP_CAPACITY_BUDGET.throttlingRateLimit, 0.08);
+  assert.equal(MCP_CAPACITY_BUDGET.maxAcceptedConcurrency, 5);
+  assert.equal(MCP_CAPACITY_BUDGET.reservedConcurrentExecutions, 5);
+  assert.equal(
+    MCP_CAPACITY_BUDGET.maxAcceptedConcurrency,
+    MCP_CAPACITY_BUDGET.reservedConcurrentExecutions,
+  );
+  assert.equal(reservedConnections, 50);
+  assert.equal(remainingConnections, 35);
+});
+
+test("MCP gateway uses HTTP API v2 with no default execute-api endpoint", (): void => {
+  const template = synthesizeMcpHttpApiTemplate();
+
+  template.hasResourceProperties("AWS::ApiGatewayV2::Api", {
+    Name: "expense-tracker-mcp-http-api",
+    ProtocolType: "HTTP",
+    DisableExecuteApiEndpoint: true,
+  });
+  template.hasResourceProperties("AWS::ApiGatewayV2::Integration", {
+    IntegrationType: "AWS_PROXY",
+    PayloadFormatVersion: "2.0",
+    TimeoutInMillis: 29_000,
+  });
+  template.resourceCountIs("AWS::ApiGateway::RestApi", 0);
+});
+
+test("MCP HTTP API exposes only the canonical transport and pathful metadata routes", (): void => {
+  const template = synthesizeMcpHttpApiTemplate();
+  const routes = template.findResources("AWS::ApiGatewayV2::Route");
+  const routeKeys = Object.values(routes).map((route) => route.Properties.RouteKey).sort();
+
+  assert.deepEqual(routeKeys, [
+    "GET /.well-known/oauth-protected-resource/mcp",
+    "GET /mcp",
+    "POST /mcp",
+  ]);
+  assert.equal(routeKeys.includes("$default"), false);
+  assert.equal(routeKeys.some((routeKey) => routeKey.includes("/v1")), false);
+});
+
+test("MCP HTTP API stage applies conservative throttling, metrics, and safe access logs", (): void => {
+  const template = synthesizeMcpHttpApiTemplate();
+
+  template.hasResourceProperties("AWS::ApiGatewayV2::Stage", {
+    StageName: "$default",
+    AutoDeploy: true,
+    DefaultRouteSettings: {
+      DetailedMetricsEnabled: true,
+      ThrottlingBurstLimit: 3,
+      ThrottlingRateLimit: 0.08,
+    },
+    AccessLogSettings: {
+      DestinationArn: Match.anyValue(),
+      Format: Match.anyValue(),
+    },
+  });
+  const format = createMcpHttpAccessLogFormat().toString();
+  assert.match(format, /\$context\.requestId/u);
+  assert.match(format, /\$context\.routeKey/u);
+  assert.match(format, /\$context\.path/u);
+  assert.equal(format.includes("$context.resourcePath"), false);
+  assert.equal(format.includes("$context.extendedRequestId"), false);
+  assert.equal(format.toLowerCase().includes("authorization"), false);
+});
+
+test("MCP HTTP API custom domain has one root mapping and regional Cloudflare target", (): void => {
+  const template = synthesizeMcpHttpApiDomainTemplate();
+
+  template.hasResourceProperties("AWS::ApiGatewayV2::DomainName", {
+    DomainName: "mcp.example.com",
+    DomainNameConfigurations: [{
+      CertificateArn: "arn:aws:acm:eu-central-1:123456789012:certificate/00000000-0000-0000-0000-000000000000",
+      EndpointType: "REGIONAL",
+    }],
+  });
+  const mappings = template.findResources("AWS::ApiGatewayV2::ApiMapping");
+  assert.equal(Object.keys(mappings).length, 1);
+  const mapping = Object.values(mappings)[0];
+  assert.ok(mapping !== undefined);
+  assert.equal(Object.hasOwn(mapping.Properties, "ApiMappingKey"), false);
+});
+
+test("MCP bundling accepts only an HTTP 200 valid PEM bundle before installation", (): void => {
+  const command = buildRdsCaDownloadCommand("/tmp/mcp bundle");
+
+  assert.match(command, /--connect-timeout 10/u);
+  assert.match(command, /--max-time 60/u);
+  assert.match(command, /--write-out '%\{http_code\}'/u);
+  assert.match(command, /\[ "\$http_status" = "200" \]/u);
+  assert.match(command, /X509Certificate/u);
+  assert.match(command, /RDS CA response contains no PEM certificates/u);
+  assert.match(command, /RDS CA response contains non-certificate content/u);
+  assert.match(command, /response=\$\{response_body:-empty\}/u);
+  assert.match(command, /transport_or_validation_error=\$\{transport_error:-none\}/u);
+  assert.match(command, /attempt \$attempt\/4 failed/u);
+  assert.match(command, /failed after 4 attempts/u);
+  assert.match(command, /'\/tmp\/mcp bundle\/rds-global-bundle\.pem'/u);
+  const statusCheckIndex = command.indexOf('    if [ "$http_status" = "200" ]');
+  const validationIndex = command.indexOf("      if node -e ");
+  const installIndex = command.indexOf("        mv ");
+  assert.ok(statusCheckIndex >= 0);
+  assert.ok(validationIndex > statusCheckIndex);
+  assert.ok(installIndex > validationIndex);
+});
+
+test("MCP request, integration, and Lambda timeouts preserve response headroom", (): void => {
+  assert.equal(MCP_TIMEOUT_BUDGET.requestExecutionMs, 20_000);
+  assert.equal(MCP_TIMEOUT_BUDGET.integrationSeconds, 29);
+  assert.equal(MCP_TIMEOUT_BUDGET.lambdaSeconds, 35);
+  assert.ok(
+    MCP_TIMEOUT_BUDGET.requestExecutionMs <= 25_000,
+  );
+  assert.ok(
+    MCP_TIMEOUT_BUDGET.integrationSeconds * 1_000
+      - MCP_TIMEOUT_BUDGET.requestExecutionMs >= 5_000,
+  );
+  assert.ok(
+    MCP_TIMEOUT_BUDGET.lambdaSeconds
+      - MCP_TIMEOUT_BUDGET.integrationSeconds >= 5,
+  );
+});

--- a/infra/aws/lib/mcp-gateway.ts
+++ b/infra/aws/lib/mcp-gateway.ts
@@ -1,0 +1,276 @@
+import * as path from "path";
+import * as cdk from "aws-cdk-lib";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as apigw from "aws-cdk-lib/aws-apigateway";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
+import * as apigwv2_integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambda_nodejs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import { SQL_API_DB_POOL_MAX_CONNECTIONS } from "@expense-budget-tracker/agent-shared";
+import { MCP_SQL_STATEMENT_TIMEOUT_MS } from "@expense-budget-tracker/agent-shared/sql-policy";
+import { Construct } from "constructs";
+
+export interface McpGatewayProps {
+  vpc: ec2.Vpc;
+  lambdaSg: ec2.SecurityGroup;
+  db: rds.DatabaseInstance;
+  appDbSecret: secretsmanager.Secret;
+  baseDomain: string;
+  mcpCertificateArn: string | undefined;
+}
+
+export interface McpGatewayResult {
+  httpApi: apigwv2.HttpApi;
+  httpStage: apigwv2.HttpStage;
+  mcpFn: lambda_nodejs.NodejsFunction;
+  customDomainTarget: string | undefined;
+}
+
+export const MCP_TIMEOUT_BUDGET = {
+  requestExecutionMs: MCP_SQL_STATEMENT_TIMEOUT_MS,
+  integrationSeconds: 29,
+  lambdaSeconds: 35,
+} as const;
+
+const MCP_RESPONSE_AND_CLEANUP_HEADROOM_SECONDS = 5;
+const MCP_MAX_ACCEPTED_OCCUPANCY_SECONDS =
+  MCP_TIMEOUT_BUDGET.requestExecutionMs / 1_000
+  + MCP_RESPONSE_AND_CLEANUP_HEADROOM_SECONDS;
+const MCP_DB_SAFE_RESERVED_CONCURRENCY = 5;
+const MCP_USEFUL_BURST_CONCURRENCY = 3;
+const MCP_SUSTAINABLE_RATE_LIMIT =
+  (MCP_DB_SAFE_RESERVED_CONCURRENCY - MCP_USEFUL_BURST_CONCURRENCY)
+  / MCP_MAX_ACCEPTED_OCCUPANCY_SECONDS;
+const MCP_MAX_ACCEPTED_CONCURRENCY = MCP_USEFUL_BURST_CONCURRENCY
+  + Math.ceil(MCP_SUSTAINABLE_RATE_LIMIT * MCP_MAX_ACCEPTED_OCCUPANCY_SECONDS);
+
+export const MCP_CAPACITY_BUDGET = {
+  approximateRdsMaxConnections: 85,
+  maxConnectionsPerExecutionEnvironment: SQL_API_DB_POOL_MAX_CONNECTIONS,
+  responseAndCleanupHeadroomSeconds: MCP_RESPONSE_AND_CLEANUP_HEADROOM_SECONDS,
+  maxAcceptedOccupancySeconds: MCP_MAX_ACCEPTED_OCCUPANCY_SECONDS,
+  maxAcceptedConcurrency: MCP_MAX_ACCEPTED_CONCURRENCY,
+  reservedConcurrentExecutions: MCP_DB_SAFE_RESERVED_CONCURRENCY,
+  throttlingBurstLimit: MCP_USEFUL_BURST_CONCURRENCY,
+  throttlingRateLimit: MCP_SUSTAINABLE_RATE_LIMIT,
+} as const;
+
+export const createMcpHttpAccessLogFormat = (): apigw.AccessLogFormat =>
+  apigw.AccessLogFormat.custom(JSON.stringify({
+    requestId: apigw.AccessLogField.contextRequestId(),
+    apiId: apigw.AccessLogField.contextApiId(),
+    domainName: apigw.AccessLogField.contextDomainName(),
+    stage: apigw.AccessLogField.contextStage(),
+    httpMethod: apigw.AccessLogField.contextHttpMethod(),
+    routeKey: apigw.AccessLogField.contextRouteKey(),
+    path: apigw.AccessLogField.contextPath(),
+    status: apigw.AccessLogField.contextStatus(),
+    protocol: apigw.AccessLogField.contextProtocol(),
+    responseLength: apigw.AccessLogField.contextResponseLength(),
+    requestTime: apigw.AccessLogField.contextRequestTime(),
+    ip: apigw.AccessLogField.contextIdentitySourceIp(),
+    userAgent: apigw.AccessLogField.contextIdentityUserAgent(),
+    integrationStatus: apigw.AccessLogField.contextIntegrationStatus(),
+    integrationLatency: apigw.AccessLogField.contextIntegrationLatency(),
+    integrationError: apigw.AccessLogField.contextIntegrationErrorMessage(),
+    errorMessage: apigw.AccessLogField.contextErrorMessage(),
+  }));
+
+export const addMcpHttpApiRoutes = (
+  httpApi: apigwv2.HttpApi,
+  integration: apigwv2.HttpRouteIntegration,
+): void => {
+  httpApi.addRoutes({
+    path: "/mcp",
+    methods: [apigwv2.HttpMethod.GET, apigwv2.HttpMethod.POST],
+    integration,
+  });
+  httpApi.addRoutes({
+    path: "/.well-known/oauth-protected-resource/mcp",
+    methods: [apigwv2.HttpMethod.GET],
+    integration,
+  });
+};
+
+export const createMcpHttpApiCustomDomain = (
+  scope: Construct,
+  mcpDomainName: string,
+  certificate: acm.ICertificate,
+  httpApi: apigwv2.HttpApi,
+  httpStage: apigwv2.HttpStage,
+): apigwv2.DomainName => {
+  const domain = new apigwv2.DomainName(scope, "McpApiDomain", {
+    domainName: mcpDomainName,
+    certificate,
+    endpointType: apigwv2.EndpointType.REGIONAL,
+  });
+  new apigwv2.ApiMapping(scope, "McpApiMapping", {
+    api: httpApi,
+    domainName: domain,
+    stage: httpStage,
+  });
+  return domain;
+};
+
+const shellQuote = (value: string): string => `'${value.replaceAll("'", `'"'"'`)}'`;
+
+const buildPemBundleValidationScript = (): string => shellQuote([
+  'const { readFileSync } = require("node:fs");',
+  'const { X509Certificate } = require("node:crypto");',
+  "try {",
+  '  const body = readFileSync(process.argv[1], "utf8");',
+  "  const certificatePattern = /-----BEGIN CERTIFICATE-----[\\s\\S]*?-----END CERTIFICATE-----/gu;",
+  "  const certificates = body.match(certificatePattern) ?? [];",
+  '  if (certificates.length === 0) throw new Error("RDS CA response contains no PEM certificates");',
+  "  if (body.replace(certificatePattern, \"\").trim() !== \"\") throw new Error(\"RDS CA response contains non-certificate content\");",
+  "  for (const certificate of certificates) new X509Certificate(certificate);",
+  "} catch (error) {",
+  '  console.error(error instanceof Error ? error.message : "RDS CA response validation failed");',
+  "  process.exit(1);",
+  "}",
+].join(" "));
+
+export const buildRdsCaDownloadCommand = (outputDir: string): string => {
+  const destination = shellQuote(path.join(outputDir, "rds-global-bundle.pem"));
+  const temporaryDestination = shellQuote(path.join(outputDir, "rds-global-bundle.pem.download"));
+  const errorDestination = shellQuote(path.join(outputDir, "rds-global-bundle.pem.error"));
+  const downloadUrl = "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem";
+  const validatePemBundle = buildPemBundleValidationScript();
+  return [
+    "attempt=1",
+    "while [ \"$attempt\" -le 4 ]; do",
+    `  rm -f ${temporaryDestination} ${errorDestination}`,
+    "  http_status=none",
+    "  curl_status=0",
+    "  validation_status=not_run",
+    `  if http_status=$(curl --silent --show-error --connect-timeout 10 --max-time 60 --output ${temporaryDestination} --write-out '%{http_code}' ${downloadUrl} 2>${errorDestination}); then`,
+    "    if [ \"$http_status\" = \"200\" ]; then",
+    `      if node -e ${validatePemBundle} ${temporaryDestination} 2>>${errorDestination}; then`,
+    `        mv ${temporaryDestination} ${destination}`,
+    `        rm -f ${errorDestination}`,
+    "        exit 0",
+    "      else",
+    "        validation_status=$?",
+    "      fi",
+    "    fi",
+    "  else",
+    "    curl_status=$?",
+    "  fi",
+    `  response_body=$(head -c 2000 ${temporaryDestination} 2>/dev/null | tr '\\n' ' ')`,
+    `  transport_error=$(head -c 2000 ${errorDestination} 2>/dev/null | tr '\\n' ' ')`,
+    `  rm -f ${temporaryDestination} ${errorDestination}`,
+    "  if [ \"$attempt\" -eq 4 ]; then",
+    `    echo \"ERROR: RDS CA bundle download failed after 4 attempts; url=${downloadUrl}; expected_http_status=200; curl_status=$curl_status; http_status=\${http_status:-none}; validation_status=$validation_status; response=\${response_body:-empty}; transport_or_validation_error=\${transport_error:-none}\" >&2`,
+    "    exit 1",
+    "  fi",
+    `  echo \"WARNING: RDS CA bundle download attempt $attempt/4 failed; url=${downloadUrl}; expected_http_status=200; curl_status=$curl_status; http_status=\${http_status:-none}; validation_status=$validation_status; response=\${response_body:-empty}; transport_or_validation_error=\${transport_error:-none}; retrying in 2 seconds\" >&2`,
+    "  sleep 2",
+    "  attempt=$((attempt + 1))",
+    "done",
+  ].join("\n");
+};
+
+const lambdaBundling: lambda_nodejs.BundlingOptions = {
+  minify: true,
+  sourceMap: true,
+  commandHooks: {
+    beforeBundling: () => [],
+    beforeInstall: () => [],
+    afterBundling: (_inputDir: string, outputDir: string) => [
+      buildRdsCaDownloadCommand(outputDir),
+    ],
+  },
+};
+
+export function mcpGateway(scope: Construct, props: McpGatewayProps): McpGatewayResult {
+  const mcpDomainName = `mcp.${props.baseDomain}`;
+  const resourceUrl = `https://${mcpDomainName}/mcp`;
+  const mcpFn = new lambda_nodejs.NodejsFunction(scope, "McpHandler", {
+    entry: path.join(__dirname, "../../../apps/sql-api/src/mcp-handler.ts"),
+    handler: "handler",
+    runtime: lambda.Runtime.NODEJS_24_X,
+    timeout: cdk.Duration.seconds(MCP_TIMEOUT_BUDGET.lambdaSeconds),
+    memorySize: 256,
+    // A burst of three plus two refill arrivals during the 25-second maximum
+    // accepted occupancy fits five reserved executions. Their explicit
+    // 10-connection pools reserve at most 50 of roughly 85 RDS connections,
+    // leaving 35 for web, auth, worker, and machine-API workloads.
+    reservedConcurrentExecutions: MCP_CAPACITY_BUDGET.reservedConcurrentExecutions,
+    vpc: props.vpc,
+    vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+    securityGroups: [props.lambdaSg],
+    environment: {
+      NODE_EXTRA_CA_CERTS: "/var/task/rds-global-bundle.pem",
+      DB_SECRET_ARN: props.appDbSecret.secretArn,
+      DB_HOST: props.db.dbInstanceEndpointAddress,
+      DB_NAME: "tracker",
+      OAUTH_ISSUER: `https://auth.${props.baseDomain}`,
+      OAUTH_RESOURCE: resourceUrl,
+    },
+    bundling: lambdaBundling,
+  });
+  props.appDbSecret.grantRead(mcpFn);
+
+  const httpApi = new apigwv2.HttpApi(scope, "McpHttpApi", {
+    apiName: "expense-tracker-mcp-http-api",
+    description: "Stateless Streamable HTTP MCP API",
+    createDefaultStage: false,
+    disableExecuteApiEndpoint: true,
+  });
+  const integration = new apigwv2_integrations.HttpLambdaIntegration(
+    "McpHttpLambdaIntegration",
+    mcpFn,
+    {
+      payloadFormatVersion: apigwv2.PayloadFormatVersion.VERSION_2_0,
+      timeout: cdk.Duration.seconds(MCP_TIMEOUT_BUDGET.integrationSeconds),
+    },
+  );
+  addMcpHttpApiRoutes(httpApi, integration);
+
+  const accessLogGroup = new logs.LogGroup(scope, "McpApiAccessLogGroup", {
+    retention: logs.RetentionDays.ONE_MONTH,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
+  const httpStage = new apigwv2.HttpStage(scope, "McpHttpApiStage", {
+    httpApi,
+    stageName: "$default",
+    autoDeploy: true,
+    throttle: {
+      burstLimit: MCP_CAPACITY_BUDGET.throttlingBurstLimit,
+      rateLimit: MCP_CAPACITY_BUDGET.throttlingRateLimit,
+    },
+    detailedMetricsEnabled: true,
+    accessLogSettings: {
+      destination: new apigwv2.LogGroupLogDestination(accessLogGroup),
+      format: createMcpHttpAccessLogFormat(),
+    },
+  });
+
+  if (props.mcpCertificateArn === undefined) {
+    return { httpApi, httpStage, mcpFn, customDomainTarget: undefined };
+  }
+
+  const certificate = acm.Certificate.fromCertificateArn(
+    scope,
+    "McpCertificate",
+    props.mcpCertificateArn,
+  );
+  const domain = createMcpHttpApiCustomDomain(
+    scope,
+    mcpDomainName,
+    certificate,
+    httpApi,
+    httpStage,
+  );
+
+  return {
+    httpApi,
+    httpStage,
+    mcpFn,
+    customDomainTarget: domain.regionalDomainName,
+  };
+}

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -4,6 +4,7 @@ import * as rds from "aws-cdk-lib/aws-rds";
 import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as cloudwatch_actions from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as logs from "aws-cdk-lib/aws-logs";
@@ -23,6 +24,8 @@ export interface MonitoringProps {
   restApi: apigw.RestApi;
   authorizerFn: lambda.IFunction;
   sqlApiFn: lambda.IFunction;
+  mcpHttpApi: apigwv2.HttpApi;
+  mcpFn: lambda.IFunction;
   customEmailSenderFn: lambda.IFunction;
 }
 
@@ -110,6 +113,24 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     threshold: 1,
     evaluationPeriods: 1,
     alarmDescription: "WAF blocked a request because of an unexpected large body",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+
+  new cloudwatch.Alarm(scope, "WafSizeQueryBlockedAlarm", {
+    metric: new cloudwatch.Metric({
+      namespace: "AWS/WAFV2",
+      metricName: "BlockedRequests",
+      dimensionsMap: {
+        WebACL: props.webAclName,
+        Region: cdk.Aws.REGION,
+        Rule: "expense-tracker-size-query-reblock",
+      },
+      period: cdk.Duration.minutes(5),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription: "WAF blocked a request because of an unexpected large query string",
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
 
@@ -283,6 +304,39 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     threshold: 1,
     evaluationPeriods: 1,
     alarmDescription: "SQL API executor Lambda had errors",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+
+  new cloudwatch.Alarm(scope, "McpApiGateway5xxAlarm", {
+    metric: props.mcpHttpApi.metricServerError({
+      period: cdk.Duration.minutes(5),
+      statistic: "Sum",
+    }),
+    threshold: 5,
+    evaluationPeriods: 1,
+    alarmDescription: "MCP HTTP API returned 5+ server errors in 5 minutes",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+
+  new cloudwatch.Alarm(scope, "McpLambdaErrorAlarm", {
+    metric: props.mcpFn.metricErrors({
+      period: cdk.Duration.minutes(15),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription: "MCP Lambda had errors",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+
+  new cloudwatch.Alarm(scope, "McpLambdaThrottleAlarm", {
+    metric: props.mcpFn.metricThrottles({
+      period: cdk.Duration.minutes(5),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription: "MCP Lambda throttled despite the five-execution HTTP API capacity envelope",
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
 

--- a/infra/aws/lib/outputs.ts
+++ b/infra/aws/lib/outputs.ts
@@ -6,6 +6,7 @@ import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
 import * as sns from "aws-cdk-lib/aws-sns";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
@@ -26,6 +27,10 @@ export interface OutputsProps {
   restApi: apigw.RestApi;
   authorizerFn: lambda.IFunction;
   sqlApiFn: lambda.IFunction;
+  mcpHttpApi: apigwv2.HttpApi;
+  mcpFn: lambda.IFunction;
+  mcpCustomDomainTarget: string | undefined;
+  mcpUrl: string;
 }
 
 export function outputs(scope: Construct, props: OutputsProps): void {
@@ -98,4 +103,22 @@ export function outputs(scope: Construct, props: OutputsProps): void {
     value: props.authorizerFn.functionName,
     description: "Lambda function name for SQL API authorizer",
   });
+  new cdk.CfnOutput(scope, "McpGatewayId", {
+    value: props.mcpHttpApi.httpApiId,
+    description: "MCP HTTP API v2 ID",
+  });
+  new cdk.CfnOutput(scope, "McpFunctionName", {
+    value: props.mcpFn.functionName,
+    description: "Lambda function name for the MCP handler",
+  });
+  if (props.mcpCustomDomainTarget !== undefined) {
+    new cdk.CfnOutput(scope, "McpCustomDomain", {
+      value: props.mcpCustomDomainTarget,
+      description: "MCP HTTP API regional custom domain target for the Cloudflare CNAME",
+    });
+    new cdk.CfnOutput(scope, "McpUrl", {
+      value: props.mcpUrl,
+      description: "Canonical MCP Streamable HTTP URL",
+    });
+  }
 }

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -10,6 +10,7 @@ import { compute } from "./compute";
 import { ingress } from "./ingress";
 import { fxFetcher } from "./fx-fetcher";
 import { apiGateway } from "./api-gateway";
+import { mcpGateway } from "./mcp-gateway";
 import { monitoring } from "./monitoring";
 import { ciCd } from "./ci-cd";
 import { backupPlan } from "./backup";
@@ -35,6 +36,7 @@ export class ExpenseBudgetTrackerStack extends cdk.Stack {
     const certificateArn = this.node.tryGetContext("certificateArn") as string;
     const githubRepo = this.node.tryGetContext("githubRepo") as string;
     const apiCertificateArn = this.node.tryGetContext("apiCertificateArn") as string | undefined;
+    const mcpCertificateArn = getOptionalContextValue(this, "mcpCertificateArn");
     const langfuseBaseUrl = this.node.tryGetContext("langfuseBaseUrl") as string | undefined
       ?? "https://cloud.langfuse.com";
     const demoEmailDostip = this.node.tryGetContext("demoEmailDostip") as string | undefined ?? "";
@@ -102,6 +104,14 @@ export class ExpenseBudgetTrackerStack extends cdk.Stack {
       baseDomain,
       apiCertificateArn,
     });
+    const mcp = mcpGateway(this, {
+      vpc: net.vpc,
+      lambdaSg: net.lambdaSg,
+      db: dbResult.db,
+      appDbSecret: dbResult.appDbSecret,
+      baseDomain,
+      mcpCertificateArn,
+    });
     const mon = monitoring(this, {
       alertEmail,
       alb: ing.alb,
@@ -115,6 +125,8 @@ export class ExpenseBudgetTrackerStack extends cdk.Stack {
       restApi: api.restApi,
       authorizerFn: api.authorizerFn,
       sqlApiFn: api.sqlApiFn,
+      mcpHttpApi: mcp.httpApi,
+      mcpFn: mcp.mcpFn,
       customEmailSenderFn: authResult.customEmailSenderFn,
     });
     ciCd(this, {
@@ -143,6 +155,10 @@ export class ExpenseBudgetTrackerStack extends cdk.Stack {
       restApi: api.restApi,
       authorizerFn: api.authorizerFn,
       sqlApiFn: api.sqlApiFn,
+      mcpHttpApi: mcp.httpApi,
+      mcpFn: mcp.mcpFn,
+      mcpCustomDomainTarget: mcp.customDomainTarget,
+      mcpUrl: `https://mcp.${baseDomain}/mcp`,
     });
   }
 }

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -5,11 +5,13 @@
   "scripts": {
     "prebuild": "npm --prefix ../.. run build --workspace @expense-budget-tracker/agent-shared",
     "prelint": "npm --prefix ../.. run build --workspace @expense-budget-tracker/agent-shared",
+    "pretest": "npm --prefix ../.. run build --workspace @expense-budget-tracker/agent-shared",
     "presynth": "npm --prefix ../.. run build --workspace @expense-budget-tracker/agent-shared",
     "predeploy": "npm --prefix ../.. run build --workspace @expense-budget-tracker/agent-shared",
     "prediff": "npm --prefix ../.. run build --workspace @expense-budget-tracker/agent-shared",
     "build": "tsc",
     "lint": "tsc --noEmit",
+    "test": "node --import tsx --test \"lib/**/*.test.ts\"",
     "cdk": "cdk",
     "deploy": "cdk deploy --all",
     "destroy": "cdk destroy --all",
@@ -19,6 +21,7 @@
   "dependencies": {
     "@aws-crypto/client-node": "^5.0.2",
     "@aws-sdk/client-secrets-manager": "^3.1108.0",
+    "@expense-budget-tracker/agent-shared": "1.2.0",
     "aws-cdk-lib": "^2.264.0",
     "constructs": "^10.8.1"
   },
@@ -26,6 +29,7 @@
     "@types/node": "^24.13.3",
     "aws-cdk": "^2.1135.1",
     "esbuild": "^0.28.2",
+    "tsx": "^4.23.12",
     "typescript": "^6.0.3"
   },
   "engines": {

--- a/infra/aws/tsconfig.json
+++ b/infra/aws/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "lib": ["ES2022"],
     "types": ["node"],
     "declaration": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
       "dependencies": {
         "@aws-crypto/client-node": "^5.0.2",
         "@aws-sdk/client-secrets-manager": "^3.1108.0",
+        "@expense-budget-tracker/agent-shared": "1.2.0",
         "aws-cdk-lib": "^2.264.0",
         "constructs": "^10.8.1"
       },
@@ -122,6 +123,7 @@
         "@types/node": "^24.13.3",
         "aws-cdk": "^2.1135.1",
         "esbuild": "^0.28.2",
+        "tsx": "^4.23.12",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -6669,6 +6671,7 @@
       "version": "1.2.0",
       "devDependencies": {
         "@types/node": "^24.13.3",
+        "esbuild": "^0.28.2",
         "tsx": "^4.23.12",
         "typescript": "^6.0.3"
       },

--- a/packages/agent-shared/package.json
+++ b/packages/agent-shared/package.json
@@ -4,37 +4,63 @@
   "private": true,
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "dist-cjs"
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist-cjs/index.d.cts",
+        "default": "./dist-cjs/index.cjs"
+      },
       "default": "./dist/index.js"
     },
     "./discovery": {
-      "types": "./dist/discovery.d.ts",
-      "import": "./dist/discovery.js",
+      "import": {
+        "types": "./dist/discovery.d.ts",
+        "default": "./dist/discovery.js"
+      },
+      "require": {
+        "types": "./dist-cjs/discovery.d.cts",
+        "default": "./dist-cjs/discovery.cjs"
+      },
       "default": "./dist/discovery.js"
     },
     "./sql-policy": {
-      "types": "./dist/sql-policy.d.ts",
-      "import": "./dist/sql-policy.js",
+      "import": {
+        "types": "./dist/sql-policy.d.ts",
+        "default": "./dist/sql-policy.js"
+      },
+      "require": {
+        "types": "./dist-cjs/sql-policy.d.cts",
+        "default": "./dist-cjs/sql-policy.cjs"
+      },
       "default": "./dist/sql-policy.js"
     },
     "./crockford": {
-      "types": "./dist/crockford.d.ts",
-      "import": "./dist/crockford.js",
+      "import": {
+        "types": "./dist/crockford.d.ts",
+        "default": "./dist/crockford.js"
+      },
+      "require": {
+        "types": "./dist-cjs/crockford.d.cts",
+        "default": "./dist-cjs/crockford.cjs"
+      },
       "default": "./dist/crockford.js"
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/build-cjs.mjs",
     "lint": "tsc --noEmit",
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
+    "esbuild": "^0.28.2",
     "tsx": "^4.23.12",
     "typescript": "^6.0.3"
   },

--- a/packages/agent-shared/scripts/build-cjs.mjs
+++ b/packages/agent-shared/scripts/build-cjs.mjs
@@ -1,0 +1,29 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { build } from "esbuild";
+
+const entryNames = ["index", "discovery", "sql-policy", "crockford"];
+
+await build({
+  entryPoints: Object.fromEntries(
+    entryNames.map((entryName) => [entryName, `src/${entryName}.ts`]),
+  ),
+  bundle: true,
+  format: "cjs",
+  outdir: "dist-cjs",
+  outExtension: { ".js": ".cjs" },
+  platform: "node",
+  sourcemap: true,
+  target: "node24",
+});
+
+await mkdir("dist-cjs", { recursive: true });
+for (const entryName of entryNames) {
+  const declaration = await readFile(`dist/${entryName}.d.ts`, "utf8");
+  await writeFile(
+    `dist-cjs/${entryName}.d.cts`,
+    declaration
+      .replaceAll(".js\"", ".cjs\"")
+      .replace(/\n\/\/# sourceMappingURL=.*$/u, ""),
+    "utf8",
+  );
+}

--- a/packages/agent-shared/src/discovery.test.ts
+++ b/packages/agent-shared/src/discovery.test.ts
@@ -18,6 +18,7 @@ test("agent discovery advertises runtime documentation and implementation source
     apiBaseUrl: API_BASE_URL,
     authBaseUrl: "https://auth.expense-budget-tracker.com",
     bootstrapUrl: "https://auth.expense-budget-tracker.com/api/agent/send-code",
+    mcpUrl: "https://mcp.expense-budget-tracker.com/mcp",
   });
 
   assert.deepEqual(envelope.data["docs"], {
@@ -25,7 +26,33 @@ test("agent discovery advertises runtime documentation and implementation source
     docsUrl: DOCS_URL,
     source: SOURCE_LINKS,
   });
-  assert.deepEqual(envelope.actions.map((action) => action.name), ["send_code", "schema"]);
+  assert.deepEqual(envelope.data["auth"], {
+    bootstrapUrl: "https://auth.expense-budget-tracker.com/api/agent/send-code",
+    scheme: "Authorization: ApiKey <key>",
+    oauth: {
+      issuer: "https://auth.expense-budget-tracker.com",
+      scopes: ["expenses:read", "expenses:write"],
+    },
+  });
+  assert.deepEqual(envelope.data["mcp"], {
+    url: "https://mcp.expense-budget-tracker.com/mcp",
+    transport: "streamable-http",
+  });
+  assert.deepEqual(envelope.actions.map((action) => action.name), [
+    "send_code",
+    "schema",
+    "run_sql_query",
+    "run_sql_execute",
+  ]);
+  assert.deepEqual(
+    envelope.actions.slice(2).map((action) => action.url),
+    [`${API_BASE_URL}/sql/query`, `${API_BASE_URL}/sql/execute`],
+  );
+  assert.equal(
+    envelope.actions.find((action) => action.name === "run_sql_execute")?.description,
+    "Run exactly one explicitly approved INSERT, UPDATE, or DELETE mutation.",
+  );
+  assert.match(envelope.instructions, /Legacy .*\/sql remains available only for compatibility/u);
   assert.equal(envelope.actions.some((action) => action.name === "openapi"), false);
 });
 

--- a/packages/agent-shared/src/discovery.ts
+++ b/packages/agent-shared/src/discovery.ts
@@ -3,9 +3,12 @@
  */
 import {
   AGENT_API_KEY_ENV_VAR_NAME,
+  AGENT_OAUTH_SCOPES,
   API_KEY_AUTHORIZATION_SCHEME,
   buildSchemaAction,
   buildSendCodeAction,
+  buildRunSqlExecuteAction,
+  buildRunSqlQueryAction,
   buildSuccessEnvelope,
   type AgentEnvelope,
 } from "./index.js";
@@ -39,6 +42,7 @@ export type AgentDiscoveryParams = Readonly<{
   apiBaseUrl: string;
   authBaseUrl: string;
   bootstrapUrl: string;
+  mcpUrl: string;
 }>;
 
 export type AgentDiscoveryDocs = Readonly<{
@@ -70,12 +74,13 @@ export const buildSourceDiscoveryResponse = (apiBaseUrl: string): SourceDiscover
 });
 
 export const buildAgentDiscoveryInstructions = (apiBaseUrl: string): string =>
-  `Ask the user for their email address first, then call send_code. The same email OTP flow handles both signup and login. After send_code succeeds, tell the user to check spam or junk if the email is not visible, then ask for the 8-digit code and call verify_code. Do not suggest immediately requesting another code. After login, save the returned key outside chat memory, preferably in a local .env file as ${AGENT_API_KEY_ENV_VAR_NAME}='<PASTE_KEY_HERE>', then call ${apiBaseUrl}/me, ${apiBaseUrl}/workspaces, and ${apiBaseUrl}/workspaces/{workspaceId}/select before SQL. Use ${apiBaseUrl}/schema to inspect allowed relations, columns, and any agent hints about constraints or write semantics. Relation operations: ledger_entries, budget_lines, workspace_settings, and account_metadata support SELECT and, under existing write-approval rules, INSERT, UPDATE, and DELETE; the derived accounts view and global worker-owned fx_rates_raw and fx_rates_daily relations are SELECT-only. Restricted SQL does not support ON CONFLICT. Only allowlisted functions are supported: SUM, COUNT, MIN, MAX, AVG, and COALESCE. All other functions are blocked; use ILIKE instead of LOWER(...) for case-insensitive text search and explicit date ranges instead of NOW() or DATE_TRUNC(). SELECT results are capped per statement; keep reading rowCount and use returnedRowCount, totalRowCount, and truncated to detect capped output. Use regular single-quoted literals. Dollar-quoted strings are not allowed. Before any long mutating INSERT or UPDATE, first try the same SQL shape on a tiny representative probe: 1-3 literal rows for INSERT or 1 targeted row for UPDATE. The user's explicit approval covers the full approved change set, including that probe and all remaining sequential batches. If the probe fails, fix the SQL and retry the small version. If the probe succeeds, immediately continue with the remaining approved data in sequential batches of at most 100 records per tool call. Do not pause only to ask the user to continue, proceed, or reconfirm for later batches. Only ask again if the requested change itself changes, new ambiguity appears, or execution fails. Example: curl -H '${API_KEY_AUTHORIZATION_SCHEME.replace("<key>", `$${AGENT_API_KEY_ENV_VAR_NAME}`)}' ${apiBaseUrl}/me.`;
+  `Ask the user for their email address first, then call send_code. The same email OTP flow handles both signup and login. After send_code succeeds, tell the user to check spam or junk if the email is not visible, then ask for the 8-digit code and call verify_code. Do not suggest immediately requesting another code. After login, save the returned key outside chat memory, preferably in a local .env file as ${AGENT_API_KEY_ENV_VAR_NAME}='<PASTE_KEY_HERE>', then call ${apiBaseUrl}/me, ${apiBaseUrl}/workspaces, and ${apiBaseUrl}/workspaces/{workspaceId}/select before SQL. Use ${apiBaseUrl}/schema to inspect allowed relations, columns, and any agent hints about constraints or write semantics. Send one read-only SELECT or WITH...SELECT statement to ${apiBaseUrl}/sql/query. Send one explicitly approved INSERT, UPDATE, or DELETE statement to ${apiBaseUrl}/sql/execute. Legacy ${apiBaseUrl}/sql remains available only for compatibility and atomic multi-statement scripts. Relation operations: ledger_entries, budget_lines, workspace_settings, and account_metadata support SELECT and, under existing write-approval rules, INSERT, UPDATE, and DELETE; the derived accounts view and global worker-owned fx_rates_raw and fx_rates_daily relations are SELECT-only. Restricted SQL does not support ON CONFLICT. Only allowlisted functions are supported: SUM, COUNT, MIN, MAX, AVG, and COALESCE. All other functions are blocked; use ILIKE instead of LOWER(...) for case-insensitive text search and explicit date ranges instead of NOW() or DATE_TRUNC(). SELECT results are capped per statement; keep reading rowCount and use returnedRowCount, totalRowCount, and truncated to detect capped output. Use regular single-quoted literals. Dollar-quoted strings are not allowed. Before any long mutating INSERT or UPDATE, first try the same SQL shape on a tiny representative probe: 1-3 literal rows for INSERT or 1 targeted row for UPDATE. The user's explicit approval covers the full approved change set, including that probe and all remaining sequential batches. If the probe fails, fix the SQL and retry the small version. If the probe succeeds, immediately continue with the remaining approved data in sequential batches of at most 100 records per tool call. Do not pause only to ask the user to continue, proceed, or reconfirm for later batches. Only ask again if the requested change itself changes, new ambiguity appears, or execution fails. Example: curl -H '${API_KEY_AUTHORIZATION_SCHEME.replace("<key>", `$${AGENT_API_KEY_ENV_VAR_NAME}`)}' ${apiBaseUrl}/me.`;
 
 export const buildAgentDiscoveryEnvelope = ({
   apiBaseUrl,
   authBaseUrl,
   bootstrapUrl,
+  mcpUrl,
 }: AgentDiscoveryParams): AgentEnvelope =>
   buildSuccessEnvelope(
     {
@@ -87,15 +92,25 @@ export const buildAgentDiscoveryEnvelope = ({
       auth: {
         bootstrapUrl,
         scheme: API_KEY_AUTHORIZATION_SCHEME,
+        oauth: {
+          issuer: authBaseUrl,
+          scopes: [...AGENT_OAUTH_SCOPES],
+        },
       },
       apiBaseUrl,
       authBaseUrl,
+      mcp: {
+        url: mcpUrl,
+        transport: "streamable-http",
+      },
       docs: buildAgentDiscoveryDocs(apiBaseUrl),
       capabilities: AGENT_DISCOVERY_CAPABILITIES,
     },
     [
       buildSendCodeAction({ url: bootstrapUrl }),
       buildSchemaAction({ baseUrl: apiBaseUrl, path: "/schema" }),
+      buildRunSqlQueryAction({ baseUrl: apiBaseUrl, path: "/sql/query" }),
+      buildRunSqlExecuteAction({ baseUrl: apiBaseUrl, path: "/sql/execute" }),
     ],
     buildAgentDiscoveryInstructions(apiBaseUrl),
   );

--- a/packages/agent-shared/src/index.ts
+++ b/packages/agent-shared/src/index.ts
@@ -5,6 +5,22 @@ import type { AllowedRelationName } from "./sql-policy.js";
  */
 export const AGENT_API_KEY_ENV_VAR_NAME = "EXPENSE_BUDGET_TRACKER_API_KEY";
 export const API_KEY_AUTHORIZATION_SCHEME = "Authorization: ApiKey <key>";
+export const AGENT_OAUTH_SCOPES = ["expenses:read", "expenses:write"] as const;
+export const SQL_API_DB_POOL_MAX_CONNECTIONS = 10;
+// Keep raw OAuth query strings below the ALB 16 KiB request-line ceiling,
+// including the authorization URL after it is nested inside /login.
+export const MAX_OAUTH_AUTHORIZE_QUERY_BYTES = 4_000;
+export const MAX_OAUTH_LOGIN_QUERY_BYTES = 12_000;
+
+export const getRawQueryByteLength = (url: string): number => {
+  const queryStart = url.indexOf("?");
+  if (queryStart < 0) return 0;
+  const fragmentStart = url.indexOf("#", queryStart + 1);
+  const rawQuery = fragmentStart < 0
+    ? url.slice(queryStart + 1)
+    : url.slice(queryStart + 1, fragmentStart);
+  return new TextEncoder().encode(rawQuery).byteLength;
+};
 
 export const SEND_CODE_INPUT: Readonly<Record<string, string>> = {
   email: "string",
@@ -260,5 +276,23 @@ export const buildRunSqlAction = (
   method: "POST",
   url: resolveActionUrl(target),
   input,
+  auth: "ApiKey",
+});
+
+export const buildRunSqlQueryAction = (target: AgentUrlTarget): AgentAction => ({
+  name: "run_sql_query",
+  method: "POST",
+  description: "Run exactly one read-only SELECT or WITH...SELECT statement.",
+  url: resolveActionUrl(target),
+  input: RUN_SQL_WITH_WORKSPACE_INPUT,
+  auth: "ApiKey",
+});
+
+export const buildRunSqlExecuteAction = (target: AgentUrlTarget): AgentAction => ({
+  name: "run_sql_execute",
+  method: "POST",
+  description: "Run exactly one explicitly approved INSERT, UPDATE, or DELETE mutation.",
+  url: resolveActionUrl(target),
+  input: RUN_SQL_WITH_WORKSPACE_INPUT,
   auth: "ApiKey",
 });

--- a/packages/agent-shared/src/sql-policy.test.ts
+++ b/packages/agent-shared/src/sql-policy.test.ts
@@ -1,22 +1,35 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  createSqlExecutionDeadline,
   executeExpenseSql,
+  executeValidatedExpenseSqlWithinDeadline,
   getAllowedRelationNames,
   MAX_SQL_MUTATION_ROWS,
   MAX_SQL_RETURNED_ROWS,
   MAX_SQL_ROWS,
   MAX_SQL_SCRIPT_LENGTH,
   MAX_SQL_STATEMENTS,
+  MCP_SQL_STATEMENT_TIMEOUT_MS,
+  SQL_STATEMENT_TIMEOUT_MS,
+  SqlExecutionDeadlineError,
   SqlPolicyError,
   validateExpenseSql,
   validateReadOnlyExpenseSql,
   validateSingleExpenseSql,
+  validateSingleMutationExpenseSql,
   validateSingleReadOnlyExpenseSql,
   type RestrictedSqlExecutionRequest,
   type RestrictedSqlQueryResult,
   type RestrictedSqlResultRow,
 } from "./sql-policy.js";
+
+test("machine and MCP SQL deadlines leave response headroom below their gateways", (): void => {
+  assert.equal(SQL_STATEMENT_TIMEOUT_MS, 25_000);
+  assert.equal(MCP_SQL_STATEMENT_TIMEOUT_MS, 20_000);
+  assert.ok(SQL_STATEMENT_TIMEOUT_MS < 29_000);
+  assert.ok(MCP_SQL_STATEMENT_TIMEOUT_MS < SQL_STATEMENT_TIMEOUT_MS);
+});
 
 const assertFunctionCallRejected = (sql: string): void => {
   assert.throws(
@@ -202,6 +215,35 @@ test("single-statement validators reject scripts without changing shared multi-s
     () => validateSingleExpenseSql(writeScript),
     (error: unknown) => error instanceof SqlPolicyError && error.code === "single_statement_required",
   );
+});
+
+test("validateSingleMutationExpenseSql accepts only a single mutation", (): void => {
+  const acceptedSql: ReadonlyArray<string> = [
+    "INSERT INTO budget_lines (workspace_id) VALUES ('workspace-1')",
+    "UPDATE account_metadata SET liquidity = 'low' WHERE workspace_id = 'workspace-1'",
+    "DELETE FROM ledger_entries WHERE workspace_id = 'workspace-1'",
+    "WITH target AS (SELECT account_id FROM accounts) UPDATE account_metadata SET liquidity = 'low' FROM target WHERE account_metadata.account_id = target.account_id",
+  ];
+  for (const sql of acceptedSql) {
+    const validated = validateSingleMutationExpenseSql(sql);
+    assert.equal(validated.isMutation, true);
+    assert.equal(validated.statements.length, 1);
+    assert.equal(validated.statements[0]?.isMutating, true);
+  }
+
+  const rejectedSql: ReadonlyArray<string> = [
+    "SELECT account_id FROM accounts",
+    "WITH target AS (SELECT account_id FROM accounts) SELECT account_id FROM target",
+  ];
+  for (const sql of rejectedSql) {
+    assert.throws(
+      () => validateSingleMutationExpenseSql(sql),
+      (error: unknown) =>
+        error instanceof SqlPolicyError
+        && error.code === "mutation_sql_required"
+        && error.message.includes("send SELECT and WITH...SELECT to the query endpoint"),
+    );
+  }
 });
 
 test("restricted SQL rejects MERGE as the effective statement after WITH", (): void => {
@@ -532,6 +574,64 @@ test("executeExpenseSql reports truncation metadata without removing rowCount", 
     "CLOSE api_sql_read_cursor_1",
   ]);
   assert.equal(requests[0]?.sql.endsWith("ORDER BY account_id"), true);
+});
+
+test("deadline execution propagates one cumulatively decreasing budget to every cursor command", async (): Promise<void> => {
+  let currentTimeMs = 1_000;
+  const receivedTimeouts: Array<number> = [];
+  const requests: Array<RestrictedSqlExecutionRequest> = [];
+  const cursorExecutor = createCursorExecutor({
+    api_sql_read_cursor_1: [{ account_id: "account-1" }],
+  }, requests);
+  const commandDurations = [2_000, 5_000, 3_000, 0] as const;
+
+  await executeValidatedExpenseSqlWithinDeadline(
+    validateExpenseSql("SELECT account_id FROM accounts ORDER BY account_id"),
+    createSqlExecutionDeadline(MCP_SQL_STATEMENT_TIMEOUT_MS, () => currentTimeMs),
+    async (request, statementTimeoutMs) => {
+      const commandIndex = receivedTimeouts.length;
+      receivedTimeouts.push(statementTimeoutMs);
+      const result = await cursorExecutor(request);
+      currentTimeMs += commandDurations[commandIndex] ?? 0;
+      return result;
+    },
+  );
+
+  assert.deepEqual(receivedTimeouts, [20_000, 18_000, 13_000, 10_000]);
+  assert.deepEqual(requests.map((request) => request.sql), [
+    "DECLARE api_sql_read_cursor_1 NO SCROLL CURSOR FOR SELECT account_id FROM accounts ORDER BY account_id",
+    `FETCH FORWARD ${String(MAX_SQL_ROWS + 1)} FROM api_sql_read_cursor_1`,
+    "MOVE FORWARD ALL FROM api_sql_read_cursor_1",
+    "CLOSE api_sql_read_cursor_1",
+  ]);
+});
+
+test("deadline execution stops before dispatching a cursor command with no remaining budget", async (): Promise<void> => {
+  let currentTimeMs = 1_000;
+  const requests: Array<RestrictedSqlExecutionRequest> = [];
+  const cursorExecutor = createCursorExecutor({
+    api_sql_read_cursor_1: [{ account_id: "account-1" }],
+  }, requests);
+
+  await assert.rejects(
+    () => executeValidatedExpenseSqlWithinDeadline(
+      validateExpenseSql("SELECT account_id FROM accounts"),
+      createSqlExecutionDeadline(MCP_SQL_STATEMENT_TIMEOUT_MS, () => currentTimeMs),
+      async (request) => {
+        const result = await cursorExecutor(request);
+        currentTimeMs += MCP_SQL_STATEMENT_TIMEOUT_MS;
+        return result;
+      },
+    ),
+    (error: unknown) =>
+      error instanceof SqlExecutionDeadlineError
+      && error.timeoutMs === MCP_SQL_STATEMENT_TIMEOUT_MS
+      && error.message.includes("total deadline"),
+  );
+
+  assert.deepEqual(requests.map((request) => request.sql), [
+    "DECLARE api_sql_read_cursor_1 NO SCROLL CURSOR FOR SELECT account_id FROM accounts",
+  ]);
 });
 
 test("executeExpenseSql bounds reads before execution and across the whole request", async (): Promise<void> => {

--- a/packages/agent-shared/src/sql-policy.ts
+++ b/packages/agent-shared/src/sql-policy.ts
@@ -6,7 +6,8 @@ export const MAX_SQL_RETURNED_ROWS = 100;
 export const MAX_SQL_MUTATION_ROWS = 100;
 export const MAX_SQL_SCRIPT_LENGTH = 100_000;
 export const MAX_SQL_STATEMENTS = 100;
-export const SQL_STATEMENT_TIMEOUT_MS = 30_000;
+export const SQL_STATEMENT_TIMEOUT_MS = 25_000;
+export const MCP_SQL_STATEMENT_TIMEOUT_MS = 20_000;
 
 export const ALLOWED_SQL_FUNCTION_NAMES = [
   "sum",
@@ -129,6 +130,7 @@ type SqlPolicyErrorCode =
   | "mutation_statement_row_limit_exceeded"
   | "mutation_request_row_limit_exceeded"
   | "read_only_sql_required"
+  | "mutation_sql_required"
   | "on_conflict_not_allowed"
   | "set_config_not_allowed"
   | "function_calls_not_allowed"
@@ -151,6 +153,15 @@ export class SqlPolicyError extends Error {
   }
 }
 
+export class SqlExecutionDeadlineError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`SQL execution exceeded its ${String(timeoutMs)} ms total deadline before the next database command could start`);
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 export type ValidatedExpenseSql = Readonly<{
   sql: string;
   statements: ReadonlyArray<ValidatedExpenseSqlStatement>;
@@ -158,6 +169,10 @@ export type ValidatedExpenseSql = Readonly<{
 
 export type ValidatedReadOnlyExpenseSql = ValidatedExpenseSql & Readonly<{
   isReadOnly: true;
+}>;
+
+export type ValidatedMutationExpenseSql = ValidatedExpenseSql & Readonly<{
+  isMutation: true;
 }>;
 
 export type RestrictedSqlResultRow = Readonly<Record<string, unknown>>;
@@ -172,6 +187,17 @@ export type RestrictedSqlExecutionRequest = Readonly<{
   sql: string;
   params: ReadonlyArray<unknown>;
 }>;
+
+export type SqlExecutionDeadline = Readonly<{
+  timeoutMs: number;
+  expiresAtMs: number;
+  now: () => number;
+}>;
+
+export type DeadlineRestrictedSqlExecutor = (
+  request: RestrictedSqlExecutionRequest,
+  statementTimeoutMs: number,
+) => Promise<RestrictedSqlQueryResult>;
 
 export type ValidatedExpenseSqlStatement = Readonly<{
   sql: string;
@@ -198,6 +224,42 @@ export type ExecutedExpenseSql = Readonly<{
 
 const fail = (code: SqlPolicyErrorCode, message: string): never => {
   throw new SqlPolicyError(code, message);
+};
+
+export const createSqlExecutionDeadline = (
+  timeoutMs: number,
+  now: () => number,
+): SqlExecutionDeadline => {
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError("SQL execution timeout must be a positive safe integer number of milliseconds");
+  }
+  const startedAtMs = now();
+  if (!Number.isSafeInteger(startedAtMs)) {
+    throw new TypeError("SQL execution clock must return a safe integer number of milliseconds");
+  }
+
+  return {
+    timeoutMs,
+    expiresAtMs: startedAtMs + timeoutMs,
+    now,
+  };
+};
+
+export const getRemainingSqlExecutionMs = (
+  deadline: SqlExecutionDeadline,
+): number => {
+  const currentTimeMs = deadline.now();
+  if (!Number.isSafeInteger(currentTimeMs)) {
+    throw new TypeError("SQL execution clock must return a safe integer number of milliseconds");
+  }
+  const remainingMs = Math.min(
+    deadline.timeoutMs,
+    deadline.expiresAtMs - currentTimeMs,
+  );
+  if (remainingMs <= 0) {
+    throw new SqlExecutionDeadlineError(deadline.timeoutMs);
+  }
+  return remainingMs;
 };
 
 const getFirstKeyword = (sql: string): string | undefined =>
@@ -1222,6 +1284,21 @@ export const validateSingleReadOnlyExpenseSql = (sql: string): ValidatedReadOnly
   };
 };
 
+export const validateSingleMutationExpenseSql = (sql: string): ValidatedMutationExpenseSql => {
+  const validated = validateSingleExpenseSql(sql);
+  if (validated.statements.every((statement) => !statement.isMutating)) {
+    fail(
+      "mutation_sql_required",
+      "Exactly one INSERT, UPDATE, or DELETE mutation is required; send SELECT and WITH...SELECT to the query endpoint",
+    );
+  }
+
+  return {
+    ...validated,
+    isMutation: true,
+  };
+};
+
 const getAffectedRowCount = (result: RestrictedSqlQueryResult): number => {
   const rowCount = result.rowCount;
   if (rowCount === null || !Number.isSafeInteger(rowCount) || rowCount < 0) {
@@ -1343,6 +1420,15 @@ export const executeValidatedExpenseSql = async (
     statements,
   };
 };
+
+export const executeValidatedExpenseSqlWithinDeadline = async (
+  validated: ValidatedExpenseSql,
+  deadline: SqlExecutionDeadline,
+  execute: DeadlineRestrictedSqlExecutor,
+): Promise<ExecutedExpenseSql> => executeValidatedExpenseSql(
+  validated,
+  (request) => execute(request, getRemainingSqlExecutionMs(deadline)),
+);
 
 export const executeExpenseSql = async (
   sql: string,

--- a/scripts/cloudflare/aws-api.sh
+++ b/scripts/cloudflare/aws-api.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+AWS_API_MAX_ATTEMPTS=3
+
+aws_api_request() {
+  local operation="$1"
+  local profile="$2"
+  local region="$3"
+  shift 3
+  if [[ -z "$profile" || -z "$region" ]]; then
+    echo "ERROR: AWS ${operation} requires explicit non-empty profile and region values." >&2
+    return 1
+  fi
+
+  local output_file
+  local error_file
+  output_file=$(mktemp)
+  error_file=$(mktemp)
+  local attempt=1
+
+  while [[ "$attempt" -le "$AWS_API_MAX_ATTEMPTS" ]]; do
+    local command_status
+    if AWS_PAGER="" "$@" \
+      --profile "$profile" \
+      --region "$region" \
+      --cli-connect-timeout 10 \
+      --cli-read-timeout 60 \
+      >"$output_file" \
+      2>"$error_file"; then
+      cat "$output_file"
+      rm -f "$output_file" "$error_file"
+      return 0
+    else
+      command_status=$?
+    fi
+
+    local response_body
+    response_body=$(sed -n '1,40p' "$error_file")
+    if [[ "$attempt" -lt "$AWS_API_MAX_ATTEMPTS" ]]; then
+      echo "WARNING: AWS ${operation} attempt ${attempt}/${AWS_API_MAX_ATTEMPTS} failed; profile=${profile}; region=${region}; status=${command_status}; response=${response_body:-empty}; retrying in 2 seconds." >&2
+      sleep 2
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    echo "ERROR: AWS ${operation} failed after ${AWS_API_MAX_ATTEMPTS} attempts; profile=${profile}; region=${region}; status=${command_status}; response=${response_body:-empty}. Verify credentials, permissions, account, region, and the requested resource." >&2
+    rm -f "$output_file" "$error_file"
+    return 1
+  done
+}

--- a/scripts/cloudflare/cloudflare-api.sh
+++ b/scripts/cloudflare/cloudflare-api.sh
@@ -1,0 +1,984 @@
+#!/usr/bin/env bash
+
+if [[ $- == *a* ]]; then
+  set +a
+  _CLOUDFLARE_ALLEXPORT_WAS_ENABLED=true
+else
+  _CLOUDFLARE_ALLEXPORT_WAS_ENABLED=false
+fi
+CLOUDFLARE_API_TOKEN_LOCAL="${CLOUDFLARE_API_TOKEN:-}"
+unset CLOUDFLARE_API_TOKEN
+CLOUDFLARE_API_BASE_URL="https://api.cloudflare.com/client/v4"
+CLOUDFLARE_API_MAX_ATTEMPTS=3
+CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS=75
+CLOUDFLARE_DNS_RECONCILIATION_ATTEMPTS=5
+CLOUDFLARE_DNS_RECONCILIATION_MAX_PAGES=20
+CLOUDFLARE_ORIGIN_CA_RECONCILIATION_ATTEMPTS=5
+CLOUDFLARE_ORIGIN_CA_RECONCILIATION_MAX_PAGES=20
+CLOUDFLARE_CURL_CONFIG_FILE=""
+export -n \
+  CLOUDFLARE_API_TOKEN_LOCAL \
+  CLOUDFLARE_API_BASE_URL \
+  CLOUDFLARE_API_MAX_ATTEMPTS \
+  CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS \
+  CLOUDFLARE_DNS_RECONCILIATION_ATTEMPTS \
+  CLOUDFLARE_DNS_RECONCILIATION_MAX_PAGES \
+  CLOUDFLARE_ORIGIN_CA_RECONCILIATION_ATTEMPTS \
+  CLOUDFLARE_ORIGIN_CA_RECONCILIATION_MAX_PAGES \
+  CLOUDFLARE_CURL_CONFIG_FILE
+if [[ "$_CLOUDFLARE_ALLEXPORT_WAS_ENABLED" == "true" ]]; then
+  set -a
+fi
+unset _CLOUDFLARE_ALLEXPORT_WAS_ENABLED
+
+cloudflare_cleanup_curl_config() {
+  if [[ -n "${CLOUDFLARE_CURL_CONFIG_FILE}" ]]; then
+    rm -f -- "${CLOUDFLARE_CURL_CONFIG_FILE}"
+    CLOUDFLARE_CURL_CONFIG_FILE=""
+    export -n CLOUDFLARE_CURL_CONFIG_FILE
+  fi
+  unset CLOUDFLARE_API_TOKEN
+  unset CLOUDFLARE_API_TOKEN_LOCAL
+}
+
+cloudflare_require_api_token() {
+  if [[ -z "${CLOUDFLARE_API_TOKEN_LOCAL:-}" ]]; then
+    echo "ERROR: CLOUDFLARE_API_TOKEN must be set before sourcing cloudflare-api.sh." >&2
+    return 1
+  fi
+}
+
+cloudflare_prepare_curl_config() {
+  unset CLOUDFLARE_API_TOKEN
+  export -n CLOUDFLARE_API_TOKEN_LOCAL CLOUDFLARE_CURL_CONFIG_FILE
+  if [[ -n "${CLOUDFLARE_CURL_CONFIG_FILE}" ]]; then
+    return 0
+  fi
+  if ! cloudflare_require_api_token; then
+    return 1
+  fi
+  if [[ ! "${CLOUDFLARE_API_TOKEN_LOCAL}" =~ ^[A-Za-z0-9._~-]+$ ]]; then
+    echo "ERROR: CLOUDFLARE_API_TOKEN contains characters that cannot be stored safely in a curl config file." >&2
+    return 1
+  fi
+
+  local previous_umask
+  previous_umask=$(umask)
+  umask 077
+  CLOUDFLARE_CURL_CONFIG_FILE=$(mktemp)
+  export -n CLOUDFLARE_CURL_CONFIG_FILE
+  umask "${previous_umask}"
+  trap 'cloudflare_cleanup_curl_config' EXIT
+  trap 'cloudflare_cleanup_curl_config; exit 129' HUP
+  trap 'cloudflare_cleanup_curl_config; exit 130' INT
+  trap 'cloudflare_cleanup_curl_config; exit 143' TERM
+
+  if ! chmod 600 "${CLOUDFLARE_CURL_CONFIG_FILE}"; then
+    echo "ERROR: Could not restrict permissions on the temporary Cloudflare curl config." >&2
+    cloudflare_cleanup_curl_config
+    return 1
+  fi
+  if ! printf 'header = "Authorization: Bearer %s"\n' "${CLOUDFLARE_API_TOKEN_LOCAL}" >"${CLOUDFLARE_CURL_CONFIG_FILE}"; then
+    echo "ERROR: Could not write the temporary Cloudflare curl config." >&2
+    cloudflare_cleanup_curl_config
+    return 1
+  fi
+}
+
+cloudflare_redact_credentials() {
+  local value="$1"
+  if [[ -n "${CLOUDFLARE_API_TOKEN_LOCAL:-}" ]]; then
+    value="${value//"${CLOUDFLARE_API_TOKEN_LOCAL}"/[REDACTED]}"
+  fi
+  printf '%s' "$value"
+}
+
+cloudflare_response_state() {
+  local response_file="$1"
+  python3 - "$response_file" <<'PY'
+import json
+import pathlib
+import sys
+
+response_path = pathlib.Path(sys.argv[1])
+try:
+    response = json.loads(response_path.read_text(encoding="utf-8"))
+except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    print("invalid")
+    raise SystemExit(0)
+
+if response.get("success") is True:
+    print("success")
+    raise SystemExit(0)
+
+errors = response.get("errors", [])
+if any("not found" in str(error.get("message", "")).lower() for error in errors if isinstance(error, dict)):
+    print("not_found")
+    raise SystemExit(0)
+
+print("error")
+PY
+}
+
+cloudflare_error_body() {
+  local response_file="$1"
+  python3 - "$response_file" <<'PY'
+import pathlib
+import sys
+
+response_path = pathlib.Path(sys.argv[1])
+try:
+    body = response_path.read_text(encoding="utf-8")
+except (OSError, UnicodeDecodeError) as error:
+    body = f"<unreadable response body: {error}>"
+print(body[:2000] if body else "<empty response body>")
+PY
+}
+
+cloudflare_is_origin_certificate_payload() {
+  local payload="$1"
+  python3 -c '
+import json
+import sys
+
+try:
+    payload = json.loads(sys.argv[1])
+except json.JSONDecodeError:
+    raise SystemExit(1)
+if not isinstance(payload, dict):
+    raise SystemExit(1)
+required = {"csr", "hostnames", "request_type"}
+raise SystemExit(0 if required.issubset(payload) else 1)
+' "$payload"
+}
+
+cloudflare_dns_creation_reconciliation() {
+  local response_file="$1"
+  local payload="$2"
+  python3 - "$response_file" "$payload" <<'PY'
+import json
+import pathlib
+import sys
+
+response = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+desired = json.loads(sys.argv[2])
+expected_name = str(desired.get("name", "")).rstrip(".").lower()
+results = response.get("result", [])
+if not expected_name or not isinstance(results, list):
+    print(json.dumps({"state": "invalid", "reason": "invalid desired name or DNS result array"}))
+    raise SystemExit(0)
+matching = [
+    record for record in results
+    if isinstance(record, dict)
+    and str(record.get("name", "")).rstrip(".").lower() == expected_name
+]
+if len(matching) == 0:
+    print(json.dumps({"state": "absent"}))
+elif len(matching) > 1:
+    print(json.dumps({
+        "state": "duplicate",
+        "reason": f"found {len(matching)} records at exact hostname {expected_name}",
+    }))
+else:
+    record = matching[0]
+    record_type = record.get("type")
+    desired_type = desired.get("type")
+    if record_type != "CNAME" or desired_type != "CNAME":
+        print(json.dumps({
+            "state": "wrong_type",
+            "reason": f"exact hostname has type {record_type!r}; expected CNAME",
+        }))
+        raise SystemExit(0)
+    exact = (
+        str(record.get("content", "")).rstrip(".").lower()
+        == str(desired.get("content", "")).rstrip(".").lower()
+        and record.get("ttl") == desired.get("ttl")
+        and record.get("proxied") == desired.get("proxied")
+    )
+    if exact:
+        print(json.dumps({
+            "state": "exact",
+            "response": {
+                "success": True,
+                "errors": [],
+                "messages": [],
+                "result": record,
+            },
+        }))
+    else:
+        print(json.dumps({
+            "state": "drift",
+            "reason": "the singleton CNAME does not match the requested content, TTL, or proxy state",
+        }))
+PY
+}
+
+cloudflare_is_dns_record_payload() {
+  local payload="$1"
+  python3 -c '
+import json
+import sys
+
+try:
+    payload = json.loads(sys.argv[1])
+except json.JSONDecodeError:
+    raise SystemExit(1)
+required = {"type", "name", "content", "ttl", "proxied"}
+raise SystemExit(
+    0
+    if isinstance(payload, dict)
+    and required.issubset(payload)
+    and payload.get("type") == "CNAME"
+    else 1
+)
+' "$payload"
+}
+
+cloudflare_read_all_dns_pages() {
+  local operation="$1"
+  local path="$2"
+  local output_file="$3"
+  local first_page_file
+  first_page_file=$(mktemp)
+  if ! cloudflare_api_request \
+    "read exact-host DNS state after ${operation}" \
+    "GET" \
+    "$path" \
+    "" >"$first_page_file"; then
+    rm -f -- "$first_page_file"
+    return 1
+  fi
+
+  local total_pages
+  if ! total_pages=$(python3 - "$first_page_file" <<'PY'
+import json
+import pathlib
+import sys
+
+response = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+result_info = response.get("result_info")
+total_pages = result_info.get("total_pages") if isinstance(result_info, dict) else None
+if not isinstance(total_pages, int) or isinstance(total_pages, bool) or total_pages < 0:
+    print("ERROR: Cloudflare DNS list response did not contain a valid result_info.total_pages value.", file=sys.stderr)
+    raise SystemExit(1)
+print(max(total_pages, 1))
+PY
+  ); then
+    rm -f -- "$first_page_file"
+    return 1
+  fi
+  if [[ "$total_pages" -gt "$CLOUDFLARE_DNS_RECONCILIATION_MAX_PAGES" ]]; then
+    echo "ERROR: Cloudflare DNS reconciliation for ${operation} requires ${total_pages} pages, exceeding the bounded limit of ${CLOUDFLARE_DNS_RECONCILIATION_MAX_PAGES}." >&2
+    rm -f -- "$first_page_file"
+    return 1
+  fi
+
+  mv -- "$first_page_file" "$output_file"
+  local page_number=2
+  local page_separator="&"
+  if [[ "$path" != *"?"* ]]; then
+    page_separator="?"
+  fi
+  while [[ "$page_number" -le "$total_pages" ]]; do
+    local page_file
+    local merged_file
+    page_file=$(mktemp)
+    merged_file=$(mktemp)
+    if ! cloudflare_api_request \
+      "read exact-host DNS state page ${page_number}/${total_pages} after ${operation}" \
+      "GET" \
+      "${path}${page_separator}page=${page_number}" \
+      "" >"$page_file"; then
+      rm -f -- "$page_file" "$merged_file" "$output_file"
+      return 1
+    fi
+    if ! python3 - "$output_file" "$page_file" >"$merged_file" <<'PY'
+import json
+import pathlib
+import sys
+
+combined = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+page = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+combined_results = combined.get("result")
+page_results = page.get("result")
+if not isinstance(combined_results, list) or not isinstance(page_results, list):
+    print("ERROR: Cloudflare paginated DNS response did not contain result arrays.", file=sys.stderr)
+    raise SystemExit(1)
+combined["result"] = [*combined_results, *page_results]
+combined["result_info"] = {
+    "count": len(combined["result"]),
+    "page": 1,
+    "per_page": len(combined["result"]),
+    "total_count": len(combined["result"]),
+    "total_pages": 1,
+}
+print(json.dumps(combined))
+PY
+    then
+      rm -f -- "$page_file" "$merged_file" "$output_file"
+      return 1
+    fi
+    mv -- "$merged_file" "$output_file"
+    rm -f -- "$page_file"
+    page_number=$((page_number + 1))
+  done
+}
+
+cloudflare_read_all_dns_records() {
+  local operation="$1"
+  local path="$2"
+  local response_file
+  response_file=$(mktemp)
+  if ! cloudflare_read_all_dns_pages "$operation" "$path" "$response_file"; then
+    rm -f -- "$response_file"
+    return 1
+  fi
+  cloudflare_redact_credentials "$(cat "$response_file")"
+  rm -f -- "$response_file"
+}
+
+cloudflare_reconcile_dns_record_create() {
+  local operation="$1"
+  local reconciliation_path="$2"
+  local payload="$3"
+  local desired_name
+  desired_name=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["name"])' "$payload")
+  local poll_attempt=1
+
+  while [[ "$poll_attempt" -le "$CLOUDFLARE_DNS_RECONCILIATION_ATTEMPTS" ]]; do
+    local reconciliation_file
+    reconciliation_file=$(mktemp)
+    if ! cloudflare_read_all_dns_pages \
+      "$operation" \
+      "$reconciliation_path" \
+      "$reconciliation_file"; then
+      rm -f -- "$reconciliation_file"
+      echo "ERROR: Cloudflare ${operation} outcome is unknown because the exact-host DNS state for ${desired_name} could not be read completely. Do not send another create request; verify the hostname in Cloudflare and rerun only after its state is known." >&2
+      return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+    fi
+
+    local reconciliation
+    local reconciliation_state
+    reconciliation=$(cloudflare_dns_creation_reconciliation "$reconciliation_file" "$payload")
+    rm -f -- "$reconciliation_file"
+    reconciliation_state=$(printf '%s' "$reconciliation" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state", "invalid"))')
+    if [[ "$reconciliation_state" == "exact" ]]; then
+      echo "WARNING: Cloudflare ${operation} response was inconclusive, but bounded exact-host reconciliation found the requested singleton CNAME; reusing it." >&2
+      printf '%s' "$reconciliation" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["response"]))'
+      return 0
+    fi
+    if [[ "$reconciliation_state" != "absent" ]]; then
+      local reconciliation_reason
+      reconciliation_reason=$(printf '%s' "$reconciliation" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("reason", "no reason returned"))')
+      echo "ERROR: Cloudflare ${operation} outcome is indeterminate because exact-host reconciliation found ${reconciliation_state} state for ${desired_name}: ${reconciliation_reason}. Do not send another create request; resolve the DNS drift explicitly." >&2
+      return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+    fi
+    if [[ "$poll_attempt" -lt "$CLOUDFLARE_DNS_RECONCILIATION_ATTEMPTS" ]]; then
+      echo "WARNING: Cloudflare ${operation} is not visible after exact-host reconciliation poll ${poll_attempt}/${CLOUDFLARE_DNS_RECONCILIATION_ATTEMPTS}; waiting 2 seconds before polling again." >&2
+      sleep 2
+    fi
+    poll_attempt=$((poll_attempt + 1))
+  done
+
+  echo "ERROR: Cloudflare ${operation} outcome remains unknown after ${CLOUDFLARE_DNS_RECONCILIATION_ATTEMPTS} complete exact-host polls for ${desired_name}. Propagation delay does not prove absence. Do not send another create request; inspect the hostname and safely rerun reconciliation later." >&2
+  return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+}
+
+cloudflare_classify_exact_cname() {
+  local expected_name="$1"
+  local expected_content="$2"
+  local expected_proxied="$3"
+  local rerun_command="$4"
+
+  python3 -c '
+import json
+import sys
+
+expected_name = sys.argv[1].rstrip(".").lower()
+expected_content = sys.argv[2].rstrip(".").lower()
+expected_proxied_text = sys.argv[3]
+rerun_command = sys.argv[4]
+if expected_proxied_text not in {"true", "false"}:
+    print("ERROR: Expected proxied state must be true or false.", file=sys.stderr)
+    raise SystemExit(1)
+expected_proxied = expected_proxied_text == "true"
+response = json.load(sys.stdin)
+records = response.get("result", [])
+if not isinstance(records, list):
+    print("ERROR: Cloudflare exact-host DNS lookup returned no result array.", file=sys.stderr)
+    raise SystemExit(1)
+matching = [
+    record for record in records
+    if isinstance(record, dict)
+    and str(record.get("name", "")).rstrip(".").lower() == expected_name
+]
+if len(matching) > 1:
+    print(
+        f"ERROR: Found {len(matching)} DNS records at exact hostname {sys.argv[1]}; expected at most one CNAME.",
+        file=sys.stderr,
+    )
+    for record in matching:
+        print(
+            "  id={} type={} content={} proxied={}".format(
+                record.get("id", "<missing>"),
+                record.get("type", "<missing>"),
+                record.get("content", "<missing>"),
+                record.get("proxied", "<missing>"),
+            ),
+            file=sys.stderr,
+        )
+    print(
+        f"ACTION: Remove the duplicate or conflicting exact-host records in Cloudflare, then rerun {rerun_command}.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+if not matching:
+    print(json.dumps({"state": "absent", "id": ""}))
+    raise SystemExit(0)
+record = matching[0]
+record_type = record.get("type")
+record_id = record.get("id")
+if record_type != "CNAME" or not isinstance(record_id, str) or not record_id:
+    print(
+        f"ERROR: DNS record at {sys.argv[1]} has type {record_type!r}; expected one CNAME.",
+        file=sys.stderr,
+    )
+    print(
+        f"ACTION: Remove or convert the conflicting record in Cloudflare, then rerun {rerun_command}.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+content = str(record.get("content", "")).rstrip(".").lower()
+proxied = record.get("proxied") is True
+state = "exact" if content == expected_content and proxied == expected_proxied else "drift"
+print(json.dumps({
+    "state": state,
+    "id": record_id,
+    "content": record.get("content", ""),
+    "proxied": proxied,
+}))
+' "$expected_name" "$expected_content" "$expected_proxied" "$rerun_command"
+}
+
+cloudflare_origin_certificate_reconciliation() {
+  local response_file="$1"
+  local payload="$2"
+  local reconciliation_dir
+  local previous_umask
+  previous_umask=$(umask)
+  umask 077
+  reconciliation_dir=$(mktemp -d)
+  umask "$previous_umask"
+
+  local preparation
+  if ! preparation=$(python3 - "$response_file" "$payload" "$reconciliation_dir" <<'PY'
+import json
+import pathlib
+import sys
+
+response_path = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[3])
+try:
+    response = json.loads(response_path.read_text(encoding="utf-8"))
+    desired = json.loads(sys.argv[2])
+except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+    print(json.dumps({"state": "invalid", "reason": f"invalid JSON: {error}"}))
+    raise SystemExit(0)
+
+csr = desired.get("csr") if isinstance(desired, dict) else None
+hostnames = desired.get("hostnames") if isinstance(desired, dict) else None
+request_type = desired.get("request_type") if isinstance(desired, dict) else None
+requested_validity = desired.get("requested_validity") if isinstance(desired, dict) else None
+if (
+    not isinstance(csr, str)
+    or not csr.strip()
+    or not isinstance(hostnames, list)
+    or not hostnames
+    or any(not isinstance(hostname, str) or not hostname for hostname in hostnames)
+    or not isinstance(request_type, str)
+    or not request_type
+    or not isinstance(requested_validity, int)
+    or requested_validity <= 1
+):
+    print(json.dumps({"state": "invalid", "reason": "invalid Origin CA request payload"}))
+    raise SystemExit(0)
+
+raw_results = response.get("result", []) if isinstance(response, dict) else []
+if isinstance(raw_results, dict):
+    results = [raw_results]
+elif isinstance(raw_results, list):
+    results = raw_results
+else:
+    print(json.dumps({"state": "invalid", "reason": "Origin CA result is not an object or array"}))
+    raise SystemExit(0)
+
+(output_path / "request.csr.pem").write_text(csr, encoding="utf-8")
+(output_path / "minimum-validity-seconds").write_text(
+    str((requested_validity - 1) * 24 * 60 * 60),
+    encoding="utf-8",
+)
+exact_metadata_without_certificate = False
+candidate_count = 0
+expected_hostnames = sorted(hostnames)
+for index, result in enumerate(results):
+    if not isinstance(result, dict):
+        continue
+    result_hostnames = result.get("hostnames")
+    exact_metadata = (
+        isinstance(result_hostnames, list)
+        and all(isinstance(hostname, str) for hostname in result_hostnames)
+        and sorted(result_hostnames) == expected_hostnames
+        and result.get("request_type") == request_type
+    )
+    certificate = result.get("certificate")
+    if not isinstance(certificate, str) or not certificate.strip():
+        if exact_metadata:
+            exact_metadata_without_certificate = True
+        continue
+    candidate_path = output_path / f"candidate-{index}"
+    candidate_path.with_suffix(".pem").write_text(certificate, encoding="utf-8")
+    candidate_path.with_suffix(".json").write_text(json.dumps(result), encoding="utf-8")
+    if exact_metadata:
+        candidate_path.with_suffix(".exact-metadata").touch()
+    candidate_count += 1
+
+print(json.dumps({
+    "state": "prepared",
+    "candidateCount": candidate_count,
+    "exactMetadataWithoutCertificate": exact_metadata_without_certificate,
+}))
+PY
+  ); then
+    rm -rf -- "$reconciliation_dir"
+    printf '%s' '{"state":"invalid","reason":"could not prepare Origin CA reconciliation"}'
+    return 0
+  fi
+
+  local preparation_state
+  preparation_state=$(printf '%s' "$preparation" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state", "invalid"))')
+  if [[ "$preparation_state" != "prepared" ]]; then
+    rm -rf -- "$reconciliation_dir"
+    printf '%s' "$preparation"
+    return 0
+  fi
+
+  if ! openssl req \
+    -in "${reconciliation_dir}/request.csr.pem" \
+    -pubkey \
+    -noout \
+    | openssl pkey -pubin -outform DER >"${reconciliation_dir}/request-public-key.der" 2>/dev/null; then
+    rm -rf -- "$reconciliation_dir"
+    printf '%s' '{"state":"invalid","reason":"could not extract the Origin CA CSR public key"}'
+    return 0
+  fi
+
+  local -a public_key_matches=()
+  local exact_metadata_invalid_certificate=false
+  local certificate_file
+  for certificate_file in "${reconciliation_dir}"/candidate-*.pem; do
+    if [[ ! -f "$certificate_file" ]]; then
+      break
+    fi
+    local candidate_base="${certificate_file%.pem}"
+    if ! openssl x509 \
+      -in "$certificate_file" \
+      -pubkey \
+      -noout \
+      | openssl pkey -pubin -outform DER >"${candidate_base}.public-key.der" 2>/dev/null; then
+      if [[ -f "${candidate_base}.exact-metadata" ]]; then
+        exact_metadata_invalid_certificate=true
+      fi
+      continue
+    fi
+    if cmp -s "${reconciliation_dir}/request-public-key.der" "${candidate_base}.public-key.der"; then
+      public_key_matches+=("$candidate_base")
+    fi
+  done
+
+  if [[ "${#public_key_matches[@]}" -gt 1 ]]; then
+    rm -rf -- "$reconciliation_dir"
+    printf '%s' '{"state":"duplicate","reason":"multiple Origin CA certificates have the CSR public key"}'
+    return 0
+  fi
+
+  if [[ "${#public_key_matches[@]}" -eq 1 ]]; then
+    local matching_base="${public_key_matches[0]}"
+    if [[ ! -f "${matching_base}.exact-metadata" ]]; then
+      rm -rf -- "$reconciliation_dir"
+      printf '%s' '{"state":"drift","reason":"the public-key-matched Origin CA certificate has different hostnames or request type"}'
+      return 0
+    fi
+    local minimum_validity_seconds
+    minimum_validity_seconds=$(cat "${reconciliation_dir}/minimum-validity-seconds")
+    if ! openssl x509 \
+      -in "${matching_base}.pem" \
+      -checkend "$minimum_validity_seconds" \
+      -noout >/dev/null 2>&1; then
+      rm -rf -- "$reconciliation_dir"
+      printf '%s' '{"state":"drift","reason":"the public-key-matched Origin CA certificate expires too soon for the requested validity"}'
+      return 0
+    fi
+    local matched_response
+    matched_response=$(python3 - "${matching_base}.json" <<'PY'
+import json
+import pathlib
+import sys
+
+result = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(json.dumps({
+    "state": "exact",
+    "response": {
+        "success": True,
+        "errors": [],
+        "messages": [],
+        "result": result,
+    },
+}))
+PY
+)
+    rm -rf -- "$reconciliation_dir"
+    printf '%s' "$matched_response"
+    return 0
+  fi
+
+  local exact_metadata_without_certificate
+  exact_metadata_without_certificate=$(printf '%s' "$preparation" | python3 -c 'import json,sys; print(str(json.load(sys.stdin).get("exactMetadataWithoutCertificate") is True).lower())')
+  rm -rf -- "$reconciliation_dir"
+  if [[ "$exact_metadata_without_certificate" == "true" || "$exact_metadata_invalid_certificate" == "true" ]]; then
+    printf '%s' '{"state":"indeterminate","reason":"an exact-metadata Origin CA result did not contain a usable certificate"}'
+    return 0
+  fi
+  printf '%s' '{"state":"absent"}'
+}
+
+cloudflare_reconcile_origin_certificate_create() {
+  local operation="$1"
+  local reconciliation_path="$2"
+  local payload="$3"
+  local poll_attempt=1
+
+  while [[ "$poll_attempt" -le "$CLOUDFLARE_ORIGIN_CA_RECONCILIATION_ATTEMPTS" ]]; do
+    local reconciliation_file
+    reconciliation_file=$(mktemp)
+    if ! cloudflare_api_request \
+      "poll Origin CA state after ${operation}" \
+      "GET" \
+      "$reconciliation_path" \
+      "" >"$reconciliation_file"; then
+      rm -f -- "$reconciliation_file"
+      echo "ERROR: Cloudflare ${operation} outcome is unknown because the Origin CA list could not be read; path=${reconciliation_path}. Do not create another certificate; retain the original CSR and private key and resume reconciliation later." >&2
+      return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+    fi
+
+    local total_pages
+    if ! total_pages=$(python3 - "$reconciliation_file" <<'PY'
+import json
+import pathlib
+import sys
+
+response = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+result_info = response.get("result_info")
+total_pages = result_info.get("total_pages") if isinstance(result_info, dict) else None
+if not isinstance(total_pages, int) or isinstance(total_pages, bool) or total_pages < 0:
+    print("ERROR: Cloudflare Origin CA list response did not contain a valid result_info.total_pages value.", file=sys.stderr)
+    raise SystemExit(1)
+print(max(total_pages, 1))
+PY
+    ); then
+      rm -f -- "$reconciliation_file"
+      echo "ERROR: Cloudflare ${operation} response was inconclusive and the Origin CA list pagination metadata was invalid; path=${reconciliation_path}. Refusing to reissue because certificate absence cannot be established." >&2
+      return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+    fi
+    if [[ "$total_pages" -gt "$CLOUDFLARE_ORIGIN_CA_RECONCILIATION_MAX_PAGES" ]]; then
+      rm -f -- "$reconciliation_file"
+      echo "ERROR: Cloudflare ${operation} response was inconclusive and Origin CA reconciliation requires ${total_pages} pages, exceeding the bounded limit of ${CLOUDFLARE_ORIGIN_CA_RECONCILIATION_MAX_PAGES}; path=${reconciliation_path}. Narrow the account certificate inventory or reconcile it manually before rerunning." >&2
+      return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+    fi
+
+    local page_number=2
+    while [[ "$page_number" -le "$total_pages" ]]; do
+      local page_file
+      local merged_file
+      page_file=$(mktemp)
+      merged_file=$(mktemp)
+      if ! cloudflare_api_request \
+        "poll Origin CA state page ${page_number}/${total_pages} after ${operation}" \
+        "GET" \
+        "${reconciliation_path}&page=${page_number}" \
+          "" >"$page_file"; then
+        rm -f -- "$page_file" "$merged_file" "$reconciliation_file"
+        echo "ERROR: Cloudflare ${operation} outcome is unknown because Origin CA reconciliation page ${page_number}/${total_pages} could not be read; path=${reconciliation_path}. Do not create another certificate; retain the original CSR and private key and resume reconciliation later." >&2
+        return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+      fi
+      if ! python3 - "$reconciliation_file" "$page_file" >"$merged_file" <<'PY'
+import json
+import pathlib
+import sys
+
+combined = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+page = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+combined_results = combined.get("result")
+page_results = page.get("result")
+if not isinstance(combined_results, list) or not isinstance(page_results, list):
+    print("ERROR: Cloudflare Origin CA paginated response did not contain result arrays.", file=sys.stderr)
+    raise SystemExit(1)
+combined["result"] = [*combined_results, *page_results]
+combined["result_info"] = {
+    "count": len(combined["result"]),
+    "page": 1,
+    "per_page": len(combined["result"]),
+    "total_count": len(combined["result"]),
+    "total_pages": 1,
+}
+print(json.dumps(combined))
+PY
+      then
+        rm -f -- "$page_file" "$merged_file" "$reconciliation_file"
+        echo "ERROR: Cloudflare ${operation} response was inconclusive and Origin CA reconciliation could not combine page ${page_number}/${total_pages}; path=${reconciliation_path}. Refusing to reissue because certificate absence cannot be established." >&2
+        return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+      fi
+      mv -- "$merged_file" "$reconciliation_file"
+      rm -f -- "$page_file"
+      page_number=$((page_number + 1))
+    done
+
+    local reconciliation
+    local reconciliation_state
+    reconciliation=$(cloudflare_origin_certificate_reconciliation "$reconciliation_file" "$payload")
+    rm -f -- "$reconciliation_file"
+    reconciliation_state=$(printf '%s' "$reconciliation" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state", "invalid"))')
+    if [[ "$reconciliation_state" == "exact" ]]; then
+      echo "WARNING: Cloudflare ${operation} response was inconclusive, but bounded reconciliation matched the issued certificate to the original CSR public key; reusing it." >&2
+      printf '%s' "$reconciliation" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["response"]))'
+      return 0
+    fi
+    if [[ "$reconciliation_state" != "absent" ]]; then
+      local reconciliation_reason
+      reconciliation_reason=$(printf '%s' "$reconciliation" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("reason", "no reason returned"))')
+      echo "ERROR: Cloudflare ${operation} outcome is unknown because Origin CA reconciliation found ${reconciliation_state} state; path=${reconciliation_path}; reason=${reconciliation_reason}. Do not create another certificate; retain the original CSR and private key and resolve or resume reconciliation." >&2
+      return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+    fi
+    if [[ "$poll_attempt" -lt "$CLOUDFLARE_ORIGIN_CA_RECONCILIATION_ATTEMPTS" ]]; then
+      echo "WARNING: Cloudflare ${operation} is not visible in the Origin CA list after reconciliation poll ${poll_attempt}/${CLOUDFLARE_ORIGIN_CA_RECONCILIATION_ATTEMPTS}; waiting 2 seconds before polling again." >&2
+      sleep 2
+    fi
+    poll_attempt=$((poll_attempt + 1))
+  done
+
+  echo "ERROR: Cloudflare ${operation} outcome remains unknown after ${CLOUDFLARE_ORIGIN_CA_RECONCILIATION_ATTEMPTS} successful list polls; path=${reconciliation_path}. Propagation delay does not prove absence. Do not create another certificate; retain the original CSR and private key and resume reconciliation later." >&2
+  return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+}
+
+cloudflare_request_was_not_sent() {
+  local curl_status="$1"
+  case "$curl_status" in
+    1|2|3|4|5|6|7) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+cloudflare_api_request() {
+  local operation="$1"
+  local method="$2"
+  local path="$3"
+  local payload="$4"
+  local reconciliation_path="${5:-}"
+  if [[ ( "$method" == "POST" || "$method" == "DELETE" ) && -z "$reconciliation_path" ]]; then
+    echo "ERROR: Cloudflare ${operation} uses ${method} and requires a reconciliation path before it can be retried safely." >&2
+    return 1
+  fi
+  if ! cloudflare_prepare_curl_config; then
+    return 1
+  fi
+  local response_file
+  local error_file
+  response_file=$(mktemp)
+  error_file=$(mktemp)
+  local attempt=1
+
+  while [[ "$attempt" -le "$CLOUDFLARE_API_MAX_ATTEMPTS" ]]; do
+    local -a curl_args=(
+      --silent
+      --show-error
+      --connect-timeout 10
+      --max-time 30
+      --request "$method"
+      --output "$response_file"
+      --write-out "%{http_code}"
+      --config "$CLOUDFLARE_CURL_CONFIG_FILE"
+      "${CLOUDFLARE_API_BASE_URL}${path}"
+      --header "Content-Type: application/json"
+    )
+    if [[ -n "$payload" ]]; then
+      curl_args+=(--data "$payload")
+    fi
+
+    local http_status
+    local curl_status
+    if http_status=$(curl "${curl_args[@]}" 2>"$error_file"); then
+      curl_status=0
+    else
+      curl_status=$?
+    fi
+    local response_state
+    response_state=$(cloudflare_response_state "$response_file")
+    if [[ "$curl_status" -eq 0 && "$http_status" =~ ^2[0-9][0-9]$ && "$response_state" == "success" ]]; then
+      cloudflare_redact_credentials "$(cat "$response_file")"
+      rm -f "$response_file" "$error_file"
+      return 0
+    fi
+
+    if [[ "$method" == "POST" ]]; then
+      if [[ "$curl_status" -ne 0 ]] && cloudflare_request_was_not_sent "$curl_status"; then
+        :
+      elif [[ "$curl_status" -eq 0 && "$http_status" =~ ^4[0-9][0-9]$ && "$response_state" != "success" ]]; then
+        local rejected_response_body
+        local rejected_transport_error
+        rejected_response_body=$(cloudflare_redact_credentials "$(cloudflare_error_body "$response_file")")
+        rejected_transport_error=$(cloudflare_redact_credentials "$(sed -n '1,20p' "$error_file")")
+        echo "ERROR: Cloudflare ${operation} was definitively rejected; method=${method}; path=${path}; curl_status=${curl_status}; http_status=${http_status}; response=${rejected_response_body}; transport_error=${rejected_transport_error:-none}. The rejected request will not be retried; correct the request or token permissions before trying again." >&2
+        rm -f -- "$response_file" "$error_file"
+        return 1
+      elif cloudflare_is_origin_certificate_payload "$payload"; then
+          local origin_reconciliation_file
+          local origin_reconciliation_status
+          origin_reconciliation_file=$(mktemp)
+          if cloudflare_reconcile_origin_certificate_create \
+            "$operation" \
+            "$reconciliation_path" \
+            "$payload" >"$origin_reconciliation_file"; then
+            cloudflare_redact_credentials "$(cat "$origin_reconciliation_file")"
+            rm -f -- "$origin_reconciliation_file" "$response_file" "$error_file"
+            return 0
+          else
+            origin_reconciliation_status=$?
+          fi
+          rm -f -- "$origin_reconciliation_file" "$response_file" "$error_file"
+          if [[ "$origin_reconciliation_status" -eq "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS" ]]; then
+            return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+          fi
+          return 1
+      elif cloudflare_is_dns_record_payload "$payload"; then
+        local dns_reconciliation_file
+        local dns_reconciliation_status
+        dns_reconciliation_file=$(mktemp)
+        if cloudflare_reconcile_dns_record_create \
+          "$operation" \
+          "$reconciliation_path" \
+          "$payload" >"$dns_reconciliation_file"; then
+          cloudflare_redact_credentials "$(cat "$dns_reconciliation_file")"
+          rm -f -- "$dns_reconciliation_file" "$response_file" "$error_file"
+          return 0
+        else
+          dns_reconciliation_status=$?
+        fi
+        rm -f -- "$dns_reconciliation_file" "$response_file" "$error_file"
+        if [[ "$dns_reconciliation_status" -eq "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS" ]]; then
+          return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+        fi
+        return 1
+      else
+        echo "ERROR: Cloudflare ${operation} uses an unsupported POST payload, so its ambiguous outcome cannot be reconciled safely. No automatic retry will be attempted." >&2
+        rm -f -- "$response_file" "$error_file"
+        return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+      fi
+    fi
+
+    if [[ "$method" == "DELETE" ]]; then
+      local reconciliation_file
+      reconciliation_file=$(mktemp)
+      if cloudflare_optional_get_request \
+        "reconcile ${operation}" \
+        "$reconciliation_path" >"$reconciliation_file"; then
+        local deletion_state
+        deletion_state=$(cloudflare_response_state "$reconciliation_file")
+        if [[ "$deletion_state" == "not_found" ]]; then
+          echo "WARNING: Cloudflare ${operation} response was inconclusive, but reconciliation confirmed that the resource is absent." >&2
+          printf '{"success":true,"result":{"reconciled":true}}'
+          rm -f "$reconciliation_file" "$response_file" "$error_file"
+          return 0
+        fi
+      else
+        rm -f "$reconciliation_file" "$response_file" "$error_file"
+        return 1
+      fi
+      rm -f "$reconciliation_file"
+    fi
+
+    local response_body
+    response_body=$(cloudflare_redact_credentials "$(cloudflare_error_body "$response_file")")
+    local transport_error
+    transport_error=$(cloudflare_redact_credentials "$(sed -n '1,20p' "$error_file")")
+    if [[ "$attempt" -lt "$CLOUDFLARE_API_MAX_ATTEMPTS" ]]; then
+      echo "WARNING: Cloudflare ${operation} attempt ${attempt}/${CLOUDFLARE_API_MAX_ATTEMPTS} failed; method=${method}; path=${path}; curl_status=${curl_status}; http_status=${http_status:-none}; response=${response_body}; transport_error=${transport_error:-none}; retrying in 2 seconds." >&2
+      sleep 2
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    echo "ERROR: Cloudflare ${operation} failed after ${CLOUDFLARE_API_MAX_ATTEMPTS} attempts; method=${method}; path=${path}; curl_status=${curl_status}; http_status=${http_status:-none}; response=${response_body}; transport_error=${transport_error:-none}. Check the zone ID, API token permissions, requested resource, and Cloudflare plan." >&2
+    rm -f "$response_file" "$error_file"
+    return 1
+  done
+}
+
+cloudflare_optional_get_request() {
+  local operation="$1"
+  local path="$2"
+  if ! cloudflare_prepare_curl_config; then
+    return 1
+  fi
+  local response_file
+  local error_file
+  response_file=$(mktemp)
+  error_file=$(mktemp)
+  local attempt=1
+
+  while [[ "$attempt" -le "$CLOUDFLARE_API_MAX_ATTEMPTS" ]]; do
+    local http_status
+    local curl_status
+    if http_status=$(curl \
+      --silent \
+      --show-error \
+      --connect-timeout 10 \
+      --max-time 30 \
+      --request GET \
+      --output "$response_file" \
+      --write-out "%{http_code}" \
+      --config "$CLOUDFLARE_CURL_CONFIG_FILE" \
+      "${CLOUDFLARE_API_BASE_URL}${path}" \
+      --header "Content-Type: application/json" \
+      2>"$error_file"); then
+      curl_status=0
+    else
+      curl_status=$?
+    fi
+    local response_state
+    response_state=$(cloudflare_response_state "$response_file")
+    if [[ "$curl_status" -eq 0 && "$http_status" =~ ^2[0-9][0-9]$ && "$response_state" == "success" ]]; then
+      cloudflare_redact_credentials "$(cat "$response_file")"
+      rm -f "$response_file" "$error_file"
+      return 0
+    fi
+    if [[ "$curl_status" -eq 0 && "$http_status" == "404" ]]; then
+      printf '{"success":false,"result":null,"errors":[{"message":"not found"}]}'
+      rm -f "$response_file" "$error_file"
+      return 0
+    fi
+
+    local response_body
+    response_body=$(cloudflare_redact_credentials "$(cloudflare_error_body "$response_file")")
+    local transport_error
+    transport_error=$(cloudflare_redact_credentials "$(sed -n '1,20p' "$error_file")")
+    if [[ "$attempt" -lt "$CLOUDFLARE_API_MAX_ATTEMPTS" ]]; then
+      echo "WARNING: Cloudflare ${operation} attempt ${attempt}/${CLOUDFLARE_API_MAX_ATTEMPTS} failed; method=GET; path=${path}; curl_status=${curl_status}; http_status=${http_status:-none}; response=${response_body}; transport_error=${transport_error:-none}; retrying in 2 seconds." >&2
+      sleep 2
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    echo "ERROR: Cloudflare ${operation} failed after ${CLOUDFLARE_API_MAX_ATTEMPTS} attempts; method=GET; path=${path}; curl_status=${curl_status}; http_status=${http_status:-none}; response=${response_body}; transport_error=${transport_error:-none}. Check the zone ID, API token permissions, requested ruleset phase, and Cloudflare plan." >&2
+    rm -f "$response_file" "$error_file"
+    return 1
+  done
+}

--- a/scripts/cloudflare/setup-api-domain.sh
+++ b/scripts/cloudflare/setup-api-domain.sh
@@ -10,11 +10,20 @@
 #   CLOUDFLARE_ZONE_ID    — Zone ID from Cloudflare
 #   AWS_PROFILE           — AWS CLI profile for the target account
 #
-# Usage:
-#   export CLOUDFLARE_API_TOKEN="..." CLOUDFLARE_ZONE_ID="..." AWS_PROFILE=expense-tracker
-#   bash scripts/cloudflare/setup-api-domain.sh --domain expense-budget-tracker.com --region eu-central-1
+# Usage from the repository root; the parent shell never receives the token:
+#   (
+#     set -euo pipefail
+#     set -a
+#     source scripts/cloudflare/.env
+#     set +a
+#     export AWS_PROFILE=expense-tracker
+#     bash scripts/cloudflare/setup-api-domain.sh --domain expense-budget-tracker.com --region eu-central-1
+#   )
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/cloudflare-api.sh"
 
 # --- Parse arguments ---
 DOMAIN=""
@@ -34,7 +43,7 @@ if [[ -z "$DOMAIN" || -z "$REGION" ]]; then
   exit 1
 fi
 
-: "${CLOUDFLARE_API_TOKEN:?Set CLOUDFLARE_API_TOKEN env var}"
+cloudflare_require_api_token
 : "${CLOUDFLARE_ZONE_ID:?Set CLOUDFLARE_ZONE_ID env var}"
 
 API_DOMAIN="${API_SUBDOMAIN}.${DOMAIN}"
@@ -83,36 +92,50 @@ echo "Validation CNAME: ${VALIDATION_NAME} -> ${VALIDATION_VALUE}"
 # --- Step 3: Create validation CNAME in Cloudflare (DNS-only, not proxied) ---
 echo "Creating ACM validation CNAME in Cloudflare (DNS-only)..."
 
-EXISTING=$(curl -s "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${VALIDATION_NAME}&type=CNAME" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json")
+EXISTING=$(cloudflare_read_all_dns_records \
+  "read all DNS records for API certificate validation hostname ${VALIDATION_NAME}" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${VALIDATION_NAME}&per_page=100")
+EXISTING_RECORD=$(echo "$EXISTING" | cloudflare_classify_exact_cname \
+  "$VALIDATION_NAME" \
+  "$VALIDATION_VALUE" \
+  "false" \
+  "setup-api-domain.sh")
+EXISTING_STATE=$(echo "$EXISTING_RECORD" | python3 -c 'import json,sys; print(json.load(sys.stdin)["state"])')
+EXISTING_ID=$(echo "$EXISTING_RECORD" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
 
-EXISTING_COUNT=$(echo "$EXISTING" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("result", [])))')
+VALIDATION_PAYLOAD=$(python3 -c '
+import json
+import sys
 
-if [[ "$EXISTING_COUNT" -gt 0 ]]; then
-  RECORD_ID=$(echo "$EXISTING" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"][0]["id"])')
-  curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records/${RECORD_ID}" \
-    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    -H "Content-Type: application/json" \
-    --data "{
-      \"type\": \"CNAME\",
-      \"name\": \"${VALIDATION_NAME}\",
-      \"content\": \"${VALIDATION_VALUE}\",
-      \"ttl\": 120,
-      \"proxied\": false
-    }" | python3 -c 'import sys,json; r=json.load(sys.stdin); print("OK" if r["success"] else json.dumps(r["errors"], indent=2))'
+print(json.dumps({
+    "type": "CNAME",
+    "name": sys.argv[1],
+    "content": sys.argv[2],
+    "ttl": 120,
+    "proxied": False,
+}))
+' "$VALIDATION_NAME" "$VALIDATION_VALUE")
+
+if [[ "$EXISTING_STATE" == "exact" ]]; then
+  echo "API certificate validation CNAME already matches and is DNS-only; reusing it."
+elif [[ "$EXISTING_STATE" == "drift" ]]; then
+  cloudflare_api_request \
+    "update API certificate validation CNAME ${VALIDATION_NAME}" \
+    "PUT" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/dns_records/${EXISTING_ID}" \
+    "$VALIDATION_PAYLOAD" >/dev/null
+elif [[ "$EXISTING_STATE" == "absent" ]]; then
+  cloudflare_api_request \
+    "create API certificate validation CNAME ${VALIDATION_NAME}" \
+    "POST" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/dns_records" \
+    "$VALIDATION_PAYLOAD" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${VALIDATION_NAME}&per_page=100" >/dev/null
 else
-  curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records" \
-    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    -H "Content-Type: application/json" \
-    --data "{
-      \"type\": \"CNAME\",
-      \"name\": \"${VALIDATION_NAME}\",
-      \"content\": \"${VALIDATION_VALUE}\",
-      \"ttl\": 120,
-      \"proxied\": false
-    }" | python3 -c 'import sys,json; r=json.load(sys.stdin); print("OK" if r["success"] else json.dumps(r["errors"], indent=2))'
+  echo "ERROR: Unexpected DNS reconciliation state '${EXISTING_STATE}' for API certificate validation hostname ${VALIDATION_NAME}." >&2
+  exit 1
 fi
+echo "ACM validation CNAME is configured as DNS-only."
 
 # --- Step 4: Wait for certificate to be ISSUED ---
 echo "Waiting for ACM certificate validation (this may take 5-30 minutes)..."
@@ -133,5 +156,5 @@ echo ""
 echo "Next steps:"
 echo "  1. Add apiCertificateArn to cdk.context.local.json"
 echo "  2. Run: npx cdk deploy"
-echo "  3. Run: bash scripts/cloudflare/setup-dns.sh --stack-name ExpenseBudgetTracker"
+echo "  3. Run setup-dns.sh using the credential-isolated subshell in infra/aws/README.md step 6"
 echo "     (setup-dns.sh will automatically create the api.* CNAME from the ApiCustomDomain stack output)"

--- a/scripts/cloudflare/setup-certificate.sh
+++ b/scripts/cloudflare/setup-certificate.sh
@@ -7,50 +7,149 @@
 #   CLOUDFLARE_ZONE_ID    — Zone ID from Cloudflare dashboard
 #   AWS_PROFILE           — AWS CLI profile for the target account
 #
-# Usage:
-#   export CLOUDFLARE_API_TOKEN="..." CLOUDFLARE_ZONE_ID="..." AWS_PROFILE=expense-tracker
-#   bash scripts/cloudflare/setup-certificate.sh --domain expense-budget-tracker.com --region eu-central-1
+# Usage from the repository root; the parent shell never receives the token:
+#   (
+#     set -euo pipefail
+#     set -a
+#     source scripts/cloudflare/.env
+#     set +a
+#     export AWS_PROFILE=expense-tracker
+#     bash scripts/cloudflare/setup-certificate.sh --domain expense-budget-tracker.com --region eu-central-1
+#   )
+# Replace the final command with the printed --resume-dir command when resuming.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/cloudflare-api.sh"
 
 # --- Parse arguments ---
 DOMAIN=""
 REGION=""
+RESUME_DIR=""
 while [[ $# -gt 0 ]]; do
   case $1 in
     --domain) DOMAIN="$2"; shift 2 ;;
     --region) REGION="$2"; shift 2 ;;
+    --resume-dir) RESUME_DIR="$2"; shift 2 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
 if [[ -z "$DOMAIN" || -z "$REGION" ]]; then
-  echo "Usage: $0 --domain <domain> --region <aws-region>" >&2
+  echo "Usage: $0 --domain <domain> --region <aws-region> [--resume-dir <retained-directory>]" >&2
   exit 1
 fi
 
-: "${CLOUDFLARE_API_TOKEN:?Set CLOUDFLARE_API_TOKEN env var}"
+cloudflare_require_api_token
 : "${CLOUDFLARE_ZONE_ID:?Set CLOUDFLARE_ZONE_ID env var}"
 
-echo "Creating Cloudflare Origin Certificate for *.${DOMAIN} and ${DOMAIN}..."
-
-# --- Generate RSA private key and CSR ---
-TMPDIR_CERT=$(mktemp -d)
+cloudflare_prepare_curl_config
+PRESERVE_CERTIFICATE_REQUEST=false
+if [[ -n "$RESUME_DIR" ]]; then
+  if [[ ! -d "$RESUME_DIR" || -L "$RESUME_DIR" ]]; then
+    echo "ERROR: Retained Origin CA recovery directory must exist and must not be a symlink: ${RESUME_DIR}" >&2
+    exit 1
+  fi
+  TMPDIR_CERT="$RESUME_DIR"
+  PRESERVE_CERTIFICATE_REQUEST=true
+else
+  previous_umask=$(umask)
+  umask 077
+  TMPDIR_CERT=$(mktemp -d)
+  umask "$previous_umask"
+fi
 KEY_FILE="${TMPDIR_CERT}/origin.key"
 CSR_FILE="${TMPDIR_CERT}/origin.csr"
+CERT_FILE="${TMPDIR_CERT}/origin.crt"
+KEY_PUBLIC_FILE="${TMPDIR_CERT}/origin-key-public.der"
+CSR_PUBLIC_FILE="${TMPDIR_CERT}/origin-csr-public.der"
+CERT_PUBLIC_FILE="${TMPDIR_CERT}/origin-cert-public.der"
+RECOVERY_INSTRUCTIONS_PRINTED=false
+RECOVERY_REASON="Origin CA reconciliation did not complete."
 
-openssl req -new -newkey rsa:2048 -nodes \
-  -keyout "$KEY_FILE" \
-  -out "$CSR_FILE" \
-  -subj "/CN=${DOMAIN}" 2>/dev/null
+print_origin_ca_recovery_instructions() {
+  if [[ "$RECOVERY_INSTRUCTIONS_PRINTED" == "true" ]]; then
+    return
+  fi
+  RECOVERY_INSTRUCTIONS_PRINTED=true
+  echo "ERROR: ${RECOVERY_REASON}" >&2
+  echo "Retained CSR: ${CSR_FILE}" >&2
+  echo "Retained private key: ${KEY_FILE}" >&2
+  echo "ACTION: Keep these files private and resume GET-only reconciliation; do not start a fresh create." >&2
+  echo "ACTION: In the credential-isolated subshell from infra/aws/README.md step 3d, replace the final command with:" >&2
+  printf '  bash %q --domain %q --region %q --resume-dir %q\n' "$0" "$DOMAIN" "$REGION" "$TMPDIR_CERT" >&2
+}
 
-CSR_PEM=$(cat "$CSR_FILE")
+cleanup() {
+  cloudflare_cleanup_curl_config
+  rm -f -- "$CERT_FILE" "$KEY_PUBLIC_FILE" "$CSR_PUBLIC_FILE" "$CERT_PUBLIC_FILE"
+  if [[ "$PRESERVE_CERTIFICATE_REQUEST" == "true" ]]; then
+    if ! chmod 700 "$TMPDIR_CERT" || ! chmod 600 "$KEY_FILE" "$CSR_FILE"; then
+      echo "ERROR: Could not restore restricted permissions on retained Origin CA recovery files in ${TMPDIR_CERT}. Secure them immediately." >&2
+    fi
+    print_origin_ca_recovery_instructions
+    return
+  fi
+  rm -f -- "$KEY_FILE" "$CSR_FILE"
+  if [[ -d "$TMPDIR_CERT" ]] && ! rmdir -- "$TMPDIR_CERT"; then
+    echo "WARNING: Temporary Origin CA directory ${TMPDIR_CERT} contains unexpected files and was not removed." >&2
+  fi
+}
+trap 'cleanup' EXIT
+trap 'cleanup; exit 129' HUP
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+preserve_unknown_origin_ca_request() {
+  PRESERVE_CERTIFICATE_REQUEST=true
+  RECOVERY_REASON="The Cloudflare Origin CA create outcome is unknown. No second certificate request was sent."
+  rm -f -- "$CERT_FILE" "$KEY_PUBLIC_FILE" "$CSR_PUBLIC_FILE" "$CERT_PUBLIC_FILE"
+  if ! chmod 700 "$TMPDIR_CERT" || ! chmod 600 "$KEY_FILE" "$CSR_FILE"; then
+    echo "ERROR: Could not restrict retained Origin CA recovery files in ${TMPDIR_CERT}. Secure them immediately." >&2
+  fi
+  print_origin_ca_recovery_instructions
+}
+
+if [[ -n "$RESUME_DIR" ]]; then
+  if [[ ! -f "$KEY_FILE" || -L "$KEY_FILE" || ! -f "$CSR_FILE" || -L "$CSR_FILE" ]]; then
+    echo "ERROR: ${TMPDIR_CERT} must contain regular, non-symlink origin.key and origin.csr recovery files." >&2
+    exit 1
+  fi
+  if ! chmod 700 "$TMPDIR_CERT" || ! chmod 600 "$KEY_FILE" "$CSR_FILE"; then
+    echo "ERROR: Could not enforce mode 0700/0600 on retained Origin CA recovery files in ${TMPDIR_CERT}." >&2
+    exit 1
+  fi
+  if ! openssl req -in "$CSR_FILE" -noout -verify >/dev/null 2>&1; then
+    echo "ERROR: Retained Origin CA CSR is invalid: ${CSR_FILE}" >&2
+    exit 1
+  fi
+  if ! openssl pkey -in "$KEY_FILE" -pubout -outform DER >"$KEY_PUBLIC_FILE" 2>/dev/null; then
+    echo "ERROR: Retained Origin CA private key is invalid: ${KEY_FILE}" >&2
+    exit 1
+  fi
+  if ! openssl req -in "$CSR_FILE" -pubkey -noout \
+    | openssl pkey -pubin -outform DER >"$CSR_PUBLIC_FILE" 2>/dev/null; then
+    echo "ERROR: Could not extract the public key from retained Origin CA CSR: ${CSR_FILE}" >&2
+    exit 1
+  fi
+  if ! cmp -s "$KEY_PUBLIC_FILE" "$CSR_PUBLIC_FILE"; then
+    echo "ERROR: Retained Origin CA private key does not match the retained CSR in ${TMPDIR_CERT}." >&2
+    exit 1
+  fi
+  rm -f -- "$KEY_PUBLIC_FILE" "$CSR_PUBLIC_FILE"
+  echo "Resuming Cloudflare Origin Certificate reconciliation for *.${DOMAIN} and ${DOMAIN}; no create request will be sent..."
+else
+  echo "Creating Cloudflare Origin Certificate for *.${DOMAIN} and ${DOMAIN}..."
+  openssl req -new -newkey rsa:2048 -nodes \
+    -keyout "$KEY_FILE" \
+    -out "$CSR_FILE" \
+    -subj "/CN=${DOMAIN}" 2>/dev/null
+  chmod 600 "$KEY_FILE" "$CSR_FILE"
+fi
 
 # --- Create Origin Certificate via Cloudflare API ---
-CERT_RESPONSE=$(curl -s -X POST "https://api.cloudflare.com/client/v4/certificates" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json" \
-  --data "$(python3 -c '
+CERT_PAYLOAD=$(python3 -c '
 import json, sys
 csr = open(sys.argv[1]).read()
 print(json.dumps({
@@ -59,19 +158,71 @@ print(json.dumps({
     "request_type": "origin-rsa",
     "csr": csr
 }))
-' "$CSR_FILE" "$DOMAIN")")
+' "$CSR_FILE" "$DOMAIN")
 
-SUCCESS=$(echo "$CERT_RESPONSE" | python3 -c 'import sys,json; print(json.load(sys.stdin)["success"])')
-if [[ "$SUCCESS" != "True" ]]; then
-  echo "Failed to create Cloudflare Origin Certificate:" >&2
-  echo "$CERT_RESPONSE" | python3 -c 'import sys,json; print(json.dumps(json.load(sys.stdin).get("errors", []), indent=2))' >&2
-  rm -rf "$TMPDIR_CERT"
-  exit 1
+ORIGIN_CA_RECONCILIATION_PATH="/certificates?zone_id=${CLOUDFLARE_ZONE_ID}&per_page=50"
+if [[ -n "$RESUME_DIR" ]]; then
+  if CERT_RESPONSE=$(cloudflare_reconcile_origin_certificate_create \
+    "resume Origin Certificate reconciliation for ${DOMAIN}" \
+    "$ORIGIN_CA_RECONCILIATION_PATH" \
+    "$CERT_PAYLOAD"); then
+    :
+  else
+    request_status=$?
+    preserve_unknown_origin_ca_request
+    exit "$request_status"
+  fi
+else
+  if CERT_RESPONSE=$(cloudflare_api_request \
+    "create Origin Certificate for ${DOMAIN}" \
+    "POST" \
+    "/certificates" \
+    "$CERT_PAYLOAD" \
+    "$ORIGIN_CA_RECONCILIATION_PATH"); then
+    :
+  else
+    request_status=$?
+    if [[ "$request_status" -eq "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS" ]]; then
+      preserve_unknown_origin_ca_request
+    fi
+    exit "$request_status"
+  fi
 fi
 
+PRESERVE_CERTIFICATE_REQUEST=true
+RECOVERY_REASON="Cloudflare issued the Origin CA certificate, but certificate validation or ACM import did not complete."
+
 # Extract signed certificate to file
-CERT_FILE="${TMPDIR_CERT}/origin.crt"
-echo "$CERT_RESPONSE" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["certificate"])' > "$CERT_FILE"
+echo "$CERT_RESPONSE" | python3 -c '
+import json
+import sys
+
+result = json.load(sys.stdin).get("result")
+certificate = result.get("certificate") if isinstance(result, dict) else None
+if not isinstance(certificate, str) or not certificate.strip():
+    print("ERROR: Cloudflare Origin Certificate response did not contain a certificate.", file=sys.stderr)
+    raise SystemExit(1)
+print(certificate)
+' > "$CERT_FILE"
+
+if ! openssl x509 -in "$CERT_FILE" -noout >/dev/null 2>&1; then
+  echo "ERROR: Cloudflare Origin CA response is not a valid X.509 certificate." >&2
+  exit 1
+fi
+if ! openssl pkey -in "$KEY_FILE" -pubout -outform DER >"$KEY_PUBLIC_FILE" 2>/dev/null; then
+  echo "ERROR: Could not extract the retained Origin CA private-key public key." >&2
+  exit 1
+fi
+if ! openssl x509 -in "$CERT_FILE" -pubkey -noout \
+  | openssl pkey -pubin -outform DER >"$CERT_PUBLIC_FILE" 2>/dev/null; then
+  echo "ERROR: Could not extract the issued Origin CA certificate public key." >&2
+  exit 1
+fi
+if ! cmp -s "$KEY_PUBLIC_FILE" "$CERT_PUBLIC_FILE"; then
+  echo "ERROR: Issued Origin CA certificate does not match the retained private key." >&2
+  exit 1
+fi
+rm -f -- "$KEY_PUBLIC_FILE" "$CERT_PUBLIC_FILE"
 
 echo "Origin Certificate created (15-year validity)."
 
@@ -84,7 +235,12 @@ CERT_ARN=$(aws acm import-certificate \
   --private-key "fileb://${KEY_FILE}" \
   --query "CertificateArn" --output text)
 
-rm -rf "$TMPDIR_CERT"
+if [[ ! "$CERT_ARN" =~ ^arn:[^:]+:acm:${REGION}:[0-9]{12}:certificate/.+ ]]; then
+  echo "ERROR: ACM import returned an invalid certificate ARN for region ${REGION}: ${CERT_ARN}" >&2
+  exit 1
+fi
+
+PRESERVE_CERTIFICATE_REQUEST=false
 
 echo ""
 echo "Certificate imported into ACM."

--- a/scripts/cloudflare/setup-dns.sh
+++ b/scripts/cloudflare/setup-dns.sh
@@ -1,21 +1,35 @@
 #!/usr/bin/env bash
-# Create a Cloudflare DNS CNAME record pointing to the ALB.
-# Run once after the first CDK deploy.
+# Configure Cloudflare DNS, cache bypass, and edge rate limiting for the deployed stack.
+# Run after the first CDK deploy and rerun to reconcile drift.
 #
 # Required env vars:
-#   CLOUDFLARE_API_TOKEN  — API token with Zone:DNS:Edit, Zone:SSL and Certificates:Edit, Zone:Zone Settings:Edit, Zone:Cache Rules:Edit
+#   CLOUDFLARE_API_TOKEN  — API token with DNS, SSL, Zone Settings, Cache Rules, and WAF edit permissions
 #   CLOUDFLARE_ZONE_ID    — Zone ID from Cloudflare dashboard
 #   AWS_PROFILE           — AWS CLI profile for the target account
+#   AWS_REGION            — AWS region for the deployed stack, or pass --region
 #
-# Usage:
-#   export CLOUDFLARE_API_TOKEN="..." CLOUDFLARE_ZONE_ID="..." AWS_PROFILE=expense-tracker
-#   bash scripts/cloudflare/setup-dns.sh --stack-name ExpenseBudgetTracker --region eu-central-1
+# Usage from the repository root; the parent shell never receives the token:
+#   (
+#     set -euo pipefail
+#     set -a
+#     source scripts/cloudflare/.env
+#     set +a
+#     export AWS_PROFILE=expense-tracker AWS_REGION=eu-central-1
+#     bash scripts/cloudflare/setup-dns.sh --stack-name ExpenseBudgetTracker --region eu-central-1
+#   )
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CDK_CONTEXT_FILE="${ROOT_DIR}/infra/aws/cdk.context.local.json"
+source "${SCRIPT_DIR}/cloudflare-api.sh"
+source "${SCRIPT_DIR}/aws-api.sh"
 
 # --- Parse arguments ---
 SUBDOMAIN="app"
 STACK_NAME="ExpenseBudgetTracker"
+AWS_PROFILE="${AWS_PROFILE:-}"
 AWS_REGION="${AWS_REGION:-}"
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -25,14 +39,21 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-: "${CLOUDFLARE_API_TOKEN:?Set CLOUDFLARE_API_TOKEN env var}"
+cloudflare_require_api_token
 : "${CLOUDFLARE_ZONE_ID:?Set CLOUDFLARE_ZONE_ID env var}"
 if [[ -z "$AWS_REGION" ]]; then
   echo "ERROR: AWS region is required. Pass --region or set AWS_REGION." >&2
   exit 1
 fi
-
-AWS_ARGS=(--region "$AWS_REGION")
+if [[ -z "$AWS_PROFILE" ]]; then
+  echo "ERROR: AWS_PROFILE is required and must identify the dedicated deployment account." >&2
+  exit 1
+fi
+if [[ ! -f "$CDK_CONTEXT_FILE" ]]; then
+  echo "ERROR: ${CDK_CONTEXT_FILE} is required before configuring deployed DNS." >&2
+  echo "Create the deployment context as described in infra/aws/README.md step 5, then rerun." >&2
+  exit 1
+fi
 
 assert_cloudflare_success() {
   python3 -c '
@@ -72,6 +93,86 @@ raise SystemExit(1)
 ' "$failure_message" "$remediation"
 }
 
+build_proxied_cname_payload() {
+  local name="$1"
+  local content="$2"
+  python3 -c '
+import json
+import sys
+
+print(json.dumps({
+    "type": "CNAME",
+    "name": sys.argv[1],
+    "content": sys.argv[2],
+    "ttl": 1,
+    "proxied": True,
+}))
+' "$name" "$content"
+}
+
+reconcile_proxied_cname_from_records() {
+  local label="$1"
+  local hostname="$2"
+  local target="$3"
+  local existing="$4"
+  local creation_reconciliation_path="$5"
+  local record
+  local state
+  local record_id
+  local payload
+
+  record=$(echo "$existing" | cloudflare_classify_exact_cname \
+    "$hostname" \
+    "$target" \
+    "true" \
+    "setup-dns.sh")
+  state=$(echo "$record" | python3 -c 'import json,sys; print(json.load(sys.stdin)["state"])')
+  record_id=$(echo "$record" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+  payload=$(build_proxied_cname_payload "$hostname" "$target")
+
+  if [[ "$state" == "exact" ]]; then
+    echo "${label} CNAME already matches ${target} and is proxied; reusing it."
+  elif [[ "$state" == "drift" ]]; then
+    local current_content
+    local current_proxied
+    current_content=$(echo "$record" | python3 -c 'import json,sys; print(json.load(sys.stdin)["content"])')
+    current_proxied=$(echo "$record" | python3 -c 'import json,sys; print(str(json.load(sys.stdin)["proxied"]).lower())')
+    echo "Reconciling singleton ${label} CNAME drift: current target=${current_content}, proxied=${current_proxied}; expected target=${target}, proxied=true."
+    cloudflare_api_request \
+      "update ${label} CNAME ${hostname}" \
+      "PUT" \
+      "/zones/${CLOUDFLARE_ZONE_ID}/dns_records/${record_id}" \
+      "$payload" | assert_cloudflare_success
+  elif [[ "$state" == "absent" ]]; then
+    cloudflare_api_request \
+      "create ${label} CNAME ${hostname}" \
+      "POST" \
+      "/zones/${CLOUDFLARE_ZONE_ID}/dns_records" \
+      "$payload" \
+      "$creation_reconciliation_path" | assert_cloudflare_success
+  else
+    echo "ERROR: Unexpected DNS reconciliation state '${state}' for ${label} hostname ${hostname}." >&2
+    return 1
+  fi
+}
+
+reconcile_proxied_cname() {
+  local label="$1"
+  local hostname="$2"
+  local target="$3"
+  local existing
+
+  existing=$(cloudflare_read_all_dns_records \
+    "read all DNS records for ${label} ${hostname}" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${hostname}&per_page=100")
+  reconcile_proxied_cname_from_records \
+    "$label" \
+    "$hostname" \
+    "$target" \
+    "$existing" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${hostname}&per_page=100"
+}
+
 build_cache_ruleset_payload() {
   local rule_description="$1"
   local rule_expression="$2"
@@ -105,6 +206,7 @@ cache_rule = {
     "expression": rule_expression,
     "description": rule_description,
     "action": "set_cache_settings",
+    "enabled": True,
     "action_parameters": {
         "cache": False,
     },
@@ -137,114 +239,207 @@ print(json.dumps({"rules": merged_rules}))
 ' "$rule_description" "$rule_expression"
 }
 
-# --- Verify CDK stack exists ---
-if ! aws cloudformation describe-stacks --stack-name "$STACK_NAME" "${AWS_ARGS[@]}" &>/dev/null; then
-  echo "ERROR: CloudFormation stack '${STACK_NAME}' not found." >&2
+build_rate_limit_ruleset_payload() {
+  local rule_description="$1"
+  local rule_expression="$2"
+
+  python3 -c '
+import json
+import sys
+
+description = sys.argv[1]
+expression = sys.argv[2]
+response = json.load(sys.stdin)
+if response.get("success") is True:
+    result = response.get("result")
+    existing_rules = result.get("rules", []) if isinstance(result, dict) else []
+else:
+    errors = response.get("errors", [])
+    not_found = any("not found" in str(error.get("message", "")).lower() for error in errors)
+    if not not_found:
+        print("ERROR: Could not fetch the Cloudflare rate limiting ruleset.", file=sys.stderr)
+        print(json.dumps(errors if errors else response, indent=2), file=sys.stderr)
+        raise SystemExit(1)
+    existing_rules = []
+
+rate_rule = {
+    "action": "block",
+    "expression": expression,
+    "description": description,
+    "enabled": True,
+    "ratelimit": {
+        "characteristics": ["cf.colo.id", "ip.src"],
+        "period": 10,
+        "requests_per_period": 5,
+        "mitigation_timeout": 10,
+    },
+}
+read_only_fields = {"id", "version", "last_updated"}
+merged_rules = []
+replaced = False
+for existing_rule in existing_rules:
+    if existing_rule.get("description") == description or existing_rule.get("expression") == expression:
+        if not replaced:
+            merged_rules.append(rate_rule)
+            replaced = True
+        continue
+    merged_rules.append({
+        key: value for key, value in existing_rule.items() if key not in read_only_fields
+    })
+if not replaced:
+    merged_rules.append(rate_rule)
+print(json.dumps({"rules": merged_rules}))
+' "$rule_description" "$rule_expression"
+}
+
+DEPLOYMENT_CONTEXT=$(python3 - "$CDK_CONTEXT_FILE" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+context_path = pathlib.Path(sys.argv[1])
+context = json.loads(context_path.read_text(encoding="utf-8"))
+if not isinstance(context, dict):
+    print(f"ERROR: {context_path} must contain a JSON object.", file=sys.stderr)
+    raise SystemExit(1)
+
+account_ids = set()
+for value in context.values():
+    if not isinstance(value, str):
+        continue
+    match = re.match(r"^arn:[^:]+:[^:]*:[^:]*:([0-9]{12}):", value)
+    if match:
+        account_ids.add(match.group(1))
+
+print(json.dumps({
+    "accountIds": sorted(account_ids),
+    "domainName": context.get("domainName"),
+    "region": context.get("region"),
+}))
+PY
+)
+CONTEXT_REGION=$(echo "$DEPLOYMENT_CONTEXT" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("region") or "")')
+CONTEXT_DOMAIN=$(echo "$DEPLOYMENT_CONTEXT" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("domainName") or "")')
+CONTEXT_ACCOUNT_COUNT=$(echo "$DEPLOYMENT_CONTEXT" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("accountIds", [])))')
+if [[ -z "$CONTEXT_REGION" || -z "$CONTEXT_DOMAIN" ]]; then
+  echo "ERROR: ${CDK_CONTEXT_FILE} must define non-empty region and domainName values." >&2
+  exit 1
+fi
+if [[ "$CONTEXT_REGION" != "$AWS_REGION" ]]; then
+  echo "ERROR: AWS region ${AWS_REGION} does not match ${CDK_CONTEXT_FILE} region ${CONTEXT_REGION}." >&2
+  exit 1
+fi
+if [[ "$CONTEXT_ACCOUNT_COUNT" -ne 1 ]]; then
+  echo "ERROR: ${CDK_CONTEXT_FILE} must contain ARNs from exactly one AWS account; found ${CONTEXT_ACCOUNT_COUNT}." >&2
+  exit 1
+fi
+CONTEXT_ACCOUNT_ID=$(echo "$DEPLOYMENT_CONTEXT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["accountIds"][0])')
+
+if ! AWS_IDENTITY=$(aws_api_request \
+  "caller identity lookup" \
+  "$AWS_PROFILE" \
+  "$AWS_REGION" \
+  aws sts get-caller-identity \
+  --output json); then
+  echo "ERROR: Failed to verify AWS caller identity with profile ${AWS_PROFILE} in region ${AWS_REGION}." >&2
+  exit 1
+fi
+AWS_ACCOUNT_ID=$(echo "$AWS_IDENTITY" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("Account", ""))')
+AWS_CALLER_ARN=$(echo "$AWS_IDENTITY" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("Arn", ""))')
+if [[ ! "$AWS_ACCOUNT_ID" =~ ^[0-9]{12}$ || -z "$AWS_CALLER_ARN" ]]; then
+  echo "ERROR: AWS STS returned an invalid caller identity for profile ${AWS_PROFILE}." >&2
+  exit 1
+fi
+if [[ "$AWS_ACCOUNT_ID" != "$CONTEXT_ACCOUNT_ID" ]]; then
+  echo "ERROR: AWS profile ${AWS_PROFILE} resolves to account ${AWS_ACCOUNT_ID}, but ${CDK_CONTEXT_FILE} targets account ${CONTEXT_ACCOUNT_ID}." >&2
+  exit 1
+fi
+echo "Verified AWS caller ${AWS_CALLER_ARN} in account ${AWS_ACCOUNT_ID}, region ${AWS_REGION}."
+
+echo "Reading deployment targets from CloudFormation stack '${STACK_NAME}'..."
+if ! STACK_JSON=$(aws_api_request \
+  "read CloudFormation stack ${STACK_NAME}" \
+  "$AWS_PROFILE" \
+  "$AWS_REGION" \
+  aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --output json); then
+  echo "ERROR: Could not read CloudFormation stack '${STACK_NAME}' in account ${AWS_ACCOUNT_ID}, region ${AWS_REGION}." >&2
   echo "Run the first deploy first (see infra/aws/README.md step 6)." >&2
   exit 1
 fi
 
-# --- Get ALB DNS from CloudFormation outputs ---
-echo "Reading ALB DNS from CloudFormation stack '${STACK_NAME}'..."
+read_stack_output() {
+  local output_key="$1"
+  echo "$STACK_JSON" | python3 -c '
+import json
+import sys
 
-ALB_DNS=$(aws cloudformation describe-stacks \
-  --stack-name "$STACK_NAME" \
-  "${AWS_ARGS[@]}" \
-  --query "Stacks[0].Outputs[?OutputKey=='AlbDns'].OutputValue" \
-  --output text)
+output_key = sys.argv[1]
+stacks = json.load(sys.stdin).get("Stacks", [])
+if len(stacks) != 1:
+    print(f"ERROR: Expected one CloudFormation stack, found {len(stacks)}.", file=sys.stderr)
+    raise SystemExit(1)
+outputs = stacks[0].get("Outputs", [])
+values = [output.get("OutputValue") for output in outputs if output.get("OutputKey") == output_key]
+if len(values) > 1:
+    print(f"ERROR: CloudFormation output {output_key} is duplicated.", file=sys.stderr)
+    raise SystemExit(1)
+print(values[0] if values else "")
+' "$output_key"
+}
+
+ALB_DNS=$(read_stack_output "AlbDns")
+API_DOMAIN_TARGET=$(read_stack_output "ApiCustomDomain")
+MCP_DOMAIN_TARGET=$(read_stack_output "McpCustomDomain")
+MCP_URL=$(read_stack_output "McpUrl")
 
 if [[ -z "$ALB_DNS" || "$ALB_DNS" == "None" ]]; then
-  echo "Could not find AlbDns output in stack ${STACK_NAME}" >&2
+  echo "ERROR: Could not find AlbDns output in stack ${STACK_NAME}." >&2
+  exit 1
+fi
+if [[ -z "$MCP_DOMAIN_TARGET" || "$MCP_DOMAIN_TARGET" == "None" ]]; then
+  echo "ERROR: Could not find the required McpCustomDomain output in stack ${STACK_NAME}." >&2
+  echo "Run setup-mcp-domain.sh, set mcpCertificateArn, and redeploy before configuring DNS." >&2
+  exit 1
+fi
+EXPECTED_MCP_URL="https://mcp.${CONTEXT_DOMAIN}/mcp"
+if [[ "$MCP_URL" != "$EXPECTED_MCP_URL" ]]; then
+  echo "ERROR: Stack ${STACK_NAME} advertises MCP URL '${MCP_URL}', expected '${EXPECTED_MCP_URL}' from ${CDK_CONTEXT_FILE}." >&2
+  echo "Redeploy the stack with the matching domain context before configuring Cloudflare." >&2
   exit 1
 fi
 
 echo "ALB DNS: ${ALB_DNS}"
 
 # --- Get zone name for fully qualified lookups ---
-ZONE_NAME=$(curl -s "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["name"])')
+ZONE_RESPONSE=$(cloudflare_api_request \
+  "read deployment zone" \
+  "GET" \
+  "/zones/${CLOUDFLARE_ZONE_ID}" \
+  "")
+ZONE_NAME=$(echo "$ZONE_RESPONSE" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["name"])')
+if [[ "$ZONE_NAME" != "$CONTEXT_DOMAIN" ]]; then
+  echo "ERROR: Cloudflare zone ${ZONE_NAME} does not match ${CDK_CONTEXT_FILE} domainName ${CONTEXT_DOMAIN}." >&2
+  echo "Use the Cloudflare zone and AWS deployment context for the same domain before rerunning." >&2
+  exit 1
+fi
 
 APP_FQDN="${SUBDOMAIN}.${ZONE_NAME}"
 
-# --- Check if record already exists ---
-EXISTING=$(curl -s "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${APP_FQDN}&type=CNAME" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json")
-
-EXISTING_COUNT=$(echo "$EXISTING" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("result", [])))')
-
-if [[ "$EXISTING_COUNT" -gt 0 ]]; then
-  # Update existing record
-  RECORD_ID=$(echo "$EXISTING" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"][0]["id"])')
-  echo "Updating existing CNAME record (${RECORD_ID})..."
-
-  curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records/${RECORD_ID}" \
-    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    -H "Content-Type: application/json" \
-    --data "{
-      \"type\": \"CNAME\",
-      \"name\": \"${SUBDOMAIN}\",
-      \"content\": \"${ALB_DNS}\",
-      \"ttl\": 1,
-      \"proxied\": true
-    }" | assert_cloudflare_success
-else
-  # Create new record
-  echo "Creating CNAME record: ${SUBDOMAIN} -> ${ALB_DNS} (proxied)..."
-
-  curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records" \
-    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    -H "Content-Type: application/json" \
-    --data "{
-      \"type\": \"CNAME\",
-      \"name\": \"${SUBDOMAIN}\",
-      \"content\": \"${ALB_DNS}\",
-      \"ttl\": 1,
-      \"proxied\": true
-    }" | assert_cloudflare_success
-fi
+reconcile_proxied_cname "app" "$APP_FQDN" "$ALB_DNS"
 
 echo ""
 echo "DNS record set: ${SUBDOMAIN} -> ${ALB_DNS} (Cloudflare proxied)"
 
 # --- Auth subdomain CNAME (auth.* → same ALB, host-based routing) ---
 AUTH_FQDN="auth.${ZONE_NAME}"
+MCP_FQDN="mcp.${ZONE_NAME}"
 echo ""
 echo "Setting up auth subdomain CNAME: ${AUTH_FQDN} -> ${ALB_DNS}..."
 
-AUTH_EXISTING=$(curl -s "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${AUTH_FQDN}&type=CNAME" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json")
-
-AUTH_EXISTING_COUNT=$(echo "$AUTH_EXISTING" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("result", [])))')
-
-if [[ "$AUTH_EXISTING_COUNT" -gt 0 ]]; then
-  AUTH_RECORD_ID=$(echo "$AUTH_EXISTING" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"][0]["id"])')
-  echo "Updating existing auth CNAME record..."
-  curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records/${AUTH_RECORD_ID}" \
-    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    -H "Content-Type: application/json" \
-    --data "{
-      \"type\": \"CNAME\",
-      \"name\": \"auth\",
-      \"content\": \"${ALB_DNS}\",
-      \"ttl\": 1,
-      \"proxied\": true
-    }" | assert_cloudflare_success
-else
-  echo "Creating CNAME: auth -> ${ALB_DNS} (proxied)..."
-  curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records" \
-    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    -H "Content-Type: application/json" \
-    --data "{
-      \"type\": \"CNAME\",
-      \"name\": \"auth\",
-      \"content\": \"${ALB_DNS}\",
-      \"ttl\": 1,
-      \"proxied\": true
-    }" | assert_cloudflare_success
-fi
+reconcile_proxied_cname "auth" "$AUTH_FQDN" "$ALB_DNS"
 
 echo "Auth DNS record set: auth -> ${ALB_DNS} (Cloudflare proxied)"
 
@@ -254,100 +449,73 @@ echo "Auth DNS record set: auth -> ${ALB_DNS} (Cloudflare proxied)"
 # just point root DNS to your site's hosting instead.
 echo ""
 
-# Check if root domain already has a non-placeholder record
-ROOT_ANY=$(curl -s "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${ZONE_NAME}" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json")
-
-ROOT_RECORDS=$(echo "$ROOT_ANY" | python3 -c '
-import sys, json
-records = json.load(sys.stdin).get("result", [])
-root = [r for r in records if r["type"] in ("A", "AAAA", "CNAME")]
-for r in root:
-    print("{} {}".format(r["type"], r["content"]))
-')
-
-ROOT_CLASSIFICATION=$(echo "$ROOT_ANY" | python3 - "$ALB_DNS" <<'PY'
+# Keep an explicitly external root routing target, but ignore valid apex records
+# that do not route web traffic when deciding whether this script owns routing.
+ROOT_ANY=$(cloudflare_read_all_dns_records \
+  "read root DNS records for ${ZONE_NAME}" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${ZONE_NAME}&per_page=100")
+ROOT_ROUTING=$(echo "$ROOT_ANY" | python3 -c '
 import json
 import sys
 
-alb_dns = sys.argv[1].rstrip(".")
+response = json.load(sys.stdin)
+records = response.get("result", [])
+if not isinstance(records, list):
+    print("ERROR: Cloudflare root DNS lookup returned no result array.", file=sys.stderr)
+    raise SystemExit(1)
+response["result"] = [
+    record for record in records
+    if isinstance(record, dict)
+    and str(record.get("type", "")).upper() in {"A", "AAAA", "CNAME"}
+]
+print(json.dumps(response))
+')
+ROOT_OWNERSHIP=$(echo "$ROOT_ROUTING" | python3 -c '
+import json
+import sys
+
+hostname = sys.argv[1].rstrip(".").lower()
+alb_dns = sys.argv[2].rstrip(".").lower()
 records = json.load(sys.stdin).get("result", [])
-managed_cname_id = ""
-external_records = []
+if not isinstance(records, list):
+    print("ERROR: Cloudflare root DNS lookup returned no result array.", file=sys.stderr)
+    raise SystemExit(1)
+matching = [
+    record for record in records
+    if isinstance(record, dict)
+    and str(record.get("name", "")).rstrip(".").lower() == hostname
+]
+if len(matching) > 1:
+    print(f"ERROR: Found {len(matching)} A/AAAA/CNAME routing records at root hostname {sys.argv[1]}; expected at most one.", file=sys.stderr)
+    print("ACTION: Resolve conflicting root web-routing records before rerunning setup-dns.sh.", file=sys.stderr)
+    raise SystemExit(1)
+if not matching:
+    print("managed")
+    raise SystemExit(0)
+record = matching[0]
+record_type = record.get("type")
+content = str(record.get("content", "")).rstrip(".").lower()
+if record_type == "A" and content == "192.0.2.1":
+    print("ERROR: Root hostname contains the placeholder A record 192.0.2.1; remove it explicitly before rerunning setup-dns.sh.", file=sys.stderr)
+    raise SystemExit(1)
+if record_type == "CNAME" and (content == alb_dns or content.endswith(".elb.amazonaws.com")):
+    print("managed")
+else:
+    print("external")
+    print("{} {}".format(record_type, record.get("content", "")), file=sys.stderr)
+' "$ZONE_NAME" "$ALB_DNS")
 
-for record in records:
-    record_type = record.get("type", "")
-    content = str(record.get("content", "")).rstrip(".")
-    if record_type not in ("A", "AAAA", "CNAME"):
-        continue
-
-    if record_type == "A" and content == "192.0.2.1":
-        continue
-
-    if record_type == "CNAME" and (content == alb_dns or ".elb.amazonaws.com" in content):
-        if managed_cname_id == "":
-            managed_cname_id = str(record.get("id", ""))
-        continue
-
-    external_records.append(f"{record_type} {content}")
-
-print(managed_cname_id)
-print("\n".join(external_records))
-PY
-)
-ROOT_MANAGED_CNAME_ID=$(echo "$ROOT_CLASSIFICATION" | sed -n '1p')
-ROOT_EXTERNAL_RECORDS=$(echo "$ROOT_CLASSIFICATION" | sed '1d')
-
-# If a non-placeholder/non-ALB record exists, skip (user manages root domain themselves)
-if [[ -n "$ROOT_EXTERNAL_RECORDS" ]]; then
-  echo "Root domain already has DNS records — skipping (managed externally):"
-  echo "$ROOT_EXTERNAL_RECORDS" | sed 's/^/  /'
-  echo "To use the ALB redirect instead, remove the existing root record in Cloudflare and re-run."
+if [[ "$ROOT_OWNERSHIP" == "external" ]]; then
+  echo "Root domain has one externally managed web-routing record; leaving it unchanged."
+  echo "To use the ALB redirect instead, remove the external root record and rerun."
 else
   echo "Setting up root domain CNAME -> ${ALB_DNS} (redirect to app.*)..."
-
-  # Delete placeholder A record (192.0.2.1) if left over from previous setup
-  PLACEHOLDER=$(curl -s "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${ZONE_NAME}&type=A&content=192.0.2.1" \
-    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    -H "Content-Type: application/json")
-
-  PLACEHOLDER_COUNT=$(echo "$PLACEHOLDER" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("result", [])))')
-
-  if [[ "$PLACEHOLDER_COUNT" -gt 0 ]]; then
-    PLACEHOLDER_ID=$(echo "$PLACEHOLDER" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"][0]["id"])')
-    echo "Deleting placeholder A record (192.0.2.1)..."
-    curl -s -X DELETE "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records/${PLACEHOLDER_ID}" \
-      -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-      -H "Content-Type: application/json" | assert_cloudflare_success
-  fi
-
-  if [[ -n "$ROOT_MANAGED_CNAME_ID" ]]; then
-    # Update root CNAME → current ALB (Cloudflare CNAME flattening handles apex automatically)
-    curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records/${ROOT_MANAGED_CNAME_ID}" \
-      -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-      -H "Content-Type: application/json" \
-      --data "{
-        \"type\": \"CNAME\",
-        \"name\": \"@\",
-        \"content\": \"${ALB_DNS}\",
-        \"ttl\": 1,
-        \"proxied\": true
-      }" | assert_cloudflare_success
-  else
-    # Create root CNAME → ALB (Cloudflare CNAME flattening handles apex automatically)
-    curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records" \
-      -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-      -H "Content-Type: application/json" \
-      --data "{
-        \"type\": \"CNAME\",
-        \"name\": \"@\",
-        \"content\": \"${ALB_DNS}\",
-        \"ttl\": 1,
-        \"proxied\": true
-      }" | assert_cloudflare_success
-  fi
-
+  reconcile_proxied_cname_from_records \
+    "root" \
+    "$ZONE_NAME" \
+    "$ALB_DNS" \
+    "$ROOT_ROUTING" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/dns_records?type=CNAME&name=${ZONE_NAME}&per_page=100"
   echo "Root domain DNS: ${ZONE_NAME} -> ${ALB_DNS} (Cloudflare proxied, redirects to app.*)"
 fi
 
@@ -355,19 +523,21 @@ fi
 echo "Setting SSL/TLS mode to Full (Strict)..."
 
 # Disable automatic SSL/TLS (switch to custom mode)
-SSL_AUTOMATIC_RESULT=$(curl -s -X PATCH "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/settings/ssl_automatic_mode" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{"value":"custom"}')
+SSL_AUTOMATIC_RESULT=$(cloudflare_api_request \
+  "set SSL automatic mode to custom" \
+  "PATCH" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/settings/ssl_automatic_mode" \
+  '{"value":"custom"}')
 
 echo "$SSL_AUTOMATIC_RESULT" | assert_required_cloudflare_success \
   "Could not disable Cloudflare automatic SSL/TLS mode for zone ${CLOUDFLARE_ZONE_ID}." \
   "Check token permission Zone:Zone Settings:Edit, or manually set SSL/TLS mode to Full (Strict) in Cloudflare Dashboard > SSL/TLS > Overview."
 
-SSL_RESULT=$(curl -s -X PATCH "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/settings/ssl" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{"value":"strict"}')
+SSL_RESULT=$(cloudflare_api_request \
+  "set SSL mode to strict" \
+  "PATCH" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/settings/ssl" \
+  '{"value":"strict"}')
 
 echo "$SSL_RESULT" | assert_required_cloudflare_success \
   "Could not set Cloudflare SSL/TLS mode to Full (Strict) for zone ${CLOUDFLARE_ZONE_ID}." \
@@ -381,73 +551,55 @@ echo "SSL/TLS mode set to Full (Strict)."
 echo ""
 echo "Setting up cache bypass rule for app..."
 
-CACHE_EXPRESSION="(http.host eq \"${APP_FQDN}\" or http.host eq \"${AUTH_FQDN}\" or http.host eq \"${ZONE_NAME}\")"
+CACHE_EXPRESSION="(http.host eq \"${APP_FQDN}\" or http.host eq \"${AUTH_FQDN}\" or http.host eq \"${MCP_FQDN}\" or http.host eq \"${ZONE_NAME}\")"
 CACHE_RULE_DESCRIPTION="Bypass cache for app — fully dynamic content"
 
-CACHE_RULESET=$(curl -s \
-  "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_request_cache_settings/entrypoint" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json")
+CACHE_RULESET=$(cloudflare_optional_get_request \
+  "read cache ruleset" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_request_cache_settings/entrypoint")
 
 CACHE_PAYLOAD=$(echo "$CACHE_RULESET" | build_cache_ruleset_payload "$CACHE_RULE_DESCRIPTION" "$CACHE_EXPRESSION")
 
-CACHE_RESULT=$(curl -s -X PUT \
-  "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_request_cache_settings/entrypoint" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d "$CACHE_PAYLOAD")
+CACHE_RESULT=$(cloudflare_api_request \
+  "replace cache ruleset" \
+  "PUT" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_request_cache_settings/entrypoint" \
+  "$CACHE_PAYLOAD")
 
 echo "$CACHE_RESULT" | assert_required_cloudflare_success \
-  "Could not set Cloudflare cache bypass rule for ${APP_FQDN}, ${AUTH_FQDN}, and ${ZONE_NAME}." \
+  "Could not set Cloudflare cache bypass rule for ${APP_FQDN}, ${AUTH_FQDN}, ${MCP_FQDN}, and ${ZONE_NAME}." \
   "Check token permission Zone:Cache Rules:Edit, or manually add a Cache Rules bypass for expression: ${CACHE_EXPRESSION}"
 
-echo "Cache bypass rule set for ${APP_FQDN}, ${AUTH_FQDN}, and ${ZONE_NAME}."
+echo "Cache bypass rule set for ${APP_FQDN}, ${AUTH_FQDN}, ${MCP_FQDN}, and ${ZONE_NAME}."
+
+# --- Rate-limit anonymous dynamic client registration by the client IP at Cloudflare edge ---
+echo ""
+echo "Setting up anonymous OAuth registration rate limit..."
+# Exact host + method + path matching requires Cloudflare Business or higher.
+REGISTER_RATE_EXPRESSION="(http.host eq \"${AUTH_FQDN}\" and http.request.method eq \"POST\" and http.request.uri.path eq \"/oauth/register\")"
+REGISTER_RATE_DESCRIPTION="Rate limit anonymous OAuth client registration by real client IP"
+RATE_RULESET=$(cloudflare_optional_get_request \
+  "read rate limiting ruleset" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_ratelimit/entrypoint")
+RATE_PAYLOAD=$(echo "$RATE_RULESET" | build_rate_limit_ruleset_payload "$REGISTER_RATE_DESCRIPTION" "$REGISTER_RATE_EXPRESSION")
+RATE_RESULT=$(cloudflare_api_request \
+  "replace rate limiting ruleset" \
+  "PUT" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_ratelimit/entrypoint" \
+  "$RATE_PAYLOAD")
+echo "$RATE_RESULT" | assert_required_cloudflare_success \
+  "Could not set the Cloudflare rate limit for anonymous POST /oauth/register." \
+  "Check Cloudflare Business-or-higher plan access and Zone:WAF:Edit permission, or add the rate limit manually with expression: ${REGISTER_RATE_EXPRESSION}"
+echo "Anonymous POST /oauth/register is limited to 5 requests per 10 seconds per real client IP."
 
 # --- API Gateway custom domain CNAME (optional) ---
 # Created only when apiCertificateArn is set in CDK context (custom domain for machine clients).
-API_DOMAIN_TARGET=$(aws cloudformation describe-stacks \
-  --stack-name "$STACK_NAME" \
-  "${AWS_ARGS[@]}" \
-  --query "Stacks[0].Outputs[?OutputKey=='ApiCustomDomain'].OutputValue" \
-  --output text 2>/dev/null || true)
-
 if [[ -n "$API_DOMAIN_TARGET" && "$API_DOMAIN_TARGET" != "None" ]]; then
   API_FQDN="api.${ZONE_NAME}"
   echo ""
   echo "Setting up API Gateway CNAME: ${API_FQDN} -> ${API_DOMAIN_TARGET}..."
 
-  API_EXISTING=$(curl -s "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${API_FQDN}&type=CNAME" \
-    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    -H "Content-Type: application/json")
-
-  API_EXISTING_COUNT=$(echo "$API_EXISTING" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("result", [])))')
-
-  if [[ "$API_EXISTING_COUNT" -gt 0 ]]; then
-    API_RECORD_ID=$(echo "$API_EXISTING" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"][0]["id"])')
-    echo "Updating existing API CNAME record..."
-    curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records/${API_RECORD_ID}" \
-      -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-      -H "Content-Type: application/json" \
-      --data "{
-        \"type\": \"CNAME\",
-        \"name\": \"api\",
-        \"content\": \"${API_DOMAIN_TARGET}\",
-        \"ttl\": 1,
-        \"proxied\": true
-      }" | assert_cloudflare_success
-  else
-    echo "Creating CNAME: api -> ${API_DOMAIN_TARGET} (proxied)..."
-    curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records" \
-      -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-      -H "Content-Type: application/json" \
-      --data "{
-        \"type\": \"CNAME\",
-        \"name\": \"api\",
-        \"content\": \"${API_DOMAIN_TARGET}\",
-        \"ttl\": 1,
-        \"proxied\": true
-      }" | assert_cloudflare_success
-  fi
+  reconcile_proxied_cname "API" "$API_FQDN" "$API_DOMAIN_TARGET"
 
   echo "API domain ready: https://${API_FQDN}/sql"
 else
@@ -455,3 +607,9 @@ else
   echo "No ApiCustomDomain output found — skipping API CNAME."
   echo "  Set apiCertificateArn in cdk.context.local.json and redeploy to enable custom domain."
 fi
+
+# --- MCP HTTP API v2 custom domain CNAME (required for the canonical /mcp endpoint) ---
+echo ""
+echo "Setting up MCP Gateway CNAME: ${MCP_FQDN} -> ${MCP_DOMAIN_TARGET}..."
+reconcile_proxied_cname "MCP" "$MCP_FQDN" "$MCP_DOMAIN_TARGET"
+echo "MCP domain ready: https://${MCP_FQDN}/mcp"

--- a/scripts/cloudflare/setup-mcp-domain.sh
+++ b/scripts/cloudflare/setup-mcp-domain.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+# Create and validate the public ACM certificate required by the regional MCP API domain.
+# Requires CLOUDFLARE_API_TOKEN, CLOUDFLARE_ZONE_ID, AWS_PROFILE, and AWS_REGION.
+# Usage from the repository root; the parent shell never receives the token:
+#   (
+#     set -euo pipefail
+#     set -a
+#     source scripts/cloudflare/.env
+#     set +a
+#     export AWS_PROFILE=expense-tracker AWS_REGION=eu-central-1
+#     bash scripts/cloudflare/setup-mcp-domain.sh --domain expense-budget-tracker.com
+#   )
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CDK_CONTEXT_FILE="${ROOT_DIR}/infra/aws/cdk.context.local.json"
+source "${SCRIPT_DIR}/cloudflare-api.sh"
+source "${SCRIPT_DIR}/aws-api.sh"
+
+DOMAIN=""
+PROFILE="${AWS_PROFILE:-}"
+REGION="${AWS_REGION:-}"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --domain) DOMAIN="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$DOMAIN" ]]; then
+  echo "Usage: AWS_PROFILE=<profile> AWS_REGION=<region> $0 --domain <domain>" >&2
+  exit 1
+fi
+
+if [[ -z "$PROFILE" ]]; then
+  echo "ERROR: AWS_PROFILE is required and must identify the dedicated deployment account." >&2
+  exit 1
+fi
+
+if [[ -z "$REGION" ]]; then
+  echo "ERROR: AWS_REGION is required and must identify the explicit deployment region." >&2
+  exit 1
+fi
+if [[ ! -f "$CDK_CONTEXT_FILE" ]]; then
+  echo "ERROR: ${CDK_CONTEXT_FILE} is required before MCP certificate bootstrap." >&2
+  echo "Complete the local deployment context as described in infra/aws/README.md, leaving only mcpCertificateArn empty, then rerun." >&2
+  exit 1
+fi
+
+cloudflare_require_api_token
+: "${CLOUDFLARE_ZONE_ID:?Set CLOUDFLARE_ZONE_ID env var}"
+export AWS_PAGER=""
+
+MCP_DOMAIN="mcp.${DOMAIN}"
+AWS_ARGS=(--profile "$PROFILE" --region "$REGION")
+
+CONTEXT_EXPECTATIONS=$(python3 - "$CDK_CONTEXT_FILE" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+context_path = pathlib.Path(sys.argv[1])
+context = json.loads(context_path.read_text(encoding="utf-8"))
+if not isinstance(context, dict):
+    print(f"ERROR: {context_path} must contain a JSON object.", file=sys.stderr)
+    raise SystemExit(1)
+
+required_strings = [
+    "region",
+    "domainName",
+    "certificateArn",
+    "apiCertificateArn",
+    "resendApiKeySecretArn",
+    "resendSenderEmail",
+    "alertEmail",
+    "githubRepo",
+]
+missing = [
+    key for key in required_strings
+    if not isinstance(context.get(key), str) or not context[key].strip()
+]
+if missing:
+    print(
+        f"ERROR: {context_path} must define non-empty deployment values for: {', '.join(missing)}.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+region = context["region"]
+account_ids = set()
+arn_keys = ["certificateArn", "apiCertificateArn", "resendApiKeySecretArn"]
+if isinstance(context.get("mcpCertificateArn"), str) and context["mcpCertificateArn"].strip():
+    arn_keys.append("mcpCertificateArn")
+for key in arn_keys:
+    value = context[key]
+    match = re.match(r"^arn:[^:]+:[^:]+:([^:]+):([0-9]{12}):", value)
+    if match is None:
+        print(f"ERROR: {context_path} value {key} is not a regional AWS ARN.", file=sys.stderr)
+        raise SystemExit(1)
+    arn_region, account_id = match.groups()
+    if arn_region != region:
+        print(
+            f"ERROR: {context_path} value {key} targets region {arn_region}, expected {region}.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    account_ids.add(account_id)
+
+print(json.dumps({
+    "accountIds": sorted(account_ids),
+    "domainName": context["domainName"],
+    "region": region,
+}))
+PY
+)
+CONTEXT_REGION=$(echo "$CONTEXT_EXPECTATIONS" | python3 -c 'import json,sys; print(json.load(sys.stdin)["region"])')
+CONTEXT_DOMAIN=$(echo "$CONTEXT_EXPECTATIONS" | python3 -c 'import json,sys; print(json.load(sys.stdin)["domainName"])')
+CONTEXT_ACCOUNT_COUNT=$(echo "$CONTEXT_EXPECTATIONS" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["accountIds"]))')
+if [[ "$CONTEXT_REGION" != "$REGION" ]]; then
+  echo "ERROR: AWS region ${REGION} does not match ${CDK_CONTEXT_FILE} region ${CONTEXT_REGION}." >&2
+  exit 1
+fi
+if [[ "$CONTEXT_DOMAIN" != "$DOMAIN" ]]; then
+  echo "ERROR: Domain ${DOMAIN} does not match ${CDK_CONTEXT_FILE} domainName ${CONTEXT_DOMAIN}." >&2
+  exit 1
+fi
+if [[ "$CONTEXT_ACCOUNT_COUNT" -ne 1 ]]; then
+  echo "ERROR: ${CDK_CONTEXT_FILE} must contain deployment ARNs from exactly one AWS account; found ${CONTEXT_ACCOUNT_COUNT}." >&2
+  exit 1
+fi
+CONTEXT_ACCOUNT_ID=$(echo "$CONTEXT_EXPECTATIONS" | python3 -c 'import json,sys; print(json.load(sys.stdin)["accountIds"][0])')
+
+if ! AWS_IDENTITY=$(aws_api_request \
+  "caller identity lookup" \
+  "$PROFILE" \
+  "$REGION" \
+  aws sts get-caller-identity \
+  --output json); then
+  echo "ERROR: Failed to verify AWS caller identity with profile ${PROFILE} in region ${REGION}." >&2
+  echo "Confirm that the profile targets the dedicated deployment account and that its credentials are valid." >&2
+  exit 1
+fi
+
+AWS_ACCOUNT_ID=$(echo "$AWS_IDENTITY" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("Account", ""))')
+AWS_CALLER_ARN=$(echo "$AWS_IDENTITY" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("Arn", ""))')
+if [[ ! "$AWS_ACCOUNT_ID" =~ ^[0-9]{12}$ || -z "$AWS_CALLER_ARN" ]]; then
+  echo "ERROR: AWS STS returned an invalid caller identity for profile ${PROFILE}." >&2
+  exit 1
+fi
+if [[ "$CONTEXT_ACCOUNT_ID" != "$AWS_ACCOUNT_ID" ]]; then
+  echo "ERROR: AWS profile ${PROFILE} resolves to account ${AWS_ACCOUNT_ID}, but ${CDK_CONTEXT_FILE} targets account ${CONTEXT_ACCOUNT_ID}." >&2
+  exit 1
+fi
+
+CLOUDFLARE_ZONE=$(cloudflare_api_request \
+  "read certificate-bootstrap zone" \
+  "GET" \
+  "/zones/${CLOUDFLARE_ZONE_ID}" \
+  "")
+CLOUDFLARE_ZONE_NAME=$(echo "$CLOUDFLARE_ZONE" | python3 -c '
+import json
+import sys
+response = json.load(sys.stdin)
+if response.get("success") is not True:
+    print(json.dumps(response.get("errors", response), indent=2), file=sys.stderr)
+    raise SystemExit(1)
+result = response.get("result")
+name = result.get("name") if isinstance(result, dict) else None
+if not isinstance(name, str) or not name:
+    print("ERROR: Cloudflare zone lookup returned no domain name.", file=sys.stderr)
+    raise SystemExit(1)
+print(name)
+')
+if [[ "$CLOUDFLARE_ZONE_NAME" != "$CONTEXT_DOMAIN" ]]; then
+  echo "ERROR: Cloudflare zone ${CLOUDFLARE_ZONE_NAME} does not match ${CDK_CONTEXT_FILE} domainName ${CONTEXT_DOMAIN}." >&2
+  exit 1
+fi
+
+echo "Verified AWS caller ${AWS_CALLER_ARN} in account ${AWS_ACCOUNT_ID}, region ${REGION}, using profile ${PROFILE}."
+
+find_matching_certificates() {
+  local certificate_summaries
+  certificate_summaries=$(aws_api_request \
+    "list active ACM certificates for ${MCP_DOMAIN}" \
+    "$PROFILE" \
+    "$REGION" \
+    aws acm list-certificates \
+    --certificate-statuses ISSUED PENDING_VALIDATION \
+    --output json)
+  local exact_certificate_arns
+  exact_certificate_arns=$(echo "$certificate_summaries" | python3 -c '
+import json
+import sys
+
+domain = sys.argv[1]
+response = json.load(sys.stdin)
+summaries = response.get("CertificateSummaryList")
+if not isinstance(summaries, list):
+    print("ERROR: ACM list-certificates returned no CertificateSummaryList array.", file=sys.stderr)
+    raise SystemExit(1)
+for summary in summaries:
+    if not isinstance(summary, dict) or summary.get("DomainName") != domain:
+        continue
+    arn = summary.get("CertificateArn")
+    if not isinstance(arn, str) or not arn:
+        print("ERROR: ACM returned an invalid exact-domain certificate summary.", file=sys.stderr)
+        raise SystemExit(1)
+    print(arn)
+' "$MCP_DOMAIN")
+
+  local described_certificates='[]'
+  while IFS= read -r candidate_arn; do
+    if [[ -z "$candidate_arn" ]]; then
+      continue
+    fi
+    local candidate_description
+    candidate_description=$(aws_api_request \
+      "describe ACM certificate ${candidate_arn}" \
+      "$PROFILE" \
+      "$REGION" \
+      aws acm describe-certificate \
+      --certificate-arn "$candidate_arn" \
+      --query Certificate \
+      --output json)
+    described_certificates=$(echo "$candidate_description" | python3 -c '
+import json
+import sys
+
+certificates = json.loads(sys.argv[1])
+certificate = json.load(sys.stdin)
+if not isinstance(certificates, list) or not isinstance(certificate, dict):
+    print("ERROR: ACM describe-certificate returned an invalid certificate object.", file=sys.stderr)
+    raise SystemExit(1)
+certificates.append(certificate)
+print(json.dumps(certificates))
+' "$described_certificates")
+  done <<< "$exact_certificate_arns"
+
+  echo "$described_certificates" | python3 -c '
+import json
+import sys
+
+domain = sys.argv[1]
+certificates = json.load(sys.stdin)
+matches = []
+for certificate in certificates:
+    arn = certificate.get("CertificateArn")
+    status = certificate.get("Status")
+    certificate_type = certificate.get("Type")
+    primary_domain = certificate.get("DomainName")
+    subject_alternative_names = certificate.get("SubjectAlternativeNames")
+    validation_options = certificate.get("DomainValidationOptions", [])
+    validation_methods = {
+        option.get("ValidationMethod")
+        for option in validation_options
+        if isinstance(option, dict) and option.get("ValidationMethod")
+    }
+    reasons = []
+    if primary_domain != domain:
+        reasons.append(f"primary domain is {primary_domain!r}")
+    if (
+        not isinstance(subject_alternative_names, list)
+        or any(not isinstance(name, str) or not name for name in subject_alternative_names)
+    ):
+        reasons.append("SubjectAlternativeNames is not a valid domain-name array")
+    else:
+        complete_name_set = set(subject_alternative_names)
+        if isinstance(primary_domain, str) and primary_domain:
+            complete_name_set.add(primary_domain)
+        if complete_name_set != {domain}:
+            reasons.append(
+                f"complete certificate name set is {sorted(complete_name_set)!r}; expected only {domain!r}"
+            )
+    if status not in {"ISSUED", "PENDING_VALIDATION"}:
+        reasons.append(f"status is {status!r}")
+    if certificate_type != "AMAZON_ISSUED":
+        reasons.append(f"type is {certificate_type!r}")
+    if validation_methods != {"DNS"}:
+        reasons.append(f"validation methods are {sorted(validation_methods)!r}")
+    if not isinstance(arn, str) or not arn:
+        print("ERROR: ACM describe-certificate returned a certificate without an ARN.", file=sys.stderr)
+        raise SystemExit(1)
+    if reasons:
+        print("Ignoring unsuitable exact-domain certificate {}: {}.".format(arn, "; ".join(reasons)), file=sys.stderr)
+        continue
+    matches.append({
+        "arn": arn,
+        "status": status,
+        "type": certificate_type,
+        "validationMethod": "DNS",
+    })
+print(json.dumps(matches))
+' "$MCP_DOMAIN"
+}
+
+request_certificate_with_reconciliation() {
+  local idempotency_token
+  idempotency_token=$(printf '%s' "${AWS_ACCOUNT_ID}:${REGION}:${MCP_DOMAIN}" | shasum -a 256 | cut -c1-32)
+  local error_file
+  error_file=$(mktemp)
+  local attempt=1
+
+  while [[ "$attempt" -le 3 ]]; do
+    local requested_arn
+    local command_status
+    if requested_arn=$(aws acm request-certificate \
+      "${AWS_ARGS[@]}" \
+      --domain-name "$MCP_DOMAIN" \
+      --validation-method DNS \
+      --idempotency-token "$idempotency_token" \
+      --query "CertificateArn" \
+      --output text \
+      --cli-connect-timeout 10 \
+      --cli-read-timeout 60 \
+      2>"$error_file"); then
+      rm -f "$error_file"
+      echo "$requested_arn"
+      return 0
+    else
+      command_status=$?
+    fi
+
+    local reconciled_certificates
+    reconciled_certificates=$(find_matching_certificates)
+    local reconciled_count
+    reconciled_count=$(echo "$reconciled_certificates" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
+    if [[ "$reconciled_count" -eq 1 ]]; then
+      local reconciled_arn
+      reconciled_arn=$(echo "$reconciled_certificates" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["arn"])')
+      echo "WARNING: ACM certificate request response was inconclusive, but reconciliation found the single suitable certificate ${reconciled_arn}; reusing it." >&2
+      rm -f "$error_file"
+      echo "$reconciled_arn"
+      return 0
+    fi
+    if [[ "$reconciled_count" -gt 1 ]]; then
+      echo "ERROR: ACM certificate request reconciliation found ${reconciled_count} suitable exact-domain certificates for ${MCP_DOMAIN}; resolve the ambiguity before rerunning." >&2
+      echo "$reconciled_certificates" >&2
+      rm -f "$error_file"
+      return 1
+    fi
+
+    local error_body
+    error_body=$(sed -n '1,40p' "$error_file")
+    if [[ "$attempt" -lt 3 ]]; then
+      echo "WARNING: ACM certificate request attempt ${attempt}/3 failed; domain=${MCP_DOMAIN}; account=${AWS_ACCOUNT_ID}; region=${REGION}; status=${command_status}; response=${error_body:-empty}; no suitable certificate appeared during reconciliation; retrying with the same idempotency token in 2 seconds." >&2
+      sleep 2
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    echo "ERROR: ACM certificate request failed after 3 reconciled attempts; domain=${MCP_DOMAIN}; account=${AWS_ACCOUNT_ID}; region=${REGION}; status=${command_status}; response=${error_body:-empty}. No suitable exact-domain certificate was found; verify ACM permissions and retry." >&2
+    rm -f "$error_file"
+    return 1
+  done
+}
+
+echo "Looking for an active exact-domain ACM certificate for ${MCP_DOMAIN} in ${REGION}..."
+MATCHING_CERTIFICATES=$(find_matching_certificates)
+MATCHING_CERTIFICATE_COUNT=$(echo "$MATCHING_CERTIFICATES" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
+
+if [[ "$MATCHING_CERTIFICATE_COUNT" -eq 0 ]]; then
+  echo "No reusable certificate found; requesting one for ${MCP_DOMAIN}..."
+  CERT_ARN=$(request_certificate_with_reconciliation)
+  echo "Certificate requested: ${CERT_ARN}"
+elif [[ "$MATCHING_CERTIFICATE_COUNT" -eq 1 ]]; then
+  CERT_ARN=$(echo "$MATCHING_CERTIFICATES" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["arn"])')
+  CERT_STATUS=$(echo "$MATCHING_CERTIFICATES" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["status"])')
+  echo "Reusing ${CERT_STATUS} certificate: ${CERT_ARN}"
+else
+  echo "ERROR: Found ${MATCHING_CERTIFICATE_COUNT} reusable public DNS-validated certificates whose complete name set is exactly ${MCP_DOMAIN}." >&2
+  echo "Resolve the duplicate certificates before rerunning; no certificate was requested and no DNS record was changed." >&2
+  echo "$MATCHING_CERTIFICATES" | python3 -c '
+import json
+import sys
+for certificate in json.load(sys.stdin):
+    print("  {} / {} / {}: {}".format(certificate["status"], certificate["type"], certificate["validationMethod"], certificate["arn"]), file=sys.stderr)
+'
+  exit 1
+fi
+
+echo "Waiting for ACM to generate the DNS validation record..."
+VALIDATION_JSON=""
+for _ in $(seq 1 24); do
+  VALIDATION_JSON=$(aws_api_request \
+    "read ACM validation record for ${CERT_ARN}" \
+    "$PROFILE" \
+    "$REGION" \
+    aws acm describe-certificate \
+    --certificate-arn "$CERT_ARN" \
+    --query "Certificate.DomainValidationOptions[0].ResourceRecord" \
+    --output json)
+  if [[ "$VALIDATION_JSON" != "null" ]]; then
+    break
+  fi
+  sleep 5
+done
+
+if [[ -z "$VALIDATION_JSON" || "$VALIDATION_JSON" == "null" ]]; then
+  echo "Timed out waiting for the ACM validation record for ${MCP_DOMAIN}." >&2
+  echo "Certificate ARN: ${CERT_ARN}" >&2
+  exit 1
+fi
+
+VALIDATION_NAME=$(echo "$VALIDATION_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['Name'].rstrip('.'))")
+VALIDATION_VALUE=$(echo "$VALIDATION_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['Value'].rstrip('.'))")
+echo "Validation CNAME: ${VALIDATION_NAME} -> ${VALIDATION_VALUE}"
+
+EXISTING=$(cloudflare_read_all_dns_records \
+  "read all DNS records for ACM validation hostname ${VALIDATION_NAME}" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${VALIDATION_NAME}&per_page=100")
+EXISTING_RECORD=$(echo "$EXISTING" | cloudflare_classify_exact_cname \
+  "$VALIDATION_NAME" \
+  "$VALIDATION_VALUE" \
+  "false" \
+  "setup-mcp-domain.sh")
+EXISTING_STATE=$(echo "$EXISTING_RECORD" | python3 -c 'import json,sys; print(json.load(sys.stdin)["state"])')
+EXISTING_ID=$(echo "$EXISTING_RECORD" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+VALIDATION_PAYLOAD=$(python3 -c '
+import json
+import sys
+print(json.dumps({
+    "type": "CNAME",
+    "name": sys.argv[1],
+    "content": sys.argv[2],
+    "ttl": 120,
+    "proxied": False,
+}))
+' "$VALIDATION_NAME" "$VALIDATION_VALUE")
+
+if [[ "$EXISTING_STATE" == "exact" ]]; then
+  echo "ACM validation CNAME already has the expected target and is DNS-only; reusing it."
+  VALIDATION_RESULT='{"success":true}'
+elif [[ "$EXISTING_STATE" == "drift" ]]; then
+  EXISTING_CONTENT=$(echo "$EXISTING_RECORD" | python3 -c 'import json,sys; print(json.load(sys.stdin)["content"])')
+  EXISTING_PROXIED=$(echo "$EXISTING_RECORD" | python3 -c 'import json,sys; print(str(json.load(sys.stdin)["proxied"]).lower())')
+  echo "Reconciling ACM validation CNAME drift: current target=${EXISTING_CONTENT}, proxied=${EXISTING_PROXIED}; expected target=${VALIDATION_VALUE}, proxied=false."
+  VALIDATION_RESULT=$(cloudflare_api_request \
+    "update ACM validation CNAME ${VALIDATION_NAME}" \
+    "PUT" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/dns_records/${EXISTING_ID}" \
+    "$VALIDATION_PAYLOAD")
+elif [[ "$EXISTING_STATE" == "absent" ]]; then
+  VALIDATION_RESULT=$(cloudflare_api_request \
+    "create ACM validation CNAME ${VALIDATION_NAME}" \
+    "POST" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/dns_records" \
+    "$VALIDATION_PAYLOAD" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/dns_records?name=${VALIDATION_NAME}&per_page=100")
+else
+  echo "ERROR: Unexpected ACM validation DNS reconciliation state '${EXISTING_STATE}' for ${VALIDATION_NAME}." >&2
+  exit 1
+fi
+
+echo "$VALIDATION_RESULT" | python3 -c '
+import json
+import sys
+response = json.load(sys.stdin)
+if response.get("success") is not True:
+    print(json.dumps(response.get("errors", response), indent=2), file=sys.stderr)
+    raise SystemExit(1)
+print("ACM validation CNAME is configured as DNS-only.")
+'
+
+echo "Waiting for ACM to issue the certificate..."
+aws_api_request \
+  "wait for ACM certificate ${CERT_ARN} validation" \
+  "$PROFILE" \
+  "$REGION" \
+  aws acm wait certificate-validated \
+  --certificate-arn "$CERT_ARN"
+
+echo ""
+echo "MCP certificate issued: ${CERT_ARN}"
+echo "Keep the validation CNAME for ACM renewal."
+echo "Store the ARN in cdk.context.local.json as mcpCertificateArn."
+echo "Store the same ARN in GitHub Actions as CDK_MCP_CERTIFICATE_ARN before promotion."

--- a/scripts/cloudflare/verify.sh
+++ b/scripts/cloudflare/verify.sh
@@ -3,63 +3,257 @@
 # Drift detection for Cloudflare resources that live outside IaC.
 #
 # Required env vars:
-#   CLOUDFLARE_API_TOKEN  — API token with Zone:Read, DNS:Read, SSL:Read
+#   CLOUDFLARE_API_TOKEN  — API token with Zone, DNS, SSL, Cache Rules, and WAF read access
 #   CLOUDFLARE_ZONE_ID    — Zone ID from Cloudflare dashboard
+#   AWS_PROFILE           — explicit AWS CLI profile for the deployment account
+#   AWS_REGION            — explicit AWS region for the deployed stack
 #
-# Optional env vars:
-#   AWS_PROFILE           — AWS CLI profile (needed for --check-stack)
-#
-# Usage:
-#   export CLOUDFLARE_API_TOKEN="..." CLOUDFLARE_ZONE_ID="..."
-#   bash scripts/cloudflare/verify.sh [--check-stack ExpenseBudgetTracker]
+# Usage from the repository root; the parent shell never receives the token:
+#   (
+#     set -euo pipefail
+#     set -a
+#     source scripts/cloudflare/.env
+#     set +a
+#     export AWS_PROFILE=expense-tracker AWS_REGION=eu-central-1
+#     bash scripts/cloudflare/verify.sh --stack-name ExpenseBudgetTracker
+#   )
 
 set -euo pipefail
 
-STACK_NAME=""
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CDK_CONTEXT_FILE="${ROOT_DIR}/infra/aws/cdk.context.local.json"
+source "${SCRIPT_DIR}/cloudflare-api.sh"
+source "${SCRIPT_DIR}/aws-api.sh"
+
+STACK_NAME="ExpenseBudgetTracker"
+AWS_PROFILE="${AWS_PROFILE:-}"
+AWS_REGION="${AWS_REGION:-}"
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --check-stack) STACK_NAME="$2"; shift 2 ;;
+    --stack-name) STACK_NAME="$2"; shift 2 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
-: "${CLOUDFLARE_API_TOKEN:?Set CLOUDFLARE_API_TOKEN env var}"
+cloudflare_require_api_token
 : "${CLOUDFLARE_ZONE_ID:?Set CLOUDFLARE_ZONE_ID env var}"
 
 ERRORS=0
+STACK_ALB_DNS=""
+STACK_API_TARGET=""
+STACK_MCP_TARGET=""
+STACK_MCP_URL=""
+
+if [[ -z "$AWS_PROFILE" ]]; then
+  echo "ERROR: AWS_PROFILE is required and must identify the dedicated deployment account." >&2
+  exit 1
+fi
+if [[ -z "$AWS_REGION" ]]; then
+  echo "ERROR: AWS_REGION is required and must identify the explicit deployment region." >&2
+  exit 1
+fi
+if [[ ! -f "$CDK_CONTEXT_FILE" ]]; then
+  echo "ERROR: ${CDK_CONTEXT_FILE} is required for verification." >&2
+  exit 1
+fi
+
+DEPLOYMENT_CONTEXT=$(python3 - "$CDK_CONTEXT_FILE" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+context_path = pathlib.Path(sys.argv[1])
+context = json.loads(context_path.read_text(encoding="utf-8"))
+if not isinstance(context, dict):
+    print(f"ERROR: {context_path} must contain a JSON object.", file=sys.stderr)
+    raise SystemExit(1)
+
+required_strings = [
+    "region",
+    "domainName",
+    "certificateArn",
+    "apiCertificateArn",
+    "mcpCertificateArn",
+    "resendApiKeySecretArn",
+]
+missing = [
+    key for key in required_strings
+    if not isinstance(context.get(key), str) or not context[key].strip()
+]
+if missing:
+    print(
+        f"ERROR: {context_path} must define non-empty deployed values for: {', '.join(missing)}.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+region = context["region"]
+account_ids = set()
+for key in ["certificateArn", "apiCertificateArn", "mcpCertificateArn", "resendApiKeySecretArn"]:
+    value = context[key]
+    match = re.match(r"^arn:[^:]+:[^:]+:([^:]+):([0-9]{12}):", value)
+    if match is None:
+        print(f"ERROR: {context_path} value {key} is not a regional AWS ARN.", file=sys.stderr)
+        raise SystemExit(1)
+    arn_region, account_id = match.groups()
+    if arn_region != region:
+        print(
+            f"ERROR: {context_path} value {key} targets region {arn_region}, expected {region}.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    account_ids.add(account_id)
+
+print(json.dumps({
+    "accountIds": sorted(account_ids),
+    "domainName": context.get("domainName"),
+    "region": region,
+}))
+PY
+)
+CONTEXT_REGION=$(echo "$DEPLOYMENT_CONTEXT" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("region") or "")')
+CONTEXT_DOMAIN=$(echo "$DEPLOYMENT_CONTEXT" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("domainName") or "")')
+CONTEXT_ACCOUNT_COUNT=$(echo "$DEPLOYMENT_CONTEXT" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("accountIds", [])))')
+if [[ "$CONTEXT_REGION" != "$AWS_REGION" ]]; then
+  echo "ERROR: AWS region ${AWS_REGION} does not match ${CDK_CONTEXT_FILE} region ${CONTEXT_REGION}." >&2
+  exit 1
+fi
+if [[ "$CONTEXT_ACCOUNT_COUNT" -ne 1 ]]; then
+  echo "ERROR: ${CDK_CONTEXT_FILE} must contain deployment ARNs from exactly one AWS account; found ${CONTEXT_ACCOUNT_COUNT}." >&2
+  exit 1
+fi
+CONTEXT_ACCOUNT_ID=$(echo "$DEPLOYMENT_CONTEXT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["accountIds"][0])')
+
+if ! AWS_IDENTITY=$(aws_api_request \
+  "caller identity lookup" \
+  "$AWS_PROFILE" \
+  "$AWS_REGION" \
+  aws sts get-caller-identity \
+  --output json); then
+  echo "ERROR: Failed to verify AWS caller identity with profile ${AWS_PROFILE} in region ${AWS_REGION}." >&2
+  exit 1
+fi
+AWS_ACCOUNT_ID=$(echo "$AWS_IDENTITY" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("Account", ""))')
+AWS_CALLER_ARN=$(echo "$AWS_IDENTITY" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("Arn", ""))')
+if [[ ! "$AWS_ACCOUNT_ID" =~ ^[0-9]{12}$ || -z "$AWS_CALLER_ARN" ]]; then
+  echo "ERROR: AWS STS returned an invalid caller identity for profile ${AWS_PROFILE}." >&2
+  exit 1
+fi
+if [[ "$AWS_ACCOUNT_ID" != "$CONTEXT_ACCOUNT_ID" ]]; then
+  echo "ERROR: AWS profile ${AWS_PROFILE} resolves to account ${AWS_ACCOUNT_ID}, but ${CDK_CONTEXT_FILE} targets account ${CONTEXT_ACCOUNT_ID}." >&2
+  exit 1
+fi
+
+if ! STACK_JSON=$(aws_api_request \
+  "read CloudFormation stack ${STACK_NAME}" \
+  "$AWS_PROFILE" \
+  "$AWS_REGION" \
+  aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --output json); then
+  echo "ERROR: Could not read CloudFormation stack ${STACK_NAME} in account ${AWS_ACCOUNT_ID}, region ${AWS_REGION}." >&2
+  exit 1
+fi
+read_stack_output() {
+  local output_key="$1"
+  echo "$STACK_JSON" | python3 -c '
+import json
+import sys
+
+output_key = sys.argv[1]
+stacks = json.load(sys.stdin).get("Stacks", [])
+if len(stacks) != 1:
+    print(f"ERROR: Expected one CloudFormation stack, found {len(stacks)}.", file=sys.stderr)
+    raise SystemExit(1)
+outputs = stacks[0].get("Outputs", [])
+values = [output.get("OutputValue") for output in outputs if output.get("OutputKey") == output_key]
+if len(values) > 1:
+    print(f"ERROR: CloudFormation output {output_key} is duplicated.", file=sys.stderr)
+    raise SystemExit(1)
+print(values[0] if values else "")
+' "$output_key"
+}
+STACK_ALB_DNS=$(read_stack_output "AlbDns")
+STACK_API_TARGET=$(read_stack_output "ApiCustomDomain")
+STACK_MCP_TARGET=$(read_stack_output "McpCustomDomain")
+STACK_MCP_URL=$(read_stack_output "McpUrl")
+if [[ -z "$STACK_ALB_DNS" || "$STACK_ALB_DNS" == "None" ]]; then
+  echo "ERROR: Could not read AlbDns from stack ${STACK_NAME}." >&2
+  exit 1
+fi
+if [[ -z "$STACK_API_TARGET" || "$STACK_API_TARGET" == "None" ]]; then
+  echo "ERROR: Could not read ApiCustomDomain from stack ${STACK_NAME}." >&2
+  exit 1
+fi
+if [[ -z "$STACK_MCP_TARGET" || "$STACK_MCP_TARGET" == "None" ]]; then
+  echo "ERROR: Could not read McpCustomDomain from stack ${STACK_NAME}." >&2
+  exit 1
+fi
+EXPECTED_MCP_URL="https://mcp.${CONTEXT_DOMAIN}/mcp"
+if [[ "$STACK_MCP_URL" != "$EXPECTED_MCP_URL" ]]; then
+  echo "ERROR: Stack ${STACK_NAME} advertises MCP URL '${STACK_MCP_URL}', expected '${EXPECTED_MCP_URL}' from ${CDK_CONTEXT_FILE}." >&2
+  echo "Redeploy the stack with the matching domain context before verifying Cloudflare." >&2
+  exit 1
+fi
+echo "Verified AWS caller ${AWS_CALLER_ARN} in account ${AWS_ACCOUNT_ID}, region ${AWS_REGION}."
 
 cf_api() {
-  curl -sf "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/$1" \
-    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-    -H "Content-Type: application/json"
+  local resource_path="$1"
+  cloudflare_api_request \
+    "read ${resource_path:-zone metadata}" \
+    "GET" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/${resource_path}" \
+    ""
 }
 
-check_dns() {
-  local name="$1" type="$2" label="$3"
+check_managed_cname() {
+  local name="$1" label="$2" expected_target="$3"
   local result
-  result=$(cf_api "dns_records?name=${name}&type=${type}")
+  result=$(cf_api "dns_records?name=${name}")
   local count
   count=$(echo "$result" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("result", [])))')
-  if [[ "$count" -eq 0 ]]; then
-    echo "FAIL: ${label} — no ${type} record for ${name}" >&2
+  if [[ "$count" -ne 1 ]]; then
+    echo "FAIL: ${label} — expected exactly one DNS record for ${name}; found ${count}" >&2
+    ERRORS=$((ERRORS + 1))
+    return
+  fi
+
+  local actual_type content proxied
+  actual_type=$(echo "$result" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"][0].get("type", ""))')
+  content=$(echo "$result" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"][0].get("content", ""))')
+  proxied=$(echo "$result" | python3 -c 'import sys,json; print(str(json.load(sys.stdin)["result"][0].get("proxied") is True).lower())')
+  if [[ "$actual_type" != "CNAME" ]]; then
+    echo "FAIL: ${label} — ${name} is ${actual_type:-an unknown type}, expected CNAME" >&2
+    ERRORS=$((ERRORS + 1))
+  elif [[ "$content" != "$expected_target" ]]; then
+    echo "FAIL: ${label} — ${name} points to '${content}', expected '${expected_target}' from stack ${STACK_NAME}" >&2
+    ERRORS=$((ERRORS + 1))
+  elif [[ "$proxied" != "true" ]]; then
+    echo "FAIL: ${label} — ${name} matches '${expected_target}' but proxied is not true" >&2
     ERRORS=$((ERRORS + 1))
   else
-    local content
-    content=$(echo "$result" | python3 -c 'import sys,json; r=json.load(sys.stdin)["result"][0]; print(r["content"])')
-    echo "  OK: ${label} — ${type} ${name} -> ${content}"
+    echo "  OK: ${label} — single proxied CNAME ${name} -> ${content}"
   fi
 }
 
 # --- Zone info ---
 ZONE_RESPONSE=$(cf_api "")
 ZONE_NAME=$(echo "$ZONE_RESPONSE" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["name"])')
+if [[ "$ZONE_NAME" != "$CONTEXT_DOMAIN" ]]; then
+  echo "ERROR: Cloudflare zone ${ZONE_NAME} does not match ${CDK_CONTEXT_FILE} domainName ${CONTEXT_DOMAIN}." >&2
+  exit 1
+fi
 echo "Zone: ${ZONE_NAME}"
 echo ""
 
 # --- DNS records ---
 echo "Checking DNS records..."
-check_dns "app.${ZONE_NAME}" "CNAME" "App subdomain"
-check_dns "auth.${ZONE_NAME}" "CNAME" "Auth subdomain"
+check_managed_cname "app.${ZONE_NAME}" "App subdomain" "$STACK_ALB_DNS"
+check_managed_cname "auth.${ZONE_NAME}" "Auth subdomain" "$STACK_ALB_DNS"
+check_managed_cname "api.${ZONE_NAME}" "Machine API subdomain" "$STACK_API_TARGET"
+check_managed_cname "mcp.${ZONE_NAME}" "MCP subdomain" "$STACK_MCP_TARGET"
 
 # Root domain — could be A or CNAME (CNAME flattening)
 ROOT_RECORDS=$(cf_api "dns_records?name=${ZONE_NAME}")
@@ -91,43 +285,75 @@ fi
 # --- Cache bypass rule ---
 echo ""
 echo "Checking cache bypass rule..."
-CACHE_RULESET=$(cf_api "rulesets/phases/http_request_cache_settings/entrypoint" 2>/dev/null || echo '{"result":{"rules":[]}}')
+CACHE_RULESET=$(cloudflare_optional_get_request \
+  "read cache ruleset" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_request_cache_settings/entrypoint")
+EXPECTED_CACHE_EXPRESSION="(http.host eq \"app.${ZONE_NAME}\" or http.host eq \"auth.${ZONE_NAME}\" or http.host eq \"mcp.${ZONE_NAME}\" or http.host eq \"${ZONE_NAME}\")"
 CACHE_RULE_COUNT=$(echo "$CACHE_RULESET" | python3 -c '
 import sys, json
+
+def normalize_expression(expression):
+    return " ".join(str(expression).split())
+
+expected_expression = normalize_expression(sys.argv[1])
 rules = json.load(sys.stdin).get("result", {}).get("rules", [])
-bypass = [r for r in rules if r.get("action_parameters", {}).get("cache") == False]
+bypass = [
+    rule for rule in rules
+    if rule.get("enabled") is True
+    and rule.get("action") == "set_cache_settings"
+    and rule.get("action_parameters", {}).get("cache") is False
+    and normalize_expression(rule.get("expression", "")) == expected_expression
+]
 print(len(bypass))
-')
+' "$EXPECTED_CACHE_EXPRESSION")
 if [[ "$CACHE_RULE_COUNT" -eq 0 ]]; then
-  echo "FAIL: No cache bypass rule found — Cloudflare may cache ALB auth redirects" >&2
+  echo "FAIL: No enabled cache-bypass rule has the exact expected host predicate and cache=false action" >&2
+  echo "  Expected: ${EXPECTED_CACHE_EXPRESSION}" >&2
   ERRORS=$((ERRORS + 1))
 else
   echo "  OK: Cache bypass rule active (${CACHE_RULE_COUNT} rule(s))"
 fi
 
-# --- Cross-check with CloudFormation stack (optional) ---
-if [[ -n "$STACK_NAME" ]]; then
-  echo ""
-  echo "Cross-checking with CloudFormation stack '${STACK_NAME}'..."
+# --- Anonymous OAuth registration rate limit ---
+echo ""
+echo "Checking anonymous OAuth registration rate limit..."
+RATE_RULESET=$(cloudflare_optional_get_request \
+  "read rate-limit ruleset" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_ratelimit/entrypoint")
+EXPECTED_RATE_EXPRESSION="(http.host eq \"auth.${ZONE_NAME}\" and http.request.method eq \"POST\" and http.request.uri.path eq \"/oauth/register\")"
+RATE_RULE_COUNT=$(echo "$RATE_RULESET" | python3 -c '
+import json
+import sys
 
-  ALB_DNS=$(aws cloudformation describe-stacks \
-    --stack-name "$STACK_NAME" \
-    --query "Stacks[0].Outputs[?OutputKey=='AlbDns'].OutputValue" \
-    --output text 2>/dev/null || echo "")
+def normalize_expression(expression):
+    return " ".join(str(expression).split())
 
-  if [[ -z "$ALB_DNS" || "$ALB_DNS" == "None" ]]; then
-    echo "FAIL: Could not read AlbDns from stack ${STACK_NAME}" >&2
-    ERRORS=$((ERRORS + 1))
-  else
-    APP_CNAME=$(cf_api "dns_records?name=app.${ZONE_NAME}&type=CNAME")
-    APP_CONTENT=$(echo "$APP_CNAME" | python3 -c 'import sys,json; r=json.load(sys.stdin)["result"]; print(r[0]["content"] if r else "")' 2>/dev/null || echo "")
-    if [[ "$APP_CONTENT" != "$ALB_DNS" ]]; then
-      echo "FAIL: app.${ZONE_NAME} CNAME points to '${APP_CONTENT}', expected ALB '${ALB_DNS}'" >&2
-      ERRORS=$((ERRORS + 1))
-    else
-      echo "  OK: app CNAME matches ALB DNS"
-    fi
-  fi
+expected_expression = normalize_expression(sys.argv[1])
+rules = json.load(sys.stdin).get("result", {}).get("rules", [])
+matches = []
+for rule in rules:
+    rate = rule.get("ratelimit", {})
+    characteristics = rate.get("characteristics", [])
+    if (
+        rule.get("enabled") is True
+        and rule.get("action") == "block"
+        and normalize_expression(rule.get("expression", "")) == expected_expression
+        and sorted(characteristics) == ["cf.colo.id", "ip.src"]
+        and rate.get("period") == 10
+        and rate.get("requests_per_period") == 5
+        and rate.get("mitigation_timeout") == 10
+    ):
+        matches.append(rule)
+print(len(matches))
+' "$EXPECTED_RATE_EXPRESSION")
+if [[ "$RATE_RULE_COUNT" -ne 1 ]]; then
+  echo "FAIL: Expected exactly one enabled rate limit for auth POST /oauth/register; found ${RATE_RULE_COUNT} exact matches" >&2
+  echo "  Expected: ${EXPECTED_RATE_EXPRESSION}" >&2
+  echo "  Expected action=block, characteristics=cf.colo.id+ip.src, rate=5/10s, mitigation=10s" >&2
+  echo "  Re-run setup-dns.sh to reconcile the rule and remove any duplicate exact matches before verifying again." >&2
+  ERRORS=$((ERRORS + 1))
+else
+  echo "  OK: Exactly one anonymous OAuth registration rate limit is active"
 fi
 
 # --- Summary ---

--- a/server.json
+++ b/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.kirill-markin/expense-budget-tracker",
+  "title": "Expense Budget Tracker",
+  "description": "Workspace-scoped expense and budget tools with OAuth read and write access.",
+  "version": "1.2.0",
+  "websiteUrl": "https://expense-budget-tracker.com",
+  "repository": {
+    "url": "https://github.com/kirill-markin/expense-budget-tracker",
+    "source": "github",
+    "subfolder": "apps/sql-api"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.expense-budget-tracker.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- publish MCP as a dedicated API Gateway HTTP API v2 backed by its dedicated Lambda
- keep OAuth/auth on the existing ECS service behind the ALB and keep the machine API on REST API Gateway
- make /v1/sql/query and /v1/sql/execute the primary split SQL endpoints while retaining legacy /v1/sql compatibility
- wire the MCP custom domain, Cloudflare rollout, discovery metadata, alarms, and deployment procedure

Swagger/OpenAPI is intentionally untouched.

## Validation

- Final fresh whole-patch review reported no P0-P4 findings.
- Per repository delivery policy, no local tests, lint, typecheck, builds, formatters, smoke tests, validation, CDK synth, or deployment were run.