### PR TITLE
Enable CI for integration PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: [main, integration-mcp-readonly-sql]
+    branches: [main, 'integration-*']
 
 concurrency:
   group: pull-request-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- preserve PR CI for main
- enable the same workflow for integration-* target branches

## Testing

- not run locally; GitHub CI owns executable validation