### PR TITLE
Rate limit OAuth token exchanges

### DIFF
--- a/infra/aws/lib/ingress.test.ts
+++ b/infra/aws/lib/ingress.test.ts
@@ -235,3 +235,48 @@ test("WAF rate limits exact dynamic client registration requests by trusted Clou
     metricName: "expense-tracker-dcr-rate-limit",
   });
 });
+
+test("WAF separately rate limits exact OAuth token exchanges by trusted Cloudflare client IP", (): void => {
+  const rules = buildIngressWafRules("app.example.com", "auth.example.com");
+  const rule = getRule(rules, "RateLimitOAuthTokenExchanges");
+  assert.equal(rule.priority, 6);
+  assert.deepEqual(rule.action, { block: {} });
+
+  const statement = requireStatement(rule.statement);
+  const rateBasedStatement = requireRateBasedStatement(statement.rateBasedStatement);
+  assert.equal(rateBasedStatement.aggregateKeyType, "FORWARDED_IP");
+  assert.equal(rateBasedStatement.evaluationWindowSec, 60);
+  assert.equal(rateBasedStatement.limit, 60);
+  assert.deepEqual(rateBasedStatement.forwardedIpConfig, {
+    headerName: "CF-Connecting-IP",
+    fallbackBehavior: "MATCH",
+  });
+
+  const scopeDownStatement = requireStatement(rateBasedStatement.scopeDownStatement);
+  const scopeDown = requireAndStatement(scopeDownStatement.andStatement);
+  const conditions = requireStatements(scopeDown.statements);
+  assert.deepEqual(
+    conditions.map((condition) =>
+      requireByteMatchStatement(condition.byteMatchStatement).searchString),
+    ["auth.example.com", "POST", "/oauth/token"],
+  );
+  assert.deepEqual(
+    conditions.map((condition) =>
+      requireByteMatchStatement(condition.byteMatchStatement).fieldToMatch),
+    [
+      { singleHeader: { Name: "host" } },
+      { method: {} },
+      { uriPath: {} },
+    ],
+  );
+  assert.deepEqual(
+    conditions.map((condition) =>
+      requireByteMatchStatement(condition.byteMatchStatement).positionalConstraint),
+    ["EXACTLY", "EXACTLY", "EXACTLY"],
+  );
+  assert.deepEqual(rule.visibilityConfig, {
+    sampledRequestsEnabled: true,
+    cloudWatchMetricsEnabled: true,
+    metricName: "expense-tracker-oauth-token-rate-limit",
+  });
+});

--- a/infra/aws/lib/ingress.ts
+++ b/infra/aws/lib/ingress.ts
@@ -34,6 +34,8 @@ type ByteMatchPositionalConstraint = "EXACTLY" | "STARTS_WITH";
 // AWS WAF's smallest native rate envelope is 10 requests over 60 seconds.
 const DYNAMIC_CLIENT_REGISTRATION_RATE_LIMIT = 10;
 const DYNAMIC_CLIENT_REGISTRATION_EVALUATION_WINDOW_SECONDS = 60;
+const OAUTH_TOKEN_EXCHANGE_RATE_LIMIT = 60;
+const OAUTH_TOKEN_EXCHANGE_EVALUATION_WINDOW_SECONDS = 60;
 
 const noneTextTransformation = (): wafv2.CfnWebACL.TextTransformationProperty => ({
   priority: 0,
@@ -293,6 +295,32 @@ export const buildIngressWafRules = (
         metricName: "expense-tracker-dcr-rate-limit",
       },
     },
+    {
+      name: "RateLimitOAuthTokenExchanges",
+      priority: 6,
+      action: { block: {} },
+      statement: {
+        rateBasedStatement: {
+          aggregateKeyType: "FORWARDED_IP",
+          evaluationWindowSec: OAUTH_TOKEN_EXCHANGE_EVALUATION_WINDOW_SECONDS,
+          forwardedIpConfig: {
+            headerName: "CF-Connecting-IP",
+            fallbackBehavior: "MATCH",
+          },
+          limit: OAUTH_TOKEN_EXCHANGE_RATE_LIMIT,
+          scopeDownStatement: andStatement([
+            headerIs("host", authDomain),
+            methodIs("POST"),
+            uriPathIs("/oauth/token"),
+          ]),
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "expense-tracker-oauth-token-rate-limit",
+      },
+    },
   ];
 };
 
@@ -376,9 +404,9 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
 
   // --- AWS WAF ---
   // The ALB security group accepts only Cloudflare edges, so CF-Connecting-IP is
-  // the trusted real-client boundary for the DCR rate rule. AWS WAF ignores this
-  // rule if that header is absent; Cloudflare supplies it on every origin request.
-  // A present malformed value uses MATCH and is blocked instead of bypassing the rule.
+  // the trusted real-client boundary for the OAuth rate rules. AWS WAF ignores these
+  // rules if that header is absent; Cloudflare supplies it on every origin request.
+  // A present malformed value uses MATCH and is blocked instead of bypassing a rule.
   const waf = new wafv2.CfnWebACL(scope, "Waf", {
     scope: "REGIONAL",
     defaultAction: { allow: {} },


### PR DESCRIPTION
Adds an exact AWS WAF rate rule for POST /oauth/token on the auth host, aggregated by the trusted CF-Connecting-IP header at 60 requests per 60 seconds. Keeps the dynamic client registration counter separate and adds static infrastructure assertions.\n\nLocal checks were not run per repository workflow; required GitHub CI owns validation.