### PR TITLE
Retain OAuth replay tombstones for active families

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -149,6 +149,12 @@ jobs:
         id: install
         run: npm ci
 
+      - name: Install PostgreSQL client
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && needs.quality_gate.outputs.auth_tests == 'true' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-client
+
       - name: Apply auth test database migrations
         if: ${{ !cancelled() && steps.install.outcome == 'success' && needs.quality_gate.outputs.auth_tests == 'true' }}
         run: bash scripts/migrate.sh

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,8 @@ jobs:
               - 'apps/**'
               - 'packages/**'
               - 'infra/**'
+              - 'db/migrations/**'
+              - 'scripts/migrate.sh'
               - '.github/workflows/pull-request.yml'
               - '.npmrc'
               - '.nvmrc'
@@ -43,6 +45,8 @@ jobs:
             auth_tests:
               - 'apps/auth/**'
               - 'packages/agent-shared/**'
+              - 'db/migrations/**'
+              - 'scripts/migrate.sh'
               - '.github/workflows/pull-request.yml'
               - '.npmrc'
               - '.nvmrc'
@@ -115,6 +119,20 @@ jobs:
       }}
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:18.4
+        env:
+          POSTGRES_USER: tracker
+          POSTGRES_PASSWORD: tracker
+          POSTGRES_DB: tracker
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U tracker -d tracker"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -131,9 +149,21 @@ jobs:
         id: install
         run: npm ci
 
-      - name: Run auth unit tests
+      - name: Apply auth test database migrations
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && needs.quality_gate.outputs.auth_tests == 'true' }}
+        run: bash scripts/migrate.sh
+        env:
+          MIGRATION_DATABASE_URL: postgresql://tracker:tracker@localhost:5432/tracker
+          APP_DB_PASSWORD: app
+          AUTH_DB_PASSWORD: auth_service
+          WORKER_DB_PASSWORD: worker
+
+      - name: Run auth tests
         if: ${{ !cancelled() && steps.install.outcome == 'success' && needs.quality_gate.outputs.auth_tests == 'true' }}
         run: npm --workspace expense-tracker-auth run test
+        env:
+          MIGRATION_DATABASE_URL: postgresql://tracker:tracker@localhost:5432/tracker
+          AUTH_DATABASE_URL: postgresql://auth_service:auth_service@localhost:5432/tracker
 
       - name: Run AWS infrastructure unit tests
         if: ${{ !cancelled() && steps.install.outcome == 'success' && needs.quality_gate.outputs.infra_tests == 'true' }}

