### PR TITLE
Prevent disabled users from renewing OAuth access

### DIFF
--- a/apps/auth/src/server/oauth/store.test.ts
+++ b/apps/auth/src/server/oauth/store.test.ts
@@ -167,6 +167,12 @@ test("authorization-code issuance cleans expired state before opening its transa
         transactionOpen = false;
       }
     },
+    getCognitoOAuthOwnerStatus: async (userId) => {
+      assert.equal(userId, "user-1");
+      assert.equal(transactionOpen, false);
+      sequence.push("validate_owner");
+      return "active";
+    },
   };
 
   await issueAuthorizationCodeWithDependencies(
@@ -176,7 +182,7 @@ test("authorization-code issuance cleans expired state before opening its transa
     dependencies,
   );
 
-  assert.deepEqual(sequence, ["cleanup", "sync_user", "upsert_connection", "insert_code"]);
+  assert.deepEqual(sequence, ["cleanup", "validate_owner", "sync_user", "upsert_connection", "insert_code"]);
 });
 
 test("cleanup failures abort issuance before a transaction opens", async (): Promise<void> => {
@@ -204,6 +210,48 @@ test("cleanup failures abort issuance before a transaction opens", async (): Pro
     ),
     (error: unknown) => error === cleanupFailure,
   );
+  assert.equal(transactionOpened, false);
+});
+
+test("inactive owners are revoked before browser identity can sync or issue an authorization code", async (): Promise<void> => {
+  let transactionOpened = false;
+  let revokedUserId: string | undefined;
+  const baseDependencies = createDependencies(async (text, params) => {
+    if (text.startsWith("UPDATE auth.oauth_connections")) {
+      assert.match(text, /WHERE user_id = \$1 AND revoked_at IS NULL/u);
+      const userId = params[0];
+      if (typeof userId !== "string") throw new Error("Inactive owner revocation expected a user ID");
+      revokedUserId = userId;
+    }
+    if (text.startsWith("SELECT auth.sync_authenticated_user")) {
+      throw new Error("Inactive browser identity must not sync the local Cognito mirror");
+    }
+    return result([]);
+  }, emptyTokens());
+  const dependencies: OAuthStoreDependencies = {
+    ...baseDependencies,
+    withTransaction: async <T>(callback: (queryFn: QueryFn) => Promise<T>): Promise<T> => {
+      transactionOpened = true;
+      return callback(async () => result([]));
+    },
+    getCognitoOAuthOwnerStatus: async (userId) => {
+      assert.equal(userId, "user-1");
+      return "inactive";
+    },
+  };
+
+  await assert.rejects(
+    issueAuthorizationCodeWithDependencies(
+      authorizationRequest,
+      "user-1",
+      "user@example.com",
+      dependencies,
+    ),
+    (error: unknown) => isOAuthProtocolError(error)
+      && error.oauthCode === "access_denied"
+      && error.status === 400,
+  );
+  assert.equal(revokedUserId, "user-1");
   assert.equal(transactionOpened, false);
 });
 
