### PR TITLE
Revoke OAuth renewal for inactive Cognito users

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -15,6 +15,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@aws-sdk/client-cognito-identity-provider": "^3.1111.0",
     "@expense-budget-tracker/agent-shared": "1.2.0",
     "@hono/node-server": "^2.1.0",
     "aws-jwt-verify": "^5.2.1",

--- a/apps/auth/src/server/cognitoUserStatus.test.ts
+++ b/apps/auth/src/server/cognitoUserStatus.test.ts
@@ -1,0 +1,455 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CognitoIdentityProviderServiceException,
+  TooManyRequestsException,
+  UserNotFoundException,
+  type AdminGetUserCommandOutput,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  getCognitoOAuthOwnerStatusWithDependencies,
+  type CognitoUserStatusDependencies,
+} from "./cognitoUserStatus.js";
+import type { CognitoOAuthOwnerRetryEvent } from "./logger.js";
+
+const userPoolId = "eu-west-1_pool";
+const userId = "sensitive-user-id";
+
+type TransientErrorCase = Readonly<{
+  label: string;
+  createError: (attempt: number) => Error;
+  expectedCognitoType: string | null;
+  expectedStatus: number | null;
+  expectedErrorType: "error" | "type_error";
+}>;
+
+const transientErrorCases: ReadonlyArray<TransientErrorCase> = [
+  {
+    label: "ENOTFOUND",
+    createError: (attempt) => Object.assign(
+      new Error(`DNS lookup failed for ${userId} on attempt ${attempt}`),
+      { code: "ENOTFOUND" },
+    ),
+    expectedCognitoType: null,
+    expectedStatus: null,
+    expectedErrorType: "error",
+  },
+  {
+    label: "EAI_AGAIN",
+    createError: (attempt) => Object.assign(
+      new Error(`Temporary DNS failure for ${userId} on attempt ${attempt}`),
+      { code: "EAI_AGAIN" },
+    ),
+    expectedCognitoType: null,
+    expectedStatus: null,
+    expectedErrorType: "error",
+  },
+  {
+    label: "TypeError",
+    createError: (attempt) => new TypeError(
+      `Smithy request failed for ${userId} on attempt ${attempt}`,
+    ),
+    expectedCognitoType: null,
+    expectedStatus: null,
+    expectedErrorType: "type_error",
+  },
+  {
+    label: "TimeoutError",
+    createError: (attempt) => Object.assign(
+      new Error(`Socket timed out for ${userId} on attempt ${attempt}`),
+      { name: "TimeoutError" },
+    ),
+    expectedCognitoType: null,
+    expectedStatus: null,
+    expectedErrorType: "error",
+  },
+  {
+    label: "ECONNRESET",
+    createError: (attempt) => Object.assign(
+      new Error(`Socket reset for ${userId} on attempt ${attempt}`),
+      { code: "ECONNRESET" },
+    ),
+    expectedCognitoType: null,
+    expectedStatus: null,
+    expectedErrorType: "error",
+  },
+  {
+    label: "RequestTimeoutException",
+    createError: (attempt) => new CognitoIdentityProviderServiceException({
+      name: "RequestTimeoutException",
+      $fault: "client",
+      $metadata: { httpStatusCode: 400 },
+      message: `Request timed out for ${userId} on attempt ${attempt}`,
+    }),
+    expectedCognitoType: "RequestTimeoutException",
+    expectedStatus: 400,
+    expectedErrorType: "error",
+  },
+  {
+    label: "server fault",
+    createError: (attempt) => new CognitoIdentityProviderServiceException({
+      name: "ServerFaultForTest",
+      $fault: "server",
+      $metadata: { httpStatusCode: 400 },
+      message: `Server fault for ${userId} on attempt ${attempt}`,
+    }),
+    expectedCognitoType: "ServerFaultForTest",
+    expectedStatus: 400,
+    expectedErrorType: "error",
+  },
+  {
+    label: "HTTP 5xx",
+    createError: (attempt) => new CognitoIdentityProviderServiceException({
+      name: "HttpFailureForTest",
+      $fault: "client",
+      $metadata: { httpStatusCode: 503 },
+      message: `HTTP failure for ${userId} on attempt ${attempt}`,
+    }),
+    expectedCognitoType: "HttpFailureForTest",
+    expectedStatus: 503,
+    expectedErrorType: "error",
+  },
+  {
+    label: "HTTP 429",
+    createError: (attempt) => new CognitoIdentityProviderServiceException({
+      name: "StatusOnlyThrottleForTest",
+      $fault: "client",
+      $metadata: { httpStatusCode: 429 },
+      message: `Status-only throttle for ${userId} on attempt ${attempt}`,
+    }),
+    expectedCognitoType: "StatusOnlyThrottleForTest",
+    expectedStatus: 429,
+    expectedErrorType: "error",
+  },
+  {
+    label: "transient service name",
+    createError: (attempt) => new CognitoIdentityProviderServiceException({
+      name: "ServiceUnavailableException",
+      $fault: "client",
+      $metadata: { httpStatusCode: 400 },
+      message: `Service unavailable for ${userId} on attempt ${attempt}`,
+    }),
+    expectedCognitoType: "ServiceUnavailableException",
+    expectedStatus: 400,
+    expectedErrorType: "error",
+  },
+];
+
+type InvalidResponseCase = Readonly<{
+  label: string;
+  response: AdminGetUserCommandOutput;
+  expectedError: RegExp;
+}>;
+
+const invalidResponseCases: ReadonlyArray<InvalidResponseCase> = [
+  {
+    label: "missing Enabled",
+    response: { $metadata: {}, Username: "cognito-username", UserStatus: "CONFIRMED" },
+    expectedError: /missing a boolean Enabled value/u,
+  },
+  {
+    label: "invalid Enabled",
+    response: {
+      $metadata: {},
+      Username: "cognito-username",
+      Enabled: "true",
+      UserStatus: "CONFIRMED",
+    } as unknown as AdminGetUserCommandOutput,
+    expectedError: /missing a boolean Enabled value/u,
+  },
+  {
+    label: "missing UserStatus",
+    response: { $metadata: {}, Username: "cognito-username", Enabled: true },
+    expectedError: /invalid UserStatus value/u,
+  },
+  {
+    label: "invalid UserStatus",
+    response: {
+      $metadata: {},
+      Username: "cognito-username",
+      Enabled: true,
+      UserStatus: "ACTIVE",
+    } as unknown as AdminGetUserCommandOutput,
+    expectedError: /invalid UserStatus value/u,
+  },
+];
+
+const response = (
+  enabled: boolean,
+  userStatus: AdminGetUserCommandOutput["UserStatus"],
+): AdminGetUserCommandOutput => ({
+  $metadata: {},
+  Username: "cognito-username",
+  Enabled: enabled,
+  UserStatus: userStatus,
+});
+
+const withUserPoolId = async (operation: () => Promise<void>): Promise<void> => {
+  const previous = process.env.COGNITO_USER_POOL_ID;
+  process.env.COGNITO_USER_POOL_ID = userPoolId;
+  try {
+    await operation();
+  } finally {
+    if (previous === undefined) delete process.env.COGNITO_USER_POOL_ID;
+    else process.env.COGNITO_USER_POOL_ID = previous;
+  }
+};
+
+const createDependencies = (
+  adminGetUser: CognitoUserStatusDependencies["adminGetUser"],
+  events: Array<CognitoOAuthOwnerRetryEvent>,
+  delays: Array<number>,
+): CognitoUserStatusDependencies => ({
+  adminGetUser,
+  wait: async (delayMs) => { delays.push(delayMs); },
+  logRetry: (event) => { events.push(event); },
+});
+
+test("confirmed enabled Cognito owners remain eligible for OAuth renewal", async (): Promise<void> => {
+  await withUserPoolId(async () => {
+    const calls: Array<Readonly<{ requestedPoolId: string; requestedUserId: string }>> = [];
+    const dependencies = createDependencies(async (requestedPoolId, requestedUserId) => {
+      calls.push({ requestedPoolId, requestedUserId });
+      return response(true, "CONFIRMED");
+    }, [], []);
+
+    const status = await getCognitoOAuthOwnerStatusWithDependencies(userId, dependencies);
+
+    assert.equal(status, "active");
+    assert.deepEqual(calls, [{ requestedPoolId: userPoolId, requestedUserId: userId }]);
+  });
+});
+
+test("disabled and non-confirmed Cognito owners are definitively inactive", async (): Promise<void> => {
+  await withUserPoolId(async () => {
+    const disabled = await getCognitoOAuthOwnerStatusWithDependencies(
+      userId,
+      createDependencies(async () => response(false, "CONFIRMED"), [], []),
+    );
+    const nonConfirmed = await getCognitoOAuthOwnerStatusWithDependencies(
+      userId,
+      createDependencies(async () => response(true, "UNCONFIRMED"), [], []),
+    );
+
+    assert.equal(disabled, "inactive");
+    assert.equal(nonConfirmed, "inactive");
+  });
+});
+
+test("AdminGetUser Enabled and UserStatus fields are parsed strictly", async (): Promise<void> => {
+  await withUserPoolId(async () => {
+    for (const responseCase of invalidResponseCases) {
+      const events: Array<CognitoOAuthOwnerRetryEvent> = [];
+      const delays: Array<number> = [];
+      let attempts = 0;
+
+      await assert.rejects(
+        getCognitoOAuthOwnerStatusWithDependencies(
+          userId,
+          createDependencies(async () => {
+            attempts += 1;
+            return responseCase.response;
+          }, events, delays),
+        ),
+        responseCase.expectedError,
+        responseCase.label,
+      );
+      assert.equal(attempts, 1, responseCase.label);
+      assert.deepEqual(delays, [], responseCase.label);
+      assert.deepEqual(events, [], responseCase.label);
+    }
+  });
+});
+
+test("missing Cognito owners are definitively inactive without retries", async (): Promise<void> => {
+  await withUserPoolId(async () => {
+    const events: Array<CognitoOAuthOwnerRetryEvent> = [];
+    let attempts = 0;
+    const missing = new UserNotFoundException({
+      $metadata: { httpStatusCode: 400 },
+      message: "User does not exist",
+    });
+    const dependencies = createDependencies(async () => {
+      attempts += 1;
+      throw missing;
+    }, events, []);
+
+    const status = await getCognitoOAuthOwnerStatusWithDependencies(userId, dependencies);
+
+    assert.equal(status, "inactive");
+    assert.equal(attempts, 1);
+    assert.deepEqual(events, []);
+  });
+});
+
+test("permanent Cognito client faults are raised without retries", async (): Promise<void> => {
+  await withUserPoolId(async () => {
+    const events: Array<CognitoOAuthOwnerRetryEvent> = [];
+    const delays: Array<number> = [];
+    let attempts = 0;
+    const permanentFailure = new CognitoIdentityProviderServiceException({
+      name: "PermanentClientFaultForTest",
+      $fault: "client",
+      $metadata: { httpStatusCode: 400 },
+      message: `Permanent client fault for ${userId}`,
+    });
+    const dependencies = createDependencies(async () => {
+      attempts += 1;
+      throw permanentFailure;
+    }, events, delays);
+
+    await assert.rejects(
+      getCognitoOAuthOwnerStatusWithDependencies(userId, dependencies),
+      (error: unknown) => error === permanentFailure,
+    );
+    assert.equal(attempts, 1);
+    assert.deepEqual(delays, []);
+    assert.deepEqual(events, []);
+  });
+});
+
+test("transient Cognito failures are retried with identifier-free warning events", async (): Promise<void> => {
+  await withUserPoolId(async () => {
+    const events: Array<CognitoOAuthOwnerRetryEvent> = [];
+    const delays: Array<number> = [];
+    let attempts = 0;
+    const throttled = new TooManyRequestsException({
+      $metadata: { httpStatusCode: 429 },
+      message: `Throttled owner ${userId}`,
+    });
+    const dependencies = createDependencies(async () => {
+      attempts += 1;
+      if (attempts === 1) throw throttled;
+      return response(true, "CONFIRMED");
+    }, events, delays);
+
+    const status = await getCognitoOAuthOwnerStatusWithDependencies(userId, dependencies);
+
+    assert.equal(status, "active");
+    assert.equal(attempts, 2);
+    assert.deepEqual(delays, [100]);
+    assert.deepEqual(events, [{
+      domain: "auth",
+      action: "cognito_oauth_owner_retry",
+      level: "warn",
+      attempt: 1,
+      retryInMs: 100,
+      cognitoType: "TooManyRequestsException",
+      status: 429,
+      errorType: "error",
+    }]);
+    assert.equal(JSON.stringify(events).includes(userId), false);
+  });
+});
+
+test("the final transient Cognito failure is raised after bounded retries", async (): Promise<void> => {
+  await withUserPoolId(async () => {
+    const events: Array<CognitoOAuthOwnerRetryEvent> = [];
+    const delays: Array<number> = [];
+    let attempts = 0;
+    const failures = [1, 2, 3].map((attempt) => new TooManyRequestsException({
+      $metadata: { httpStatusCode: 429 },
+      message: `Transient failure ${attempt}`,
+    }));
+    const dependencies = createDependencies(async () => {
+      const failure = failures[attempts];
+      attempts += 1;
+      if (failure === undefined) throw new Error("Missing test failure");
+      throw failure;
+    }, events, delays);
+
+    await assert.rejects(
+      getCognitoOAuthOwnerStatusWithDependencies(userId, dependencies),
+      (error: unknown) => error === failures[2],
+    );
+    assert.equal(attempts, 3);
+    assert.deepEqual(delays, [100, 200]);
+    assert.deepEqual(events.map((event) => event.attempt), [1, 2]);
+  });
+});
+
+test("transient classifier cases succeed after one outer retry", async (): Promise<void> => {
+  await withUserPoolId(async () => {
+    for (const errorCase of transientErrorCases) {
+      const events: Array<CognitoOAuthOwnerRetryEvent> = [];
+      const delays: Array<number> = [];
+      let attempts = 0;
+      const transientError = errorCase.createError(1);
+      const dependencies = createDependencies(async () => {
+        attempts += 1;
+        if (attempts === 1) throw transientError;
+        return response(true, "CONFIRMED");
+      }, events, delays);
+
+      const status = await getCognitoOAuthOwnerStatusWithDependencies(userId, dependencies);
+
+      assert.equal(status, "active", errorCase.label);
+      assert.equal(attempts, 2, errorCase.label);
+      assert.deepEqual(delays, [100], errorCase.label);
+      assert.deepEqual(events.map((event) => ({
+        attempt: event.attempt,
+        retryInMs: event.retryInMs,
+        cognitoType: event.cognitoType,
+        status: event.status,
+        errorType: event.errorType,
+      })), [{
+        attempt: 1,
+        retryInMs: 100,
+        cognitoType: errorCase.expectedCognitoType,
+        status: errorCase.expectedStatus,
+        errorType: errorCase.expectedErrorType,
+      }], errorCase.label);
+      assert.equal(JSON.stringify(events).includes(userId), false, errorCase.label);
+      assert.equal(JSON.stringify(events).includes(userPoolId), false, errorCase.label);
+    }
+  });
+});
+
+test("transient classifier cases raise the final error after three attempts", async (): Promise<void> => {
+  await withUserPoolId(async () => {
+    for (const errorCase of transientErrorCases) {
+      const events: Array<CognitoOAuthOwnerRetryEvent> = [];
+      const delays: Array<number> = [];
+      const failures = [1, 2, 3].map((attempt) => errorCase.createError(attempt));
+      let attempts = 0;
+      const dependencies = createDependencies(async () => {
+        const failure = failures[attempts];
+        attempts += 1;
+        if (failure === undefined) throw new Error(`Missing ${errorCase.label} test failure`);
+        throw failure;
+      }, events, delays);
+
+      await assert.rejects(
+        getCognitoOAuthOwnerStatusWithDependencies(userId, dependencies),
+        (error: unknown) => error === failures[2],
+        errorCase.label,
+      );
+      assert.equal(attempts, 3, errorCase.label);
+      assert.deepEqual(delays, [100, 200], errorCase.label);
+      assert.deepEqual(events.map((event) => ({
+        attempt: event.attempt,
+        retryInMs: event.retryInMs,
+        cognitoType: event.cognitoType,
+        status: event.status,
+        errorType: event.errorType,
+      })), [
+        {
+          attempt: 1,
+          retryInMs: 100,
+          cognitoType: errorCase.expectedCognitoType,
+          status: errorCase.expectedStatus,
+          errorType: errorCase.expectedErrorType,
+        },
+        {
+          attempt: 2,
+          retryInMs: 200,
+          cognitoType: errorCase.expectedCognitoType,
+          status: errorCase.expectedStatus,
+          errorType: errorCase.expectedErrorType,
+        },
+      ], errorCase.label);
+      assert.equal(JSON.stringify(events).includes(userId), false, errorCase.label);
+      assert.equal(JSON.stringify(events).includes(userPoolId), false, errorCase.label);
+    }
+  });
+});

