### PR TITLE
Merge main identity lock into MCP integration

### DIFF
--- a/apps/sql-api/src/db.ts
+++ b/apps/sql-api/src/db.ts
@@ -82,10 +82,20 @@ export const withTransaction = async <T>(
   }
 };
 
+/**
+ * Upsert the local identity mirror from trusted auth claims.
+ *
+ * Callers must already be in a transaction. The transaction-scoped advisory
+ * lock serializes identity writes for this user across runtime instances.
+ */
 const upsertUserIdentity = async (
   client: pg.PoolClient,
   identity: UserIdentity,
 ): Promise<void> => {
+  await client.query(
+    "SELECT pg_advisory_xact_lock((('x' || substr(md5($1), 1, 16))::bit(64))::bigint)",
+    [identity.userId],
+  );
   await client.query(
     `INSERT INTO users (
        user_id,

--- a/apps/web/src/server/users.ts
+++ b/apps/web/src/server/users.ts
@@ -24,6 +24,9 @@ export type UserIdentity = Readonly<{
 /**
  * Upsert the local identity mirror from trusted auth claims.
  *
+ * Callers must already be in a transaction. The transaction-scoped advisory
+ * lock serializes identity writes for this user across runtime instances.
+ *
  * `last_seen_at` and `updated_at` move forward on every authenticated request
  * so the row reflects recent activity without changing `first_seen_at`.
  */
@@ -31,6 +34,10 @@ export const upsertUserIdentity = async (
   client: PoolClient,
   identity: UserIdentity,
 ): Promise<void> => {
+  await client.query(
+    "SELECT pg_advisory_xact_lock((('x' || substr(md5($1), 1, 16))::bit(64))::bigint)",
+    [identity.userId],
+  );
   await client.query(
     `INSERT INTO users (
        user_id,


### PR DESCRIPTION
Sync current main into the MCP integration branch while preserving the transaction-scoped identity-upsert advisory lock across SQL API and web provisioning paths.