### PR TITLE
fix: repair promotion CI failures

### DIFF
--- a/apps/auth/src/routes/oauth.test.ts
+++ b/apps/auth/src/routes/oauth.test.ts
@@ -296,16 +296,17 @@ const registrationBody = (padding: string): string => JSON.stringify({
 
 const utf8Length = (value: string): number => new TextEncoder().encode(value).byteLength;
 
-const consentParametersWithEncodedSize = (targetBytes: number): URLSearchParams => {
-  const params = authorizationParams();
-  const prefix = "é/?&=+";
-  params.set("state", prefix);
+const consentParametersWithEncodedSize = (
+  oauthClient: OAuthClient,
+  targetBytes: number,
+): URLSearchParams => {
+  const params = authorizationParamsForClient(oauthClient, "");
   params.set("decision", "allow");
   const remainingBytes = targetBytes - utf8Length(params.toString());
   if (remainingBytes < 0) throw new RangeError("Target consent size is smaller than the fixed form fields");
-  const multibyteCharacters = Math.floor(remainingBytes / 6);
-  const asciiCharacters = remainingBytes % 6;
-  params.set("state", `${prefix}${"é".repeat(multibyteCharacters)}${"x".repeat(asciiCharacters)}`);
+  const encodedCharacters = Math.floor(remainingBytes / 3);
+  const asciiCharacters = remainingBytes % 3;
+  params.set("state", `${"~".repeat(encodedCharacters)}${"x".repeat(asciiCharacters)}`);
   const state = params.get("state");
   if (state === null || state.length > 2048 || utf8Length(params.toString()) !== targetBytes) {
     throw new RangeError("Target consent size cannot be represented within the state parameter limit");
@@ -447,14 +448,25 @@ test("authorization GET enforces its raw query ceiling and keeps nested login be
 
 test("consent renders only when both encoded decisions fit the POST byte limit", async (): Promise<void> => {
   let sessionResolutionCount = 0;
+  const boundaryClient: OAuthClient = {
+    clientId: "ebt_cl_boundary-client",
+    clientName: "Boundary client",
+    redirectUris: [`https://client.example/${"~".repeat(600)}`],
+  };
   const app = createOAuthApp(createDependencies({
+    getOAuthClient: async (clientId) => clientId === boundaryClient.clientId ? boundaryClient : null,
     resolveBrowserSession: async () => {
       sessionResolutionCount += 1;
       return { userId: "user-1", email: "user@example.com" };
     },
   }));
-  const exactBoundary = consentParametersWithEncodedSize(MAX_CONSENT_REQUEST_BYTES);
-  const page = await app.request(`${issuer}/oauth/authorize?${exactBoundary.toString()}`);
+  const exactBoundary = consentParametersWithEncodedSize(
+    boundaryClient,
+    MAX_CONSENT_REQUEST_BYTES,
+  );
+  const exactQuery = exactBoundary.toString().replaceAll("%7E", "~");
+  assert.ok(utf8Length(exactQuery) <= MAX_OAUTH_AUTHORIZE_QUERY_BYTES);
+  const page = await app.request(`${issuer}/oauth/authorize?${exactQuery}`);
   assert.equal(page.status, 200);
   assert.match(await page.text(), /<form method="post" action="\/oauth\/authorize">/u);
 
@@ -467,8 +479,13 @@ test("consent renders only when both encoded decisions fit the POST byte limit",
   const submission = await app.fetch(consentRequest(allowed, issuer));
   assert.equal(submission.status, 302);
 
-  const oversized = consentParametersWithEncodedSize(MAX_CONSENT_REQUEST_BYTES + 1);
-  const rejected = await app.request(`${issuer}/oauth/authorize?${oversized.toString()}`);
+  const oversized = consentParametersWithEncodedSize(
+    boundaryClient,
+    MAX_CONSENT_REQUEST_BYTES + 1,
+  );
+  const oversizedQuery = oversized.toString().replaceAll("%7E", "~");
+  assert.ok(utf8Length(oversizedQuery) <= MAX_OAUTH_AUTHORIZE_QUERY_BYTES);
+  const rejected = await app.request(`${issuer}/oauth/authorize?${oversizedQuery}`);
   assert.equal(rejected.status, 302);
   const location = rejected.headers.get("location") ?? "";
   assert.match(location, /[?&]error=invalid_request(?:&|$)/u);

--- a/apps/auth/src/server/oauth/session.test.ts
+++ b/apps/auth/src/server/oauth/session.test.ts
@@ -31,7 +31,7 @@ const createDependencies = (
   ...overrides,
 });
 
-const requestSession = (
+const requestSession = async (
   cookie: string,
   dependencies: BrowserSessionDependencies,
 ): Promise<Response> => {

--- a/apps/sql-api/src/dbDeadline.ts
+++ b/apps/sql-api/src/dbDeadline.ts
@@ -379,7 +379,7 @@ export const withDeadlineTransactionUsingPool = async <T>(
       result = await callback(transaction);
       await transaction.query("RESET ROLE", [], deadline.timeoutMs);
     } catch (error) {
-      await rethrowAfterTransactionFailure(lease, runtime, error);
+      return await rethrowAfterTransactionFailure(lease, runtime, error);
     }
 
     try {

--- a/apps/sql-api/src/machineApi/sqlService.ts
+++ b/apps/sql-api/src/machineApi/sqlService.ts
@@ -279,7 +279,7 @@ const executeSqlWithWorkspaceGetter = async (
                 rowCount: queryResult.rowCount,
               };
             } catch (error) {
-              throwUserSqlExecutionError(error);
+              return throwUserSqlExecutionError(error);
             }
           },
         );

--- a/infra/aws/lib/ingress.test.ts
+++ b/infra/aws/lib/ingress.test.ts
@@ -64,24 +64,92 @@ const requireRateBasedStatement = (
   return statement;
 };
 
+const requireAndStatement = (
+  statement: IResolvable | wafv2.CfnWebACL.AndStatementProperty | undefined,
+): wafv2.CfnWebACL.AndStatementProperty => {
+  if (statement === undefined || "resolve" in statement) {
+    throw new Error("Expected an inline WAF and statement");
+  }
+  return statement;
+};
+
+const requireOrStatement = (
+  statement: IResolvable | wafv2.CfnWebACL.OrStatementProperty | undefined,
+): wafv2.CfnWebACL.OrStatementProperty => {
+  if (statement === undefined || "resolve" in statement) {
+    throw new Error("Expected an inline WAF or statement");
+  }
+  return statement;
+};
+
+const requireNotStatement = (
+  statement: IResolvable | wafv2.CfnWebACL.NotStatementProperty | undefined,
+): wafv2.CfnWebACL.NotStatementProperty => {
+  if (statement === undefined || "resolve" in statement) {
+    throw new Error("Expected an inline WAF not statement");
+  }
+  return statement;
+};
+
+const requireByteMatchStatement = (
+  statement: IResolvable | wafv2.CfnWebACL.ByteMatchStatementProperty | undefined,
+): wafv2.CfnWebACL.ByteMatchStatementProperty => {
+  if (statement === undefined || "resolve" in statement) {
+    throw new Error("Expected an inline WAF byte-match statement");
+  }
+  return statement;
+};
+
+const requireSizeConstraintStatement = (
+  statement: IResolvable | wafv2.CfnWebACL.SizeConstraintStatementProperty | undefined,
+): wafv2.CfnWebACL.SizeConstraintStatementProperty => {
+  if (statement === undefined || "resolve" in statement) {
+    throw new Error("Expected an inline WAF size-constraint statement");
+  }
+  return statement;
+};
+
+const requireManagedRuleGroupStatement = (
+  statement: IResolvable | wafv2.CfnWebACL.ManagedRuleGroupStatementProperty | undefined,
+): wafv2.CfnWebACL.ManagedRuleGroupStatementProperty => {
+  if (statement === undefined || "resolve" in statement) {
+    throw new Error("Expected an inline WAF managed-rule-group statement");
+  }
+  return statement;
+};
+
+const requireLabelMatchStatement = (
+  statement: IResolvable | wafv2.CfnWebACL.LabelMatchStatementProperty | undefined,
+): wafv2.CfnWebACL.LabelMatchStatementProperty => {
+  if (statement === undefined || "resolve" in statement) {
+    throw new Error("Expected an inline WAF label-match statement");
+  }
+  return statement;
+};
+
 const assertBoundedGetRoute = (
   statement: wafv2.CfnWebACL.StatementProperty,
   host: string,
   path: string,
   maxBytes: number,
 ): void => {
-  const statements = requireStatements(statement.andStatement?.statements);
+  const and = requireAndStatement(statement.andStatement);
+  const statements = requireStatements(and.statements);
   assert.deepEqual(
-    statements.slice(0, 3).map((part) => part.byteMatchStatement?.searchString),
+    statements.slice(0, 3).map((part) =>
+      requireByteMatchStatement(part.byteMatchStatement).searchString),
     ["GET", host, path],
   );
+  const sizeConstraint = requireSizeConstraintStatement(
+    statements[3]?.sizeConstraintStatement,
+  );
   assert.equal(
-    statements[3]?.sizeConstraintStatement?.comparisonOperator,
+    sizeConstraint.comparisonOperator,
     "LE",
   );
-  assert.equal(statements[3]?.sizeConstraintStatement?.size, maxBytes);
+  assert.equal(sizeConstraint.size, maxBytes);
   assert.deepEqual(
-    statements[3]?.sizeConstraintStatement?.fieldToMatch,
+    sizeConstraint.fieldToMatch,
     { queryString: {} },
   );
 };
@@ -90,8 +158,11 @@ test("WAF counts the managed query-size rule and re-blocks outside exact bounded
   const rules = buildIngressWafRules("app.example.com", "auth.example.com");
   const managedRule = getRule(rules, "AWSManagedCommonRules");
   const managedStatement = requireStatement(managedRule.statement);
+  const managedRuleGroup = requireManagedRuleGroupStatement(
+    managedStatement.managedRuleGroupStatement,
+  );
   const overrides = requireRuleActionOverrides(
-    managedStatement.managedRuleGroupStatement?.ruleActionOverrides,
+    managedRuleGroup.ruleActionOverrides,
   );
   assert.deepEqual(
     overrides.map((override) => override.name),
@@ -100,13 +171,16 @@ test("WAF counts the managed query-size rule and re-blocks outside exact bounded
 
   const queryRule = getRule(rules, "BlockUnexpectedQuerySizeMatches");
   const queryStatement = requireStatement(queryRule.statement);
-  const reblockStatements = requireStatements(queryStatement.andStatement?.statements);
+  const reblock = requireAndStatement(queryStatement.andStatement);
+  const reblockStatements = requireStatements(reblock.statements);
   assert.equal(
-    reblockStatements[0]?.labelMatchStatement?.key,
+    requireLabelMatchStatement(reblockStatements[0]?.labelMatchStatement).key,
     "awswaf:managed:aws:core-rule-set:SizeRestrictions_QueryString",
   );
-  const exception = requireStatement(reblockStatements[1]?.notStatement?.statement);
-  const allowedRoutes = requireStatements(exception.orStatement?.statements);
+  const exception = requireNotStatement(reblockStatements[1]?.notStatement);
+  const allowed = requireStatement(exception.statement);
+  const allowedRouteGroup = requireOrStatement(allowed.orStatement);
+  const allowedRoutes = requireStatements(allowedRouteGroup.statements);
   assert.equal(allowedRoutes.length, 2);
   assertBoundedGetRoute(
     allowedRoutes[0] ?? {},
@@ -139,13 +213,16 @@ test("WAF rate limits exact dynamic client registration requests by trusted Clou
   });
 
   const scopeDownStatement = requireStatement(rateBasedStatement.scopeDownStatement);
-  const conditions = requireStatements(scopeDownStatement.andStatement?.statements);
+  const scopeDown = requireAndStatement(scopeDownStatement.andStatement);
+  const conditions = requireStatements(scopeDown.statements);
   assert.deepEqual(
-    conditions.map((condition) => condition.byteMatchStatement?.searchString),
+    conditions.map((condition) =>
+      requireByteMatchStatement(condition.byteMatchStatement).searchString),
     ["auth.example.com", "POST", "/oauth/register"],
   );
   assert.deepEqual(
-    conditions.map((condition) => condition.byteMatchStatement?.fieldToMatch),
+    conditions.map((condition) =>
+      requireByteMatchStatement(condition.byteMatchStatement).fieldToMatch),
     [
       { singleHeader: { Name: "host" } },
       { method: {} },


### PR DESCRIPTION
## Summary
- repair strict async return typing in OAuth session tests
- make SQL deadline and executor failure paths explicitly terminal
- strictly narrow nested CDK WAF statement unions in tests
- preserve independent OAuth GET and consent POST byte boundaries

## Validation
- local project checks intentionally not run; GitHub Actions owns validation