--- a/apps/auth/src/server/cognitoUserStatus.ts
+++ b/apps/auth/src/server/cognitoUserStatus.ts
@@ -1,0 +1,161 @@
+import {
+  AdminGetUserCommand,
+  CognitoIdentityProviderClient,
+  CognitoIdentityProviderServiceException,
+  UserNotFoundException,
+  UserStatusType,
+  type AdminGetUserCommandOutput,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  getSafeErrorType,
+  log,
+  type CognitoOAuthOwnerRetryEvent,
+} from "./logger.js";
+
+const RETRY_DELAYS_MS = [100, 200] as const;
+const TRANSIENT_COGNITO_ERROR_NAMES = new Set([
+  "LimitExceededException",
+  "RequestLimitExceeded",
+  "ServiceUnavailableException",
+  "SlowDown",
+  "Throttling",
+  "ThrottlingException",
+  "TooManyRequestsException",
+]);
+const TRANSIENT_ERROR_NAMES = new Set([
+  "ConnectionError",
+  "RequestTimeout",
+  "RequestTimeoutException",
+  "TimeoutError",
+]);
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+]);
+const USER_STATUSES = new Set<string>(Object.values(UserStatusType));
+
+export type CognitoOAuthOwnerStatus = "active" | "inactive";
+
+export type CognitoUserStatusDependencies = Readonly<{
+  adminGetUser: (userPoolId: string, userId: string) => Promise<AdminGetUserCommandOutput>;
+  wait: (delayMs: number) => Promise<void>;
+  logRetry: (event: CognitoOAuthOwnerRetryEvent) => void;
+}>;
+
+type ErrorWithCode = Error & Readonly<{ code: string }>;
+
+const hasErrorCode = (error: Error): error is ErrorWithCode =>
+  typeof (error as Partial<ErrorWithCode>).code === "string";
+
+const isTransientCognitoError = (error: unknown): boolean => {
+  if (error instanceof CognitoIdentityProviderServiceException) {
+    const status = error.$metadata.httpStatusCode;
+    return error.$fault === "server"
+      || TRANSIENT_COGNITO_ERROR_NAMES.has(error.name)
+      || TRANSIENT_ERROR_NAMES.has(error.name)
+      || status === 429
+      || (status !== undefined && status >= 500);
+  }
+  return error instanceof TypeError
+    || (
+      error instanceof Error
+      && (
+        TRANSIENT_ERROR_NAMES.has(error.name)
+        || (hasErrorCode(error) && TRANSIENT_NETWORK_ERROR_CODES.has(error.code))
+      )
+    );
+};
+
+const createRetryEvent = (
+  error: unknown,
+  attempt: number,
+  retryInMs: number,
+): CognitoOAuthOwnerRetryEvent => ({
+  domain: "auth",
+  action: "cognito_oauth_owner_retry",
+  level: "warn",
+  attempt,
+  retryInMs,
+  cognitoType: error instanceof CognitoIdentityProviderServiceException ? error.name : null,
+  status: error instanceof CognitoIdentityProviderServiceException
+    ? error.$metadata.httpStatusCode ?? null
+    : null,
+  errorType: getSafeErrorType(error),
+});
+
+const parseCognitoOAuthOwnerStatus = (
+  response: AdminGetUserCommandOutput,
+): CognitoOAuthOwnerStatus => {
+  if (typeof response.Enabled !== "boolean") {
+    throw new Error("Cognito AdminGetUser response is missing a boolean Enabled value");
+  }
+  if (typeof response.UserStatus !== "string" || !USER_STATUSES.has(response.UserStatus)) {
+    throw new Error("Cognito AdminGetUser response has an invalid UserStatus value");
+  }
+  return response.Enabled && response.UserStatus === UserStatusType.CONFIRMED
+    ? "active"
+    : "inactive";
+};
+
+export const getCognitoOAuthOwnerStatusWithDependencies = async (
+  userId: string,
+  dependencies: CognitoUserStatusDependencies,
+): Promise<CognitoOAuthOwnerStatus> => {
+  const userPoolId = process.env.COGNITO_USER_POOL_ID ?? "";
+  if (userPoolId === "") {
+    throw new Error("Cognito OAuth owner validation requires COGNITO_USER_POOL_ID");
+  }
+
+  const maximumAttempts = RETRY_DELAYS_MS.length + 1;
+  for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
+    try {
+      const response = await dependencies.adminGetUser(userPoolId, userId);
+      return parseCognitoOAuthOwnerStatus(response);
+    } catch (error) {
+      if (error instanceof UserNotFoundException) return "inactive";
+      const retryInMs = RETRY_DELAYS_MS[attempt - 1];
+      if (!isTransientCognitoError(error) || retryInMs === undefined) throw error;
+      dependencies.logRetry(createRetryEvent(error, attempt, retryInMs));
+      await dependencies.wait(retryInMs);
+    }
+  }
+  throw new Error("Cognito OAuth owner validation retry loop ended without a result");
+};
+
+let client: CognitoIdentityProviderClient | undefined;
+
+const getClient = (): CognitoIdentityProviderClient => {
+  if (client !== undefined) return client;
+  const region = process.env.COGNITO_REGION ?? "";
+  if (region === "") {
+    throw new Error("Cognito OAuth owner validation requires COGNITO_REGION");
+  }
+  client = new CognitoIdentityProviderClient({ region, maxAttempts: 1 });
+  return client;
+};
+
+const adminGetUser = (
+  userPoolId: string,
+  userId: string,
+): Promise<AdminGetUserCommandOutput> => getClient().send(new AdminGetUserCommand({
+  UserPoolId: userPoolId,
+  Username: userId,
+}));
+
+const dependencies: CognitoUserStatusDependencies = {
+  adminGetUser,
+  wait: (delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs)),
+  logRetry: log,
+};
+
+export const getCognitoOAuthOwnerStatus = (
+  userId: string,
+): Promise<CognitoOAuthOwnerStatus> =>
+  getCognitoOAuthOwnerStatusWithDependencies(userId, dependencies);

