### PR TITLE
Publish MCP runtime contracts

### DIFF
--- a/apps/sql-api/src/mcp-handler.test.ts
+++ b/apps/sql-api/src/mcp-handler.test.ts
@@ -211,6 +211,7 @@ test("MCP Lambda handler consumes HTTP API v2 metadata events without REST alias
     authorization_servers: [CONFIG.issuer],
     bearer_methods_supported: ["header"],
     scopes_supported: ["expenses:read", "expenses:write"],
+    resource_documentation: "https://expense-budget-tracker.com/docs/mcp/",
   });
 });
 
@@ -273,6 +274,7 @@ test("MCP handler serves only the pathful protected-resource metadata location",
     authorization_servers: [CONFIG.issuer],
     bearer_methods_supported: ["header"],
     scopes_supported: ["expenses:read", "expenses:write"],
+    resource_documentation: "https://expense-budget-tracker.com/docs/mcp/",
   });
   assert.deepEqual(logEvents, []);
 });

--- a/apps/sql-api/src/mcp/config.ts
+++ b/apps/sql-api/src/mcp/config.ts
@@ -1,4 +1,7 @@
 export const MCP_SCOPES = ["expenses:read", "expenses:write"] as const;
+export const MCP_WEBSITE_URL = "https://expense-budget-tracker.com/";
+export const MCP_ICON_URL = "https://expense-budget-tracker.com/icon.svg";
+export const MCP_DOCUMENTATION_URL = "https://expense-budget-tracker.com/docs/mcp/";
 
 export type McpScope = typeof MCP_SCOPES[number];
 

--- a/apps/sql-api/src/mcp/resourceMetadata.ts
+++ b/apps/sql-api/src/mcp/resourceMetadata.ts
@@ -1,10 +1,15 @@
-import { MCP_SCOPES, type McpRuntimeConfig } from "./config.js";
+import {
+  MCP_DOCUMENTATION_URL,
+  MCP_SCOPES,
+  type McpRuntimeConfig,
+} from "./config.js";
 
 export type ProtectedResourceMetadata = Readonly<{
   resource: string;
   authorization_servers: ReadonlyArray<string>;
   bearer_methods_supported: ReadonlyArray<"header">;
   scopes_supported: ReadonlyArray<string>;
+  resource_documentation: string;
 }>;
 
 export const buildProtectedResourceMetadata = (
@@ -14,6 +19,7 @@ export const buildProtectedResourceMetadata = (
   authorization_servers: [config.issuer],
   bearer_methods_supported: ["header"],
   scopes_supported: [...MCP_SCOPES],
+  resource_documentation: MCP_DOCUMENTATION_URL,
 });
 
 export const buildBearerChallenge = (config: McpRuntimeConfig): string =>

--- a/apps/sql-api/src/mcp/results.ts
+++ b/apps/sql-api/src/mcp/results.ts
@@ -3,6 +3,7 @@ import {
   SqlExecutionDeadlineError,
   SqlPolicyError,
 } from "@expense-budget-tracker/agent-shared/sql-policy";
