### PR TITLE
Bound revoked OAuth cleanup work

### DIFF
--- a/apps/auth/src/server/oauth/store.postgres.test.ts
+++ b/apps/auth/src/server/oauth/store.postgres.test.ts
@@ -302,3 +302,175 @@ test(
     }
   },
 );
+
+test(
+  "real revoked-family cleanup makes bounded round-robin progress across multiple calls",
+  { skip: postgresTestSkip },
+  async (): Promise<void> => {
+    const suffix = randomUUID().replaceAll("-", "");
+    const clientId = `ebt_cl_cleanup_${suffix}`;
+    const largeConnectionId = randomUUID();
+    const emptyConnectionIds: ReadonlyArray<string> = [randomUUID(), randomUUID()];
+    const laterConnectionId = randomUUID();
+    const connectionIds: ReadonlyArray<string> = [
+      largeConnectionId,
+      ...emptyConnectionIds,
+      laterConnectionId,
+    ];
+    const largeCodeHashes: ReadonlyArray<string> = Array.from(
+      { length: 101 },
+      (_, index) => hashOpaqueToken(`ebt_ac_cleanup_large_${suffix}_${index}`),
+    );
+    const laterCodeHash = hashOpaqueToken(`ebt_ac_cleanup_later_${suffix}`);
+    const laterRefreshHash = hashOpaqueToken(`ebt_rt_cleanup_later_${suffix}`);
+    const migrationPool = new pg.Pool({ connectionString: migrationDatabaseUrl });
+    const authPool = new pg.Pool({ connectionString: authDatabaseUrl });
+
+    try {
+      const client = await migrationPool.connect();
+      try {
+        await client.query("BEGIN");
+        await client.query(
+          `INSERT INTO auth.oauth_clients (client_id, client_name, redirect_uris)
+           VALUES ($1, $2, $3)`,
+          [clientId, "Postgres OAuth cleanup queue test", ["https://client.example/callback"]],
+        );
+        for (const [index, connectionId] of connectionIds.entries()) {
+          await client.query(
+            `INSERT INTO auth.oauth_connections (connection_id, client_id, user_id, resource)
+             VALUES ($1, $2, $3, $4)`,
+            [connectionId, clientId, `cleanup-user-${suffix}-${index}`, "https://mcp.example.com/mcp"],
+          );
+        }
+        await client.query(
+          `INSERT INTO auth.oauth_authorization_codes
+             (code_hash, connection_id, redirect_uri, code_challenge, scopes, created_at, expires_at, used_at)
+           SELECT generated.code_hash, $2, $3, $4, $5,
+                  now() - INTERVAL '10 minutes',
+                  now() - INTERVAL '5 minutes',
+                  now() - INTERVAL '9 minutes'
+           FROM unnest($1::TEXT[]) AS generated(code_hash)`,
+          [
+            largeCodeHashes,
+            largeConnectionId,
+            "https://client.example/callback",
+            "a".repeat(43),
+            ["expenses:read"],
+          ],
+        );
+        await client.query(
+          `INSERT INTO auth.oauth_authorization_codes
+             (code_hash, connection_id, redirect_uri, code_challenge, scopes, created_at, expires_at, used_at)
+           VALUES ($1, $2, $3, $4, $5,
+                   now() - INTERVAL '10 minutes',
+                   now() - INTERVAL '5 minutes',
+                   now() - INTERVAL '9 minutes')`,
+          [
+            laterCodeHash,
+            laterConnectionId,
+            "https://client.example/callback",
+            "a".repeat(43),
+            ["expenses:read"],
+          ],
+        );
+        await client.query(
+          `INSERT INTO auth.oauth_refresh_tokens
+             (token_hash, connection_id, scopes, created_at, expires_at, used_at)
+           VALUES ($1, $2, $3,
+                   now() - INTERVAL '31 days',
+                   now() - INTERVAL '1 day',
+                   now() - INTERVAL '30 days')`,
+          [laterRefreshHash, laterConnectionId, ["expenses:read"]],
+        );
+        for (const connectionId of connectionIds) {
+          await client.query(
+            `UPDATE auth.oauth_connections
+             SET revoked_at = now()
+             WHERE connection_id = $1`,
+            [connectionId],
+          );
+        }
+        await client.query("COMMIT");
+      } catch (error: unknown) {
+        await client.query("ROLLBACK");
+        throw error;
+      } finally {
+        client.release();
+      }
+
+      const authQuery = createQueryFn(authPool);
+      const privilegeResult = await authQuery(
+        `SELECT NOT has_table_privilege(
+           current_user,
+           'auth.oauth_revoked_connection_cleanup_queue',
+           'DELETE'
+         ) AS delete_denied`,
+        [],
+      );
+      assert.equal(
+        readBooleanColumn(privilegeResult.rows[0], "delete_denied", "OAuth cleanup queue privilege check"),
+        true,
+      );
+
+      await authQuery("SELECT auth.cleanup_expired_oauth_transient_state()", []);
+
+      const afterLargeBatch = await migrationPool.query(
+        `SELECT
+           (SELECT count(*) FROM auth.oauth_authorization_codes
+            WHERE connection_id = $1 AND used_at IS NOT NULL) = 1 AS large_family_has_one_code,
+           EXISTS (SELECT 1 FROM auth.oauth_authorization_codes WHERE code_hash = $2) AS later_code_retained,
+           EXISTS (SELECT 1 FROM auth.oauth_refresh_tokens WHERE token_hash = $3) AS later_refresh_retained,
+           (SELECT count(*) FROM auth.oauth_revoked_connection_cleanup_queue
+            WHERE connection_id = ANY($4::TEXT[])) = 4 AS all_families_queued`,
+        [largeConnectionId, laterCodeHash, laterRefreshHash, connectionIds],
+      );
+      const afterLargeBatchRow = afterLargeBatch.rows[0];
+      assert.equal(readBooleanColumn(afterLargeBatchRow, "large_family_has_one_code", "OAuth large-family batch check"), true);
+      assert.equal(readBooleanColumn(afterLargeBatchRow, "later_code_retained", "OAuth later code setup check"), true);
+      assert.equal(readBooleanColumn(afterLargeBatchRow, "later_refresh_retained", "OAuth later refresh setup check"), true);
+      assert.equal(readBooleanColumn(afterLargeBatchRow, "all_families_queued", "OAuth cleanup queue setup check"), true);
+
+      await authQuery("SELECT auth.cleanup_expired_oauth_transient_state()", []);
+      await authQuery("SELECT auth.cleanup_expired_oauth_transient_state()", []);
+      await authQuery("SELECT auth.cleanup_expired_oauth_transient_state()", []);
+
+      const afterLaterFamily = await migrationPool.query(
+        `SELECT
+           NOT EXISTS (SELECT 1 FROM auth.oauth_authorization_codes WHERE code_hash = $1) AS later_code_deleted,
+           NOT EXISTS (SELECT 1 FROM auth.oauth_refresh_tokens WHERE token_hash = $2) AS later_refresh_deleted,
+           EXISTS (SELECT 1 FROM auth.oauth_authorization_codes
+                   WHERE connection_id = $3 AND used_at IS NOT NULL) AS large_family_still_queued,
+           NOT EXISTS (SELECT 1 FROM auth.oauth_revoked_connection_cleanup_queue
+                       WHERE connection_id = ANY($4::TEXT[])) AS empty_and_later_families_dequeued`,
+        [laterCodeHash, laterRefreshHash, largeConnectionId, [...emptyConnectionIds, laterConnectionId]],
+      );
+      const afterLaterFamilyRow = afterLaterFamily.rows[0];
+      assert.equal(readBooleanColumn(afterLaterFamilyRow, "later_code_deleted", "OAuth later code cleanup check"), true);
+      assert.equal(readBooleanColumn(afterLaterFamilyRow, "later_refresh_deleted", "OAuth later refresh cleanup check"), true);
+      assert.equal(readBooleanColumn(afterLaterFamilyRow, "large_family_still_queued", "OAuth round-robin fairness check"), true);
+      assert.equal(
+        readBooleanColumn(afterLaterFamilyRow, "empty_and_later_families_dequeued", "OAuth empty-family progress check"),
+        true,
+      );
+
+      await authQuery("SELECT auth.cleanup_expired_oauth_transient_state()", []);
+
+      const afterDrain = await migrationPool.query(
+        `SELECT
+           NOT EXISTS (SELECT 1 FROM auth.oauth_authorization_codes
+                       WHERE connection_id = $1 AND used_at IS NOT NULL) AS large_family_drained,
+           NOT EXISTS (SELECT 1 FROM auth.oauth_revoked_connection_cleanup_queue
+                       WHERE connection_id = ANY($2::TEXT[])) AS queue_drained`,
+        [largeConnectionId, connectionIds],
+      );
+      assert.equal(readBooleanColumn(afterDrain.rows[0], "large_family_drained", "OAuth large-family drain check"), true);
+      assert.equal(readBooleanColumn(afterDrain.rows[0], "queue_drained", "OAuth cleanup queue drain check"), true);
+    } finally {
+      try {
+        await migrationPool.query("DELETE FROM auth.oauth_clients WHERE client_id = $1", [clientId]);
+      } finally {
+        await Promise.all([authPool.end(), migrationPool.end()]);
+      }
+    }
+  },
+);