--- a/apps/auth/src/server/oauth/store.postgres.test.ts
+++ b/apps/auth/src/server/oauth/store.postgres.test.ts
@@ -1,0 +1,304 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import pg from "pg";
+import type { QueryFn } from "../db.js";
+import {
+  exchangeRefreshTokenWithDependencies,
+  type OAuthStoreDependencies,
+} from "./store.js";
+import { hashOpaqueToken, isOAuthProtocolError } from "./core.js";
+
+type OAuthPostgresFixture = Readonly<{
+  clientId: string;
+  connectionId: string;
+  userId: string;
+  resource: string;
+  usedAuthorizationCodeHash: string;
+  expiredUnusedAuthorizationCodeHash: string;
+  activeAccessTokenHash: string;
+  expiredAccessTokenHash: string;
+  ancestorRefreshToken: string;
+  ancestorRefreshTokenHash: string;
+  replacementRefreshToken: string;
+  replacementRefreshTokenHash: string;
+  expiredUnusedRefreshTokenHash: string;
+}>;
+
+const migrationDatabaseUrl = process.env.MIGRATION_DATABASE_URL ?? "";
+const authDatabaseUrl = process.env.AUTH_DATABASE_URL ?? "";
+const postgresTestSkip: boolean | string = migrationDatabaseUrl === "" || authDatabaseUrl === ""
+  ? "MIGRATION_DATABASE_URL and AUTH_DATABASE_URL are required for Postgres-backed OAuth tests"
+  : false;
+
+const createFixture = (): OAuthPostgresFixture => {
+  const suffix = randomUUID().replaceAll("-", "");
+  const ancestorRefreshToken = `ebt_rt_ancestor_${suffix}`;
+  const replacementRefreshToken = `ebt_rt_replacement_${suffix}`;
+  return {
+    clientId: `ebt_cl_postgres_${suffix}`,
+    connectionId: randomUUID(),
+    userId: `postgres-user-${suffix}`,
+    resource: "https://mcp.example.com/mcp",
+    usedAuthorizationCodeHash: hashOpaqueToken(`ebt_ac_used_${suffix}`),
+    expiredUnusedAuthorizationCodeHash: hashOpaqueToken(`ebt_ac_expired_${suffix}`),
+    activeAccessTokenHash: hashOpaqueToken(`ebt_at_active_${suffix}`),
+    expiredAccessTokenHash: hashOpaqueToken(`ebt_at_expired_${suffix}`),
+    ancestorRefreshToken,
+    ancestorRefreshTokenHash: hashOpaqueToken(ancestorRefreshToken),
+    replacementRefreshToken,
+    replacementRefreshTokenHash: hashOpaqueToken(replacementRefreshToken),
+    expiredUnusedRefreshTokenHash: hashOpaqueToken(`ebt_rt_expired_${suffix}`),
+  };
+};
+
+const insertFixture = async (
+  pool: pg.Pool,
+  fixture: OAuthPostgresFixture,
+): Promise<void> => {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `INSERT INTO auth.oauth_clients (client_id, client_name, redirect_uris)
+       VALUES ($1, $2, $3)`,
+      [fixture.clientId, "Postgres OAuth replay test", ["https://client.example/callback"]],
+    );
+    await client.query(
+      `INSERT INTO auth.oauth_connections (connection_id, client_id, user_id, resource)
+       VALUES ($1, $2, $3, $4)`,
+      [fixture.connectionId, fixture.clientId, fixture.userId, fixture.resource],
+    );
+    await client.query(
+      `INSERT INTO auth.oauth_authorization_codes
+         (code_hash, connection_id, redirect_uri, code_challenge, scopes, created_at, expires_at, used_at)
+       VALUES
+         ($1, $3, $4, $5, $6, now() - INTERVAL '40 days 5 minutes', now() - INTERVAL '40 days', now() - INTERVAL '40 days 4 minutes'),
+         ($2, $3, $4, $5, $6, now() - INTERVAL '10 minutes', now() - INTERVAL '5 minutes', NULL)`,
+      [
+        fixture.usedAuthorizationCodeHash,
+        fixture.expiredUnusedAuthorizationCodeHash,
+        fixture.connectionId,
+        "https://client.example/callback",
+        "a".repeat(43),
+        ["expenses:read"],
+      ],
+    );
+    await client.query(
+      `INSERT INTO auth.oauth_access_tokens
+         (token_hash, connection_id, scopes, created_at, expires_at)
+       VALUES
+         ($1, $3, $4, now(), now() + INTERVAL '1 hour'),
+         ($2, $3, $4, now() - INTERVAL '2 hours', now() - INTERVAL '1 hour')`,
+      [
+        fixture.activeAccessTokenHash,
+        fixture.expiredAccessTokenHash,
+        fixture.connectionId,
+        ["expenses:read"],
+      ],
+    );
+    await client.query(
+      `INSERT INTO auth.oauth_refresh_tokens
+         (token_hash, connection_id, scopes, created_at, expires_at, used_at)
+       VALUES
+         ($1, $4, $5, now() - INTERVAL '61 days', now() - INTERVAL '31 days', now() - INTERVAL '60 days'),
+         ($2, $4, $5, now(), now() + INTERVAL '30 days', NULL),
+         ($3, $4, $5, now() - INTERVAL '31 days', now() - INTERVAL '1 day', NULL)`,
+      [
+        fixture.ancestorRefreshTokenHash,
+        fixture.replacementRefreshTokenHash,
+        fixture.expiredUnusedRefreshTokenHash,
+        fixture.connectionId,
+        ["expenses:read"],
+      ],
+    );
+    await client.query("COMMIT");
+  } catch (error: unknown) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+const createQueryFn = (pool: pg.Pool): QueryFn =>
+  (text: string, params: ReadonlyArray<unknown>) => pool.query(text, Array.from(params));
+
+const createTransactionRunner = (
+  pool: pg.Pool,
+): OAuthStoreDependencies["withTransaction"] => async <T>(
+  callback: (queryFn: QueryFn) => Promise<T>,
+): Promise<T> => {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const transactionQuery: QueryFn = (text: string, params: ReadonlyArray<unknown>) =>
+      client.query(text, Array.from(params));
+    const result = await callback(transactionQuery);
+    await client.query("COMMIT");
+    return result;
+  } catch (error: unknown) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+const readBooleanColumn = (
+  row: unknown,
+  key: string,
+  operation: string,
+): boolean => {
+  if (typeof row !== "object" || row === null || Array.isArray(row)) {
+    throw new Error(`${operation}: database returned an invalid row`);
+  }
+  const value = (row as Readonly<Record<string, unknown>>)[key];
+  if (typeof value !== "boolean") {
+    throw new Error(`${operation}: database column ${key} must be a boolean`);
+  }
+  return value;
+};
+
+const rejectsInvalidGrant = async (operation: Promise<unknown>): Promise<void> => {
+  await assert.rejects(
+    operation,
+    (error: unknown): boolean => isOAuthProtocolError(error) && error.oauthCode === "invalid_grant",
+  );
+};
+
+test(
+  "real cleanup retains an active ancestor tombstone and production replay revokes its replacement family",
+  { skip: postgresTestSkip },
+  async (): Promise<void> => {
+    const fixture = createFixture();
+    const migrationPool = new pg.Pool({ connectionString: migrationDatabaseUrl });
+    const authPool = new pg.Pool({ connectionString: authDatabaseUrl });
+
+    try {
+      await insertFixture(migrationPool, fixture);
+
+      const authQuery = createQueryFn(authPool);
+      const roleResult = await authQuery("SELECT current_user = 'auth_service' AS is_auth_service", []);
+      assert.equal(readBooleanColumn(roleResult.rows[0], "is_auth_service", "OAuth Postgres role check"), true);
+
+      const dependencies: OAuthStoreDependencies = {
+        query: authQuery,
+        withTransaction: createTransactionRunner(authPool),
+        createOpaqueToken: (prefix) => {
+          throw new Error(`OAuth Postgres replay test unexpectedly created a ${prefix} token`);
+        },
+        getCognitoOAuthOwnerStatus: async (userId) => {
+          throw new Error(`OAuth Postgres replay test unexpectedly checked Cognito owner ${userId}`);
+        },
+      };
+
+      const activeAccessBeforeReplay = await migrationPool.query(
+        `SELECT EXISTS (
+           SELECT 1
+           FROM auth.validate_oauth_access_token($1)
+         ) AS usable`,
+        [fixture.activeAccessTokenHash],
+      );
+      assert.equal(
+        readBooleanColumn(activeAccessBeforeReplay.rows[0], "usable", "OAuth active-family setup check"),
+        true,
+      );
+
+      await rejectsInvalidGrant(exchangeRefreshTokenWithDependencies(
+        fixture.ancestorRefreshToken,
+        fixture.clientId,
+        fixture.resource,
+        null,
+        dependencies,
+      ));
+
+      const afterAncestorReplay = await migrationPool.query(
+        `SELECT
+           EXISTS (
+             SELECT 1 FROM auth.oauth_connections
+             WHERE connection_id = $1 AND revoked_at IS NOT NULL
+           ) AS connection_revoked,
+           EXISTS (
+             SELECT 1 FROM auth.oauth_authorization_codes
+             WHERE code_hash = $2
+           ) AS used_code_retained,
+           EXISTS (
+             SELECT 1 FROM auth.oauth_refresh_tokens
+             WHERE token_hash = $3
+           ) AS ancestor_retained,
+           NOT EXISTS (
+             SELECT 1 FROM auth.oauth_authorization_codes
+             WHERE code_hash = $4
+           ) AS expired_unused_code_deleted,
+           NOT EXISTS (
+             SELECT 1 FROM auth.oauth_refresh_tokens
+             WHERE token_hash = $5
+           ) AS expired_unused_refresh_deleted,
+           NOT EXISTS (
+             SELECT 1 FROM auth.oauth_access_tokens
+             WHERE token_hash = $6
+           ) AS expired_access_deleted,
+           NOT EXISTS (
+             SELECT 1 FROM auth.validate_oauth_access_token($7)
+           ) AS replacement_access_revoked`,
+        [
+          fixture.connectionId,
+          fixture.usedAuthorizationCodeHash,
+          fixture.ancestorRefreshTokenHash,
+          fixture.expiredUnusedAuthorizationCodeHash,
+          fixture.expiredUnusedRefreshTokenHash,
+          fixture.expiredAccessTokenHash,
+          fixture.activeAccessTokenHash,
+        ],
+      );
+      const afterAncestorReplayRow = afterAncestorReplay.rows[0];
+      assert.equal(readBooleanColumn(afterAncestorReplayRow, "connection_revoked", "OAuth ancestor replay check"), true);
+      assert.equal(readBooleanColumn(afterAncestorReplayRow, "used_code_retained", "OAuth used-code retention check"), true);
+      assert.equal(readBooleanColumn(afterAncestorReplayRow, "ancestor_retained", "OAuth ancestor retention check"), true);
+      assert.equal(readBooleanColumn(afterAncestorReplayRow, "expired_unused_code_deleted", "OAuth expired-code cleanup check"), true);
+      assert.equal(readBooleanColumn(afterAncestorReplayRow, "expired_unused_refresh_deleted", "OAuth expired-refresh cleanup check"), true);
+      assert.equal(readBooleanColumn(afterAncestorReplayRow, "expired_access_deleted", "OAuth expired-access cleanup check"), true);
+      assert.equal(readBooleanColumn(afterAncestorReplayRow, "replacement_access_revoked", "OAuth family revocation check"), true);
+
+      await rejectsInvalidGrant(exchangeRefreshTokenWithDependencies(
+        fixture.replacementRefreshToken,
+        fixture.clientId,
+        fixture.resource,
+        null,
+        dependencies,
+      ));
+
+      const afterRevokedCleanup = await migrationPool.query(
+        `SELECT
+           NOT EXISTS (
+             SELECT 1 FROM auth.oauth_authorization_codes
+             WHERE code_hash = $1
+           ) AS used_code_deleted,
+           NOT EXISTS (
+             SELECT 1 FROM auth.oauth_refresh_tokens
+             WHERE token_hash = $2
+           ) AS ancestor_deleted,
+           EXISTS (
+             SELECT 1 FROM auth.oauth_refresh_tokens
+             WHERE token_hash = $3
+           ) AS replacement_retained`,
+        [
+          fixture.usedAuthorizationCodeHash,
+          fixture.ancestorRefreshTokenHash,
+          fixture.replacementRefreshTokenHash,
+        ],
+      );
+      const afterRevokedCleanupRow = afterRevokedCleanup.rows[0];
+      assert.equal(readBooleanColumn(afterRevokedCleanupRow, "used_code_deleted", "OAuth revoked-code cleanup check"), true);
+      assert.equal(readBooleanColumn(afterRevokedCleanupRow, "ancestor_deleted", "OAuth revoked-refresh cleanup check"), true);
+      assert.equal(readBooleanColumn(afterRevokedCleanupRow, "replacement_retained", "OAuth active-replacement cleanup check"), true);
+    } finally {
+      try {
+        await migrationPool.query("DELETE FROM auth.oauth_clients WHERE client_id = $1", [fixture.clientId]);
+      } finally {
+        await Promise.all([authPool.end(), migrationPool.end()]);
+      }
+    }
+  },
+);