@@ -257,6 +305,72 @@ test("authorization-code exchange cleanup failure precedes every exchange side e
   assert.equal(cognitoCalled, false);
   assert.equal(tokenIssued, false);
   assert.equal(connectionRevoked, false);
+  assert.equal(activityRecorded, false);
+});
+
+test("inactive owners cannot exchange authorization codes and lose every active connection", async (): Promise<void> => {
+  let transactionOpened = false;
+  let credentialConsumed = false;
+  let tokenIssued = false;
+  let activityRecorded = false;
+  let revokedUserId: string | undefined;
+  const queryFn: QueryFn = async (text, params) => {
+    if (text.includes("FROM auth.oauth_authorization_codes")) {
+      assert.doesNotMatch(text, /FOR UPDATE/u);
+      return result([{
+        connection_id: "connection-1",
+        user_id: "user-1",
+        redirect_uri: authorizationRequest.redirectUri,
+        code_challenge: challenge,
+        scopes: authorizationRequest.scopes,
+        used: false,
+        unexpired: true,
+        client_id: authorizationRequest.clientId,
+        resource: authorizationRequest.resource,
+        revoked: false,
+      }]);
+    }
+    if (text.startsWith("UPDATE auth.oauth_connections")) {
+      assert.match(text, /WHERE user_id = \$1 AND revoked_at IS NULL/u);
+      const userId = params[0];
+      if (typeof userId !== "string") throw new Error("Inactive owner revocation expected a user ID");
+      revokedUserId = userId;
+    }
+    if (text.startsWith("UPDATE auth.oauth_authorization_codes")) credentialConsumed = true;
+    if (text.startsWith("INSERT INTO auth.oauth_")) tokenIssued = true;
+    if (isOAuthActivityQuery(text)) activityRecorded = true;
+    return result([]);
+  };
+  const baseDependencies = createDependencies(queryFn, emptyTokens());
+  const dependencies: OAuthStoreDependencies = {
+    ...baseDependencies,
+    withTransaction: async <T>(callback: (queryFn: QueryFn) => Promise<T>): Promise<T> => {
+      transactionOpened = true;
+      return callback(queryFn);
+    },
+    getCognitoOAuthOwnerStatus: async (userId) => {
+      assert.equal(userId, "user-1");
+      return "inactive";
+    },
+  };
+
+  await assert.rejects(
+    exchangeAuthorizationCodeWithDependencies(
+      "ebt_ac_inactive-owner",
+      authorizationRequest.clientId,
+      authorizationRequest.redirectUri,
+      authorizationRequest.resource,
+      verifier,
+      dependencies,
+    ),
+    (error: unknown) => isOAuthProtocolError(error)
+      && error.oauthCode === "invalid_grant"
+      && error.status === 400,
+  );
+  assert.equal(revokedUserId, "user-1");
+  assert.equal(transactionOpened, false);
+  assert.equal(credentialConsumed, false);
+  assert.equal(tokenIssued, false);
   assert.equal(activityRecorded, false);
 });
 
