### PR TITLE
Fix RDS-compatible API reader migration

### DIFF
--- a/apps/sql-api/src/apiSqlReaderMigration.test.ts
+++ b/apps/sql-api/src/apiSqlReaderMigration.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const readApiSqlReaderMigration = (): string =>
+  readFileSync(
+    fileURLToPath(new URL("../../../db/migrations/0066_api_sql_reader.sql", import.meta.url)),
+    "utf8",
+  );
+
+test("API SQL reader migration uses RDS-compatible least-privilege role management", (): void => {
+  const migration = readApiSqlReaderMigration();
+
+  assert.match(migration, /CREATE ROLE api_sql_reader WITH NOLOGIN NOINHERIT;/u);
+  assert.doesNotMatch(migration, /\bALTER\s+ROLE\s+(?:api_sql_reader\b|"api_sql_reader")/iu);
+  assert.match(migration, /existing_role\.rolsuper/u);
+  assert.match(migration, /existing_role\.rolcreatedb/u);
+  assert.match(migration, /existing_role\.rolcreaterole/u);
+  assert.match(migration, /existing_role\.rolinherit/u);
+  assert.match(migration, /existing_role\.rolcanlogin/u);
+  assert.match(migration, /existing_role\.rolreplication/u);
+  assert.match(migration, /existing_role\.rolbypassrls/u);
+  assert.match(migration, /FROM pg_catalog\.pg_auth_members AS membership/u);
+  assert.match(migration, /WHERE membership\.member = existing_role\.oid/u);
+  assert.match(migration, /RAISE EXCEPTION USING/u);
+  assert.match(migration, /GRANT api_sql_reader TO app;/u);
+});

--- a/db/migrations/0066_api_sql_reader.sql
+++ b/db/migrations/0066_api_sql_reader.sql
@@ -1,16 +1,68 @@
 -- Create a least-privilege role for the read-only machine SQL endpoint.
 
 DO $$
+DECLARE
+  existing_role RECORD;
+  parent_role_names NAME[];
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'api_sql_reader') THEN
-    CREATE ROLE api_sql_reader WITH
-      NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOLOGIN NOREPLICATION NOBYPASSRLS;
+  SELECT
+    oid,
+    rolsuper,
+    rolcreatedb,
+    rolcreaterole,
+    rolinherit,
+    rolcanlogin,
+    rolreplication,
+    rolbypassrls
+  INTO existing_role
+  FROM pg_roles
+  WHERE rolname = 'api_sql_reader';
+
+  IF NOT FOUND THEN
+    CREATE ROLE api_sql_reader WITH NOLOGIN NOINHERIT;
+  ELSIF
+    existing_role.rolsuper
+    OR existing_role.rolcreatedb
+    OR existing_role.rolcreaterole
+    OR existing_role.rolinherit
+    OR existing_role.rolcanlogin
+    OR existing_role.rolreplication
+    OR existing_role.rolbypassrls
+  THEN
+    RAISE EXCEPTION USING
+      MESSAGE = 'Existing role api_sql_reader violates least-privilege requirements.',
+      DETAIL = format(
+        'Expected NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOLOGIN NOREPLICATION NOBYPASSRLS; actual values: rolsuper=%s, rolcreatedb=%s, rolcreaterole=%s, rolinherit=%s, rolcanlogin=%s, rolreplication=%s, rolbypassrls=%s.',
+        existing_role.rolsuper,
+        existing_role.rolcreatedb,
+        existing_role.rolcreaterole,
+        existing_role.rolinherit,
+        existing_role.rolcanlogin,
+        existing_role.rolreplication,
+        existing_role.rolbypassrls
+      ),
+      HINT = 'Have a database administrator repair or replace api_sql_reader with the expected attributes, then rerun migration 0066_api_sql_reader.sql.';
+  ELSE
+    SELECT array_agg(parent_role.rolname ORDER BY parent_role.rolname)
+    INTO parent_role_names
+    FROM pg_catalog.pg_auth_members AS membership
+    JOIN pg_catalog.pg_roles AS parent_role
+      ON parent_role.oid = membership.roleid
+    WHERE membership.member = existing_role.oid;
+
+    IF parent_role_names IS NOT NULL THEN
+      RAISE EXCEPTION USING
+        MESSAGE = 'Existing role api_sql_reader has unexpected outgoing role memberships.',
+        DETAIL = format(
+          'Expected no parent roles; actual parent roles: %s.',
+          array_to_string(parent_role_names, ', ')
+        ),
+        HINT = 'Have a database administrator revoke each listed parent role from api_sql_reader, then rerun migration 0066_api_sql_reader.sql.';
+    END IF;
   END IF;
 END
 $$;
 
-ALTER ROLE api_sql_reader WITH
-  NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOLOGIN NOREPLICATION NOBYPASSRLS;
 GRANT api_sql_reader TO app;
 
 REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM api_sql_reader;


### PR DESCRIPTION
## Summary

- create api_sql_reader with RDS-compatible least-privilege role options
- fail closed when an existing reader role has dangerous attributes or outgoing memberships
- add a static migration contract for the privileged ALTER ROLE regression

## Why migration 0066 is edited

The production deploy failed while applying migration 0066 inside the migration transaction. PostgreSQL rolled the transaction back, so the role creation did not persist and 0066 was not recorded in schema_migrations. Because migration execution stops at the failed file, a later migration cannot repair or bypass 0066. Editing this already-numbered migration is therefore safe and required for the unapplied production sequence.

## Validation

Local project checks were intentionally not run. GitHub CI owns executable validation.