### PR TITLE
Publish MCP Registry release contract

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -40,8 +40,8 @@ jobs:
             'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json' \
             --output "${schema_path}"
           npx --yes ajv-cli@5 validate \
-            --schema "${schema_path}" \
-            --data server.json \
+            -s "${schema_path}" \
+            -d server.json \
             --strict=false
 
       - name: Check version alignment

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,0 +1,212 @@
+name: MCP Registry Publish
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: mcp-registry-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish server.json to MCP Registry
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Require main branch dispatch
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::MCP Registry publication must be dispatched from main after the shared version lands there. Current ref: ${GITHUB_REF}. Re-run this workflow with branch 'main' selected."
+            exit 1
+          fi
+
+      - name: Validate MCP Registry manifest
+        run: |
+          set -euo pipefail
+          schema_path="${RUNNER_TEMP}/mcp-server-schema-2025-12-11.json"
+          curl --fail --location --show-error --silent \
+            --retry 2 --retry-delay 2 --retry-all-errors \
+            'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json' \
+            --output "${schema_path}"
+          npx --yes ajv-cli@5 validate \
+            --schema "${schema_path}" \
+            --data server.json \
+            --strict=false
+
+      - name: Check version alignment
+        run: node scripts/checks/pr/check-version-alignment.mjs
+
+      - name: Check unpublished Registry version
+        id: manifest
+        run: |
+          set -euo pipefail
+          server_name="$(jq -r '.name // empty' server.json)"
+          server_version="$(jq -r '.version // empty' server.json)"
+
+          if [ -z "${server_name}" ]; then
+            echo "::error::server.json must include a non-empty .name before publication."
+            exit 1
+          fi
+          if [ -z "${server_version}" ]; then
+            echo "::error::server.json must include a non-empty .version before publication."
+            exit 1
+          fi
+
+          encoded_name="$(printf '%s' "${server_name}" | jq -sRr @uri)"
+          encoded_version="$(printf '%s' "${server_version}" | jq -sRr @uri)"
+          version_endpoint="https://registry.modelcontextprotocol.io/v0.1/servers/${encoded_name}/versions/${encoded_version}"
+          response_body="${RUNNER_TEMP}/mcp-registry-version-before.json"
+          max_attempts=3
+          retry_delay_seconds=5
+
+          for attempt in $(seq 1 "${max_attempts}"); do
+            : > "${response_body}"
+            set +e
+            status="$(curl --show-error --silent \
+              --output "${response_body}" \
+              --write-out '%{http_code}' \
+              "${version_endpoint}")"
+            curl_exit=$?
+            set -e
+
+            if [ "${curl_exit}" -eq 0 ] && [ "${status}" = "404" ]; then
+              {
+                echo "name=${server_name}"
+                echo "version=${server_version}"
+                echo "version_endpoint=${version_endpoint}"
+              } >> "${GITHUB_OUTPUT}"
+              echo "MCP Registry version is unpublished: ${server_name} ${server_version}"
+              exit 0
+            fi
+
+            if [ "${curl_exit}" -eq 0 ] && [ "${status}" = "200" ]; then
+              echo "::error::MCP Registry version ${server_name} ${server_version} already exists at ${version_endpoint}. Registry versions are immutable; use the next shared product version before publishing changed metadata."
+              exit 1
+            fi
+
+            if [ "${attempt}" -lt "${max_attempts}" ]; then
+              if [ "${curl_exit}" -ne 0 ]; then
+                echo "::warning::Registry lookup failed with curl exit code ${curl_exit}; retrying ${version_endpoint} in ${retry_delay_seconds}s (${attempt}/${max_attempts})."
+              else
+                echo "::warning::Registry lookup returned HTTP ${status}; retrying ${version_endpoint} in ${retry_delay_seconds}s (${attempt}/${max_attempts})."
+              fi
+              sleep "${retry_delay_seconds}"
+              continue
+            fi
+
+            if [ "${curl_exit}" -ne 0 ]; then
+              echo "::error::Registry lookup failed after ${max_attempts} attempts for ${version_endpoint}; last curl exit code: ${curl_exit}."
+            else
+              echo "::error::Registry lookup failed after ${max_attempts} attempts for ${version_endpoint}; last HTTP status: ${status}. Response body follows."
+              cat "${response_body}"
+            fi
+            exit 1
+          done
+
+      - name: Require Registry credential
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MCP_PRIVATE_KEY}" ]; then
+            echo "::error::MCP_PRIVATE_KEY is not configured. Run scripts/cloudflare/setup-mcp-registry-credential.sh as documented in docs/mcp-registry-publishing.md before dispatching this workflow."
+            exit 1
+          fi
+
+      - name: Install mcp-publisher CLI
+        id: publisher
+        run: |
+          set -euo pipefail
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          archive_path="${RUNNER_TEMP}/mcp-publisher.tar.gz"
+          publisher_path="${RUNNER_TEMP}/mcp-publisher"
+          curl --fail --location --show-error --silent \
+            --retry 2 --retry-delay 2 --retry-all-errors \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${os}_${arch}.tar.gz" \
+            --output "${archive_path}"
+          tar --extract --gzip --file "${archive_path}" --directory "${RUNNER_TEMP}" mcp-publisher
+          chmod 700 "${publisher_path}"
+          echo "path=${publisher_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Authenticate to MCP Registry with DNS
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+          MCP_PUBLISHER: ${{ steps.publisher.outputs.path }}
+        run: |
+          set -euo pipefail
+          "${MCP_PUBLISHER}" login dns \
+            --domain expense-budget-tracker.com \
+            --private-key "${MCP_PRIVATE_KEY}"
+
+      - name: Publish server to MCP Registry
+        env:
+          MCP_PUBLISHER: ${{ steps.publisher.outputs.path }}
+        run: |
+          set -euo pipefail
+          "${MCP_PUBLISHER}" publish
+
+      - name: Verify published Registry version
+        env:
+          SERVER_NAME: ${{ steps.manifest.outputs.name }}
+          SERVER_VERSION: ${{ steps.manifest.outputs.version }}
+          VERSION_ENDPOINT: ${{ steps.manifest.outputs.version_endpoint }}
+        run: |
+          set -euo pipefail
+          response_body="${RUNNER_TEMP}/mcp-registry-version-after.json"
+          max_attempts=6
+          retry_delay_seconds=10
+
+          for attempt in $(seq 1 "${max_attempts}"); do
+            : > "${response_body}"
+            set +e
+            status="$(curl --show-error --silent \
+              --output "${response_body}" \
+              --write-out '%{http_code}' \
+              "${VERSION_ENDPOINT}")"
+            curl_exit=$?
+            set -e
+
+            if [ "${curl_exit}" -eq 0 ] && [ "${status}" = "200" ]; then
+              {
+                echo "## MCP Registry publication"
+                echo ""
+                echo "- Published SHA: \`${GITHUB_SHA}\`"
+                echo "- Manifest: \`server.json\`"
+                echo "- Registry name: \`${SERVER_NAME}\`"
+                echo "- Registry version: \`${SERVER_VERSION}\`"
+                echo "- Verified endpoint: \`${VERSION_ENDPOINT}\`"
+                echo "- Remote endpoint: \`https://mcp.expense-budget-tracker.com/mcp\`"
+              } >> "${GITHUB_STEP_SUMMARY}"
+              exit 0
+            fi
+
+            if [ "${attempt}" -lt "${max_attempts}" ]; then
+              if [ "${curl_exit}" -ne 0 ]; then
+                echo "::warning::Published version verification failed with curl exit code ${curl_exit}; retrying in ${retry_delay_seconds}s (${attempt}/${max_attempts})."
+              else
+                echo "::warning::Published version verification returned HTTP ${status}; retrying in ${retry_delay_seconds}s (${attempt}/${max_attempts})."
+              fi
+              sleep "${retry_delay_seconds}"
+              continue
+            fi
+
+            if [ "${curl_exit}" -ne 0 ]; then
+              echo "::error::Published version verification failed after ${max_attempts} attempts for ${VERSION_ENDPOINT}; last curl exit code: ${curl_exit}."
+            else
+              echo "::error::Published version verification failed after ${max_attempts} attempts for ${VERSION_ENDPOINT}; last HTTP status: ${status}. Response body follows."
+              cat "${response_body}"
+            fi
+            exit 1
+          done

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -69,6 +69,10 @@ jobs:
               - '.nvmrc'
               - 'package.json'
               - 'package-lock.json'