--- a/apps/auth/src/server/logger.ts
+++ b/apps/auth/src/server/logger.ts
@@ -3,6 +3,8 @@
  *
  * Auth-only event types. Chat/API/SQL events stay in the web app.
  */
+export type SafeErrorType = "error" | "type_error" | "range_error" | "non_error";
+
 export type CognitoRefreshRetryEvent = Readonly<{
   domain: "auth";
   action: "cognito_refresh_retry";
@@ -14,7 +16,16 @@ export type CognitoRefreshRetryEvent = Readonly<{
   error: string;
 }>;
 
-export type SafeErrorType = "error" | "type_error" | "range_error" | "non_error";
+export type CognitoOAuthOwnerRetryEvent = Readonly<{
+  domain: "auth";
+  action: "cognito_oauth_owner_retry";
+  level: "warn";
+  attempt: number;
+  retryInMs: number;
+  cognitoType: string | null;
+  status: number | null;
+  errorType: SafeErrorType;
+}>;
 
 export const getSafeErrorType = (error: unknown): SafeErrorType => {
   if (error instanceof TypeError) return "type_error";
@@ -61,6 +72,7 @@ type AuthEvent =
   | Readonly<{ domain: "auth"; action: "verify_code_error"; error: string }>
   | Readonly<{ domain: "auth"; action: "otp_sweep_error"; error: string }>
   | CognitoRefreshRetryEvent
+  | CognitoOAuthOwnerRetryEvent
   | OAuthAuthorizationServerErrorEvent
   | OAuthEndpointServerErrorEvent
   | AuthUnhandledErrorEvent

--- a/apps/auth/src/server/oauth/store.test.ts
+++ b/apps/auth/src/server/oauth/store.test.ts
@@ -10,7 +10,7 @@ import {
   registerOAuthClientWithDependencies,
   type OAuthStoreDependencies,
 } from "./store.js";
-import type { AuthorizationRequest } from "./core.js";
+import { isOAuthProtocolError, type AuthorizationRequest } from "./core.js";
 
 type QueryCall = Readonly<{ text: string; params: ReadonlyArray<unknown> }>;
 
@@ -36,6 +36,7 @@ const createDependencies = (
       offsets[prefix] += 1;
       return token;
     },
+    getCognitoOAuthOwnerStatus: async () => "active",
   };
 };
 
