### PR TITLE
Enable PR checks for SQL integration branch

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, integration-mcp-readonly-sql]
 
 concurrency:
   group: pull-request-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Adds the integration branch to the existing pull-request workflow target filter while preserving main. This is the bootstrap required before integration-item PRs can register the cloud CI gate. Local validation was intentionally not run; no checks can register for this PR until this change is present on the integration base.