+            mcp_registry:
+              - 'server.json'
+              - '.github/workflows/mcp-registry-publish.yml'
+              - '.github/workflows/pull-request.yml'
             sql_api_tests:
               - 'apps/sql-api/**'
               - 'packages/agent-shared/**'
@@ -92,6 +96,20 @@ jobs:
               - '.nvmrc'
               - 'package.json'
               - 'package-lock.json'
+
+      - name: Validate MCP Registry manifest
+        if: steps.changes.outputs.mcp_registry == 'true'
+        run: |
+          set -euo pipefail
+          schema_path="${RUNNER_TEMP}/mcp-server-schema-2025-12-11.json"
+          curl --fail --location --show-error --silent \
+            --retry 2 --retry-delay 2 --retry-all-errors \
+            'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json' \
+            --output "${schema_path}"
+          npx --yes ajv-cli@5 validate \
+            --schema "${schema_path}" \
+            --data server.json \
+            --strict=false
 
       - name: Set up npm
         if: steps.changes.outputs.code == 'true'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -107,8 +107,8 @@ jobs:
             'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json' \
             --output "${schema_path}"
           npx --yes ajv-cli@5 validate \
-            --schema "${schema_path}" \
-            --data server.json \
+            -s "${schema_path}" \
+            -d server.json \
             --strict=false
 
       - name: Set up npm