+import { z } from "zod";
 import { getSafeErrorType, log } from "../logger.js";
 import {
   isAmbiguousSqlMutationOutcomeError,
@@ -34,20 +35,95 @@ export type McpResultDependencies = Readonly<{
 
 const defaultDependencies: McpResultDependencies = { log };
 
-const buildTextContent = (payload: Readonly<Record<string, unknown>>): CallToolResult["content"] => {
+export type McpJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ReadonlyArray<McpJsonValue>
+  | McpJsonObject;
+
+export type McpJsonObject = Readonly<{ [key: string]: McpJsonValue }>;
+
+export type McpSuccessPayload<TData extends McpJsonObject> = Readonly<{
+  ok: true;
+  data: TData;
+  instructions: string;
+}>;
+
+export const mcpJsonValueSchema: z.ZodType<McpJsonValue> = z.lazy(() => z.union([
+  z.string(),
+  z.number().finite(),
+  z.boolean(),
+  z.null(),
+  z.array(mcpJsonValueSchema),
+  z.record(z.string(), mcpJsonValueSchema),
+]));
+
+const successOkSchema = z.literal(true).describe(
+  "Whether the tool call completed successfully.",
+);
+const successInstructionsSchema = z.string().min(1).describe(
+  "Actionable guidance for using the returned data.",
+);
+
+export const buildMcpSuccessOutputSchema = <TDataSchema extends z.ZodObject>(
+  dataSchema: TDataSchema,
+) => z.object({
+  ok: successOkSchema,
+  data: dataSchema,
+  instructions: successInstructionsSchema,
+});
+
+const isMcpJsonObject = (value: unknown): value is McpJsonObject =>
+  typeof value === "object"
+  && value !== null
+  && !Array.isArray(value)
+  && Object.values(value).every(isMcpJsonValue);
+
+const isMcpJsonValue = (value: unknown): value is McpJsonValue => {
+  if (
+    typeof value === "string"
+    || typeof value === "boolean"
+    || value === null
+  ) {
+    return true;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+  if (Array.isArray(value)) {
+    return value.every(isMcpJsonValue);
+  }
+  return isMcpJsonObject(value);
+};
+
+const serializePayload = (payload: Readonly<Record<string, unknown>>): string => {
   const text = JSON.stringify(payload, null, 2);
   if (text === undefined) {
     throw new Error("MCP result payload could not be serialized");
   }
-  return [{ type: "text", text }];
+  return text;
 };
 
-export const buildMcpSuccessResult = (
-  data: Readonly<Record<string, unknown>>,
+const buildTextContent = (payload: Readonly<Record<string, unknown>>): CallToolResult["content"] => {
+  return [{ type: "text", text: serializePayload(payload) }];
+};
+
+export const buildMcpSuccessResult = <TData extends Readonly<Record<string, unknown>>>(
+  data: TData,
   instructions: string,
-): CallToolResult => ({
-  content: buildTextContent({ ok: true, data, instructions }),
-});
+): CallToolResult => {
+  const text = serializePayload({ ok: true, data, instructions });
+  const payload: unknown = JSON.parse(text);
+  if (!isMcpJsonObject(payload)) {
+    throw new Error("MCP success result payload did not serialize to a JSON object");
+  }
+  return {
+    structuredContent: payload,
+    content: [{ type: "text", text }],
+  };
+};
 
 const getSqlPolicyInstructions = (error: SqlPolicyError, toolName: string): string => {
   if (error.code === "relation_not_allowed" || error.code === "invalid_relation_reference") {

--- a/apps/sql-api/src/mcp/server.test.ts
+++ b/apps/sql-api/src/mcp/server.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import {
   createSqlExecutionDeadline,
   MCP_SQL_STATEMENT_TIMEOUT_MS,
@@ -34,6 +35,60 @@ type ToolCalls = {
 
 type JsonObject = Readonly<Record<string, unknown>>;
 
+type ExpectedToolDescriptor = Readonly<{
+  name: string;
+  title: string;
+  description: string;
+  inputProperties: ReadonlyArray<string>;
+  requiredInputProperties: ReadonlyArray<string>;
+  outputDataProperties: ReadonlyArray<string>;
+  requiredOutputDataProperties: ReadonlyArray<string>;
+  scope: "expenses:read" | "expenses:write";
+}>;
+
+const EXPECTED_TOOL_DESCRIPTORS: ReadonlyArray<ExpectedToolDescriptor> = [
+  {
+    name: "list_workspaces",
+    title: "List accessible workspaces",
+    description: "Use this read-only discovery tool to list every workspace accessible to the authenticated user. It does not create or modify workspaces; pass a returned workspaceId to other tools when more than one is available.",
+    inputProperties: [],
+    requiredInputProperties: [],
+    outputDataProperties: ["workspaces"],
+    requiredOutputDataProperties: ["workspaces"],
+    scope: "expenses:read",
+  },
+  {
+    name: "get_schema",
+    title: "Inspect expense SQL schema",
+    description: "Use this read-only discovery tool before writing SQL to inspect allowed relations, columns, constraints, and agent hints for an accessible workspace. It does not expose or query system catalogs.",
+    inputProperties: ["workspaceId"],
+    requiredInputProperties: [],
+    outputDataProperties: ["limits", "relations", "workspace"],
+    requiredOutputDataProperties: ["workspace", "relations", "limits"],
+    scope: "expenses:read",
+  },
+  {
+    name: "sql_query",
+    title: "Query expense data",
+    description: "Use this read-only query tool to run exactly one policy-approved SELECT or WITH...SELECT statement against an accessible workspace. It executes in a repeatable-read, read-only transaction under the restricted SQL reader role.",
+    inputProperties: ["sql", "workspaceId"],
+    requiredInputProperties: ["sql"],
+    outputDataProperties: ["limits", "statements", "workspace"],
+    requiredOutputDataProperties: ["statements", "workspace", "limits"],
+    scope: "expenses:read",
+  },
+  {
+    name: "sql_execute",
+    title: "Execute expense data mutation",
+    description: "Use this write-capable tool only for an approved expense-data mutation. It runs exactly one policy-approved INSERT, UPDATE, or DELETE statement under the restricted SQL executor role and may destructively modify workspace data.",
+    inputProperties: ["sql", "workspaceId"],
+    requiredInputProperties: ["sql"],
+    outputDataProperties: ["limits", "statements", "workspace"],
+    requiredOutputDataProperties: ["statements", "workspace", "limits"],
+    scope: "expenses:write",
+  },
+];
+
 const isJsonObject = (value: unknown): value is JsonObject =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
@@ -48,6 +103,129 @@ const parseToolPayload = (result: Awaited<ReturnType<Client["callTool"]>>): Json
   const payload: unknown = JSON.parse(text as string);
   assert.ok(isJsonObject(payload));
   return payload;
+};
+
+const readSuccessPayload = (
+  result: Awaited<ReturnType<Client["callTool"]>>,
+): JsonObject => {
+  const payload = parseToolPayload(result);
+  assert.notEqual(result.isError, true);
+  assert.equal(payload["ok"], true);
+  assert.deepEqual(result.structuredContent, payload);
+  return payload;
+};
+
+const requireJsonObject = (value: unknown, message: string): JsonObject => {
+  assert.ok(isJsonObject(value), message);
+  return value;
+};
+
+const requireTool = (tools: ReadonlyArray<Tool>, name: string): Tool => {
+  const tool = tools.find((candidate) => candidate.name === name);
+  assert.ok(tool !== undefined, `Expected tools/list to include ${name}`);
+  return tool;
+};
+
+const assertToolSchemas = (
+  tool: Tool,
+  expected: ExpectedToolDescriptor,
+): JsonObject => {
+  const inputProperties = requireJsonObject(
+    tool.inputSchema.properties ?? {},
+    `Expected ${tool.name} input properties`,
+  );
+  assert.deepEqual(Object.keys(inputProperties).sort(), [...expected.inputProperties].sort());
+  assert.deepEqual(tool.inputSchema.required ?? [], expected.requiredInputProperties);
+
+  const outputSchema = requireJsonObject(
+    tool.outputSchema,
+    `Expected ${tool.name} output schema`,
+  );
+  assert.equal(outputSchema["type"], "object");
+  assert.deepEqual(outputSchema["required"], ["ok", "data", "instructions"]);
+  const outputProperties = requireJsonObject(
+    outputSchema["properties"],
+    `Expected ${tool.name} output properties`,
+  );
+  const okProperty = requireJsonObject(outputProperties["ok"], "Expected ok output property");
+  const dataProperty = requireJsonObject(outputProperties["data"], "Expected data output property");
+  const instructionsProperty = requireJsonObject(
+    outputProperties["instructions"],
+    "Expected instructions output property",
+  );
+  assert.equal(okProperty["type"], "boolean");
+  assert.equal(okProperty["const"], true);
+  assert.equal(dataProperty["type"], "object");
+  const dataProperties = requireJsonObject(
+    dataProperty["properties"],
+    `Expected ${tool.name} data properties`,
+  );
+  assert.deepEqual(Object.keys(dataProperties).sort(), [...expected.outputDataProperties].sort());
+  assert.deepEqual(dataProperty["required"], expected.requiredOutputDataProperties);
+  assert.equal(instructionsProperty["type"], "string");
+  assert.equal(instructionsProperty["minLength"], 1);
+  return dataProperty;
+};
+
+const readSchemaProperties = (schema: JsonObject, message: string): JsonObject =>
+  requireJsonObject(schema["properties"], message);
+
+const readArrayItemSchema = (schema: JsonObject, message: string): JsonObject => {
+  assert.equal(schema["type"], "array", message);
+  return requireJsonObject(schema["items"], message);
+};
+
+const assertWorkspaceSchema = (schema: JsonObject): void => {
+  assert.equal(schema["type"], "object");
+  assert.deepEqual(schema["required"], ["workspaceId", "name"]);
+  assert.deepEqual(Object.keys(readSchemaProperties(schema, "Expected workspace fields")).sort(), [
+    "name",
+    "workspaceId",
+  ]);
+};
+
+const assertLimitsSchema = (schema: JsonObject): void => {
+  assert.equal(schema["type"], "object");
+  assert.deepEqual(schema["required"], ["maxRows", "statementTimeoutMs"]);
+};
+
+const readSqlCommandSchema = (dataSchema: JsonObject): JsonObject => {
+  const dataProperties = readSchemaProperties(dataSchema, "Expected SQL data fields");
+  const statementsSchema = requireJsonObject(
+    dataProperties["statements"],
+    "Expected SQL statements schema",
+  );
+  const statementSchema = readArrayItemSchema(statementsSchema, "Expected SQL statement items");
+  assert.deepEqual(statementSchema["required"], [
+    "sql",
+    "command",
+    "rows",
+    "rowCount",
+    "returnedRowCount",
+    "totalRowCount",
+    "truncated",
+    "referencedRelations",
+  ]);
+  const statementProperties = readSchemaProperties(
+    statementSchema,
+    "Expected SQL statement fields",
+  );
+  const rowsSchema = requireJsonObject(statementProperties["rows"], "Expected SQL rows schema");
+  const rowSchema = readArrayItemSchema(rowsSchema, "Expected SQL row items");
+  const rowValueSchema = requireJsonObject(
+    rowSchema["additionalProperties"],
+    "Expected recursive JSON schema for SQL row values",
+  );
+  assert.notDeepEqual(rowValueSchema, {});
+
+  const workspaceSchema = requireJsonObject(
+    dataProperties["workspace"],
+    "Expected SQL workspace schema",
+  );
+  const limitsSchema = requireJsonObject(dataProperties["limits"], "Expected SQL limits schema");
+  assertWorkspaceSchema(workspaceSchema);
+  assertLimitsSchema(limitsSchema);
+  return requireJsonObject(statementProperties["command"], "Expected SQL command schema");
 };
 
 const readErrorCode = (payload: JsonObject): string => {
@@ -99,7 +277,19 @@ const createDependencies = (
   loadAllowedSchemaForWorkspace: async (_identity, workspaceId, deadline) => {
     calls.schemaWorkspaceIds.push(workspaceId);
     calls.schemaDeadlines.push(deadline);
-    return [];
+    return [{
+      name: "ledger_entries",
+      columns: [{
+        name: "amount",
+        type: "numeric",
+        nullable: false,
+        defaultValue: null,
+      }],
+      hints: {
+        optional: false,
+        notes: ["One row per account movement."],
+      },
+    }];
   },
   validateSingleReadOnlyExpenseSql,
   validateSingleMutationExpenseSql,
@@ -107,16 +297,45 @@ const createDependencies = (
     calls.queriedWorkspaceIds.push(workspaceId);
     calls.queryDeadlines.push(deadline);
     return {
-      statements: [{ sql: validated.sql, rows: [{ amount: "10.00" }] }],
+      statements: [{
+        sql: validated.sql,
+        command: "SELECT",
+        rows: [{
+          amount: "10.00",
+          postedAt: new Date("2026-08-14T12:00:00.000Z"),
+        }],
+        rowCount: 1,
+        returnedRowCount: 1,
+        totalRowCount: 1,
+        truncated: false,
+        referencedRelations: ["ledger_entries"],
+      }],
       workspace: { workspaceId, name: "Personal" },
+      limits: {
+        maxRows: 100,
+        statementTimeoutMs: deadline.timeoutMs,
+      },
     };
   },
   runSql: async (_authenticated, workspaceId, validated, deadline) => {
     calls.executedWorkspaceIds.push(workspaceId);
     calls.executeDeadlines.push(deadline);
     return {
-      statements: [{ sql: validated.sql, command: "INSERT", rowCount: 1 }],
+      statements: [{
+        sql: validated.sql,
+        command: "DELETE",
+        rows: [],
+        rowCount: 1,
+        returnedRowCount: 0,
+        totalRowCount: 1,
+        truncated: false,
+        referencedRelations: ["budget_lines"],
+      }],
       workspace: { workspaceId, name: "Personal" },
+      limits: {
+        maxRows: 100,
+        statementTimeoutMs: deadline.timeoutMs,
+      },
     };
   },
 });
@@ -152,7 +371,7 @@ const withClient = async (
   }
 };
 
-test("MCP server registers four annotated tools and routes explicit workspaces", async (): Promise<void> => {
+test("MCP server emits the public runtime contract and routes successful tool calls", async (): Promise<void> => {
   const calls = createCalls();
   const dependencies = createDependencies(
     [PERSONAL_WORKSPACE_ID, BUSINESS_WORKSPACE_ID],
@@ -164,34 +383,157 @@ test("MCP server registers four annotated tools and routes explicit workspaces",
     dependencies,
     async (client): Promise<void> => {
       const tools = (await client.listTools()).tools;
-      assert.deepEqual(tools.map((tool) => tool.name).sort(), [
-        "get_schema",
-        "list_workspaces",
-        "sql_execute",
-        "sql_query",
+      assert.deepEqual(
+        tools.map((tool) => tool.name).sort(),
+        EXPECTED_TOOL_DESCRIPTORS.map((tool) => tool.name).sort(),
+      );
+      const outputDataSchemas = new Map<string, JsonObject>();
+      for (const expected of EXPECTED_TOOL_DESCRIPTORS) {
+        const tool = requireTool(tools, expected.name);
+        assert.equal(tool.title, expected.title);
+        assert.equal(tool.description, expected.description);
+        outputDataSchemas.set(tool.name, assertToolSchemas(tool, expected));
+        assert.deepEqual(tool._meta, {
+          securitySchemes: [{ type: "oauth2", scopes: [expected.scope] }],
+        });
+        assert.equal(Object.prototype.hasOwnProperty.call(tool, "securitySchemes"), false);
+      }
+
+      const listDataSchema = requireJsonObject(
+        outputDataSchemas.get("list_workspaces"),
+        "Expected list_workspaces data schema",
+      );
+      const listDataProperties = readSchemaProperties(
+        listDataSchema,
+        "Expected list_workspaces data fields",
+      );
+      const workspacesSchema = requireJsonObject(
+        listDataProperties["workspaces"],
+        "Expected workspaces array schema",
+      );
+      assertWorkspaceSchema(readArrayItemSchema(
+        workspacesSchema,
+        "Expected workspace array items",
+      ));
+
+      const schemaDataSchema = requireJsonObject(
+        outputDataSchemas.get("get_schema"),
+        "Expected get_schema data schema",
+      );
+      const schemaDataProperties = readSchemaProperties(
+        schemaDataSchema,
+        "Expected get_schema data fields",
+      );
+      assertWorkspaceSchema(requireJsonObject(
+        schemaDataProperties["workspace"],
+        "Expected get_schema workspace schema",
+      ));
+      assertLimitsSchema(requireJsonObject(
+        schemaDataProperties["limits"],
+        "Expected get_schema limits schema",
+      ));
+      const relationsSchema = requireJsonObject(
+        schemaDataProperties["relations"],
+        "Expected relations array schema",
+      );
+      const relationSchema = readArrayItemSchema(relationsSchema, "Expected relation array items");
+      assert.deepEqual(relationSchema["required"], ["name", "columns"]);
+      const relationProperties = readSchemaProperties(
+        relationSchema,
+        "Expected relation fields",
+      );
+      const relationNameSchema = requireJsonObject(
+        relationProperties["name"],
+        "Expected relation name schema",
+      );
+      assert.deepEqual(relationNameSchema["enum"], [
+        "ledger_entries",
+        "accounts",
+        "budget_lines",
+        "workspace_settings",
+        "account_metadata",
+        "fx_rates_raw",
+        "fx_rates_daily",
       ]);
+      const columnsSchema = requireJsonObject(
+        relationProperties["columns"],
+        "Expected relation columns schema",
+      );
+      const columnSchema = readArrayItemSchema(columnsSchema, "Expected relation column items");
+      assert.deepEqual(columnSchema["required"], [
+        "name",
+        "type",
+        "nullable",
+        "defaultValue",
+      ]);
+      const hintsSchema = requireJsonObject(
+        relationProperties["hints"],
+        "Expected relation hints schema",
+      );
+      assert.deepEqual(hintsSchema["required"], ["optional", "notes"]);
+
+      const queryCommandSchema = readSqlCommandSchema(requireJsonObject(
+        outputDataSchemas.get("sql_query"),
+        "Expected sql_query data schema",
+      ));
+      assert.equal(queryCommandSchema["const"], "SELECT");
+      const executeCommandSchema = readSqlCommandSchema(requireJsonObject(
+        outputDataSchemas.get("sql_execute"),
+        "Expected sql_execute data schema",
+      ));
+      assert.deepEqual(executeCommandSchema["enum"], ["INSERT", "UPDATE", "DELETE"]);
+
       for (const toolName of ["get_schema", "list_workspaces", "sql_query"]) {
-        assert.deepEqual(tools.find((tool) => tool.name === toolName)?.annotations, {
+        assert.deepEqual(requireTool(tools, toolName).annotations, {
           readOnlyHint: true,
           destructiveHint: false,
           idempotentHint: true,
           openWorldHint: false,
         });
       }
-      assert.deepEqual(tools.find((tool) => tool.name === "sql_execute")?.annotations, {
+      assert.deepEqual(requireTool(tools, "sql_execute").annotations, {
         readOnlyHint: false,
         destructiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       });
 
+      assert.deepEqual(client.getServerVersion(), {
+        name: "expense-budget-tracker",
+        version: "1.2.0",
+        title: "Expense Budget Tracker",
+        websiteUrl: "https://expense-budget-tracker.com/",
+        icons: [{
+          src: "https://expense-budget-tracker.com/icon.svg",
+          mimeType: "image/svg+xml",
+          sizes: ["any"],
+        }],
+      });
+      const instructions = client.getInstructions();
+      assert.equal(typeof instructions, "string");
+      for (const requiredText of [
+        "list_workspaces",
+        "workspaceId",
+        "get_schema",
+        "sql_query",
+        "expenses:read",
+        "sql_execute",
+        "expenses:write",
+        "https://api.expense-budget-tracker.com/v1/",
+        "https://api.expense-budget-tracker.com/v1/openapi.json",
+        "https://api.expense-budget-tracker.com/v1/swagger.json",
+        "source-discovery compatibility probes",
+      ]) {
+        assert.equal(instructions?.includes(requiredText), true, requiredText);
+      }
+
       const listed = await client.callTool({ name: "list_workspaces", arguments: {} });
-      assert.equal(parseToolPayload(listed)["ok"], true);
+      readSuccessPayload(listed);
       const schema = await client.callTool({
         name: "get_schema",
         arguments: { workspaceId: BUSINESS_WORKSPACE_ID },
       });
-      assert.equal(parseToolPayload(schema)["ok"], true);
+      readSuccessPayload(schema);
       const query = await client.callTool({
         name: "sql_query",
         arguments: {
@@ -199,7 +541,15 @@ test("MCP server registers four annotated tools and routes explicit workspaces",
           sql: "SELECT amount FROM ledger_entries",
         },
       });
-      assert.equal(parseToolPayload(query)["ok"], true);
+      const queryPayload = readSuccessPayload(query);
+      const queryData = requireJsonObject(queryPayload["data"], "Expected sql_query data");
+      const queryStatements = queryData["statements"];
+      assert.ok(Array.isArray(queryStatements));
+      const queryStatement = requireJsonObject(queryStatements[0], "Expected sql_query statement");
+      const queryRows = queryStatement["rows"];
+      assert.ok(Array.isArray(queryRows));
+      const queryRow = requireJsonObject(queryRows[0], "Expected sql_query row");
+      assert.equal(queryRow["postedAt"], "2026-08-14T12:00:00.000Z");
       const execute = await client.callTool({
         name: "sql_execute",
         arguments: {
@@ -207,7 +557,7 @@ test("MCP server registers four annotated tools and routes explicit workspaces",
           sql: "DELETE FROM budget_lines WHERE category = 'Food'",
         },
       });
-      assert.equal(parseToolPayload(execute)["ok"], true);
+      readSuccessPayload(execute);
     },
   );
 

--- a/apps/sql-api/src/mcp/server.ts
+++ b/apps/sql-api/src/mcp/server.ts
@@ -11,11 +11,17 @@ import { z } from "zod";
 import { getReadOnlyTransactionDeadlineError } from "../dbDeadline.js";
 import type { WorkspaceSummary } from "../machineApi/types.js";
 import type { AuthenticatedMcpAccessToken } from "./auth.js";
-import type { McpScope } from "./config.js";
+import {
+  MCP_ICON_URL,
+  MCP_WEBSITE_URL,
+  type McpScope,
+} from "./config.js";
 import { mcpDataServices, type McpDataServices } from "./dataService.js";
 import {
+  buildMcpSuccessOutputSchema,
   buildMcpSuccessResult,
   buildMcpToolErrorResult,
+  mcpJsonValueSchema,
   McpToolError,
 } from "./results.js";
 
@@ -25,6 +31,8 @@ const LIST_WORKSPACES_TOOL_NAME = "list_workspaces";
 const GET_SCHEMA_TOOL_NAME = "get_schema";
 const SQL_QUERY_TOOL_NAME = "sql_query";
 const SQL_EXECUTE_TOOL_NAME = "sql_execute";
+const READ_SCOPE: McpScope = "expenses:read";
+const WRITE_SCOPE: McpScope = "expenses:write";
 type ReadOnlyMcpToolName =
   | typeof LIST_WORKSPACES_TOOL_NAME
   | typeof GET_SCHEMA_TOOL_NAME
@@ -33,6 +41,100 @@ type ReadOnlyMcpToolName =
 const workspaceIdSchema = z.string().trim().min(1).optional().describe(
   "Optional workspaceId returned by list_workspaces. Omit only when exactly one workspace is available.",
 );
+
+const allowedRelationNameSchema = z.enum([
+  "ledger_entries",
+  "accounts",
+  "budget_lines",
+  "workspace_settings",
+  "account_metadata",
+  "fx_rates_raw",
+  "fx_rates_daily",
+]);
+
+const workspaceSummarySchema = z.object({
+  workspaceId: z.string().min(1),
+  name: z.string(),
+});
+
+const limitsSchema = z.object({
+  maxRows: z.number().int().nonnegative(),
+  statementTimeoutMs: z.number().int().positive(),
+});
+
+const agentSchemaColumnConstraintSchema = z.object({
+  column: z.string(),
+  allowedValues: z.array(z.string()).optional(),
+  notes: z.array(z.string()).optional(),
+});
+
+const agentSchemaHintsSchema = z.object({
+  optional: z.boolean(),
+  primaryKey: z.array(z.string()).optional(),
+  notes: z.array(z.string()),
+  columnConstraints: z.array(agentSchemaColumnConstraintSchema).optional(),
+});
+
+const schemaRelationSchema = z.object({
+  name: allowedRelationNameSchema,
+  columns: z.array(z.object({
+    name: z.string(),
+    type: z.string(),
+    nullable: z.boolean(),
+    defaultValue: z.string().nullable(),
+  })),
+  hints: agentSchemaHintsSchema.optional(),
+});
+
+const entityHintSchema = z.object({
+  name: allowedRelationNameSchema,
+  summary: z.string(),
+});
+
+const entityHintsSchema = z.object({
+  primary: entityHintSchema,
+  related: z.array(entityHintSchema),
+});
+
+const buildSqlStatementSchema = <TCommandSchema extends z.ZodType<string>>(
+  commandSchema: TCommandSchema,
+) => z.object({
+  sql: z.string(),
+  command: commandSchema,
+  rows: z.array(z.record(z.string(), mcpJsonValueSchema)),
+  rowCount: z.number().int().nonnegative(),
+  returnedRowCount: z.number().int().nonnegative(),
+  totalRowCount: z.number().int().nonnegative(),
+  truncated: z.boolean(),
+  referencedRelations: z.array(allowedRelationNameSchema),
+  entityHints: entityHintsSchema.optional(),
+});
+
+const buildSqlResultDataSchema = <TStatementSchema extends z.ZodObject>(
+  statementSchema: TStatementSchema,
+) => z.object({
+  statements: z.array(statementSchema),
+  workspace: workspaceSummarySchema,
+  limits: limitsSchema,
+});
+
+const listWorkspacesOutputSchema = buildMcpSuccessOutputSchema(z.object({
+  workspaces: z.array(workspaceSummarySchema),
+}));
+
+const getSchemaOutputSchema = buildMcpSuccessOutputSchema(z.object({
+  workspace: workspaceSummarySchema,
+  relations: z.array(schemaRelationSchema),
+  limits: limitsSchema,
+}));
+
+const sqlQueryOutputSchema = buildMcpSuccessOutputSchema(buildSqlResultDataSchema(
+  buildSqlStatementSchema(z.literal("SELECT")),
+));
+
+const sqlExecuteOutputSchema = buildMcpSuccessOutputSchema(buildSqlResultDataSchema(
+  buildSqlStatementSchema(z.enum(["INSERT", "UPDATE", "DELETE"])),
+));
 
 export type McpServerDependencies = McpDataServices & Readonly<{
   validateSingleReadOnlyExpenseSql: typeof validateSingleReadOnlyExpenseSql;
@@ -44,6 +146,19 @@ const defaultDependencies: McpServerDependencies = {
   validateSingleReadOnlyExpenseSql,
   validateSingleMutationExpenseSql,
 };
+
+type OAuthSecurityScheme = Readonly<{
+  type: "oauth2";
+  scopes: ReadonlyArray<McpScope>;
+}>;
+
+type OpenAiToolSecurityMetadata = Readonly<{
+  securitySchemes: ReadonlyArray<OAuthSecurityScheme>;
+}>;
+
+const buildToolSecurityMetadata = (scope: McpScope): OpenAiToolSecurityMetadata => ({
+  securitySchemes: [{ type: "oauth2", scopes: [scope] }],
+});
 
 const requireScope = (
   connection: AuthenticatedMcpAccessToken,
@@ -156,28 +271,32 @@ export const createMcpServerWithDependencies = (
       name: SERVER_NAME,
       version: SERVER_VERSION,
       title: "Expense Budget Tracker",
+      websiteUrl: MCP_WEBSITE_URL,
+      icons: [{ src: MCP_ICON_URL, mimeType: "image/svg+xml", sizes: ["any"] }],
     },
     {
-      instructions: "Call list_workspaces first. Use get_schema before writing SQL, sql_query for reads, and sql_execute for approved mutations. Always pass workspaceId when more than one workspace is available.",
+      instructions: "Start with list_workspaces. If it returns multiple workspaces, pass one returned workspaceId to get_schema, sql_query, or sql_execute; workspaceId may be omitted only when exactly one workspace is available. Use get_schema before writing SQL. Use sql_query for read-only SELECT or WITH...SELECT statements requiring expenses:read. Use sql_execute only for approved INSERT, UPDATE, or DELETE mutations requiring expenses:write. Discover the canonical machine API and authentication onboarding with GET https://api.expense-budget-tracker.com/v1/. The public https://api.expense-budget-tracker.com/v1/openapi.json and https://api.expense-budget-tracker.com/v1/swagger.json routes are source-discovery compatibility probes, not OpenAPI specifications.",
     },
   );
 
   server.registerTool(
     LIST_WORKSPACES_TOOL_NAME,
     {
-      title: "List workspaces",
-      description: "Lists every workspace accessible to the authenticated user. Use returned workspaceId values with the other tools.",
+      title: "List accessible workspaces",
+      description: "Use this read-only discovery tool to list every workspace accessible to the authenticated user. It does not create or modify workspaces; pass a returned workspaceId to other tools when more than one is available.",
       inputSchema: {},
+      outputSchema: listWorkspacesOutputSchema,
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
+      _meta: buildToolSecurityMetadata(READ_SCOPE),
     },
     async (): Promise<CallToolResult> => {
       try {
-        requireScope(connection, "expenses:read");
+        requireScope(connection, READ_SCOPE);
         const workspaces = await dependencies.listWorkspaces(connection.identity, deadline);
         return buildMcpSuccessResult(
           { workspaces },
@@ -192,19 +311,21 @@ export const createMcpServerWithDependencies = (
   server.registerTool(
     GET_SCHEMA_TOOL_NAME,
     {
-      title: "Get expense schema",
-      description: "Returns the allowed SQL relations, columns, constraints, and agent hints for an accessible workspace.",
+      title: "Inspect expense SQL schema",
+      description: "Use this read-only discovery tool before writing SQL to inspect allowed relations, columns, constraints, and agent hints for an accessible workspace. It does not expose or query system catalogs.",
       inputSchema: { workspaceId: workspaceIdSchema },
+      outputSchema: getSchemaOutputSchema,
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
+      _meta: buildToolSecurityMetadata(READ_SCOPE),
     },
     async ({ workspaceId }): Promise<CallToolResult> => {
       try {
-        requireScope(connection, "expenses:read");
+        requireScope(connection, READ_SCOPE);
         const workspace = await resolveWorkspace(
           connection,
           workspaceId,
@@ -237,21 +358,23 @@ export const createMcpServerWithDependencies = (
     SQL_QUERY_TOOL_NAME,
     {
       title: "Query expense data",
-      description: "Runs exactly one policy-approved read-only SQL statement in a repeatable-read, read-only transaction under the restricted SQL reader role.",
+      description: "Use this read-only query tool to run exactly one policy-approved SELECT or WITH...SELECT statement against an accessible workspace. It executes in a repeatable-read, read-only transaction under the restricted SQL reader role.",
       inputSchema: {
         sql: z.string().trim().min(1).describe("Exactly one policy-approved SELECT or WITH...SELECT statement."),
         workspaceId: workspaceIdSchema,
       },
+      outputSchema: sqlQueryOutputSchema,
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
       },
+      _meta: buildToolSecurityMetadata(READ_SCOPE),
     },
     async ({ sql, workspaceId }): Promise<CallToolResult> => {
       try {
-        requireScope(connection, "expenses:read");
+        requireScope(connection, READ_SCOPE);
         const validated = dependencies.validateSingleReadOnlyExpenseSql(sql);
         const workspace = await resolveWorkspace(
           connection,
@@ -278,22 +401,24 @@ export const createMcpServerWithDependencies = (
   server.registerTool(
     SQL_EXECUTE_TOOL_NAME,
     {
-      title: "Execute expense mutations",
-      description: "Runs exactly one policy-approved SQL mutation under the restricted SQL executor role.",
+      title: "Execute expense data mutation",
+      description: "Use this write-capable tool only for an approved expense-data mutation. It runs exactly one policy-approved INSERT, UPDATE, or DELETE statement under the restricted SQL executor role and may destructively modify workspace data.",
       inputSchema: {
         sql: z.string().trim().min(1).describe("Exactly one policy-approved INSERT, UPDATE, or DELETE statement."),
         workspaceId: workspaceIdSchema,
       },
+      outputSchema: sqlExecuteOutputSchema,
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },
+      _meta: buildToolSecurityMetadata(WRITE_SCOPE),
     },
     async ({ sql, workspaceId }): Promise<CallToolResult> => {
       try {
-        requireScope(connection, "expenses:write");
+        requireScope(connection, WRITE_SCOPE);
         const validated = dependencies.validateSingleMutationExpenseSql(sql);
         const workspace = await resolveWorkspace(
           connection,


### PR DESCRIPTION
## Summary
- publish precise MCP tool descriptors and OAuth scope metadata
- emit validated per-tool structured output while preserving text compatibility
- expose canonical website, icon, and protected-resource documentation metadata
- cover runtime descriptors and successful tool results in tests

## Validation
- Static review passed with no P0-P4 findings
- Local project checks intentionally not run; GitHub CI owns validation