--- a/apps/auth/src/server/oauth/store.test.ts
+++ b/apps/auth/src/server/oauth/store.test.ts
@@ -35,25 +35,32 @@ const cleanupMigration = readFileSync(
   "utf8",
 );
 
-const readMigrationSection = (marker: string): string => {
-  const markerIndex = cleanupMigration.indexOf(marker);
+const tombstoneRetentionMigration = readFileSync(
+  fileURLToPath(new URL("../../../../../db/migrations/0070_oauth_used_credential_tombstone_retention.sql", import.meta.url)),
+  "utf8",
+);
+
+const readMigrationSection = (migration: string, marker: string): string => {
+  const markerIndex = migration.indexOf(marker);
   if (markerIndex === -1) throw new Error(`OAuth cleanup migration is missing ${marker}`);
-  return cleanupMigration.slice(markerIndex);
+  return migration.slice(markerIndex);
 };
 
-const readMigrationRange = (startMarker: string, endMarker: string): string => {
-  const startIndex = cleanupMigration.indexOf(startMarker);
-  const endIndex = cleanupMigration.indexOf(endMarker);
+const readMigrationRange = (migration: string, startMarker: string, endMarker: string): string => {
+  const startIndex = migration.indexOf(startMarker);
+  const endIndex = migration.indexOf(endMarker);
   if (startIndex === -1) throw new Error(`OAuth cleanup migration is missing ${startMarker}`);
   if (endIndex <= startIndex) throw new Error(`OAuth cleanup migration is missing ${endMarker} after ${startMarker}`);
-  return cleanupMigration.slice(startIndex, endIndex);
+  return migration.slice(startIndex, endIndex);
 };
 
 const cleanupFunctionSql = readMigrationSection(
-  "CREATE FUNCTION auth.cleanup_expired_oauth_transient_state()",
+  tombstoneRetentionMigration,
+  "CREATE OR REPLACE FUNCTION auth.cleanup_expired_oauth_transient_state()",
 );
 
 const ownerListingFunctionSql = readMigrationRange(
+  cleanupMigration,
   "CREATE OR REPLACE FUNCTION auth.list_current_user_oauth_connections()",
   "CREATE FUNCTION auth.record_oauth_connection_activity(p_connection_id TEXT)",
 );
@@ -95,18 +102,32 @@ const authorizationRequest: AuthorizationRequest = {
   codeChallengeMethod: "S256",
 };
 
-test("OAuth cleanup bounds expiry-only deletes, retains unexpired used rows, and skips locks", (): void => {
-  assert.equal(cleanupFunctionSql.match(/WHERE expires_at <= now\(\)/gu)?.length, 3);
-  assert.equal(cleanupFunctionSql.match(/ORDER BY expires_at/gu)?.length, 3);
+test("OAuth cleanup retains active-family tombstones and uses bounded indexed eligibility paths", (): void => {
+  assert.match(
+    tombstoneRetentionMigration,
+    /CREATE INDEX idx_oauth_connections_revoked_connection_id\s+ON auth\.oauth_connections \(connection_id\)\s+WHERE revoked_at IS NOT NULL/u,
+  );
+  assert.match(
+    tombstoneRetentionMigration,
+    /CREATE INDEX idx_oauth_authorization_codes_unused_expires_at\s+ON auth\.oauth_authorization_codes \(expires_at, code_hash\)\s+WHERE used_at IS NULL/u,
+  );
+  assert.match(
+    tombstoneRetentionMigration,
+    /CREATE INDEX idx_oauth_refresh_tokens_unused_expires_at\s+ON auth\.oauth_refresh_tokens \(expires_at, token_hash\)\s+WHERE used_at IS NULL/u,
+  );
+  assert.equal(cleanupFunctionSql.match(/used_at IS NULL/gu)?.length, 2);
+  assert.equal(cleanupFunctionSql.match(/revoked_at IS NOT NULL/gu)?.length, 2);
+  assert.equal(cleanupFunctionSql.match(/GET DIAGNOSTICS v_deleted_count = ROW_COUNT/gu)?.length, 2);
   assert.equal(cleanupFunctionSql.match(/LIMIT 100/gu)?.length, 3);
-  assert.equal(cleanupFunctionSql.match(/FOR UPDATE SKIP LOCKED/gu)?.length, 3);
-  assert.equal(cleanupFunctionSql.includes("used_at"), false);
-  assert.match(cleanupFunctionSql, /DELETE FROM auth\.oauth_authorization_codes/u);
+  assert.equal(cleanupFunctionSql.match(/LIMIT \(100 - v_deleted_count\)/gu)?.length, 4);
+  assert.equal(cleanupFunctionSql.match(/FOR UPDATE SKIP LOCKED/gu)?.length, 5);
+  assert.equal(cleanupFunctionSql.match(/DELETE FROM auth\.oauth_authorization_codes/gu)?.length, 2);
   assert.match(cleanupFunctionSql, /DELETE FROM auth\.oauth_access_tokens/u);
-  assert.match(cleanupFunctionSql, /DELETE FROM auth\.oauth_refresh_tokens/u);
+  assert.equal(cleanupFunctionSql.match(/DELETE FROM auth\.oauth_refresh_tokens/gu)?.length, 2);
+  assert.doesNotMatch(cleanupFunctionSql, /INTERVAL '30 days'/u);
   assert.match(cleanupFunctionSql, /SECURITY DEFINER/u);
-  assert.match(cleanupMigration, /GRANT EXECUTE ON FUNCTION auth\.cleanup_expired_oauth_transient_state\(\) TO auth_service/u);
-  assert.doesNotMatch(cleanupMigration, /GRANT DELETE/u);
+  assert.match(tombstoneRetentionMigration, /GRANT EXECUTE ON FUNCTION auth\.cleanup_expired_oauth_transient_state\(\) TO auth_service/u);
+  assert.doesNotMatch(tombstoneRetentionMigration, /GRANT DELETE/u);
 });
 
 test("OAuth activity is backfilled durably and read without transient credential rows", (): void => {

--- a/db/migrations/0070_oauth_used_credential_tombstone_retention.sql
+++ b/db/migrations/0070_oauth_used_credential_tombstone_retention.sql
@@ -1,0 +1,117 @@
+-- Retain used OAuth credentials as replay-detection tombstones while their
+-- connection is active, and keep each cleanup path directly indexable.
+
+CREATE INDEX idx_oauth_connections_revoked_connection_id
+  ON auth.oauth_connections (connection_id)
+  WHERE revoked_at IS NOT NULL;
+
+CREATE INDEX idx_oauth_authorization_codes_unused_expires_at
+  ON auth.oauth_authorization_codes (expires_at, code_hash)
+  WHERE used_at IS NULL;
+
+CREATE INDEX idx_oauth_refresh_tokens_unused_expires_at
+  ON auth.oauth_refresh_tokens (expires_at, token_hash)
+  WHERE used_at IS NULL;
+
+CREATE OR REPLACE FUNCTION auth.cleanup_expired_oauth_transient_state()
+RETURNS VOID
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog, auth, pg_temp
+AS $$
+DECLARE
+  v_deleted_count INTEGER;
+BEGIN
+  WITH expired_unused AS MATERIALIZED (
+    SELECT code_hash
+    FROM auth.oauth_authorization_codes
+    WHERE used_at IS NULL
+      AND expires_at <= now()
+    ORDER BY expires_at, code_hash
+    LIMIT 100
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM auth.oauth_authorization_codes AS authorization_code
+  USING expired_unused
+  WHERE authorization_code.code_hash = expired_unused.code_hash;
+
+  GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+
+  WITH used_on_revoked_connection AS MATERIALIZED (
+    SELECT used_authorization_code.code_hash
+    FROM (
+      SELECT connection_id
+      FROM auth.oauth_connections
+      WHERE revoked_at IS NOT NULL
+      ORDER BY connection_id
+    ) AS revoked_connection
+    CROSS JOIN LATERAL (
+      SELECT authorization_code.code_hash
+      FROM auth.oauth_authorization_codes AS authorization_code
+      WHERE authorization_code.connection_id = revoked_connection.connection_id
+        AND authorization_code.used_at IS NOT NULL
+      ORDER BY authorization_code.used_at DESC
+      LIMIT (100 - v_deleted_count)
+      FOR UPDATE SKIP LOCKED
+    ) AS used_authorization_code
+    LIMIT (100 - v_deleted_count)
+  )
+  DELETE FROM auth.oauth_authorization_codes AS authorization_code
+  USING used_on_revoked_connection
+  WHERE authorization_code.code_hash = used_on_revoked_connection.code_hash;
+
+  WITH expired AS MATERIALIZED (
+    SELECT token_hash
+    FROM auth.oauth_access_tokens
+    WHERE expires_at <= now()
+    ORDER BY expires_at
+    LIMIT 100
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM auth.oauth_access_tokens AS access_token
+  USING expired
+  WHERE access_token.token_hash = expired.token_hash;
+
+  WITH expired_unused AS MATERIALIZED (
+    SELECT token_hash
+    FROM auth.oauth_refresh_tokens
+    WHERE used_at IS NULL
+      AND expires_at <= now()
+    ORDER BY expires_at, token_hash
+    LIMIT 100
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM auth.oauth_refresh_tokens AS refresh_token
+  USING expired_unused
+  WHERE refresh_token.token_hash = expired_unused.token_hash;
+
+  GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+
+  WITH used_on_revoked_connection AS MATERIALIZED (
+    SELECT used_refresh_token.token_hash
+    FROM (
+      SELECT connection_id
+      FROM auth.oauth_connections
+      WHERE revoked_at IS NOT NULL
+      ORDER BY connection_id
+    ) AS revoked_connection
+    CROSS JOIN LATERAL (
+      SELECT refresh_token.token_hash
+      FROM auth.oauth_refresh_tokens AS refresh_token
+      WHERE refresh_token.connection_id = revoked_connection.connection_id
+        AND refresh_token.used_at IS NOT NULL
+      ORDER BY refresh_token.used_at DESC
+      LIMIT (100 - v_deleted_count)
+      FOR UPDATE SKIP LOCKED
+    ) AS used_refresh_token
+    LIMIT (100 - v_deleted_count)
+  )
+  DELETE FROM auth.oauth_refresh_tokens AS refresh_token
+  USING used_on_revoked_connection
+  WHERE refresh_token.token_hash = used_on_revoked_connection.token_hash;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION auth.cleanup_expired_oauth_transient_state() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION auth.cleanup_expired_oauth_transient_state() TO auth_service;


### PR DESCRIPTION
## Summary
- retain used OAuth authorization-code and refresh-token evidence while its connection remains active
- keep bounded cleanup directly indexable for expired-unused and revoked-family candidates
- exercise the real PostgreSQL cleanup and refresh replay path in the existing PR CI gate

## Validation
- local checks intentionally not run; GitHub CI owns validation