### PR TITLE
fix(mcp): update runtime documentation URL

### DIFF
--- a/apps/sql-api/src/mcp-handler.test.ts
+++ b/apps/sql-api/src/mcp-handler.test.ts
@@ -211,7 +211,7 @@ test("MCP Lambda handler consumes HTTP API v2 metadata events without REST alias
     authorization_servers: [CONFIG.issuer],
     bearer_methods_supported: ["header"],
     scopes_supported: ["expenses:read", "expenses:write"],
-    resource_documentation: "https://expense-budget-tracker.com/docs/mcp/",
+    resource_documentation: "https://expense-budget-tracker.com/docs/mcp-connector/",
   });
 });
 
@@ -274,7 +274,7 @@ test("MCP handler serves only the pathful protected-resource metadata location",
     authorization_servers: [CONFIG.issuer],
     bearer_methods_supported: ["header"],
     scopes_supported: ["expenses:read", "expenses:write"],
-    resource_documentation: "https://expense-budget-tracker.com/docs/mcp/",
+    resource_documentation: "https://expense-budget-tracker.com/docs/mcp-connector/",
   });
   assert.deepEqual(logEvents, []);
 });

--- a/apps/sql-api/src/mcp/config.ts
+++ b/apps/sql-api/src/mcp/config.ts
@@ -1,7 +1,7 @@
 export const MCP_SCOPES = ["expenses:read", "expenses:write"] as const;
 export const MCP_WEBSITE_URL = "https://expense-budget-tracker.com/";
 export const MCP_ICON_URL = "https://expense-budget-tracker.com/icon.svg";
-export const MCP_DOCUMENTATION_URL = "https://expense-budget-tracker.com/docs/mcp/";
+export const MCP_DOCUMENTATION_URL = "https://expense-budget-tracker.com/docs/mcp-connector/";
 
 export type McpScope = typeof MCP_SCOPES[number];
 


### PR DESCRIPTION
## Summary
- point MCP runtime metadata at the canonical connector guide
- update the exact protected-resource metadata assertions

## Validation
- not run locally; cloud CI owns executable validation