@@ -337,15 +451,19 @@ test("DCR and authorization-code issuance persist identifiers but only code hash
 test("authorization-code replay revokes the family and its previously minted credentials", async (): Promise<void> => {
   let used = false;
   let connectionRevoked = false;
+  let preflightReadCount = 0;
+  let lockedReadCount = 0;
   let activityCount = 0;
   let storedRefreshTokenHash: string | null = null;
   const accessTokenHashes = new Set<string>();
   const tokenInserts: Array<QueryCall> = [];
   const queryFn: QueryFn = async (text, params) => {
     if (text.includes("FROM auth.oauth_authorization_codes")) {
-      assert.match(text, /FOR UPDATE OF oac, oc/u);
+      if (text.includes("FOR UPDATE OF oac, oc")) lockedReadCount += 1;
+      else preflightReadCount += 1;
       return result([{
         connection_id: "connection-1",
+        user_id: "user-1",
         redirect_uri: authorizationRequest.redirectUri,
         code_challenge: challenge,
         scopes: authorizationRequest.scopes,
@@ -399,6 +517,8 @@ test("authorization-code replay revokes the family and its previously minted cre
 
   assert.equal(issued.scope, authorizationRequest.scope);
   assert.equal(activityCount, 1);
+  assert.equal(preflightReadCount, 1);
+  assert.equal(lockedReadCount, 1);
   assert.deepEqual(tokenInserts.map((call) => call.params[2]), [authorizationRequest.scopes, authorizationRequest.scopes]);
   assert.deepEqual(tokenInserts.map((call) => call.params[0]), [hash(accessToken), hash(refreshToken)]);
   assert.equal(tokenInserts.some((call) => call.params.includes(accessToken) || call.params.includes(refreshToken)), false);
@@ -410,6 +530,8 @@ test("authorization-code replay revokes the family and its previously minted cre
     /already used/u,
   );
   assert.equal(activityCount, 1);
+  assert.equal(preflightReadCount, 2);
+  assert.equal(lockedReadCount, 2);
   assert.equal(accessTokenHashes.has(hash(issued.accessToken)) && !connectionRevoked, false);
   await assert.rejects(
     exchangeRefreshTokenWithDependencies(
@@ -430,6 +552,7 @@ test("unknown and unused misbound credentials do not revoke a connection", async
       if (params[0] !== hash(knownCode)) return result([]);
       return result([{
         connection_id: "connection-1",
+        user_id: "user-1",
         redirect_uri: authorizationRequest.redirectUri,
         code_challenge: challenge,
         scopes: authorizationRequest.scopes,
@@ -1149,6 +1272,7 @@ test("revoked connections cannot exchange authorization codes or refresh tokens"
       codeLoaded = true;
       return result([{
         connection_id: "connection-1",
+        user_id: "user-1",
         redirect_uri: authorizationRequest.redirectUri,
         code_challenge: challenge,
         scopes: authorizationRequest.scopes,

--- a/apps/auth/src/server/oauth/store.ts
+++ b/apps/auth/src/server/oauth/store.ts
@@ -85,6 +85,36 @@ type RefreshTokenRecord = Readonly<{
   revoked: boolean;
 }>;
 
+type AuthorizationCodeRecord = Readonly<{
+  connectionId: string;
+  userId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scopes: ReadonlyArray<string>;
+  used: boolean;
+  unexpired: boolean;
+  clientId: string;
+  resource: string;
+  revoked: boolean;
+}>;
+
+const readAuthorizationCodeRecord = (value: unknown): AuthorizationCodeRecord => {
+  const operation = "exchangeAuthorizationCode";
+  const row = readRow(value, operation);
+  return {
+    connectionId: readString(row, "connection_id", operation),
+    userId: readString(row, "user_id", operation),
+    redirectUri: readString(row, "redirect_uri", operation),
+    codeChallenge: readString(row, "code_challenge", operation),
+    scopes: readScopes(row, operation),
+    used: readBoolean(row, "used", operation),
+    unexpired: readBoolean(row, "unexpired", operation),
+    clientId: readString(row, "client_id", operation),
+    resource: readString(row, "resource", operation),
+    revoked: readBoolean(row, "revoked", operation),
+  };
+};
+
 const readRefreshTokenRecord = (value: unknown): RefreshTokenRecord => {
   const operation = "exchangeRefreshToken";
   const row = readRow(value, operation);
@@ -146,6 +176,18 @@ export const getOAuthClientWithDependencies = async (
 export const getOAuthClient = (clientId: string): Promise<OAuthClient | null> =>
   getOAuthClientWithDependencies(clientId, defaultDependencies);
 
+const revokeActiveConnectionsForUser = async (
+  userId: string,
+  dependencies: OAuthStoreDependencies,
+): Promise<void> => {
+  await dependencies.query(
+    `UPDATE auth.oauth_connections
+     SET revoked_at = now()
+     WHERE user_id = $1 AND revoked_at IS NULL`,
+    [userId],
+  );
+};
+
 export const issueAuthorizationCodeWithDependencies = async (
   request: AuthorizationRequest,
   userId: string,
@@ -153,6 +195,11 @@ export const issueAuthorizationCodeWithDependencies = async (
   dependencies: OAuthStoreDependencies,
 ): Promise<string> => {
   await cleanupExpiredOAuthState(dependencies.query);
+  const ownerStatus = await dependencies.getCognitoOAuthOwnerStatus(userId);
+  if (ownerStatus === "inactive") {
+    await revokeActiveConnectionsForUser(userId, dependencies);
+    throw oauthError("access_denied", "User is not eligible for OAuth authorization", 400);
+  }
   const code = dependencies.createOpaqueToken("ac");
   const codeHash = hashOpaqueToken(code);
   return dependencies.withTransaction(async (queryFn: QueryFn) => {
@@ -224,6 +271,72 @@ const revokeActiveConnection = async (
   }
 };
 
+const invalidAuthorizationCodeGrant = (): ReturnType<typeof oauthError> =>
+  oauthError("invalid_grant", "Authorization code is invalid, expired, or already used", 400);
+
+const AUTHORIZATION_CODE_SELECT = `SELECT oac.connection_id, oc.user_id,
+       oac.redirect_uri, oac.code_challenge, oac.scopes,
+       oac.used_at IS NOT NULL AS used,
+       oac.expires_at > now() AS unexpired,
+       oc.client_id, oc.resource,
+       oc.revoked_at IS NOT NULL AS revoked
+FROM auth.oauth_authorization_codes oac
+JOIN auth.oauth_connections oc ON oc.connection_id = oac.connection_id
+WHERE oac.code_hash = $1`;
+
+const readAuthorizationCodeBeforeOwnerCheck = async (
+  codeHash: string,
+  dependencies: OAuthStoreDependencies,
+): Promise<AuthorizationCodeRecord> => {
+  const result = await dependencies.query(AUTHORIZATION_CODE_SELECT, [codeHash]);
+  if (result.rows.length !== 1) throw invalidAuthorizationCodeGrant();
+  return readAuthorizationCodeRecord(result.rows[0]);
+};
+
+const lockAuthorizationCodeForExchange = async (
+  queryFn: QueryFn,
+  codeHash: string,
+): Promise<AuthorizationCodeRecord> => {
+  const result = await queryFn(
+    `${AUTHORIZATION_CODE_SELECT}
+FOR UPDATE OF oac, oc`,
+    [codeHash],
+  );
+  if (result.rows.length !== 1) throw invalidAuthorizationCodeGrant();
+  return readAuthorizationCodeRecord(result.rows[0]);
+};
+
+const validateAuthorizationCodeBinding = (
+  record: AuthorizationCodeRecord,
+  clientId: string,
+  redirectUri: string,
+  resource: string,
+  codeVerifier: string,
+): void => {
+  if (
+    record.clientId !== clientId
+    || record.redirectUri !== redirectUri
+    || record.resource !== resource
+    || !verifyCodeVerifier(codeVerifier, record.codeChallenge)
+  ) {
+    throw oauthError("invalid_grant", "Authorization code binding validation failed", 400);
+  }
+};
+
+const rejectAuthorizationCodeReplay = async (
+  codeHash: string,
+  dependencies: OAuthStoreDependencies,
+): Promise<never> => {
+  await dependencies.withTransaction(async (queryFn: QueryFn): Promise<void> => {
+    const record = await lockAuthorizationCodeForExchange(queryFn, codeHash);
+    if (!record.used) throw invalidAuthorizationCodeGrant();
+    if (!record.revoked) {
+      await revokeActiveConnection(queryFn, record.connectionId, "exchangeAuthorizationCode");
+    }
+  });
+  throw invalidAuthorizationCodeGrant();
+};
+
 export const exchangeAuthorizationCodeWithDependencies = async (
   code: string,
   clientId: string,
@@ -232,44 +345,37 @@ export const exchangeAuthorizationCodeWithDependencies = async (
   codeVerifier: string,
   dependencies: OAuthStoreDependencies,
 ): Promise<OAuthTokenResult> => {
-  const invalidGrant = (): ReturnType<typeof oauthError> =>
-    oauthError("invalid_grant", "Authorization code is invalid, expired, or already used", 400);
   await cleanupExpiredOAuthState(dependencies.query);
   const codeHash = hashOpaqueToken(code);
+  const record = await readAuthorizationCodeBeforeOwnerCheck(codeHash, dependencies);
+  if (record.used) return rejectAuthorizationCodeReplay(codeHash, dependencies);
+  if (record.revoked || !record.unexpired) throw invalidAuthorizationCodeGrant();
+  validateAuthorizationCodeBinding(record, clientId, redirectUri, resource, codeVerifier);
+
+  const ownerStatus = await dependencies.getCognitoOAuthOwnerStatus(record.userId);
+  if (ownerStatus === "inactive") {
+    await revokeActiveConnectionsForUser(record.userId, dependencies);
+    throw invalidAuthorizationCodeGrant();
+  }
+
+  // Cognito eligibility is a point-in-time snapshot. The locked read below
+  // revalidates all authorization-code state without holding a row lock over AWS retries.
   const exchangeResult = await dependencies.withTransaction(async (queryFn: QueryFn): Promise<OAuthTokenResult | null> => {
-    const result = await queryFn(
-      `SELECT oac.connection_id, oac.redirect_uri, oac.code_challenge,
-              oac.scopes, oac.used_at IS NOT NULL AS used,
-              oac.expires_at > now() AS unexpired,
-              oc.client_id, oc.resource, oc.revoked_at IS NOT NULL AS revoked
-       FROM auth.oauth_authorization_codes oac
-       JOIN auth.oauth_connections oc ON oc.connection_id = oac.connection_id
-       WHERE oac.code_hash = $1
-       FOR UPDATE OF oac, oc`,
-      [codeHash],
-    );
-    if (result.rows.length !== 1) throw invalidGrant();
-    const row = readRow(result.rows[0], "exchangeAuthorizationCode");
-    const connectionId = readString(row, "connection_id", "exchangeAuthorizationCode");
-    const revoked = readBoolean(row, "revoked", "exchangeAuthorizationCode");
-    if (readBoolean(row, "used", "exchangeAuthorizationCode")) {
-      if (!revoked) await revokeActiveConnection(queryFn, connectionId, "exchangeAuthorizationCode");
+    const lockedRecord = await lockAuthorizationCodeForExchange(queryFn, codeHash);
+    if (lockedRecord.used) {
+      if (!lockedRecord.revoked) {
+        await revokeActiveConnection(queryFn, lockedRecord.connectionId, "exchangeAuthorizationCode");
+      }
       return null;
     }
-    if (revoked || !readBoolean(row, "unexpired", "exchangeAuthorizationCode")) throw invalidGrant();
-    if (
-      readString(row, "client_id", "exchangeAuthorizationCode") !== clientId
-      || readString(row, "redirect_uri", "exchangeAuthorizationCode") !== redirectUri
-      || readString(row, "resource", "exchangeAuthorizationCode") !== resource
-      || !verifyCodeVerifier(codeVerifier, readString(row, "code_challenge", "exchangeAuthorizationCode"))
-    ) {
-      throw oauthError("invalid_grant", "Authorization code binding validation failed", 400);
+    if (lockedRecord.revoked || lockedRecord.userId !== record.userId || !lockedRecord.unexpired) {
+      throw invalidAuthorizationCodeGrant();
     }
-    const scopes = readScopes(row, "exchangeAuthorizationCode");
+    validateAuthorizationCodeBinding(lockedRecord, clientId, redirectUri, resource, codeVerifier);
     await queryFn("UPDATE auth.oauth_authorization_codes SET used_at = now() WHERE code_hash = $1", [codeHash]);
-    return insertTokenPair(queryFn, connectionId, scopes, dependencies);
+    return insertTokenPair(queryFn, lockedRecord.connectionId, lockedRecord.scopes, dependencies);
   });
-  if (exchangeResult === null) throw invalidGrant();
+  if (exchangeResult === null) throw invalidAuthorizationCodeGrant();
   return exchangeResult;
 };
 
@@ -339,18 +445,6 @@ const rejectRefreshTokenReplay = async (
     }
   });
   throw invalidRefreshGrant();
-};
-
-const revokeActiveConnectionsForUser = async (
-  userId: string,
-  dependencies: OAuthStoreDependencies,
-): Promise<void> => {
-  await dependencies.query(
-    `UPDATE auth.oauth_connections
-     SET revoked_at = now()
-     WHERE user_id = $1 AND revoked_at IS NULL`,
-    [userId],
-  );
 };
 
 const rotateRefreshToken = async (


### PR DESCRIPTION
## Summary
- validate Cognito owner eligibility before issuing authorization codes or syncing browser identity
- revalidate Cognito eligibility before authorization-code token exchange and revoke inactive owners connections
- preserve PKCE, binding, expiry, replay, and locked exchange behavior with focused static coverage

## Validation
- Not run locally; GitHub CI owns executable validation.