@@ -104,6 +105,7 @@ test("authorization-code replay revokes the family and its previously minted cre
     if (text.includes("FROM auth.oauth_refresh_tokens")) {
       return params[0] === storedRefreshTokenHash ? result([{
         connection_id: "connection-1",
+        user_id: "user-1",
         scopes: authorizationRequest.scopes,
         used: false,
         unexpired: true,
@@ -180,6 +182,7 @@ test("unknown and unused misbound credentials do not revoke a connection", async
       if (params[0] !== hash(knownRefreshToken)) return result([]);
       return result([{
         connection_id: "connection-1",
+        user_id: "user-1",
         scopes: authorizationRequest.scopes,
         used: false,
         unexpired: true,
@@ -232,9 +235,9 @@ const createRefreshDependencies = (
   let connectionRevoked = false;
   const queryFn: QueryFn = async (text, params) => {
     if (text.includes("FROM auth.oauth_refresh_tokens")) {
-      assert.match(text, /FOR UPDATE OF ort, oc/u);
       return result([{
         connection_id: "connection-1",
+        user_id: "user-1",
         scopes: grantedScopes,
         used: updateCount.value > 0,
         unexpired: true,
@@ -297,6 +300,259 @@ test("refresh rotation supports down-scope, rejects replay and expansion, and pr
   assert.deepEqual(unchangedScopes, [authorizationRequest.scopes, authorizationRequest.scopes]);
 });
 
+test("active owner validation runs outside the transaction before locked refresh revalidation", async (): Promise<void> => {
+  const sequence: Array<string> = [];
+  let transactionOpen = false;
+  let used = false;
+  const queryFn: QueryFn = async (text) => {
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      sequence.push(text.includes("FOR UPDATE") ? "locked_read" : "preflight_read");
+      return result([{
+        connection_id: "connection-1",
+        user_id: "user-1",
+        scopes: authorizationRequest.scopes,
+        used,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: false,
+      }]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_refresh_tokens")) {
+      used = true;
+      sequence.push("consume");
+    }
+    if (text.startsWith("INSERT INTO auth.oauth_access_tokens")) sequence.push("insert_access");
+    if (text.startsWith("INSERT INTO auth.oauth_refresh_tokens")) sequence.push("insert_refresh");
+    return result([]);
+  };
+  const dependencies = createDependencies(queryFn, {
+    ...emptyTokens(),
+    at: ["ebt_at_active-owner"],
+    rt: ["ebt_rt_active-owner"],
+  });
+  const activeDependencies: OAuthStoreDependencies = {
+    ...dependencies,
+    withTransaction: async <T>(callback: (transactionQuery: QueryFn) => Promise<T>): Promise<T> => {
+      transactionOpen = true;
+      try {
+        return await callback(queryFn);
+      } finally {
+        transactionOpen = false;
+      }
+    },
+    getCognitoOAuthOwnerStatus: async (requestedUserId) => {
+      assert.equal(requestedUserId, "user-1");
+      assert.equal(transactionOpen, false);
+      sequence.push("cognito_check");
+      return "active";
+    },
+  };
+
+  await exchangeRefreshTokenWithDependencies(
+    "ebt_rt_active-owner-presented",
+    authorizationRequest.clientId,
+    authorizationRequest.resource,
+    null,
+    activeDependencies,
+  );
+
+  assert.deepEqual(sequence, [
+    "preflight_read",
+    "cognito_check",
+    "locked_read",
+    "consume",
+    "insert_access",
+    "insert_refresh",
+  ]);
+});
+
+test("inactive owners revoke every active OAuth connection and receive generic invalid_grant", async (): Promise<void> => {
+  let consumed = false;
+  let tokenInserted = false;
+  let transactionOpened = false;
+  let revokedUserId: string | undefined;
+  const queryFn: QueryFn = async (text, params) => {
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      return result([{
+        connection_id: "connection-1",
+        user_id: "user-1",
+        scopes: authorizationRequest.scopes,
+        used: false,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: false,
+      }]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_connections")) {
+      assert.match(text, /WHERE user_id = \$1 AND revoked_at IS NULL/u);
+      const value = params[0];
+      if (typeof value !== "string") throw new Error("Inactive-owner test expected a user ID");
+      revokedUserId = value;
+      return result([]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_refresh_tokens")) consumed = true;
+    if (text.startsWith("INSERT INTO auth.oauth_")) tokenInserted = true;
+    return result([]);
+  };
+  const baseDependencies = createDependencies(queryFn, emptyTokens());
+  const dependencies: OAuthStoreDependencies = {
+    ...baseDependencies,
+    withTransaction: async <T>(callback: (transactionQuery: QueryFn) => Promise<T>): Promise<T> => {
+      transactionOpened = true;
+      return callback(queryFn);
+    },
+    getCognitoOAuthOwnerStatus: async () => "inactive",
+  };
+
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      "ebt_rt_inactive-owner",
+      authorizationRequest.clientId,
+      authorizationRequest.resource,
+      null,
+      dependencies,
+    ),
+    (error: unknown) => isOAuthProtocolError(error)
+      && error.oauthCode === "invalid_grant"
+      && !error.message.includes("inactive"),
+  );
+  assert.equal(revokedUserId, "user-1");
+  assert.equal(transactionOpened, false);
+  assert.equal(consumed, false);
+  assert.equal(tokenInserted, false);
+});
+
+test("transient owner validation failure neither consumes the refresh token nor revokes connections", async (): Promise<void> => {
+  const transientFailure = new Error("Cognito unavailable after retries");
+  let mutationAttempted = false;
+  let transactionOpened = false;
+  const queryFn: QueryFn = async (text) => {
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      return result([{
+        connection_id: "connection-1",
+        user_id: "user-1",
+        scopes: authorizationRequest.scopes,
+        used: false,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: false,
+      }]);
+    }
+    if (text.startsWith("UPDATE") || text.startsWith("INSERT")) mutationAttempted = true;
+    return result([]);
+  };
+  const baseDependencies = createDependencies(queryFn, emptyTokens());
+  const dependencies: OAuthStoreDependencies = {
+    ...baseDependencies,
+    withTransaction: async <T>(callback: (transactionQuery: QueryFn) => Promise<T>): Promise<T> => {
+      transactionOpened = true;
+      return callback(queryFn);
+    },
+    getCognitoOAuthOwnerStatus: async () => { throw transientFailure; },
+  };
+
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      "ebt_rt_transient-owner",
+      authorizationRequest.clientId,
+      authorizationRequest.resource,
+      null,
+      dependencies,
+    ),
+    (error: unknown) => error === transientFailure,
+  );
+  assert.equal(transactionOpened, false);
+  assert.equal(mutationAttempted, false);
+});
+
+test("disablement immediately after an active snapshot is enforced at the next renewal", async (): Promise<void> => {
+  const originalToken = "ebt_rt_race-original";
+  const storedRefreshTokens = new Map<string, boolean>([[hash(originalToken), false]]);
+  const storedAccessTokens = new Set<string>();
+  let connectionRevoked = false;
+  let ownerActive = true;
+  let ownerChecks = 0;
+  const queryFn: QueryFn = async (text, params) => {
+    if (text.includes("FROM auth.oauth_refresh_tokens")) {
+      const tokenHash = params[0];
+      if (typeof tokenHash !== "string") throw new Error("Race test expected a refresh-token hash");
+      const used = storedRefreshTokens.get(tokenHash);
+      if (used === undefined) return result([]);
+      return result([{
+        connection_id: "connection-1",
+        user_id: "user-1",
+        scopes: authorizationRequest.scopes,
+        used,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: connectionRevoked,
+      }]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_refresh_tokens")) {
+      const tokenHash = params[0];
+      if (typeof tokenHash !== "string") throw new Error("Race test expected a consumed refresh-token hash");
+      storedRefreshTokens.set(tokenHash, true);
+    }
+    if (text.startsWith("INSERT INTO auth.oauth_access_tokens")) {
+      const tokenHash = params[0];
+      if (typeof tokenHash !== "string") throw new Error("Race test expected an access-token hash");
+      storedAccessTokens.add(tokenHash);
+    }
+    if (text.startsWith("INSERT INTO auth.oauth_refresh_tokens")) {
+      const tokenHash = params[0];
+      if (typeof tokenHash !== "string") throw new Error("Race test expected a rotated refresh-token hash");
+      storedRefreshTokens.set(tokenHash, false);
+    }
+    if (text.startsWith("UPDATE auth.oauth_connections")) connectionRevoked = true;
+    return result([]);
+  };
+  const baseDependencies = createDependencies(queryFn, {
+    ...emptyTokens(),
+    at: ["ebt_at_race-window"],
+    rt: ["ebt_rt_race-rotated"],
+  });
+  const dependencies: OAuthStoreDependencies = {
+    ...baseDependencies,
+    getCognitoOAuthOwnerStatus: async () => {
+      ownerChecks += 1;
+      if (ownerChecks === 1) {
+        ownerActive = false;
+        return "active";
+      }
+      return ownerActive ? "active" : "inactive";
+    },
+  };
+
+  const issuedDuringRace = await exchangeRefreshTokenWithDependencies(
+    originalToken,
+    authorizationRequest.clientId,
+    authorizationRequest.resource,
+    null,
+    dependencies,
+  );
+  assert.equal(issuedDuringRace.expiresIn, 3600);
+  assert.equal(storedAccessTokens.has(hash(issuedDuringRace.accessToken)), true);
+  assert.equal(connectionRevoked, false);
+
+  await assert.rejects(
+    exchangeRefreshTokenWithDependencies(
+      issuedDuringRace.refreshToken,
+      authorizationRequest.clientId,
+      authorizationRequest.resource,
+      null,
+      dependencies,
+    ),
+    /invalid, expired, or already used/u,
+  );
+  assert.equal(ownerChecks, 2);
+  assert.equal(connectionRevoked, true);
+  assert.equal(storedAccessTokens.has(hash(issuedDuringRace.accessToken)) && !connectionRevoked, false);
+});
+
 test("binding-mismatched replay of a used refresh token revokes its replacement credentials", async (): Promise<void> => {
   const originalToken = "ebt_rt_original";
   let originalUsed = false;
@@ -309,6 +565,7 @@ test("binding-mismatched replay of a used refresh token revokes its replacement 
       if (tokenHash !== hash(originalToken) && tokenHash !== rotatedTokenHash) return result([]);
       return result([{
         connection_id: "connection-1",
+        user_id: "user-1",
         scopes: authorizationRequest.scopes,
         used: tokenHash === hash(originalToken) ? originalUsed : false,
         unexpired: true,
@@ -417,6 +674,7 @@ const createConcurrentRefreshStore = (): Readonly<{
         if (token === undefined) return result([]);
         return result([{
           connection_id: token.connectionId,
+          user_id: "user-1",
           scopes: token.scopes,
           used: token.used,
           unexpired: true,
@@ -486,7 +744,27 @@ const createConcurrentRefreshStore = (): Readonly<{
     at: ["ebt_at_concurrent-replacement"],
     rt: ["ebt_rt_concurrent-replacement"],
   };
-  const dependencies = { ...createDependencies(async () => result([]), tokens), withTransaction };
+  const queryFn: QueryFn = async (text, params) => {
+    if (!text.includes("FROM auth.oauth_refresh_tokens")) {
+      throw new Error(`Concurrent refresh preflight received an unexpected query: ${text}`);
+    }
+    assert.doesNotMatch(text, /FOR UPDATE/u);
+    const tokenHash = params[0];
+    if (typeof tokenHash !== "string") throw new Error("Concurrent refresh preflight expected a token hash");
+    const token = refreshTokens.get(tokenHash);
+    if (token === undefined) return result([]);
+    return result([{
+      connection_id: token.connectionId,
+      user_id: "user-1",
+      scopes: token.scopes,
+      used: token.used,
+      unexpired: true,
+      client_id: authorizationRequest.clientId,
+      resource: authorizationRequest.resource,
+      revoked: connectionRevoked,
+    }]);
+  };
+  const dependencies = { ...createDependencies(queryFn, tokens), withTransaction };
   return {
     dependencies,
     validatesAccessToken: (token) => accessTokens.has(hash(token)) && !connectionRevoked,
@@ -526,6 +804,7 @@ test("an expired unused refresh token is rejected without revoking its connectio
     if (text.includes("FROM auth.oauth_refresh_tokens")) {
       return result([{
         connection_id: "connection-1",
+        user_id: "user-1",
         scopes: authorizationRequest.scopes,
         used: false,
         unexpired: false,
@@ -554,6 +833,7 @@ test("replaying an expired used refresh token revokes its active family", async 
     if (text.includes("FROM auth.oauth_refresh_tokens")) {
       return result([{
         connection_id: "connection-1",
+        user_id: "user-1",
         scopes: authorizationRequest.scopes,
         used: true,
         unexpired: false,
@@ -604,6 +884,7 @@ test("revoked connections cannot exchange authorization codes or refresh tokens"
       refreshTokenLoaded = true;
       return result([{
         connection_id: "connection-1",
+        user_id: "user-1",
         scopes: authorizationRequest.scopes,
         used: false,
         unexpired: true,

--- a/apps/auth/src/server/oauth/store.ts
+++ b/apps/auth/src/server/oauth/store.ts
@@ -1,5 +1,9 @@
 import { query, withTransaction, type QueryFn } from "../db.js";
 import {
+  getCognitoOAuthOwnerStatus,
+  type CognitoOAuthOwnerStatus,
+} from "../cognitoUserStatus.js";
+import {
   createOpaqueToken,
   hashOpaqueToken,
   narrowScopes,
@@ -16,9 +20,15 @@ export type OAuthStoreDependencies = Readonly<{
   query: QueryFn;
   withTransaction: TransactionRunner;
   createOpaqueToken: (prefix: "cl" | "ac" | "at" | "rt") => string;
+  getCognitoOAuthOwnerStatus: (userId: string) => Promise<CognitoOAuthOwnerStatus>;
 }>;
 
-const defaultDependencies: OAuthStoreDependencies = { query, withTransaction, createOpaqueToken };
+const defaultDependencies: OAuthStoreDependencies = {
+  query,
+  withTransaction,
+  createOpaqueToken,
+  getCognitoOAuthOwnerStatus,
+};
 
 export type OAuthTokenResult = Readonly<{
   accessToken: string;
@@ -56,6 +66,32 @@ const readBoolean = (row: Row, key: string, operation: string): boolean => {
     throw new Error(`${operation}: database column ${key} must be a boolean`);
   }
   return value;
+};
+
+type RefreshTokenRecord = Readonly<{
+  connectionId: string;
+  userId: string;
+  scopes: ReadonlyArray<string>;
+  used: boolean;
+  unexpired: boolean;
+  clientId: string;
+  resource: string;
+  revoked: boolean;
+}>;
+
+const readRefreshTokenRecord = (value: unknown): RefreshTokenRecord => {
+  const operation = "exchangeRefreshToken";
+  const row = readRow(value, operation);
+  return {
+    connectionId: readString(row, "connection_id", operation),
+    userId: readString(row, "user_id", operation),
+    scopes: readScopes(row, operation),
+    used: readBoolean(row, "used", operation),
+    unexpired: readBoolean(row, "unexpired", operation),
+    clientId: readString(row, "client_id", operation),
+    resource: readString(row, "resource", operation),
+    revoked: readBoolean(row, "revoked", operation),
+  };
 };
 
 export const registerOAuthClientWithDependencies = async (
@@ -238,6 +274,101 @@ export const exchangeAuthorizationCode = (
   code, clientId, redirectUri, resource, codeVerifier, defaultDependencies,
 );
 
+const invalidRefreshGrant = (): ReturnType<typeof oauthError> =>
+  oauthError("invalid_grant", "Refresh token is invalid, expired, or already used", 400);
+
+const REFRESH_TOKEN_SELECT = `SELECT ort.connection_id, oc.user_id, ort.scopes,
+       ort.used_at IS NOT NULL AS used,
+       ort.expires_at > now() AS unexpired,
+       oc.client_id, oc.resource,
+       oc.revoked_at IS NOT NULL AS revoked
+FROM auth.oauth_refresh_tokens ort
+JOIN auth.oauth_connections oc ON oc.connection_id = ort.connection_id
+WHERE ort.token_hash = $1`;
+
+const readRefreshTokenBeforeOwnerCheck = async (
+  tokenHash: string,
+  dependencies: OAuthStoreDependencies,
+): Promise<RefreshTokenRecord> => {
+  const result = await dependencies.query(REFRESH_TOKEN_SELECT, [tokenHash]);
+  if (result.rows.length !== 1) throw invalidRefreshGrant();
+  return readRefreshTokenRecord(result.rows[0]);
+};
+
+const lockRefreshTokenForRotation = async (
+  queryFn: QueryFn,
+  tokenHash: string,
+): Promise<RefreshTokenRecord> => {
+  const result = await queryFn(
+    `${REFRESH_TOKEN_SELECT}
+FOR UPDATE OF ort, oc`,
+    [tokenHash],
+  );
+  if (result.rows.length !== 1) throw invalidRefreshGrant();
+  return readRefreshTokenRecord(result.rows[0]);
+};
+
+const validateRefreshTokenBinding = (
+  record: RefreshTokenRecord,
+  clientId: string,
+  resource: string,
+): void => {
+  if (record.clientId !== clientId || record.resource !== resource) {
+    throw oauthError("invalid_grant", "Refresh token binding validation failed", 400);
+  }
+};
+
+const rejectRefreshTokenReplay = async (
+  tokenHash: string,
+  dependencies: OAuthStoreDependencies,
+): Promise<never> => {
+  await dependencies.withTransaction(async (queryFn: QueryFn): Promise<void> => {
+    const record = await lockRefreshTokenForRotation(queryFn, tokenHash);
+    if (!record.used) throw invalidRefreshGrant();
+    if (!record.revoked) {
+      await revokeActiveConnection(queryFn, record.connectionId, "exchangeRefreshToken");
+    }
+  });
+  throw invalidRefreshGrant();
+};
+
+const revokeActiveConnectionsForUser = async (
+  userId: string,
+  dependencies: OAuthStoreDependencies,
+): Promise<void> => {
+  await dependencies.query(
+    `UPDATE auth.oauth_connections
+     SET revoked_at = now()
+     WHERE user_id = $1 AND revoked_at IS NULL`,
+    [userId],
+  );
+};
+
+const rotateRefreshToken = async (
+  tokenHash: string,
+  expectedUserId: string,
+  clientId: string,
+  resource: string,
+  requestedScopes: ReadonlyArray<string> | null,
+  dependencies: OAuthStoreDependencies,
+): Promise<OAuthTokenResult | null> => dependencies.withTransaction(
+  async (queryFn: QueryFn): Promise<OAuthTokenResult | null> => {
+    const record = await lockRefreshTokenForRotation(queryFn, tokenHash);
+    if (record.used) {
+      if (!record.revoked) {
+        await revokeActiveConnection(queryFn, record.connectionId, "exchangeRefreshToken");
+      }
+      return null;
+    }
+    if (record.revoked || record.userId !== expectedUserId) throw invalidRefreshGrant();
+    validateRefreshTokenBinding(record, clientId, resource);
+    if (!record.unexpired) throw invalidRefreshGrant();
+    const effectiveScopes = narrowScopes(record.scopes, requestedScopes);
+    await queryFn("UPDATE auth.oauth_refresh_tokens SET used_at = now() WHERE token_hash = $1", [tokenHash]);
+    return insertTokenPair(queryFn, record.connectionId, effectiveScopes, dependencies);
+  },
+);
+
 export const exchangeRefreshTokenWithDependencies = async (
   refreshToken: string,
   clientId: string,
@@ -245,43 +376,31 @@ export const exchangeRefreshTokenWithDependencies = async (
   requestedScopes: ReadonlyArray<string> | null,
   dependencies: OAuthStoreDependencies,
 ): Promise<OAuthTokenResult> => {
-  const invalidGrant = (): ReturnType<typeof oauthError> =>
-    oauthError("invalid_grant", "Refresh token is invalid, expired, or already used", 400);
   const tokenHash = hashOpaqueToken(refreshToken);
-  const exchangeResult = await dependencies.withTransaction(async (queryFn: QueryFn): Promise<OAuthTokenResult | null> => {
-    const result = await queryFn(
-      `SELECT ort.connection_id, ort.scopes,
-              ort.used_at IS NOT NULL AS used,
-              ort.expires_at > now() AS unexpired,
-              oc.client_id, oc.resource,
-              oc.revoked_at IS NOT NULL AS revoked
-       FROM auth.oauth_refresh_tokens ort
-       JOIN auth.oauth_connections oc ON oc.connection_id = ort.connection_id
-       WHERE ort.token_hash = $1
-       FOR UPDATE OF ort, oc`,
-      [tokenHash],
-    );
-    if (result.rows.length !== 1) throw invalidGrant();
-    const row = readRow(result.rows[0], "exchangeRefreshToken");
-    const connectionId = readString(row, "connection_id", "exchangeRefreshToken");
-    const revoked = readBoolean(row, "revoked", "exchangeRefreshToken");
-    if (readBoolean(row, "used", "exchangeRefreshToken")) {
-      if (!revoked) await revokeActiveConnection(queryFn, connectionId, "exchangeRefreshToken");
-      return null;
-    }
-    if (revoked) throw invalidGrant();
-    if (
-      readString(row, "client_id", "exchangeRefreshToken") !== clientId
-      || readString(row, "resource", "exchangeRefreshToken") !== resource
-    ) {
-      throw oauthError("invalid_grant", "Refresh token binding validation failed", 400);
-    }
-    if (!readBoolean(row, "unexpired", "exchangeRefreshToken")) throw invalidGrant();
-    const effectiveScopes = narrowScopes(readScopes(row, "exchangeRefreshToken"), requestedScopes);
-    await queryFn("UPDATE auth.oauth_refresh_tokens SET used_at = now() WHERE token_hash = $1", [tokenHash]);
-    return insertTokenPair(queryFn, connectionId, effectiveScopes, dependencies);
-  });
-  if (exchangeResult === null) throw invalidGrant();
+  const record = await readRefreshTokenBeforeOwnerCheck(tokenHash, dependencies);
+  if (record.used) return rejectRefreshTokenReplay(tokenHash, dependencies);
+  if (record.revoked) throw invalidRefreshGrant();
+  validateRefreshTokenBinding(record, clientId, resource);
+  if (!record.unexpired) throw invalidRefreshGrant();
+  narrowScopes(record.scopes, requestedScopes);
+
+  const ownerStatus = await dependencies.getCognitoOAuthOwnerStatus(record.userId);
+  if (ownerStatus === "inactive") {
+    await revokeActiveConnectionsForUser(record.userId, dependencies);
+    throw invalidRefreshGrant();
+  }
+
+  // Cognito eligibility is a point-in-time snapshot. The locked read below
+  // revalidates all refresh-token state without holding a row lock over AWS retries.
+  const exchangeResult = await rotateRefreshToken(
+    tokenHash,
+    record.userId,
+    clientId,
+    resource,
+    requestedScopes,
+    dependencies,
+  );
+  if (exchangeResult === null) throw invalidRefreshGrant();
   return exchangeResult;
 };
 

--- a/infra/aws/lib/compute.ts
+++ b/infra/aws/lib/compute.ts
@@ -20,6 +20,7 @@ export interface ComputeProps {
   langfusePublicKeySecret: cdk.aws_secretsmanager.Secret;
   langfuseSecretKeySecret: cdk.aws_secretsmanager.Secret;
   userPoolId: string;
+  userPoolArn: string;
   userPoolClientId: string;
   appDomain: string;
   authDomain: string;
@@ -275,6 +276,11 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
       startPeriod: cdk.Duration.seconds(60),
     },
   });
+
+  authTaskDef.addToTaskRolePolicy(new iam.PolicyStatement({
+    actions: ["cognito-idp:AdminGetUser"],
+    resources: [props.userPoolArn],
+  }));
 
   const authService = new ecs.FargateService(scope, "AuthService", {
     cluster,

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -72,6 +72,7 @@ export class ExpenseBudgetTrackerStack extends cdk.Stack {
       langfusePublicKeySecret: sec.langfusePublicKeySecret,
       langfuseSecretKeySecret: sec.langfuseSecretKeySecret,
       userPoolId: authResult.userPool.userPoolId,
+      userPoolArn: authResult.userPool.userPoolArn,
       userPoolClientId: authResult.userPoolClient.userPoolClientId,
       appDomain,
       authDomain,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "name": "expense-tracker-auth",
       "version": "1.2.0",
       "dependencies": {
+        "@aws-sdk/client-cognito-identity-provider": "^3.1111.0",
         "@expense-budget-tracker/agent-shared": "1.2.0",
         "@hono/node-server": "^2.1.0",
         "aws-jwt-verify": "^5.2.1",
@@ -357,6 +358,350 @@
         "bn.js": "^5.2.3",
         "tslib": "^2.2.0",
         "uuid": "^11.1.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1111.0.tgz",
+      "integrity": "sha512-wMMwWOJIaSnoMKitEi1ZCanKMo0kXdN7DQMT8TJA/s2yRwKMw2z6rayBxTbzLENRO8Ct3tInHtbh/9+g3b6/OA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/core": {
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/types": {
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/core": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.0.tgz",
+      "integrity": "sha512-uKbkxgqLyepQDZoq8aRSdUqD1ID//rOqG96ixBhp++O7vBtmwYM6fwldGhr9HJP0iYrdc7GP/AlgzPWEZIrNRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.0.tgz",
+      "integrity": "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/signature-v4": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/types": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {


### PR DESCRIPTION
## Summary
- validate OAuth refresh owners against authoritative Cognito AdminGetUser state
- revoke active OAuth connections for definitively inactive owners without exposing account state
- preserve refresh rotation semantics while retrying transient Cognito failures outside database transactions
- grant the auth task exact-pool AdminGetUser permission and add the AWS SDK v3 dependency

## Checks
- Not run locally, per repository workflow and task instructions.