--- a/docs/mcp-registry-publishing.md
+++ b/docs/mcp-registry-publishing.md
@@ -1,0 +1,190 @@
+# Publishing to the MCP Registry
+
+This is the canonical operator guide for publishing the hosted Expense Budget
+Tracker MCP server to the official MCP Registry. The Registry manifest is the
+root [`server.json`](../server.json). Publication is intentionally manual and
+independent of the ordinary application deploy.
+
+The server uses the DNS-owned Registry name
+`com.expense-budget-tracker/expense-budget-tracker` and the hosted Streamable
+HTTP endpoint `https://mcp.expense-budget-tracker.com/mcp`. The DNS namespace is
+authenticated by an Ed25519 ownership proof at `expense-budget-tracker.com`.
+
+The MCP Registry is preview software. Recheck the official
+[authentication](https://modelcontextprotocol.io/registry/authentication),
+[remote-server](https://modelcontextprotocol.io/registry/remote-servers), and
+[versioning](https://modelcontextprotocol.io/registry/versioning) requirements
+before credential setup or publication.
+
+## What is published
+
+`server.json` publishes metadata only. It points clients to the existing remote
+server and does not package or deploy application code. The manifest includes:
+
+- the domain-owned Registry name and shared product version;
+- the public GitHub repository and stable repository identifier;
+- the hosted Streamable HTTP MCP endpoint;
+- first-party website, [MCP connector guide](https://expense-budget-tracker.com/docs/mcp-connector/),
+  API documentation, support, privacy, and terms links;
+- SVG and PNG icons; and
+- publisher metadata describing categories, authentication, and the four tools.
+
+The publisher-provided metadata must remain below the Registry's 4,096-byte
+limit. Keep detailed operational documentation in the linked pages instead of
+expanding the manifest indefinitely.
+
+## Pull-request validation
+
+The required `PR Quality Gate` runs the shared version-alignment checker on
+every pull request. When `server.json` or either Registry workflow changes, the
+same required job also downloads the pinned 2025-12-11 schema and validates the
+manifest. These checks do not use `MCP_PRIVATE_KEY` and cannot publish.
+
+Do not create a separate version checker or Registry validation workflow. Keep
+the shared version in `server.json` aligned by following
+[`version-bump.md`](version-bump.md).
+
+## Prerequisites
+
+Complete credential setup and first publication only after this workflow and
+manifest have been promoted to `main` and an operator has approved the external
+writes.
+
+The setup operator needs:
+
+- repository-admin access through an authenticated GitHub CLI session;
+- `curl`, `dig`, `gh`, `openssl`, `python3`, and `base64`;
+- `scripts/cloudflare/.env` with `CLOUDFLARE_API_TOKEN` and
+  `CLOUDFLARE_ZONE_ID`; and
+- a Cloudflare token that can read the zone and create DNS records for
+  `expense-budget-tracker.com`.
+
+The setup script verifies that the current checkout resolves to
+`kirill-markin/expense-budget-tracker` and that the configured Cloudflare zone
+is exactly `expense-budget-tracker.com` before it writes anything.
+
+## One-time credential setup
+
+From the repository root on `main`, run:
+
+```sh
+bash scripts/cloudflare/setup-mcp-registry-credential.sh
+```
+
+The script reads the existing gitignored Cloudflare credentials, inspects all
+root TXT records and the GitHub secret list, and changes state only when both the
+MCP ownership proof and `MCP_PRIVATE_KEY` are absent. It then:
+
+1. generates one Ed25519 keypair in a restricted temporary directory;
+2. adds one root TXT record in the form
+   `v=MCPv1; k=ed25519; p=<PUBLIC_KEY>` without replacing unrelated TXT records;
+3. re-reads Cloudflare state and stores the 64-character private key as the
+   `MCP_PRIVATE_KEY` GitHub Actions secret;
+4. verifies the exact proof through Cloudflare and Google public DNS resolvers;
+   and
+5. removes local key material without printing the private key.
+
+When both the valid TXT proof and GitHub secret already exist, the script
+verifies public DNS and exits without rotating the credential. It fails on a
+malformed, duplicate, or one-sided state and prints the corresponding recovery
+action.
+
+## Manual publication
+
+Before dispatching, confirm every URL in `server.json` is public and returns the
+intended content or authentication response. In particular, verify the MCP
+guide, API guide, support, privacy, terms, three icon URLs, and the hosted MCP
+endpoint.
+
+Confirm that the exact manifest version is still absent. For version `1.2.0`:
+
+```sh
+curl -i \
+  'https://registry.modelcontextprotocol.io/v0.1/servers/com.expense-budget-tracker%2Fexpense-budget-tracker/versions/1.2.0'
+```
+
+HTTP 404 is the publishable state. HTTP 200 means the immutable version already
+exists and must not be republished with changed metadata.
+
+Dispatch the workflow explicitly from `main`:
+
+```sh
+gh workflow run mcp-registry-publish.yml \
+  --repo kirill-markin/expense-budget-tracker \
+  --ref main
+```
+
+The workflow rejects every non-`main` ref. Before reading the private key, it
+validates `server.json`, runs the shared version checker, and confirms that the
+exact name/version returns 404. It then downloads the current official
+`mcp-publisher`, authenticates the DNS namespace, publishes, retries exact
+version verification, and writes a secret-free GitHub job summary.
+
+## Successful verification
+
+Read the exact published record:
+
+```sh
+server_version="$(jq -r '.version' server.json)"
+curl -fsS \
+  "https://registry.modelcontextprotocol.io/v0.1/servers/com.expense-budget-tracker%2Fexpense-budget-tracker/versions/${server_version}"
+```
+
+Also check the Registry's latest search result:
+
+```sh
+curl -fsS \
+  'https://registry.modelcontextprotocol.io/v0.1/servers?search=com.expense-budget-tracker%2Fexpense-budget-tracker&version=latest'
+```
+
+Confirm the returned name, version, remote URL, repository identity, website,
+documentation, support, privacy, terms, and icon URLs. A successful workflow
+summary records the published commit and exact verification endpoint without
+including credentials.
+
+## Immutable-version behavior
+
+Registry name/version pairs are immutable. The manual workflow treats:
+
+- HTTP 404 from the exact version endpoint as permission to continue; and
+- HTTP 200 as a hard duplicate error requiring a later shared product version.
+
+Do not edit and retry an already published version. Do not switch back to the
+abandoned `io.github.kirill-markin/expense-budget-tracker` identity.
+
+## Publication after a version bump
+
+Use this order for every later release:
+
+1. Follow [`version-bump.md`](version-bump.md) so every product, runtime,
+   lockfile, and `server.json` version is identical.
+2. Merge and promote the release to `main` through the normal reviewed flow.
+3. Confirm the deployed remote and every public manifest URL are healthy.
+4. Confirm the new exact Registry name/version returns 404.
+5. Dispatch `mcp-registry-publish.yml` from `main`.
+6. Verify the exact record and latest search response.
+
+Application deployment does not publish Registry metadata automatically.
+
+## Credential recovery and rotation
+
+The GitHub secret value cannot be read back. The setup script therefore refuses
+to guess whether a one-sided state matches and never rotates credentials
+silently.
+
+- TXT proof present, secret missing: restore the original matching private key
+  as `MCP_PRIVATE_KEY`. If it is unavailable, remove only that MCP ownership TXT
+  record, verify its public disappearance, and rerun the setup script.
+- Secret present, TXT proof missing: restore the matching public proof if the
+  private key is recoverable. Otherwise delete `MCP_PRIVATE_KEY` and rerun after
+  confirming that no MCP ownership TXT record remains.
+- Multiple or malformed MCP proofs: determine which key is intended, then
+  remove only the duplicate or malformed records beginning with `v=MCPv1;`.
+  Preserve SPF, DKIM, site-verification, and every other unrelated TXT record.
+- Ambiguous GitHub secret update: inspect whether `MCP_PRIVATE_KEY` exists. For
+  a clean rotation, delete both the secret and only its matching MCP ownership
+  TXT proof before rerunning.
+
+Credential deletion and DNS changes are deliberate operator actions. Perform
+them only with explicit approval and never as part of ordinary deployment or
+pull-request validation.

--- a/scripts/cloudflare/setup-mcp-registry-credential.sh
+++ b/scripts/cloudflare/setup-mcp-registry-credential.sh
@@ -1,0 +1,497 @@
+#!/usr/bin/env bash
+# Provision the MCP Registry DNS ownership proof and GitHub Actions secret.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLOUDFLARE_ENV_FILE="${SCRIPT_DIR}/.env"
+DOMAIN="expense-budget-tracker.com"
+EXPECTED_REPO="kirill-markin/expense-budget-tracker"
+SECRET_NAME="MCP_PRIVATE_KEY"
+KEY_DIR=""
+KEY_FILE=""
+PRIVATE_KEY=""
+
+if [[ $# -ne 0 ]]; then
+  echo "ERROR: This script accepts no arguments; it provisions ${DOMAIN} for ${EXPECTED_REPO}." >&2
+  exit 1
+fi
+
+if [[ ! -f "$CLOUDFLARE_ENV_FILE" ]]; then
+  echo "ERROR: Missing ${CLOUDFLARE_ENV_FILE}. Add CLOUDFLARE_API_TOKEN and CLOUDFLARE_ZONE_ID to that gitignored file before running this script." >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$CLOUDFLARE_ENV_FILE"
+set +a
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/cloudflare-api.sh"
+
+require_command() {
+  local command_name="$1"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "ERROR: ${command_name} is required to provision the MCP Registry credential." >&2
+    exit 1
+  fi
+}
+
+require_command base64
+require_command curl
+require_command dig
+require_command gh
+require_command mktemp
+require_command openssl
+require_command python3
+
+cloudflare_require_api_token
+: "${CLOUDFLARE_ZONE_ID:?Set CLOUDFLARE_ZONE_ID in scripts/cloudflare/.env}"
+cloudflare_prepare_curl_config
+
+cleanup() {
+  unset PRIVATE_KEY
+  if [[ -n "$KEY_FILE" && -f "$KEY_FILE" ]]; then
+    rm -f -- "$KEY_FILE"
+  fi
+  if [[ -n "$KEY_DIR" && -d "$KEY_DIR" && ! -L "$KEY_DIR" ]]; then
+    if ! rmdir -- "$KEY_DIR"; then
+      echo "WARNING: Temporary MCP Registry key directory ${KEY_DIR} contains unexpected files and was not removed." >&2
+    fi
+  fi
+  cloudflare_cleanup_curl_config
+}
+trap 'cleanup' EXIT
+trap 'cleanup; exit 129' HUP
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+run_gh_read() {
+  local operation="$1"
+  shift
+  local error_file
+  error_file="$(mktemp)"
+  local attempt=1
+  local max_attempts=3
+
+  while [[ "$attempt" -le "$max_attempts" ]]; do
+    local output
+    local command_status
+    if output=$("$@" 2>"$error_file"); then
+      rm -f -- "$error_file"
+      printf '%s' "$output"
+      return 0
+    else
+      command_status=$?
+    fi
+
+    if [[ "$attempt" -lt "$max_attempts" ]]; then
+      echo "WARNING: ${operation} failed with status ${command_status}; retrying in 2 seconds (${attempt}/${max_attempts})." >&2
+      sleep 2
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    echo "ERROR: ${operation} failed after ${max_attempts} attempts with status ${command_status}." >&2
+    sed -n '1,40p' "$error_file" >&2
+    rm -f -- "$error_file"
+    return "$command_status"
+  done
+}
+
+fetch_github_secrets() {
+  local repository="$1"
+  run_gh_read \
+    "GitHub Actions secret lookup for ${repository}" \
+    gh secret list --repo "$repository" --json name
+}
+
+github_secret_exists() {
+  local secrets_json="$1"
+
+  python3 -c '
+import json
+import sys
+
+secrets = json.loads(sys.argv[1])
+secret_name = sys.argv[2]
+if not isinstance(secrets, list):
+    print("ERROR: GitHub secret lookup did not return a JSON array.", file=sys.stderr)
+    raise SystemExit(2)
+raise SystemExit(0 if any(
+    isinstance(secret, dict) and secret.get("name") == secret_name
+    for secret in secrets
+) else 1)
+' "$secrets_json" "$SECRET_NAME"
+}
+
+fetch_root_txt_records() {
+  cloudflare_read_all_dns_records \
+    "read root TXT records for MCP Registry ownership" \
+    "/zones/${CLOUDFLARE_ZONE_ID}/dns_records?type=TXT&name=${DOMAIN}&per_page=100"
+}
+
+classify_mcp_txt_records() {
+  python3 -c '
+import base64
+import binascii
+import json
+import re
+import sys
+
+domain = sys.argv[1].rstrip(".").lower()
+response = json.load(sys.stdin)
+records = response.get("result")
+if response.get("success") is not True or not isinstance(records, list):
+    print("ERROR: Cloudflare TXT lookup did not return a successful result array.", file=sys.stderr)
+    raise SystemExit(1)
+
+root_txt_records = [
+    record
+    for record in records
+    if isinstance(record, dict)
+    and str(record.get("name", "")).rstrip(".").lower() == domain
+    and record.get("type") == "TXT"
+]
+candidates = [
+    record
+    for record in root_txt_records
+    if str(record.get("content", "")).startswith("v=MCPv1;")
+]
+pattern = re.compile(r"^v=MCPv1; k=ed25519; p=([A-Za-z0-9+/]+={0,2})$")
+valid = []
+invalid = []
+for record in candidates:
+    content = str(record.get("content", ""))
+    match = pattern.fullmatch(content)
+    if match is None:
+        invalid.append(record)
+        continue
+    try:
+        decoded = base64.b64decode(match.group(1), validate=True)
+    except (binascii.Error, ValueError):
+        invalid.append(record)
+        continue
+    if len(decoded) != 32:
+        invalid.append(record)
+        continue
+    valid.append(record)
+
+print(json.dumps({
+    "rootTxtCount": len(root_txt_records),
+    "candidateCount": len(candidates),
+    "validCount": len(valid),
+    "invalidCount": len(invalid),
+    "validContent": valid[0].get("content", "") if len(valid) == 1 else "",
+}))
+' "$DOMAIN"
+}
+
+read_mcp_dns_state() {
+  local records
+  records="$(fetch_root_txt_records)"
+  printf '%s' "$records" | classify_mcp_txt_records
+}
+
+reconcile_created_txt_record() {
+  local expected_content="$1"
+  local max_attempts=5
+  local attempt=1
+
+  while [[ "$attempt" -le "$max_attempts" ]]; do
+    local state
+    local valid_count
+    local invalid_count
+    local valid_content
+    state="$(read_mcp_dns_state)"
+    valid_count="$(printf '%s' "$state" | python3 -c 'import json,sys; print(json.load(sys.stdin)["validCount"])')"
+    invalid_count="$(printf '%s' "$state" | python3 -c 'import json,sys; print(json.load(sys.stdin)["invalidCount"])')"
+    valid_content="$(printf '%s' "$state" | python3 -c 'import json,sys; print(json.load(sys.stdin)["validContent"])')"
+
+    if [[ "$valid_count" -eq 1 && "$invalid_count" -eq 0 && "$valid_content" == "$expected_content" ]]; then
+      return 0
+    fi
+    if [[ "$valid_count" -gt 0 || "$invalid_count" -gt 0 ]]; then
+      echo "ERROR: Cloudflare reconciliation found MCP Registry TXT state that does not match the generated key; valid=${valid_count}, invalid=${invalid_count}." >&2
+      return 1
+    fi
+
+    if [[ "$attempt" -lt "$max_attempts" ]]; then
+      echo "WARNING: The created MCP Registry TXT record is not visible through the Cloudflare API; retrying in 2 seconds (${attempt}/${max_attempts})." >&2
+      sleep 2
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "ERROR: The Cloudflare TXT-create outcome remains unknown after ${max_attempts} complete state reads." >&2
+  return "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS"
+}
+
+verify_public_dns() {
+  local expected_content="$1"
+  local max_attempts=30
+  local retry_delay_seconds=10
+  local -a resolvers=("1.1.1.1" "8.8.8.8")
+  local attempt=1
+
+  while [[ "$attempt" -le "$max_attempts" ]]; do
+    local all_resolvers_match=true
+    local resolver
+    for resolver in "${resolvers[@]}"; do
+      local answers
+      if answers=$(dig +time=5 +tries=1 +short TXT "$DOMAIN" "@${resolver}"); then
+        if ! printf '%s\n' "$answers" | python3 -c '
+import shlex
+import sys
+
+expected = sys.argv[1]
+answers = []
+for line in sys.stdin:
+    stripped = line.strip()
+    if not stripped:
+        continue
+    try:
+        answers.append("".join(shlex.split(stripped)))
+    except ValueError:
+        raise SystemExit(2)
+raise SystemExit(0 if expected in answers else 1)
+' "$expected_content"; then
+          all_resolvers_match=false
+        fi
+      else
+        all_resolvers_match=false
+      fi
+    done
+
+    if [[ "$all_resolvers_match" == "true" ]]; then
+      echo "Verified the MCP Registry ownership TXT record through Cloudflare and Google public DNS resolvers."
+      return 0
+    fi
+
+    if [[ "$attempt" -lt "$max_attempts" ]]; then
+      echo "WARNING: MCP Registry ownership TXT propagation is incomplete; retrying in ${retry_delay_seconds} seconds (${attempt}/${max_attempts})." >&2
+      sleep "$retry_delay_seconds"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "ERROR: The MCP Registry ownership TXT record did not appear through both public resolvers after ${max_attempts} attempts." >&2
+  echo "ACTION: Wait for DNS propagation, then rerun this script. It will reuse the existing DNS record and will not rotate the key." >&2
+  return 1
+}
+
+set_github_secret() {
+  local repository="$1"
+  local private_key="$2"
+  local error_file
+  error_file="$(mktemp)"
+  local attempt=1
+  local max_attempts=3
+
+  while [[ "$attempt" -le "$max_attempts" ]]; do
+    local command_status
+    if printf '%s' "$private_key" | gh secret set "$SECRET_NAME" --repo "$repository" 2>"$error_file" >/dev/null; then
+      rm -f -- "$error_file"
+      return 0
+    else
+      command_status=$?
+    fi
+
+    if [[ "$attempt" -lt "$max_attempts" ]]; then
+      echo "WARNING: GitHub secret update failed with status ${command_status}; retrying the same key in 2 seconds (${attempt}/${max_attempts})." >&2
+      sleep 2
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    echo "ERROR: GitHub secret update failed after ${max_attempts} attempts with status ${command_status}." >&2
+    sed -n '1,40p' "$error_file" >&2
+    rm -f -- "$error_file"
+    return "$command_status"
+  done
+}
+
+REPO="$(run_gh_read "GitHub repository resolution" gh repo view --json nameWithOwner --jq .nameWithOwner)"
+if [[ "$REPO" != "$EXPECTED_REPO" ]]; then
+  echo "ERROR: Current checkout resolves to GitHub repository ${REPO}; expected ${EXPECTED_REPO}." >&2
+  echo "ACTION: Run this script from the ${EXPECTED_REPO} checkout." >&2
+  exit 1
+fi
+
+ZONE_RESPONSE="$(cloudflare_api_request \
+  "read MCP Registry credential zone" \
+  "GET" \
+  "/zones/${CLOUDFLARE_ZONE_ID}" \
+  "")"
+ZONE_NAME="$(printf '%s' "$ZONE_RESPONSE" | python3 -c '
+import json
+import sys
+
+response = json.load(sys.stdin)
+result = response.get("result")
+name = result.get("name") if isinstance(result, dict) else None
+if response.get("success") is not True or not isinstance(name, str) or not name:
+    print("ERROR: Cloudflare zone lookup returned no valid zone name.", file=sys.stderr)
+    raise SystemExit(1)
+print(name.rstrip(".").lower())
+')"
+if [[ "$ZONE_NAME" != "$DOMAIN" ]]; then
+  echo "ERROR: CLOUDFLARE_ZONE_ID resolves to ${ZONE_NAME}; expected ${DOMAIN}." >&2
+  echo "ACTION: Correct scripts/cloudflare/.env before provisioning the Registry credential." >&2
+  exit 1
+fi
+
+GITHUB_SECRETS_JSON="$(fetch_github_secrets "$REPO")"
+if github_secret_exists "$GITHUB_SECRETS_JSON"; then
+  GITHUB_SECRET_EXISTS=true
+else
+  secret_lookup_status=$?
+  if [[ "$secret_lookup_status" -ne 1 ]]; then
+    exit "$secret_lookup_status"
+  fi
+  GITHUB_SECRET_EXISTS=false
+fi
+
+DNS_STATE="$(read_mcp_dns_state)"
+MCP_VALID_COUNT="$(printf '%s' "$DNS_STATE" | python3 -c 'import json,sys; print(json.load(sys.stdin)["validCount"])')"
+MCP_INVALID_COUNT="$(printf '%s' "$DNS_STATE" | python3 -c 'import json,sys; print(json.load(sys.stdin)["invalidCount"])')"
+MCP_VALID_CONTENT="$(printf '%s' "$DNS_STATE" | python3 -c 'import json,sys; print(json.load(sys.stdin)["validContent"])')"
+
+if [[ "$MCP_INVALID_COUNT" -gt 0 ]]; then
+  echo "ERROR: Found ${MCP_INVALID_COUNT} malformed or unsupported MCP Registry TXT record(s) at ${DOMAIN}." >&2
+  echo "ACTION: Resolve only the root TXT records beginning with 'v=MCPv1;' before rerunning; preserve all unrelated TXT records." >&2
+  exit 1
+fi
+if [[ "$MCP_VALID_COUNT" -gt 1 ]]; then
+  echo "ERROR: Found ${MCP_VALID_COUNT} valid MCP Registry ownership TXT records at ${DOMAIN}; exactly one is allowed." >&2
+  echo "ACTION: Keep the record matching the intended ${SECRET_NAME} key and remove only duplicate MCP Registry records before rerunning." >&2
+  exit 1
+fi
+
+if [[ "$MCP_VALID_COUNT" -eq 1 && "$GITHUB_SECRET_EXISTS" == "true" ]]; then
+  verify_public_dns "$MCP_VALID_CONTENT"
+  echo "MCP Registry credential is already configured for ${DOMAIN} and ${REPO}; no key was generated and no state was changed."
+  exit 0
+fi
+if [[ "$MCP_VALID_COUNT" -eq 1 && "$GITHUB_SECRET_EXISTS" == "false" ]]; then
+  echo "ERROR: Partial MCP Registry credential state: a valid ownership TXT record exists at ${DOMAIN}, but ${SECRET_NAME} is missing from ${REPO}." >&2
+  echo "ACTION: Restore the original matching private key as ${SECRET_NAME}, or remove only that MCP Registry TXT record and rerun to generate a new pair." >&2
+  exit 1
+fi
+if [[ "$MCP_VALID_COUNT" -eq 0 && "$GITHUB_SECRET_EXISTS" == "true" ]]; then
+  echo "ERROR: Partial MCP Registry credential state: ${SECRET_NAME} exists in ${REPO}, but no valid ownership TXT record exists at ${DOMAIN}." >&2
+  echo "ACTION: Restore the matching public TXT proof if the private key is recoverable, or delete ${SECRET_NAME} and rerun to generate a new pair." >&2
+  exit 1
+fi
+
+previous_umask="$(umask)"
+umask 077
+KEY_DIR="$(mktemp -d)"
+umask "$previous_umask"
+KEY_FILE="${KEY_DIR}/mcp-registry-ed25519.pem"
+openssl genpkey -algorithm Ed25519 -out "$KEY_FILE" >/dev/null 2>&1
+
+PUBLIC_KEY="$(openssl pkey -in "$KEY_FILE" -pubout -outform DER 2>/dev/null | tail -c 32 | base64)"
+PRIVATE_KEY="$(openssl pkey -in "$KEY_FILE" -noout -text 2>/dev/null | grep -A3 'priv:' | tail -n +2 | tr -d ' :\n')"
+
+if ! printf '%s' "$PUBLIC_KEY" | python3 -c '
+import base64
+import binascii
+import sys
+
+try:
+    key = base64.b64decode(sys.stdin.read(), validate=True)
+except (binascii.Error, ValueError):
+    raise SystemExit(1)
+raise SystemExit(0 if len(key) == 32 else 1)
+'; then
+  echo "ERROR: Failed to derive a valid 32-byte Ed25519 public key for the DNS ownership proof." >&2
+  exit 1
+fi
+if [[ ! "$PRIVATE_KEY" =~ ^[0-9a-fA-F]{64}$ ]]; then
+  echo "ERROR: Failed to derive the 64-character Ed25519 private key required by mcp-publisher." >&2
+  exit 1
+fi
+
+TXT_CONTENT="v=MCPv1; k=ed25519; p=${PUBLIC_KEY}"
+TXT_PAYLOAD="$(python3 -c '
+import json
+import sys
+
+print(json.dumps({
+    "type": "TXT",
+    "name": sys.argv[1],
+    "content": sys.argv[2],
+    "ttl": 120,
+}))
+' "$DOMAIN" "$TXT_CONTENT")"
+
+CREATE_STATUS=0
+if cloudflare_api_request \
+  "create MCP Registry ownership TXT record for ${DOMAIN}" \
+  "POST" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/dns_records" \
+  "$TXT_PAYLOAD" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/dns_records?type=TXT&name=${DOMAIN}&per_page=100" >/dev/null; then
+  :
+else
+  CREATE_STATUS=$?
+  if [[ "$CREATE_STATUS" -ne "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS" ]]; then
+    exit "$CREATE_STATUS"
+  fi
+  echo "WARNING: Cloudflare returned an ambiguous TXT-create outcome; reconciling the complete root TXT state without sending another create request." >&2
+fi
+
+if reconcile_created_txt_record "$TXT_CONTENT"; then
+  :
+else
+  reconciliation_status=$?
+  if [[ "$CREATE_STATUS" -eq "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS" || "$reconciliation_status" -eq "$CLOUDFLARE_API_UNKNOWN_OUTCOME_STATUS" ]]; then
+    echo "ACTION: Do not rerun immediately. Inspect the root TXT records in Cloudflare and resume only after the create outcome is known." >&2
+  else
+    echo "ACTION: Resolve only MCP Registry TXT conflicts at ${DOMAIN}; preserve unrelated TXT records." >&2
+  fi
+  exit "$reconciliation_status"
+fi
+
+if ! set_github_secret "$REPO" "$PRIVATE_KEY"; then
+  POST_FAILURE_SECRETS_JSON="$(fetch_github_secrets "$REPO")"
+  if github_secret_exists "$POST_FAILURE_SECRETS_JSON"; then
+    echo "ERROR: ${SECRET_NAME} now exists after an unsuccessful GitHub CLI response, so its value cannot be proven." >&2
+    echo "ACTION: Delete ${SECRET_NAME} and the matching MCP Registry TXT record, then rerun once the partial state is absent." >&2
+  else
+    post_failure_lookup_status=$?
+    if [[ "$post_failure_lookup_status" -eq 1 ]]; then
+      echo "ERROR: The ownership TXT record exists, but ${SECRET_NAME} was not created in ${REPO}." >&2
+      echo "ACTION: Remove only the MCP Registry TXT record, then rerun to generate a new credential pair." >&2
+    else
+      echo "ERROR: GitHub secret state could not be proven after the failed update." >&2
+      echo "ACTION: Inspect ${SECRET_NAME} in ${REPO} and the MCP Registry TXT record before rerunning." >&2
+    fi
+  fi
+  exit 1
+fi
+
+FINAL_SECRETS_JSON="$(fetch_github_secrets "$REPO")"
+if github_secret_exists "$FINAL_SECRETS_JSON"; then
+  :
+else
+  final_lookup_status=$?
+  if [[ "$final_lookup_status" -eq 1 ]]; then
+    echo "ERROR: GitHub reported a successful secret update, but ${SECRET_NAME} is absent from ${REPO}." >&2
+  else
+    echo "ERROR: GitHub secret state could not be parsed after the successful update." >&2
+  fi
+  exit "$final_lookup_status"
+fi
+
+verify_public_dns "$TXT_CONTENT"
+
+cleanup
+trap - EXIT HUP INT TERM
+echo "Created the MCP Registry ownership TXT record for ${DOMAIN} without changing unrelated TXT records."
+echo "Stored ${SECRET_NAME} in ${REPO}."
+echo "Temporary key material was removed without printing the private key."
+echo "After this code is promoted to main, publish with:"
+echo "  gh workflow run mcp-registry-publish.yml --repo ${REPO} --ref main"

--- a/server.json
+++ b/server.json
@@ -1,13 +1,31 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.kirill-markin/expense-budget-tracker",
+  "name": "com.expense-budget-tracker/expense-budget-tracker",
   "title": "Expense Budget Tracker",
-  "description": "Workspace-scoped expense and budget tools with OAuth read and write access.",
+  "description": "Track expenses, budgets, balances, transfers, and multi-currency reports with OAuth-secured tools.",
   "version": "1.2.0",
   "websiteUrl": "https://expense-budget-tracker.com",
+  "icons": [
+    {
+      "src": "https://expense-budget-tracker.com/icon.svg",
+      "mimeType": "image/svg+xml",
+      "sizes": ["any"]
+    },
+    {
+      "src": "https://expense-budget-tracker.com/icon-preview.png",
+      "mimeType": "image/png",
+      "sizes": ["512x512"]
+    },
+    {
+      "src": "https://expense-budget-tracker.com/logo-512.png",
+      "mimeType": "image/png",
+      "sizes": ["512x512"]
+    }
+  ],
   "repository": {
     "url": "https://github.com/kirill-markin/expense-budget-tracker",
     "source": "github",
+    "id": "1162889929",
     "subfolder": "apps/sql-api"
   },
   "remotes": [
@@ -15,5 +33,47 @@
       "type": "streamable-http",
       "url": "https://mcp.expense-budget-tracker.com/mcp"
     }
-  ]
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "categories": ["Finance", "Productivity"],
+      "tags": ["expenses", "budgeting", "personal-finance", "multi-currency"],
+      "mcpServerUrl": "https://mcp.expense-budget-tracker.com/mcp",
+      "documentationUrl": "https://expense-budget-tracker.com/docs/mcp-connector/",
+      "apiDocumentationUrl": "https://expense-budget-tracker.com/docs/api/",
+      "privacyPolicyUrl": "https://expense-budget-tracker.com/privacy/",
+      "termsOfServiceUrl": "https://expense-budget-tracker.com/terms/",
+      "supportUrl": "https://expense-budget-tracker.com/support/",
+      "iconUrls": {
+        "svg": "https://expense-budget-tracker.com/icon.svg",
+        "previewPng": "https://expense-budget-tracker.com/icon-preview.png",
+        "logo512Png": "https://expense-budget-tracker.com/logo-512.png"
+      },
+      "authentication": [
+        "OAuth 2.1 authorization code with PKCE and Dynamic Client Registration"
+      ],
+      "tools": [
+        {
+          "name": "list_workspaces",
+          "description": "Lists workspaces available to the authenticated user.",
+          "readOnly": true
+        },
+        {
+          "name": "get_schema",
+          "description": "Describes allowed financial relations, columns, constraints, limits, and guidance for one workspace.",
+          "readOnly": true
+        },
+        {
+          "name": "sql_query",
+          "description": "Runs one policy-approved read-only SELECT or WITH...SELECT statement.",
+          "readOnly": true
+        },
+        {
+          "name": "sql_execute",
+          "description": "Runs one approved INSERT, UPDATE, or DELETE statement within the selected workspace.",
+          "readOnly": false
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- publish the domain-scoped rich MCP Registry manifest
- add required PR schema validation and a manual main-only Registry publisher
- add safe Cloudflare/GitHub credential setup and the canonical operator runbook

## Validation
- not run locally; required GitHub CI owns executable validation

## Rollout
- DNS, GitHub secret setup, workflow dispatch, and Registry publication remain deferred post-promotion owner actions