--- a/apps/auth/src/server/oauth/store.test.ts
+++ b/apps/auth/src/server/oauth/store.test.ts
@@ -40,6 +40,11 @@ const tombstoneRetentionMigration = readFileSync(
   "utf8",
 );
 
+const revokedCleanupQueueMigration = readFileSync(
+  fileURLToPath(new URL("../../../../../db/migrations/0071_oauth_revoked_connection_cleanup_queue.sql", import.meta.url)),
+  "utf8",
+);
+
 const readMigrationSection = (migration: string, marker: string): string => {
   const markerIndex = migration.indexOf(marker);
   if (markerIndex === -1) throw new Error(`OAuth cleanup migration is missing ${marker}`);
@@ -55,7 +60,7 @@ const readMigrationRange = (migration: string, startMarker: string, endMarker: s
 };
 
 const cleanupFunctionSql = readMigrationSection(
-  tombstoneRetentionMigration,
+  revokedCleanupQueueMigration,
   "CREATE OR REPLACE FUNCTION auth.cleanup_expired_oauth_transient_state()",
 );
 
@@ -102,7 +107,7 @@ const authorizationRequest: AuthorizationRequest = {
   codeChallengeMethod: "S256",
 };
 
-test("OAuth cleanup retains active-family tombstones and uses bounded indexed eligibility paths", (): void => {
+test("OAuth cleanup retains active-family tombstones and fairly bounds revoked-family work", (): void => {
   assert.match(
     tombstoneRetentionMigration,
     /CREATE INDEX idx_oauth_connections_revoked_connection_id\s+ON auth\.oauth_connections \(connection_id\)\s+WHERE revoked_at IS NOT NULL/u,
@@ -115,19 +120,45 @@ test("OAuth cleanup retains active-family tombstones and uses bounded indexed el
     tombstoneRetentionMigration,
     /CREATE INDEX idx_oauth_refresh_tokens_unused_expires_at\s+ON auth\.oauth_refresh_tokens \(expires_at, token_hash\)\s+WHERE used_at IS NULL/u,
   );
+  assert.match(
+    revokedCleanupQueueMigration,
+    /CREATE TABLE auth\.oauth_revoked_connection_cleanup_queue/u,
+  );
+  assert.match(
+    revokedCleanupQueueMigration,
+    /CREATE UNIQUE INDEX idx_oauth_revoked_cleanup_queue_position\s+ON auth\.oauth_revoked_connection_cleanup_queue \(queue_position\)/u,
+  );
+  assert.match(
+    revokedCleanupQueueMigration,
+    /AFTER UPDATE OF revoked_at ON auth\.oauth_connections/u,
+  );
+  assert.match(
+    revokedCleanupQueueMigration,
+    /WHERE connection\.revoked_at IS NOT NULL[\s\S]*authorization_code\.used_at IS NOT NULL[\s\S]*refresh_token\.used_at IS NOT NULL/u,
+  );
+  assert.match(
+    cleanupFunctionSql,
+    /FROM auth\.oauth_revoked_connection_cleanup_queue AS queued_connection\s+ORDER BY queued_connection\.queue_position\s+LIMIT 1\s+FOR UPDATE SKIP LOCKED/u,
+  );
   assert.equal(cleanupFunctionSql.match(/used_at IS NULL/gu)?.length, 2);
-  assert.equal(cleanupFunctionSql.match(/revoked_at IS NOT NULL/gu)?.length, 2);
+  assert.equal(cleanupFunctionSql.match(/connection_id = v_cleanup_connection_id/gu)?.length, 4);
   assert.equal(cleanupFunctionSql.match(/GET DIAGNOSTICS v_deleted_count = ROW_COUNT/gu)?.length, 2);
   assert.equal(cleanupFunctionSql.match(/LIMIT 100/gu)?.length, 3);
-  assert.equal(cleanupFunctionSql.match(/LIMIT \(100 - v_deleted_count\)/gu)?.length, 4);
-  assert.equal(cleanupFunctionSql.match(/FOR UPDATE SKIP LOCKED/gu)?.length, 5);
+  assert.equal(cleanupFunctionSql.match(/LIMIT \(100 - v_deleted_count\)/gu)?.length, 2);
+  assert.equal(cleanupFunctionSql.match(/FOR UPDATE SKIP LOCKED/gu)?.length, 6);
   assert.equal(cleanupFunctionSql.match(/DELETE FROM auth\.oauth_authorization_codes/gu)?.length, 2);
   assert.match(cleanupFunctionSql, /DELETE FROM auth\.oauth_access_tokens/u);
   assert.equal(cleanupFunctionSql.match(/DELETE FROM auth\.oauth_refresh_tokens/gu)?.length, 2);
+  assert.match(cleanupFunctionSql, /DELETE FROM auth\.oauth_revoked_connection_cleanup_queue/u);
+  assert.match(
+    cleanupFunctionSql,
+    /SET queue_position = nextval\('auth\.oauth_revoked_cleanup_queue_position_seq'::regclass\)/u,
+  );
+  assert.doesNotMatch(cleanupFunctionSql, /FROM auth\.oauth_connections/u);
   assert.doesNotMatch(cleanupFunctionSql, /INTERVAL '30 days'/u);
   assert.match(cleanupFunctionSql, /SECURITY DEFINER/u);
-  assert.match(tombstoneRetentionMigration, /GRANT EXECUTE ON FUNCTION auth\.cleanup_expired_oauth_transient_state\(\) TO auth_service/u);
-  assert.doesNotMatch(tombstoneRetentionMigration, /GRANT DELETE/u);
+  assert.match(revokedCleanupQueueMigration, /GRANT EXECUTE ON FUNCTION auth\.cleanup_expired_oauth_transient_state\(\) TO auth_service/u);
+  assert.doesNotMatch(revokedCleanupQueueMigration, /GRANT DELETE/u);
 });
 
 test("OAuth activity is backfilled durably and read without transient credential rows", (): void => {

--- a/db/migrations/0071_oauth_revoked_connection_cleanup_queue.sql
+++ b/db/migrations/0071_oauth_revoked_connection_cleanup_queue.sql
@@ -1,0 +1,183 @@
+-- Bound revoked OAuth tombstone cleanup with a database-enforced fair queue.
+
+CREATE SEQUENCE auth.oauth_revoked_cleanup_queue_position_seq AS BIGINT;
+
+CREATE TABLE auth.oauth_revoked_connection_cleanup_queue (
+  connection_id  TEXT   NOT NULL PRIMARY KEY
+    REFERENCES auth.oauth_connections(connection_id) ON DELETE CASCADE,
+  queue_position BIGINT NOT NULL DEFAULT nextval('auth.oauth_revoked_cleanup_queue_position_seq'::regclass)
+);
+
+ALTER SEQUENCE auth.oauth_revoked_cleanup_queue_position_seq
+  OWNED BY auth.oauth_revoked_connection_cleanup_queue.queue_position;
+
+CREATE UNIQUE INDEX idx_oauth_revoked_cleanup_queue_position
+  ON auth.oauth_revoked_connection_cleanup_queue (queue_position);
+
+REVOKE ALL ON TABLE auth.oauth_revoked_connection_cleanup_queue FROM PUBLIC, auth_service;
+REVOKE ALL ON SEQUENCE auth.oauth_revoked_cleanup_queue_position_seq FROM PUBLIC, auth_service;
+
+CREATE FUNCTION auth.enqueue_revoked_oauth_connection_cleanup()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog, auth, pg_temp
+AS $$
+BEGIN
+  INSERT INTO auth.oauth_revoked_connection_cleanup_queue (connection_id)
+  VALUES (NEW.connection_id)
+  ON CONFLICT (connection_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION auth.enqueue_revoked_oauth_connection_cleanup() FROM PUBLIC;
+
+CREATE TRIGGER enqueue_inserted_revoked_oauth_connection_cleanup
+AFTER INSERT ON auth.oauth_connections
+FOR EACH ROW
+WHEN (NEW.revoked_at IS NOT NULL)
+EXECUTE FUNCTION auth.enqueue_revoked_oauth_connection_cleanup();
+
+CREATE TRIGGER enqueue_newly_revoked_oauth_connection_cleanup
+AFTER UPDATE OF revoked_at ON auth.oauth_connections
+FOR EACH ROW
+WHEN (OLD.revoked_at IS NULL AND NEW.revoked_at IS NOT NULL)
+EXECUTE FUNCTION auth.enqueue_revoked_oauth_connection_cleanup();
+
+INSERT INTO auth.oauth_revoked_connection_cleanup_queue (connection_id)
+SELECT connection.connection_id
+FROM auth.oauth_connections AS connection
+WHERE connection.revoked_at IS NOT NULL
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM auth.oauth_authorization_codes AS authorization_code
+      WHERE authorization_code.connection_id = connection.connection_id
+        AND authorization_code.used_at IS NOT NULL
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM auth.oauth_refresh_tokens AS refresh_token
+      WHERE refresh_token.connection_id = connection.connection_id
+        AND refresh_token.used_at IS NOT NULL
+    )
+  )
+ORDER BY connection.connection_id
+ON CONFLICT (connection_id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION auth.cleanup_expired_oauth_transient_state()
+RETURNS VOID
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pg_catalog, auth, pg_temp
+AS $$
+DECLARE
+  v_cleanup_connection_id TEXT;
+  v_deleted_count INTEGER;
+BEGIN
+  WITH expired_unused AS MATERIALIZED (
+    SELECT code_hash
+    FROM auth.oauth_authorization_codes
+    WHERE used_at IS NULL
+      AND expires_at <= now()
+    ORDER BY expires_at, code_hash
+    LIMIT 100
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM auth.oauth_authorization_codes AS authorization_code
+  USING expired_unused
+  WHERE authorization_code.code_hash = expired_unused.code_hash;
+
+  GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+
+  SELECT queued_connection.connection_id
+  INTO v_cleanup_connection_id
+  FROM auth.oauth_revoked_connection_cleanup_queue AS queued_connection
+  ORDER BY queued_connection.queue_position
+  LIMIT 1
+  FOR UPDATE SKIP LOCKED;
+
+  IF v_cleanup_connection_id IS NOT NULL THEN
+    WITH used_on_revoked_connection AS MATERIALIZED (
+      SELECT authorization_code.code_hash
+      FROM auth.oauth_authorization_codes AS authorization_code
+      WHERE authorization_code.connection_id = v_cleanup_connection_id
+        AND authorization_code.used_at IS NOT NULL
+      ORDER BY authorization_code.used_at DESC, authorization_code.code_hash
+      LIMIT (100 - v_deleted_count)
+      FOR UPDATE SKIP LOCKED
+    )
+    DELETE FROM auth.oauth_authorization_codes AS authorization_code
+    USING used_on_revoked_connection
+    WHERE authorization_code.code_hash = used_on_revoked_connection.code_hash;
+  END IF;
+
+  WITH expired AS MATERIALIZED (
+    SELECT token_hash
+    FROM auth.oauth_access_tokens
+    WHERE expires_at <= now()
+    ORDER BY expires_at
+    LIMIT 100
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM auth.oauth_access_tokens AS access_token
+  USING expired
+  WHERE access_token.token_hash = expired.token_hash;
+
+  WITH expired_unused AS MATERIALIZED (
+    SELECT token_hash
+    FROM auth.oauth_refresh_tokens
+    WHERE used_at IS NULL
+      AND expires_at <= now()
+    ORDER BY expires_at, token_hash
+    LIMIT 100
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM auth.oauth_refresh_tokens AS refresh_token
+  USING expired_unused
+  WHERE refresh_token.token_hash = expired_unused.token_hash;
+
+  GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+
+  IF v_cleanup_connection_id IS NOT NULL THEN
+    WITH used_on_revoked_connection AS MATERIALIZED (
+      SELECT refresh_token.token_hash
+      FROM auth.oauth_refresh_tokens AS refresh_token
+      WHERE refresh_token.connection_id = v_cleanup_connection_id
+        AND refresh_token.used_at IS NOT NULL
+      ORDER BY refresh_token.used_at DESC, refresh_token.token_hash
+      LIMIT (100 - v_deleted_count)
+      FOR UPDATE SKIP LOCKED
+    )
+    DELETE FROM auth.oauth_refresh_tokens AS refresh_token
+    USING used_on_revoked_connection
+    WHERE refresh_token.token_hash = used_on_revoked_connection.token_hash;
+
+    DELETE FROM auth.oauth_revoked_connection_cleanup_queue AS queued_connection
+    WHERE queued_connection.connection_id = v_cleanup_connection_id
+      AND NOT EXISTS (
+        SELECT 1
+        FROM auth.oauth_authorization_codes AS authorization_code
+        WHERE authorization_code.connection_id = queued_connection.connection_id
+          AND authorization_code.used_at IS NOT NULL
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM auth.oauth_refresh_tokens AS refresh_token
+        WHERE refresh_token.connection_id = queued_connection.connection_id
+          AND refresh_token.used_at IS NOT NULL
+      );
+
+    UPDATE auth.oauth_revoked_connection_cleanup_queue AS queued_connection
+    SET queue_position = nextval('auth.oauth_revoked_cleanup_queue_position_seq'::regclass)
+    WHERE queued_connection.connection_id = v_cleanup_connection_id;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION auth.cleanup_expired_oauth_transient_state() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION auth.cleanup_expired_oauth_transient_state() TO auth_service;


### PR DESCRIPTION
Adds a database-enforced fair cleanup queue for revoked OAuth connection tombstones, preserving the existing per-table delete caps while preventing unbounded driver scans and family starvation.

Adds real Postgres coverage for bounded multi-call progress, later-family fairness, final drain, and auth_service privilege boundaries.

Local checks were not run; GitHub CI owns validation.