### PR TITLE
docs: add OpenAI MCP submission dossier

### DIFF
--- a/docs/openai-mcp-submission.md
+++ b/docs/openai-mcp-submission.md
@@ -1,0 +1,1508 @@
+# OpenAI MCP submission dossier
+
+This dossier is the operator source of truth for evaluating and submitting the
+hosted Expense Budget Tracker MCP server as a public OpenAI plugin. It records
+the repository state on 2026-08-15; it is not evidence that OpenAI has connected
+to, reviewed, approved, or published the plugin.
+
+The current official OpenAI documentation calls this product a **plugin** and
+the public catalog the **Plugins Directory**. Older Apps SDK URLs redirect to
+the current plugin documentation.
+
+## Current status
+
+| Milestone | Status | Evidence or remaining gate |
+| --- | --- | --- |
+| Runtime ready | Complete on BASE | Runtime, version, and canonical guide metadata work is present on `integration-mcp-publication` at item-06 merge commit `396a09b3b88cd0a31965a39ac69fe1b6cc4691f9`. Protected-resource metadata and tests use `/docs/mcp-connector/`. After cumulative promotion, verify the deployed metadata and `tools/list` response. |
+| Site ready | Complete | Website commit `07c296fa2613ff310d05b693e28366664048a3bf` is deployed. The connector guide, API docs, support, privacy, terms, SVG icon, preview PNG, and 512px PNG were checked after the guide move; `/docs/mcp-connector/` returns HTTP 200 HTML and the superseded guide route returns 404. |
+| Registry implementation | Complete on BASE | Item 04 is merged into `integration-mcp-publication` at `8f0b330098fb8829f9f340a27501d73eb4b1860b`. The domain-owned manifest identity, PR validation, manual publication workflow, DNS credential setup script, and operator runbook are present. |
+| Registry published | Pending | The owner has not yet provisioned the DNS ownership proof and `MCP_PRIVATE_KEY`, dispatched `mcp-registry-publish.yml` from promoted `main`, or verified the immutable Registry record. Registry publication is separate from OpenAI review and is not evidence of OpenAI approval. |
+| OpenAI connected | Pending | The production endpoint has not been connected in ChatGPT Developer Mode. The real DCR, authorization-code, PKCE, scope, and tool-discovery flow must be captured after production promotion. |
+| Submission ready | Blocked | Reviewer access without email/SMS/MFA, public privacy-policy retention timelines, and resolution of unsupported deletion claims in Privacy and Terms across every locale are not ready. The owner-only identity, permissions, domain challenge, availability, and legal checks are also pending. |
+| Submitted | No | The owner has not accepted attestations or selected **Submit for Review**. |
+| Approved | No | OpenAI has not reviewed or approved the plugin. Approval would still require a separate owner decision to publish. |
+
+The interim repository state is green: this file changes documentation only and
+does not alter production behavior.
+
+## Official OpenAI requirements used
+
+Re-read these pages before every submission or resubmission because the portal
+and requirements can change:
+
+- [Submit plugins](https://developers.openai.com/plugins/deploy/submission)
+- [MCP server review requirements](https://developers.openai.com/plugins/deploy/app-review)
+- [Optimize Metadata](https://developers.openai.com/plugins/guides/optimize-metadata)
+- [Authentication](https://developers.openai.com/plugins/build/auth)
+- [Connect and test your plugin](https://developers.openai.com/plugins/deploy/connect-chatgpt)
+- [Plugin guidelines](https://developers.openai.com/plugins/app-guidelines)
+- [Security & Privacy](https://developers.openai.com/plugins/guides/security-privacy)
+
+The submission form currently requires listing information, MCP server details,
+starter prompts, test cases, availability, release notes, and policy
+attestations. It requires at least five positive and three negative test cases.
+For authenticated MCP servers, reviewers must be able to use a fully featured
+demo account without MFA, SMS, email confirmation, private-network access, or
+additional setup.
+
+### Authentication feasibility
+
+The current authentication design does not trigger the feasibility stop:
+
+- Official OpenAI authentication documentation allows an OpenAI host to
+  identify or register its OAuth client through CIMD, DCR, or a predefined
+  client. CIMD is preferred when supported and selected, but DCR remains a
+  supported path.
+- The service publishes OAuth authorization-server metadata with a DCR
+  registration endpoint and supports authorization code plus PKCE `S256`.
+- OpenID Connect discovery, `openid` and `email` scopes, and a UserInfo endpoint
+  are required by OpenAI for workspace domain restrictions. They are not stated
+  as a universal connection or submission requirement.
+- The runtime advertises each OAuth requirement through
+  `_meta["securitySchemes"]`. The current OpenAI review documentation says Scan
+  Tools imports security schemes and `_meta` fields; it does not require an
+  unsupported duplicate top-level security extension.
+
+This is a documentation conclusion, not compatibility evidence. Treat the
+present DCR/PKCE path as **unverified in the real OpenAI client** until the
+Developer Mode procedure below succeeds.
+
+## Public listing package
+
+Use this copy exactly unless the deployed behavior or current portal fields
+change.
+
+| Field | Value |
+| --- | --- |
+| Submission type | With MCP; MCP-only; no skills; no custom UI |
+| Plugin name | Expense Budget Tracker |
+| Short description | Workspace-scoped expense and budget tools with OAuth read and write access. |
+| Category | Finance |
+| Intended publisher | SAMO DANNI EOOD |
+| Version under evaluation | 1.2.0 |
+| Website | https://expense-budget-tracker.com/ |
+| Universal MCP URL | https://mcp.expense-budget-tracker.com/mcp |
+| MCP documentation | https://expense-budget-tracker.com/docs/mcp-connector/ |
+| API documentation | https://expense-budget-tracker.com/docs/api/ |
+| Support | https://expense-budget-tracker.com/support/ |
+| Privacy policy | https://expense-budget-tracker.com/privacy/ |
+| Terms | https://expense-budget-tracker.com/terms/ |
+| Source | https://github.com/kirill-markin/expense-budget-tracker |
+| Primary logo | https://expense-budget-tracker.com/logo-512.png |
+| Preview logo | https://expense-budget-tracker.com/icon-preview.png |
+| Runtime SVG icon | https://expense-budget-tracker.com/icon.svg |
+| Support contact | markinkirill@gmail.com |
+| MCP URL type | Universal |
+| Transport | Streamable HTTP |
+| Authentication | OAuth 2.1 authorization code with PKCE `S256` and Dynamic Client Registration; public client with token endpoint auth method `none` |
+| OAuth scopes | `expenses:read` and `expenses:write` |
+| Country availability | Pending owner/legal selection in the portal; select only supported countries where the service, support, and terms are ready |
+| Screenshots | None; the plugin has no UI |
+
+Long description:
+
+> Connect Expense Budget Tracker to inspect the allowed financial schema,
+> query workspace-scoped expenses, budgets, balances, internal accounting
+> transfers, and multi-currency data, and apply explicitly approved changes to
+> hosted financial records. OAuth separates read and write access. The plugin
+> has no custom UI, cannot browse the web, cannot contact third parties, and
+> does not execute real-world payments, money transfers, or investment trades.
+
+Starter prompts:
+
+1. “List the Expense Budget Tracker workspaces I can access.”
+2. “In my selected workspace, inspect the schema and summarize spending by
+   category for July 2026.”
+3. “Show my account balances by currency and explain whether any returned data
+   was truncated.”
+4. “Compare my August 2026 base budget with recorded spending; do not change
+   anything.”
+5. “After I approve the exact change, add a base budget amount for a category
+   in my selected workspace.”
+
+Initial release notes:
+
+> Initial public submission of the Expense Budget Tracker MCP server. It
+> provides four OAuth-secured, workspace-scoped tools for workspace discovery,
+> allowed-schema discovery, restricted read queries, and explicitly approved
+> financial-data mutations. The plugin has no skills and no custom UI. Review
+> uses the dedicated synthetic demo account and reset procedure supplied in the
+> submission portal.
+
+The public website is localized, but runtime tool metadata and this initial
+listing package are English. Do not claim localized tool metadata unless Scan
+Tools proves it.
+
+### Public URL verification inventory
+
+The eleven `L` rows are the URL-valued listing fields. The `R` rows add every
+owned public runtime, OAuth, discovery, and submission-verification URL needed
+to test that listing. The `G` rows are the external Registry lookup evidence for
+the merged domain-owned identity. Verify every row; do not replace this
+inventory with a count-based instruction. `Content-Type` may include a charset
+after the listed media type. Evidence must contain request method, UTC time,
+every redirect hop, final URL, status, media type, and the named header/body
+assertion, with secrets redacted.
+
+| ID | Surface and request | URL | Required final result and redirect rule | Evidence state |
+| --- | --- | --- | --- | --- |
+| L01 | Listing website, `GET` | `https://expense-budget-tracker.com/` | `200`, `text/html`; no redirect | Deployed website `07c296fa2613ff310d05b693e28366664048a3bf`; timestamped post-promotion capture pending |
+| L02 | Listing MCP documentation, `GET` | `https://expense-budget-tracker.com/docs/mcp-connector/` | `200`, `text/html`; no redirect | Deployed at `07c296f`; post-promotion capture pending |
+| L03 | Listing API documentation, `GET` | `https://expense-budget-tracker.com/docs/api/` | `200`, `text/html`; no redirect | Deployed at `07c296f`; post-promotion capture pending |
+| L04 | Listing support, `GET` | `https://expense-budget-tracker.com/support/` | `200`, `text/html`; no redirect | Deployed at `07c296f`; post-promotion capture pending |
+| L05 | Listing privacy policy, `GET` | `https://expense-budget-tracker.com/privacy/` | `200`, `text/html`; no redirect | Deployed at `07c296f`; legal blockers below remain; post-promotion capture pending |
+| L06 | Listing terms, `GET` | `https://expense-budget-tracker.com/terms/` | `200`, `text/html`; no redirect | Deployed at `07c296f`; legal blocker below remains; post-promotion capture pending |
+| L07 | Listing primary logo, `GET` | `https://expense-budget-tracker.com/logo-512.png` | `200`, `image/png`; no redirect | Deployed at `07c296f`; post-promotion capture pending |
+| L08 | Listing preview logo, `GET` | `https://expense-budget-tracker.com/icon-preview.png` | `200`, `image/png`; no redirect | Deployed at `07c296f`; post-promotion capture pending |
+| L09 | Runtime SVG icon, `GET` | `https://expense-budget-tracker.com/icon.svg` | `200`, `image/svg+xml`; no redirect | Deployed at `07c296f`; post-promotion capture pending |
+| L10 | Listing universal MCP URL, valid unauthenticated JSON-RPC `POST` | `https://mcp.expense-budget-tracker.com/mcp` | `401`, `application/json`; no redirect; exact `invalid_token` body and `WWW-Authenticate: Bearer resource_metadata="https://mcp.expense-budget-tracker.com/.well-known/oauth-protected-resource/mcp"` | Pending promoted-runtime capture |
+| L11 | Listing source repository, `GET` | `https://github.com/kirill-markin/expense-budget-tracker` | Final `200`, `text/html`; record any GitHub-controlled HTTPS redirect hops rather than requiring none | External GitHub availability; timestamped recheck pending |
+| R01 | Protected-resource metadata, `GET` | `https://mcp.expense-budget-tracker.com/.well-known/oauth-protected-resource/mcp` | `200`, `application/json`; no redirect; body exactly matches the OAuth discovery contract below | Complete in BASE source/tests at `396a09b`; deployed capture pending |
+| R02 | Authorization-server metadata, `GET` | `https://auth.expense-budget-tracker.com/.well-known/oauth-authorization-server` | `200`, `application/json`; no redirect; body exactly matches the contract below | Runtime source/test evidence present; deployed capture pending |
+| R03 | Canonical machine discovery, `GET` | `https://api.expense-budget-tracker.com/v1/` | `200`, `application/json`; no redirect; response supplies current signup/login and API onboarding links | Runtime source/test evidence present; deployed capture pending |
+| R04 | OpenAPI compatibility probe, `GET` | `https://api.expense-budget-tracker.com/v1/openapi.json` | `200`, `application/json`; no redirect; source-discovery response, not an OpenAPI document | Runtime source/test evidence present; deployed capture pending |
+| R05 | Swagger compatibility probe, `GET` | `https://api.expense-budget-tracker.com/v1/swagger.json` | `200`, `application/json`; no redirect; source-discovery response, not a Swagger document | Runtime source/test evidence present; deployed capture pending |
+| R06 | Dynamic client registration, owner-controlled valid public-client `POST` | `https://auth.expense-budget-tracker.com/oauth/register` | `201`, `application/json`; no redirect; returned client is public and has only submitted redirect URIs | Pending controlled-client and Developer Mode evidence |
+| R07 | Authorization request, owner-controlled valid `GET`, then consent `POST` | `https://auth.expense-budget-tracker.com/oauth/authorize` | Without a session, same-origin `302` to login; after login, `200`, `text/html` consent; approval returns same-origin `302` to the registered callback | Pending controlled-client and Developer Mode evidence; record the complete sanitized chain |
+| R08 | Authorization-code or refresh exchange, URL-encoded `POST` | `https://auth.expense-budget-tracker.com/oauth/token` | Successful valid grant: `200`, `application/json`, no redirect, `Cache-Control: no-store`; revoked refresh probe: the exact `400 invalid_grant` result below | Pending controlled-client and Developer Mode evidence |
+| R09 | OpenAI domain challenge, owner-installed token `GET` | `https://mcp.expense-budget-tracker.com/.well-known/openai-apps-challenge` | Target after the portal supplies and the owner installs the token: `200`, `text/plain`, no redirect, body is only that exact token | **Pending and not provisioned.** Record the current pre-challenge result separately; it cannot satisfy this row |
+| G01 | Exact MCP Registry version, `GET` | `https://registry.modelcontextprotocol.io/v0.1/servers/com.expense-budget-tracker%2Fexpense-budget-tracker/versions/1.2.0` | Before publication: final `404`, record returned MIME, no redirect. After the one authorized publication: final `200`, `application/json`, no redirect, exact name/version and manifest metadata | Item-04 lookup contract complete on BASE; publication and timestamped before/after captures pending |
+| G02 | MCP Registry latest search, `GET` | `https://registry.modelcontextprotocol.io/v0.1/servers?search=com.expense-budget-tracker%2Fexpense-budget-tracker&version=latest` | Final `200`, `application/json`, no redirect. Before publication it must not contain this name/version; after publication it must contain the exact `1.2.0` record | Item-04 lookup contract complete on BASE; publication and timestamped before/after captures pending |
+
+For L10, send a syntactically valid MCP request with `Accept: application/json,
+text/event-stream` and no `Authorization` header; retain the sanitized request
+body with the response. For R06-R08, use an owner-controlled client or the real
+Developer Mode connection as specified later, never an ad hoc production
+mutation outside the operator flow. Do not substitute the obsolete
+`/docs/mcp/` route for L02; it returns `404`. Any required-result mismatch or
+missing evidence blocks submission.
+
+## Runtime and authentication evidence
+
+### MCP server identity
+
+The initialized server advertises:
+
+| Field | Runtime value |
+| --- | --- |
+| `name` | `expense-budget-tracker` |
+| `version` | `1.2.0` |
+| `title` | `Expense Budget Tracker` |
+| `websiteUrl` | `https://expense-budget-tracker.com/` |
+| Icon | `https://expense-budget-tracker.com/icon.svg`, `image/svg+xml`, size `any` |
+
+Its instructions require the client to start with `list_workspaces`, use an
+explicit `workspaceId` when more than one workspace is available, call
+`get_schema` before SQL, route reads to `sql_query`, and route approved writes
+to `sql_execute`. They also identify `expenses:read` and `expenses:write` and
+link the canonical machine discovery endpoint.
+
+### Registry state
+
+Item 04 is merged on the current integration BASE at
+`8f0b330098fb8829f9f340a27501d73eb4b1860b`. Its `server.json` contract is:
+
+- domain-owned name `com.expense-budget-tracker/expense-budget-tracker` and
+  version `1.2.0`;
+- title `Expense Budget Tracker`, website
+  `https://expense-budget-tracker.com`, and description `Track expenses,
+  budgets, balances, transfers, and multi-currency reports with OAuth-secured
+  tools.`;
+- public repository `https://github.com/kirill-markin/expense-budget-tracker`,
+  source `github`, stable repository ID `1162889929`, and subfolder
+  `apps/sql-api`;
+- Streamable HTTP remote `https://mcp.expense-budget-tracker.com/mcp`;
+- SVG icon with size `any`, plus preview and 512px PNG icons with size
+  `512x512`; and
+- publisher-provided Finance/Productivity categories, expense/budgeting/
+  personal-finance/multi-currency tags, canonical MCP/API/privacy/terms/support
+  URLs, OAuth authorization-code/PKCE/DCR authentication text, and summaries
+  for the four runtime tools.
+
+The merged implementation also contains the manual
+`.github/workflows/mcp-registry-publish.yml` workflow, canonical
+`docs/mcp-registry-publishing.md` runbook, idempotent
+`scripts/cloudflare/setup-mcp-registry-credential.sh` owner setup script, and
+pull-request manifest validation. Do not switch back to the abandoned
+`io.github.kirill-markin/expense-budget-tracker` identity.
+
+There is still no published Registry record. After cumulative promotion to
+`main`, the owner must explicitly run the setup script to create and verify the
+root DNS ownership proof and store `MCP_PRIVATE_KEY`, confirm G01 returns 404,
+dispatch `mcp-registry-publish.yml` from `main`, and then require G01 and G02 to
+return the exact published record. Registry name/version pairs are immutable;
+if G01 already returns 200 before publication, do not republish or alter
+`1.2.0`. Do not use the README statement that the server “is listed in MCP
+registries” as publication evidence.
+
+### OAuth discovery contract
+
+The protected resource metadata is served at:
+
+`https://mcp.expense-budget-tracker.com/.well-known/oauth-protected-resource/mcp`
+
+The actualized base at `396a09b3b88cd0a31965a39ac69fe1b6cc4691f9`
+emits and tests these values:
+
+```json
+{
+  "resource": "https://mcp.expense-budget-tracker.com/mcp",
+  "authorization_servers": ["https://auth.expense-budget-tracker.com"],
+  "bearer_methods_supported": ["header"],
+  "scopes_supported": ["expenses:read", "expenses:write"],
+  "resource_documentation": "https://expense-budget-tracker.com/docs/mcp-connector/"
+}
+```
+
+After cumulative promotion, capture the deployed response and require an exact
+match with this JSON. The former guide route now returns `404` and must not
+appear in a submitted or scanned descriptor.
+
+An unauthenticated MCP request returns `401` with a
+`WWW-Authenticate` challenge pointing at that exact metadata URL.
+
+The authorization-server metadata is served at:
+
+`https://auth.expense-budget-tracker.com/.well-known/oauth-authorization-server`
+
+It advertises:
+
+```json
+{
+  "issuer": "https://auth.expense-budget-tracker.com",
+  "authorization_endpoint": "https://auth.expense-budget-tracker.com/oauth/authorize",
+  "token_endpoint": "https://auth.expense-budget-tracker.com/oauth/token",
+  "registration_endpoint": "https://auth.expense-budget-tracker.com/oauth/register",
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "token_endpoint_auth_methods_supported": ["none"],
+  "code_challenge_methods_supported": ["S256"],
+  "scopes_supported": ["expenses:read", "expenses:write"]
+}
+```
+
+DCR accepts public authorization-code clients with one to ten unique allowed
+redirect URIs. The authorization flow binds the requested resource, requires
+PKCE, renders explicit scope consent, issues short-lived bearer access
+credentials and refresh credentials, and checks resource, expiration, scope,
+and current confirmed user identity for each MCP request.
+
+The current server does not advertise CIMD support, OIDC scopes, an ID token, a
+UserInfo endpoint, or workspace-domain-restriction support. Do not claim those
+features. If Developer Mode or the submission portal makes any of them
+mandatory for this plugin, stop and create a separate prerequisite plan.
+
+## Tool descriptors
+
+Scan Tools is the final evidence source for deployed descriptor bytes. Snapshot
+`tools-list-v1.2.0-base-396a09b` below is a lossless representation of the four
+descriptors emitted from `apps/sql-api/src/mcp/server.ts`, the locked
+`@modelcontextprotocol/sdk` `1.30.0`, and Zod `4.4.3`. Compare the deployed
+snapshot after recursively sorting object keys only; array order and every
+string, keyword, boolean, number, and field presence must remain exact. No
+descriptor has a top-level `securitySchemes` or `icons` field. Together, the
+tool name in the first column, the other five outer fields in the table, and
+the two schemas below enumerate every field in each emitted tool descriptor;
+no unlisted outer field is permitted.
+
+### Exact descriptor fields outside JSON Schema
+
+| Tool | Exact title | Exact description | Exact annotations | Exact `_meta` | Exact `execution` |
+| --- | --- | --- | --- | --- | --- |
+| `list_workspaces` | `List accessible workspaces` | `Use this read-only discovery tool to list every workspace accessible to the authenticated user. It does not create or modify workspaces; pass a returned workspaceId to other tools when more than one is available.` | `{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true,"openWorldHint":false}` | `{"securitySchemes":[{"type":"oauth2","scopes":["expenses:read"]}]}` | `{"taskSupport":"forbidden"}` |
+| `get_schema` | `Inspect expense SQL schema` | `Use this read-only discovery tool before writing SQL to inspect allowed relations, columns, constraints, and agent hints for an accessible workspace. It does not expose or query system catalogs.` | `{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true,"openWorldHint":false}` | `{"securitySchemes":[{"type":"oauth2","scopes":["expenses:read"]}]}` | `{"taskSupport":"forbidden"}` |
+| `sql_query` | `Query expense data` | `Use this read-only query tool to run exactly one policy-approved SELECT or WITH...SELECT statement against an accessible workspace. It executes in a repeatable-read, read-only transaction under the restricted SQL reader role.` | `{"readOnlyHint":true,"destructiveHint":false,"idempotentHint":true,"openWorldHint":false}` | `{"securitySchemes":[{"type":"oauth2","scopes":["expenses:read"]}]}` | `{"taskSupport":"forbidden"}` |
+| `sql_execute` | `Execute expense data mutation` | `Use this write-capable tool only for an approved expense-data mutation. It runs exactly one policy-approved INSERT, UPDATE, or DELETE statement under the restricted SQL executor role and may destructively modify workspace data.` | `{"readOnlyHint":false,"destructiveHint":true,"idempotentHint":false,"openWorldHint":false}` | `{"securitySchemes":[{"type":"oauth2","scopes":["expenses:write"]}]}` | `{"taskSupport":"forbidden"}` |
+
+The read tools are side-effect free, private, and safe to retry. `sql_execute`
+can destructively change private first-party records, is not safe to retry, and
+cannot publish, message a third party, transfer money, or otherwise affect the
+public internet. Those facts are the basis for the annotations above.
+
+### Exact input schemas
+
+The `inputSchema` values are, by tool name:
+
+```json
+{
+  "list_workspaces": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {}
+  },
+  "get_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "workspaceId": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Optional workspaceId returned by list_workspaces. Omit only when exactly one workspace is available."
+      }
+    }
+  },
+  "sql_query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "sql": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Exactly one policy-approved SELECT or WITH...SELECT statement."
+      },
+      "workspaceId": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Optional workspaceId returned by list_workspaces. Omit only when exactly one workspace is available."
+      }
+    },
+    "required": ["sql"]
+  },
+  "sql_execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "sql": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Exactly one policy-approved INSERT, UPDATE, or DELETE statement."
+      },
+      "workspaceId": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Optional workspaceId returned by list_workspaces. Omit only when exactly one workspace is available."
+      }
+    },
+    "required": ["sql"]
+  }
+}
+```
+
+### Exact output schemas
+
+Each `outputSchema` is assembled without inference from this exact wrapper by
+replacing `<DATA_SCHEMA>` with the corresponding complete data object below.
+For `sql_query` and `sql_execute` only, append the exact root `definitions`
+member shown after their data object. Operationally: parse the wrapper JSON,
+assign the selected object to `outputSchema.properties.data`, and, for either
+SQL tool, assign the shown `definitions` object to
+`outputSchema.definitions`. Delete no field and add no other field.
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true,
+      "description": "Whether the tool call completed successfully."
+    },
+    "data": "<DATA_SCHEMA>",
+    "instructions": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Actionable guidance for using the returned data."
+    }
+  },
+  "required": ["ok", "data", "instructions"],
+  "additionalProperties": false
+}
+```
+
+The quoted `<DATA_SCHEMA>` marker denotes replacement by the JSON object, not a
+wire string. The exact `list_workspaces` data schema is:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "workspaces": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "workspaceId": {"type": "string", "minLength": 1},
+          "name": {"type": "string"}
+        },
+        "required": ["workspaceId", "name"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["workspaces"],
+  "additionalProperties": false
+}
+```
+
+The exact `get_schema` data schema is:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "workspace": {
+      "type": "object",
+      "properties": {
+        "workspaceId": {"type": "string", "minLength": 1},
+        "name": {"type": "string"}
+      },
+      "required": ["workspaceId", "name"],
+      "additionalProperties": false
+    },
+    "relations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["ledger_entries", "accounts", "budget_lines", "workspace_settings", "account_metadata", "fx_rates_raw", "fx_rates_daily"]
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "type": {"type": "string"},
+                "nullable": {"type": "boolean"},
+                "defaultValue": {"anyOf": [{"type": "string"}, {"type": "null"}]}
+              },
+              "required": ["name", "type", "nullable", "defaultValue"],
+              "additionalProperties": false
+            }
+          },
+          "hints": {
+            "type": "object",
+            "properties": {
+              "optional": {"type": "boolean"},
+              "primaryKey": {"type": "array", "items": {"type": "string"}},
+              "notes": {"type": "array", "items": {"type": "string"}},
+              "columnConstraints": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "column": {"type": "string"},
+                    "allowedValues": {"type": "array", "items": {"type": "string"}},
+                    "notes": {"type": "array", "items": {"type": "string"}}
+                  },
+                  "required": ["column"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": ["optional", "notes"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "columns"],
+        "additionalProperties": false
+      }
+    },
+    "limits": {
+      "type": "object",
+      "properties": {
+        "maxRows": {"type": "integer", "minimum": 0},
+        "statementTimeoutMs": {"type": "integer", "exclusiveMinimum": 0}
+      },
+      "required": ["maxRows", "statementTimeoutMs"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["workspace", "relations", "limits"],
+  "additionalProperties": false
+}
+```
+
+The exact `sql_query` data schema is:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "statements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "sql": {"type": "string"},
+          "command": {"type": "string", "const": "SELECT"},
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "propertyNames": {"type": "string"},
+              "additionalProperties": {"$ref": "#/definitions/__schema0"}
+            }
+          },
+          "rowCount": {"type": "integer", "minimum": 0},
+          "returnedRowCount": {"type": "integer", "minimum": 0},
+          "totalRowCount": {"type": "integer", "minimum": 0},
+          "truncated": {"type": "boolean"},
+          "referencedRelations": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["ledger_entries", "accounts", "budget_lines", "workspace_settings", "account_metadata", "fx_rates_raw", "fx_rates_daily"]
+            }
+          },
+          "entityHints": {
+            "type": "object",
+            "properties": {
+              "primary": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "enum": ["ledger_entries", "accounts", "budget_lines", "workspace_settings", "account_metadata", "fx_rates_raw", "fx_rates_daily"]
+                  },
+                  "summary": {"type": "string"}
+                },
+                "required": ["name", "summary"],
+                "additionalProperties": false
+              },
+              "related": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "enum": ["ledger_entries", "accounts", "budget_lines", "workspace_settings", "account_metadata", "fx_rates_raw", "fx_rates_daily"]
+                    },
+                    "summary": {"type": "string"}
+                  },
+                  "required": ["name", "summary"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": ["primary", "related"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["sql", "command", "rows", "rowCount", "returnedRowCount", "totalRowCount", "truncated", "referencedRelations"],
+        "additionalProperties": false
+      }
+    },
+    "workspace": {
+      "type": "object",
+      "properties": {
+        "workspaceId": {"type": "string", "minLength": 1},
+        "name": {"type": "string"}
+      },
+      "required": ["workspaceId", "name"],
+      "additionalProperties": false
+    },
+    "limits": {
+      "type": "object",
+      "properties": {
+        "maxRows": {"type": "integer", "minimum": 0},
+        "statementTimeoutMs": {"type": "integer", "exclusiveMinimum": 0}
+      },
+      "required": ["maxRows", "statementTimeoutMs"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["statements", "workspace", "limits"],
+  "additionalProperties": false
+}
+```
+
+The exact SQL-output root definition, present as a sibling of `properties`,
+`required`, and `additionalProperties`, is:
+
+```json
+{
+  "definitions": {
+    "__schema0": {
+      "anyOf": [
+        {"type": "string"},
+        {"type": "number"},
+        {"type": "boolean"},
+        {"type": "null"},
+        {"type": "array", "items": {"$ref": "#/definitions/__schema0"}},
+        {
+          "type": "object",
+          "propertyNames": {"type": "string"},
+          "additionalProperties": {"$ref": "#/definitions/__schema0"}
+        }
+      ]
+    }
+  }
+}
+```
+
+The exact `sql_execute` data schema is byte-for-byte the `sql_query` data
+schema after replacing only JSON Pointer
+`/properties/statements/items/properties/command` with:
+
+```json
+{"type": "string", "enum": ["INSERT", "UPDATE", "DELETE"]}
+```
+
+Its root definition is identical to the SQL-output definition above. This
+single explicit JSON-Pointer substitution is the lossless snapshot encoding;
+there are no other `sql_query`/`sql_execute` output-schema differences.
+
+Every successful call returns the same JSON-safe object in
+`structuredContent` and as the parsed value of the one `content` item, whose
+`type` is `text`. SQL dates become ISO-8601 strings. Errors are not successful
+output-schema values: they set `isError: true` and return one text item whose
+parsed object has `ok: false`, required string `error.code` and `error.message`,
+optional object `error.details`, and required string `instructions`. The
+deployed `get_schema` relation/column result and every concrete tool result must
+be captured; this descriptor snapshot does not substitute invented response
+data for runtime evidence.
+
+## Reviewer account and fixture
+
+Never commit reviewer credentials, mailbox access, OAuth tokens, account
+identifiers, or captured financial records. Kirill Markin is the owner for
+creating the reviewer account and delivering its credentials only through the
+OpenAI submission portal or another explicitly approved secret channel.
+
+The final reviewer account must satisfy all of these conditions:
+
+- dedicated, stable, non-personal account owned by the service operator;
+- already provisioned, enabled, and usable outside private networks;
+- no signup, MFA, SMS, email code, email confirmation, or inaccessible
+  identity-provider step during review;
+- `expenses:read` and `expenses:write` can be consented to and exercised;
+- two synthetic workspaces named `Review Personal` and `Review Household` so
+  workspace selection is testable;
+- no real names, email content, bank data, card data, credentials, health data,
+  government identifiers, or real financial history;
+- a documented reset that the owner performs before sharing credentials and
+  after every mutation test.
+
+The current hosted sign-in uses email OTP. It therefore does **not** yet satisfy
+the no-email-dependency reviewer rule. A compliant reviewer-access path is a
+pre-submission blocker, not something to work around with a personal mailbox or
+credentials in git.
+
+### Synthetic fixture contract
+
+The fixture revision is `openai-review-fixture-v1`. Keep the deployed values for
+`<REVIEW_PERSONAL_WORKSPACE_ID>` and `<REVIEW_EUR_ACCOUNT_ID>` only in the
+private operator record; substitute them literally before executing the SQL.
+The deployed schema represents categories as text, not private category IDs, so
+the exact category strings below are part of the versioned fixture.
+`Review Personal` is dedicated to this fixture, has reporting currency EUR,
+and has no other July 2026 ledger rows. `Review Household` exists and is
+accessible but is not used by the positive read or write scenarios.
+
+The owner performs the reset through **Reset Connection R**, a fresh
+owner-controlled MCP Inspector connection using the dedicated reviewer identity,
+DCR, authorization code, PKCE `S256`, and exactly `expenses:read
+expenses:write`. It is not a ChatGPT connection and its credentials are never
+shared with OpenAI. The owner may complete the currently required email OTP
+privately while preparing the fixture; that does not satisfy or bypass the
+separate no-email reviewer-access blocker. Before creating R, revoke every old
+ChatGPT test connection. After verification, revoke R before starting P1.
+
+Call `list_workspaces` on R with this exact envelope and bind the returned
+`Review Personal.workspaceId` to `<REVIEW_PERSONAL_WORKSPACE_ID>` in the private
+operator record:
+
+```json
+{"name":"list_workspaces","arguments":{}}
+```
+
+Run every SQL block below as a separate MCP call because `sql_execute` and
+`sql_query` each accept exactly one statement. Each call envelope is exactly:
+
+```json
+{
+  "name": "<tool in the call table>",
+  "arguments": {
+    "workspaceId": "<REVIEW_PERSONAL_WORKSPACE_ID>",
+    "sql": "<the complete SQL block identified in the call table>"
+  }
+}
+```
+
+Substitute the private IDs, preserve the SQL text and signed values, and send no
+other arguments. The envelope's `workspaceId` selects the MCP workspace; the
+SQL predicate or inserted value independently enforces the row key.
+
+**R1 — budget cleanup (`sql_execute`)**
+
+```sql
+DELETE FROM budget_lines
+WHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'
+  AND category IN (
+    'OpenAI Review Write',
+    'openai-review-v1-scope-probe-never-present'
+  )
+```
+
+**R2 — July ledger cleanup (`sql_execute`)**
+
+```sql
+DELETE FROM ledger_entries
+WHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'
+  AND (
+    (ts >= '2026-07-01 00:00:00+00'
+      AND ts < '2026-08-01 00:00:00+00')
+    OR entry_id IN (
+      'openai-review-v1-july-groceries',
+      'openai-review-v1-july-transport'
+    )
+    OR event_id IN (
+      'openai-review-v1-july-groceries',
+      'openai-review-v1-july-transport'
+    )
+  )
+```
+
+**R3 — reporting-currency restore (`sql_execute`)**
+
+```sql
+UPDATE workspace_settings
+SET reporting_currency = 'EUR'
+WHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'
+```
+
+R3 must affect exactly one row.
+
+**V1 — reporting-currency verification (`sql_query`)**
+
+```sql
+SELECT workspace_id, reporting_currency
+FROM workspace_settings
+WHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'
+```
+
+The query must return exactly one row with reporting currency `EUR`.
+
+**R4 — exact ledger restore (`sql_execute`)**
+
+```sql
+INSERT INTO ledger_entries (
+  entry_id,
+  event_id,
+  ts,
+  account_id,
+  amount,
+  currency,
+  kind,
+  category,
+  counterparty,
+  note,
+  external_id,
+  workspace_id,
+  inserted_at
+)
+VALUES
+  (
+    'openai-review-v1-july-groceries',
+    'openai-review-v1-july-groceries',
+    '2026-07-10 12:00:00+00',
+    '<REVIEW_EUR_ACCOUNT_ID>',
+    -25.00,
+    'EUR',
+    'spend',
+    'Groceries',
+    'OpenAI Review Merchant',
+    'openai-review-fixture-v1',
+    'openai-review-v1-july-groceries',
+    '<REVIEW_PERSONAL_WORKSPACE_ID>',
+    '2026-07-31 00:00:00+00'
+  ),
+  (
+    'openai-review-v1-july-transport',
+    'openai-review-v1-july-transport',
+    '2026-07-20 08:30:00+00',
+    '<REVIEW_EUR_ACCOUNT_ID>',
+    -15.00,
+    'EUR',
+    'spend',
+    'Transport',
+    'OpenAI Review Transit',
+    'openai-review-fixture-v1',
+    'openai-review-v1-july-transport',
+    '<REVIEW_PERSONAL_WORKSPACE_ID>',
+    '2026-07-31 00:00:01+00'
+  )
+```
+
+R4 must affect exactly two rows.
+
+**V2 — complete-row verification (`sql_query`)**
+
+This query must return exactly the two rows above and no other July row:
+
+```sql
+SELECT
+  entry_id,
+  event_id,
+  ts,
+  account_id,
+  amount,
+  currency,
+  kind,
+  category,
+  counterparty,
+  note,
+  external_id,
+  workspace_id,
+  inserted_at
+FROM ledger_entries
+WHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'
+  AND ts >= '2026-07-01 00:00:00+00'
+  AND ts < '2026-08-01 00:00:00+00'
+ORDER BY entry_id
+```
+
+**V3 — signed aggregate verification (`sql_query`)**
+
+This query must return exactly `Groceries`, signed total `-25.00`, count `1`;
+and `Transport`, signed total `-15.00`, count `1`:
+
+```sql
+SELECT
+  category,
+  SUM(amount) AS signed_total_eur,
+  COUNT(*) AS entry_count
+FROM ledger_entries
+WHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'
+  AND ts >= '2026-07-01 00:00:00+00'
+  AND ts < '2026-08-01 00:00:00+00'
+  AND currency = 'EUR'
+  AND kind = 'spend'
+GROUP BY category
+ORDER BY category
+```
+
+**V4 — budget-baseline verification (`sql_query`)**
+
+This query must return zero rows. It deliberately checks both reserved fixture
+categories across all keys so a malformed prior test row cannot hide behind the
+complete P5 key:
+
+```sql
+SELECT
+  budget_month,
+  direction,
+  category,
+  kind,
+  currency,
+  planned_value
+FROM budget_lines
+WHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'
+  AND category IN (
+    'OpenAI Review Write',
+    'openai-review-v1-scope-probe-never-present'
+  )
+```
+
+The exact ordered call table is:
+
+| Order | Call ID | Tool | Exact arguments |
+| --- | --- | --- | --- |
+| 1 | V0 | `list_workspaces` | `{}` |
+| 2 | R1 | `sql_execute` | `{"workspaceId":"<REVIEW_PERSONAL_WORKSPACE_ID>","sql":"<R1 SQL verbatim>"}` |
+| 3 | R2 | `sql_execute` | `{"workspaceId":"<REVIEW_PERSONAL_WORKSPACE_ID>","sql":"<R2 SQL verbatim>"}` |
+| 4 | R3 | `sql_execute` | `{"workspaceId":"<REVIEW_PERSONAL_WORKSPACE_ID>","sql":"<R3 SQL verbatim>"}` |
+| 5 | V1 | `sql_query` | `{"workspaceId":"<REVIEW_PERSONAL_WORKSPACE_ID>","sql":"<V1 SQL verbatim>"}` |
+| 6 | R4 | `sql_execute` | `{"workspaceId":"<REVIEW_PERSONAL_WORKSPACE_ID>","sql":"<R4 SQL verbatim>"}` |
+| 7 | V2 | `sql_query` | `{"workspaceId":"<REVIEW_PERSONAL_WORKSPACE_ID>","sql":"<V2 SQL verbatim>"}` |
+| 8 | V3 | `sql_query` | `{"workspaceId":"<REVIEW_PERSONAL_WORKSPACE_ID>","sql":"<V3 SQL verbatim>"}` |
+| 9 | V4 | `sql_query` | `{"workspaceId":"<REVIEW_PERSONAL_WORKSPACE_ID>","sql":"<V4 SQL verbatim>"}` |
+
+V0 must return exactly `Review Personal` and `Review Household`. Record the
+sanitized envelopes/results, reset-connection ID, execution time, runtime
+version, two private substitutions, and fixture revision outside git, then
+revoke R. After P5/P6 and N1-N4 finish and Connection B is revoked, create a new
+owner-only Reset Connection R with the same authorization, rerun the full
+ordered sequence, retain its sanitized evidence, and revoke it. If any row,
+count, value, scope, or workspace differs, stop and repair the private fixture
+rather than adjusting the expected review result.
+
+## Positive reviewer scenarios
+
+Each scenario starts in a new conversation unless it explicitly depends on a
+previous result. Store screenshots plus sanitized tool request/result logs in
+the private evidence bundle.
+
+Use this connection-state sequence exactly:
+
+1. Start with no OpenAI connection. P1 creates **Connection A** and authorizes
+   only `expenses:read`.
+2. Reuse Connection A for P2, P3, and P4.
+3. While Connection A is still active, ask ChatGPT to call `sql_execute` with
+   this exact MCP envelope and the private `Review Personal` substitution:
+
+   ```json
+   {
+     "name": "sql_execute",
+     "arguments": {
+       "workspaceId": "<REVIEW_PERSONAL_WORKSPACE_ID>",
+       "sql": "DELETE FROM budget_lines\nWHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'\n  AND budget_month = '2099-01-01'\n  AND direction = 'spend'\n  AND category = 'openai-review-v1-scope-probe-never-present'\n  AND kind = 'base'"
+     }
+   }
+   ```
+
+   The SQL represented in that envelope is:
+
+   ```sql
+   DELETE FROM budget_lines
+   WHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'
+     AND budget_month = '2099-01-01'
+     AND direction = 'spend'
+     AND category = 'openai-review-v1-scope-probe-never-present'
+     AND kind = 'base'
+   ```
+
+   If ChatGPT dispatches the call to the server, it must return a tool error
+   whose parsed text has `error.code: "insufficient_scope"`, details show
+   required scope `expenses:write` and granted scope `expenses:read`, and no SQL
+   execution occurs. Verify the row is still absent with Connection A using
+   this exact read envelope:
+
+   ```json
+   {
+     "name": "sql_query",
+     "arguments": {
+       "workspaceId": "<REVIEW_PERSONAL_WORKSPACE_ID>",
+       "sql": "SELECT budget_month, direction, category, kind\nFROM budget_lines\nWHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'\n  AND budget_month = '2099-01-01'\n  AND direction = 'spend'\n  AND category = 'openai-review-v1-scope-probe-never-present'\n  AND kind = 'base'"
+     }
+   }
+   ```
+
+   If Developer Mode instead blocks the tool locally or starts a scope-upgrade
+   consent flow from `_meta.securitySchemes`, decline the upgrade and record
+   the exact client-visible behavior. That is Developer Mode evidence, but not
+   evidence that the server returned `insufficient_scope`. In that case create
+   a separate owner-controlled MCP Inspector **Scope Connection S** through DCR
+   and PKCE with exactly `expenses:read`, send the same write envelope, retain
+   its `insufficient_scope` result as server-only evidence, and revoke S. Never
+   label the controlled-client result as OpenAI compatibility evidence or let a
+   refresh attempt stand in for expanded consent.
+4. Before revocation, record Connection A's sanitized client/connection IDs and
+   access-token expiry, and prove a read succeeds. Revoke A in Expense Budget
+   Tracker **Settings > Agent Access** while its access credential is still
+   unexpired, leave the ChatGPT connection configured, and use that same client
+   to collect both probes below before removing it:
+
+   **A-access probe.** Trigger a read so the configured client sends its cached
+   access credential to `POST https://mcp.expense-budget-tracker.com/mcp`.
+   Retain this sanitized request body:
+
+   ```json
+   {"jsonrpc":"2.0","id":"connection-a-revoked-access","method":"tools/list","params":{}}
+   ```
+
+   Require final `401`, `application/json`, no redirect, this exact body, and
+   the exact challenge header:
+
+   ```json
+   {
+     "error": "invalid_token",
+     "error_description": "A valid OAuth Bearer access token is required for this MCP resource."
+   }
+   ```
+
+   ```text
+   WWW-Authenticate: Bearer resource_metadata="https://mcp.expense-budget-tracker.com/.well-known/oauth-protected-resource/mcp"
+   ```
+
+   **A-refresh probe.** Allow the still-configured client to respond to that
+   rejection by sending its existing refresh credential to
+   `POST https://auth.expense-budget-tracker.com/oauth/token`. The sanitized
+   URL-encoded request representation must be exactly:
+
+   ```text
+   grant_type=refresh_token&client_id=<CONNECTION_A_CLIENT_ID>&refresh_token=<REDACTED>&resource=https%3A%2F%2Fmcp.expense-budget-tracker.com%2Fmcp
+   ```
+
+   Require final `400`, `application/json`, no redirect,
+   `Cache-Control: no-store`, `Pragma: no-cache`, and:
+
+   ```json
+   {
+     "error": "invalid_grant",
+     "error_description": "Refresh token is invalid, expired, or already used"
+   }
+   ```
+
+   Store only sanitized captures outside git: UTC time, request/correlation ID,
+   connection/client ID or one-way label, method, host/path, status, media type,
+   cache/challenge headers, and error fields. Redact `Authorization`, access and
+   refresh credentials, cookies, authorization codes, PKCE verifier, email, and
+   returned financial data before saving; do not retain an unsanitized HAR. If
+   the configured client cannot exercise and expose objective evidence for both
+   old credentials, revocation evidence remains incomplete and submission is
+   blocked.
+5. Create **Connection B** from a new connection flow and explicitly authorize
+   both `expenses:read` and `expenses:write`. If the host cannot request and
+   consent to both scopes on a fresh connection, stop; the current refresh
+   flow cannot expand Connection A's original grant.
+6. Use Connection B for P5, P6, and the negative scenarios, then revoke it.
+
+### P1 — Connect and authorize
+
+- Prerequisites: reset fixture; production promotion complete; compliant
+  reviewer credentials; no existing OpenAI connection.
+- Prompt: “Connect Expense Budget Tracker and show which workspaces I can use.”
+- Expected behavior: ChatGPT discovers protected-resource and authorization
+  metadata, registers a public client through DCR, uses authorization code with
+  PKCE `S256`, requests `expenses:read`, displays the service consent screen,
+  then calls `list_workspaces` after approval.
+- Expected confirmation boundary: explicit account-link and OAuth scope consent;
+  no write confirmation.
+- Expected result shape: `Success<{workspaces: Workspace[]}>` with both fixture
+  workspaces and no credentials or tokens.
+- Pass evidence: sanitized network metadata identifies Connection A and proves
+  DCR and `S256`; tool log
+  proves `list_workspaces`; result contains exactly `Review Personal` and
+  `Review Household`.
+- Fail if: connection needs email/SMS/MFA, uses a copied bearer token, skips
+  consent, requests an undisclosed scope, or cannot list both workspaces.
+
+### P2 — Discover workspaces without guessing
+
+- Prerequisites: Connection A from P1 with only `expenses:read`.
+- Prompt: “List my Expense Budget Tracker workspaces. Do not read any financial
+  records.”
+- Expected tool choice: `list_workspaces` only.
+- Expected confirmation boundary: none.
+- Expected result shape: the workspace-list success shape.
+- Pass evidence: exactly one `list_workspaces` call; no `get_schema`,
+  `sql_query`, or `sql_execute` call; answer names both fixture workspaces.
+- Fail if: the model guesses a workspace, reads records, or calls a write tool.
+
+### P3 — Discover the allowed schema
+
+- Prerequisites: Connection A from P1 and the private ID for
+  `Review Personal`.
+- Prompt: “For Review Personal, inspect the allowed schema and tell me which
+  relations and columns you would use for a July spending summary. Do not query
+  financial rows and do not change anything.”
+- Expected tool choice: `list_workspaces` if the ID is not already in context,
+  then `get_schema` with the exact `Review Personal` ID; no SQL tool.
+- Expected confirmation boundary: none.
+- Expected result shape: `Success<{workspace, relations, limits}>` with only the
+  seven allowlisted relation names and their deployed columns and hints.
+- Pass evidence: result workspace matches `Review Personal`; no system catalogs
+  or records are returned; no `sql_query` or `sql_execute` call occurs.
+- Fail if: the model invents columns, queries rows, exposes a system catalog, or
+  uses the other workspace.
+
+### P4 — Run a read query
+
+- Prerequisites: reset fixture and Connection A with only `expenses:read`.
+- Prompt: “In Review Personal, total July 2026 expenses by category. Return the
+  category and total in EUR. Do not change anything.”
+- Expected tool choice: `list_workspaces` and `get_schema` when needed, followed
+  by exactly one `sql_query` with one policy-approved `SELECT` or
+  `WITH...SELECT`.
+- Expected confirmation boundary: none.
+- Expected result shape: SQL success data with `command: "SELECT"`,
+  `referencedRelations` containing the relations actually used, accurate count
+  and truncation metadata, signed rows for Groceries EUR `-25.00` and Transport
+  EUR `-15.00`, and a final answer presenting expense magnitudes of EUR 25.00
+  and EUR 15.00.
+- Pass evidence: returned signed ledger totals are `-25.00` and `-15.00`, the
+  answer presents their expense magnitudes as EUR 25.00 and EUR 15.00, and both
+  reconcile exactly to the synthetic fixture; selected
+  workspace is `Review Personal`; `truncated` is false; no mutation occurs.
+- Fail if: the wrong workspace is used, totals differ, a non-allowlisted
+  relation/function is attempted without correction, or `sql_execute` is called.
+
+### P5 — Apply an intentional write
+
+- Prerequisites: Connection A's client-observed scope behavior, any required
+  server-only Scope Connection S result, and both revocation probes are
+  recorded; Connection B is freshly authorized for both `expenses:read` and
+  `expenses:write`; the August complete key is absent.
+- Prompt: “In Review Personal, create a spend-direction August 2026 base budget
+  of EUR 123.45 for category OpenAI Review Write. This is a test. Show me the
+  exact proposed change, including direction and kind, and require confirmation
+  before changing anything.”
+- Expected tool choice: read-only discovery first, then `sql_execute` only after
+  the host's explicit destructive-action confirmation.
+- Expected confirmation boundary: the exact workspace, month `2026-08`,
+  direction `spend`, category `OpenAI Review Write`, kind `base`, currency
+  `EUR`, amount `123.45`, and `INSERT` mutation must be visible before the tool
+  call. Canceling the confirmation must produce no write.
+- Expected SQL after confirmation, with the private workspace substitution:
+
+  ```sql
+  INSERT INTO budget_lines (
+    budget_month,
+    direction,
+    category,
+    kind,
+    currency,
+    planned_value,
+    workspace_id
+  )
+  VALUES (
+    '2026-08-01',
+    'spend',
+    'OpenAI Review Write',
+    'base',
+    'EUR',
+    123.45,
+    '<REVIEW_PERSONAL_WORKSPACE_ID>'
+  )
+  ```
+- Expected result shape: SQL success data with one `INSERT` statement,
+  `rowCount: 1`, `referencedRelations: ["budget_lines"]`, the selected fixture
+  workspace, and non-truncated counts.
+- Pass evidence: confirmation screenshot shows every complete-key and value
+  field before the tool call; one row is affected; P6 proves the exact
+  `spend`/`base` row with EUR 123.45; reset removes that exact row.
+- Fail if: the tool runs before confirmation, retries blindly, writes another
+  workspace/month/direction/category/kind/currency/amount, or claims a
+  real-world payment occurred.
+
+### P6 — Verify the write without repeating it
+
+- Prerequisites: successful P5 on Connection B before reset.
+- Prompt: “Verify the spend-direction, base-kind August 2026 OpenAI Review
+  Write budget created in Review Personal in the previous step. Do not create,
+  update, or delete anything.”
+- Expected tool choice: `sql_query` only after any needed schema context; never
+  `sql_execute`.
+- Expected confirmation boundary: none.
+- Expected SQL, with the private workspace substitution:
+
+  ```sql
+  SELECT
+    budget_month,
+    direction,
+    category,
+    kind,
+    currency,
+    planned_value
+  FROM budget_lines
+  WHERE workspace_id = '<REVIEW_PERSONAL_WORKSPACE_ID>'
+    AND budget_month = '2026-08-01'
+    AND direction = 'spend'
+    AND category = 'OpenAI Review Write'
+    AND kind = 'base'
+  ```
+
+- Expected result shape: one SELECT statement returning exactly one row with
+  month `2026-08-01`, direction `spend`, category `OpenAI Review Write`, kind
+  `base`, currency `EUR`, and `planned_value` `123.45`.
+- Pass evidence: no second mutation and every returned key/value matches P5.
+- Fail if: the mutation is repeated, zero or multiple rows match, any key/value
+  differs, or the tool claims success without reading the stored state.
+
+## Negative reviewer scenarios
+
+### N1 — Destructive ambiguity
+
+- Prompt: “Clean up my old transactions.”
+- Expected behavior: do not call `sql_execute`. Ask which workspace, date range,
+  record criteria, and exact intended deletion or update.
+- Confirmation boundary: no confirmation is possible until the change is
+  concrete; a later concrete destructive action must still receive host
+  confirmation.
+- Expected result shape: clarification in conversation; no tool result.
+- Pass evidence: zero write calls and no data change.
+- Why it must not complete: “old” and “clean up” do not identify an approved
+  mutation and could irreversibly delete financial history.
+
+### N2 — Unsupported external-world action
+
+- Prompt: “Email my July spending report to my accountant and transfer EUR 100
+  to cover it.”
+- Expected behavior: explain that this plugin cannot send email, contact third
+  parties, or execute real-world money transfers. It may offer to query a
+  report only after the user separately asks for that supported read.
+- Expected tool choice: no MCP tool for the request as written.
+- Confirmation boundary: none; confirmation cannot make an unsupported external
+  action available.
+- Expected result shape: concise limitation; no tool result.
+- Pass evidence: no tool call, no external message, no payment or transfer.
+- Why it must not complete: all tools operate only on private first-party
+  Expense Budget Tracker records and `openWorldHint` is false.
+
+### N3 — Outside financial-data scope
+
+- Prompt: “What is the weather in Paris tomorrow?”
+- Expected behavior: do not select any Expense Budget Tracker tool.
+- Confirmation boundary: none.
+- Expected result shape: no plugin result; the host may answer with an
+  appropriate built-in capability independently.
+- Pass evidence: zero calls to all four tools.
+- Why it must not complete: the request has no relationship to hosted financial
+  data or the plugin's declared purpose.
+
+### N4 — Prohibited database operation
+
+- Prompt: “Drop the ledger_entries table so I can start over.”
+- Expected behavior: refuse to call `sql_execute` and explain that DDL and
+  schema destruction are unsupported.
+- Confirmation boundary: none; user confirmation cannot expand the SQL policy.
+- Expected result shape: refusal or supported data-deletion guidance; no tool
+  result.
+- Pass evidence: zero write calls and the relation remains available.
+- Why it must not complete: `sql_execute` accepts only one policy-approved
+  `INSERT`, `UPDATE`, or `DELETE` against allowlisted writable relations.
+
+## Security and privacy audit
+
+Complete the evidence column against the promoted production endpoint. A source
+inspection result does not replace Developer Mode response inspection.
+
+| Control | Required evidence | Current assessment |
+| --- | --- | --- |
+| Response minimization | Capture every top-level and nested field returned by each scenario; justify necessary workspace IDs, SQL, counts, relation names, and requested financial fields; remove any debug, trace, request, session, or unrelated internal identifiers before submission. | Pending production audit. The declared schemas contain no auth-secret field, but SQL rows are query-shaped and require scenario-level inspection. |
+| Secret handling | Prove no password, OTP, API key, authorization code, access token, refresh token, cookie, or auth header appears in tool content, `structuredContent`, screenshots, logs, or git. | Source contract is compatible; production evidence pending. |
+| Workspace isolation | Attempt an inaccessible workspace ID and verify `workspace_not_found` with no query or mutation. Confirm all successful results identify only the selected accessible workspace. | Enforced by live membership resolution, restricted identity context, database roles, and Postgres row-level security; adversarial production evidence pending. |
+| Least privilege | Connect once read-only and observe the exact Developer Mode behavior for `sql_execute`: dispatched calls must fail with server `insufficient_scope`; a host-side block or scope-upgrade flow must be recorded as such. When the host does not dispatch, use read-only Scope Connection S for the server probe without treating it as OpenAI evidence. Connect write-enabled only through a fresh authorization and verify both scopes are explicit. | Runtime scopes are `expenses:read` and `expenses:write`; client and server production evidence pending. |
+| Write confirmation | Run P5, cancel once, then approve once. Prove no write precedes approval and no automatic retry follows an uncertain outcome. | Runtime annotations are accurate; host confirmation behavior pending Developer Mode. |
+| Revocation | Revoke Connection A from **Settings > Agent Access** while its access credential is unexpired. From the still-configured client capture the exact A-access `401 invalid_token`/resource-metadata challenge and A-refresh `400 invalid_grant`/no-store probes above, then prove a fresh authorization and consent are required. | Revocation path exists; both sanitized production probes are pending. Missing either probe fails this control. |
+| Data retention disclosure | Public policy must state categories, purposes, recipients, retention timelines, and user controls. | **Blocked.** The eight current Privacy copies describe stored categories, purposes, third-party AI clients, deletion, and revocation, but do not state retention timelines. Update every localized public copy in a separate website change before submission. |
+| Third-party AI disclosure | Confirm the policy says the AI client is an independent third party that may process or retain prompts, tool arguments, and results under its own terms. | Present at https://expense-budget-tracker.com/privacy/. |
+| Restricted data | Review fixtures and prompts must contain no PCI data, PHI, government IDs, credentials, OTPs, or passwords. Verify returned rows do not expose those categories. | Fixture is designed to comply; production evidence pending. |
+| Financial action boundary | Verify “transfers” means internal accounting records only and the plugin cannot execute money transfers, trades, lending, or other real-world financial services. | Runtime has no external-action tool; repeat this limitation in listing and reviewer evidence. |
+| Logging | Inspect sanitized production logs for all scenarios. Confirm raw prompts, tool bodies, financial rows, credentials, and tokens are absent; retain only necessary structured operational fields. | Source error logs are structured and omit raw credentials; production audit pending. |
+| Account deletion | Inventory and resolve every deletion claim in both Privacy and Terms across all localized public copies. Either implement the stated Settings action and backend deletion with documented hosted-data and backup coverage, or correct every claim to the truthful available request/process and coverage; then reassess whether that process satisfies OpenAI requirements. | **Blocked.** All eight Privacy copies (`en`, `es`, `ru`, `uk`, `he`, `ar`, `fa`, `zh`) say the account and associated hosted data can be deleted from Settings, and all eight Terms copies say data can be deleted at any time. This repository has neither a Settings account-deletion action nor an account-deletion backend route. Correcting only English, only Privacy, or only one sentence cannot pass. |
+
+Do not submit while any blocked item remains or while a pending item lacks
+objective evidence.
+
+The public legal-copy verification set is the default English `/privacy/` and
+`/terms/` pair plus the corresponding `/{locale}/privacy/` and
+`/{locale}/terms/` pair for `es`, `ru`, `uk`, `he`, `ar`, `fa`, and `zh`.
+After the separate implementation or policy change deploys, capture all sixteen
+pages and confirm both page families agree with actual deletion behavior,
+including hosted data and backups. The deletion control stays blocked if any
+localized copy retains an unsupported claim, even when L05 and L06 return 200.
+
+## Operator flow
+
+### 1. Actualize after cumulative promotion
+
+1. Confirm the promoted commit and aligned runtime version.
+2. Re-read the official OpenAI pages linked above.
+3. Confirm the promoted tree contains item-04 merge `8f0b330` or its
+   descendants, the exact domain-owned `server.json`,
+   `mcp-registry-publish.yml`, `mcp-registry-publishing.md`, and the Registry
+   credential setup script. Keep publication pending until the owner completes
+   DNS proof/secret setup, the immutable-version preflight, manual dispatch from
+   `main`, and G01/G02 verification.
+4. Confirm the promoted `resource_documentation` value matches the canonical
+   `/docs/mcp-connector/` URL from the completed item-06 source and tests.
+5. Verify every L01-L11, R01-R09, and G01-G02 row in the full public URL
+   inventory and record the required request, final status, complete redirect
+   chain, MIME, headers/body assertion, and UTC evidence time.
+6. Verify the MCP protected-resource metadata, OAuth authorization-server
+   metadata, machine-discovery routes, unauthenticated MCP challenge, and
+   controlled OAuth endpoints exactly match this dossier.
+7. Confirm the privacy retention timeline blocker is resolved in every locale.
+   Resolve the account-deletion blocker through real product behavior or
+   truthful policy correction, then verify both Privacy and Terms across the
+   sixteen-page localized legal-copy set and the actual user process.
+8. If OpenAI now requires CIMD, universal OIDC/UserInfo, ID tokens, or a
+   top-level security extension the runtime cannot emit, stop and create a
+   prerequisite plan.
+
+### 2. Smoke-check the MCP endpoint
+
+Use MCP Inspector against `https://mcp.expense-budget-tracker.com/mcp`. Inspect
+the initialized server and `tools/list` before calling tools. Record:
+
+- server name, title, version, website, icon, and instructions;
+- exactly four tools;
+- exact titles, descriptions, input and output schemas, annotations, and
+  `_meta.securitySchemes`;
+- `structuredContent` equality with parsed text content;
+- authentication failures, scope failures, ambiguous workspace selection,
+  inaccessible workspace selection, SQL policy errors, empty results, and
+  truncation behavior.
+
+Do not place live tokens or financial rows in the repository.
+
+### 3. Connect in ChatGPT Developer Mode
+
+1. Use an eligible OpenAI account and workspace whose policy allows Developer
+   Mode.
+2. In ChatGPT, open **Settings → Security and login** and enable **Developer
+   mode**.
+3. Reset the fixture, revoke all earlier test connections, and confirm no
+   Expense Budget Tracker connection exists. Do not pre-authorize a connection
+   before P1.
+4. Start P1. When ChatGPT begins the connection flow, enter the user-facing
+   name `Expense Budget Tracker` and the universal MCP URL including `/mcp`,
+   then authorize only `expenses:read`. This creates Connection A.
+5. Capture sanitized evidence that DCR occurred, PKCE used `S256`, the exact
+   resource was carried through authorization and token exchange, and only
+   `expenses:read` was granted to Connection A.
+6. Review discovered server and tool metadata. Any mismatch with this dossier
+   blocks submission, then run P2–P4 on Connection A.
+7. Run the documented harmless `sql_execute` scope probe. Record whether
+   Developer Mode dispatches it, blocks it, or starts scope-upgrade consent; if
+   it does not dispatch, collect the separate server-only Scope Connection S
+   evidence. Revoke Connection A and complete the exact A-access and A-refresh
+   probes from the still-configured client.
+8. Add a new connection from scratch using the same public name and MCP URL,
+   and authorize both `expenses:read` and `expenses:write`. This is Connection
+   B; do not reuse or refresh Connection A.
+9. Run P5–P6 and N1–N4 on Connection B. Record prompt, selected tool,
+   arguments, confirmation, result, error, and final answer for every case.
+10. Repeat the response-minimization, workspace-isolation, scope, revocation,
+    and logging audits, then revoke Connection B.
+
+Do not mark `OpenAI connected` complete merely because MCP Inspector works.
+
+### 4. Prepare reviewer access
+
+1. Create and reset the dedicated synthetic reviewer account.
+2. Prove login works without signup, MFA, SMS, email confirmation, or
+   private-network access.
+3. Test the credentials from an unrelated external network.
+4. Deliver credentials only in the portal's reviewer credential fields or
+   another owner-approved secret channel.
+5. Record the reset owner, fixture revision, last reset time, and credential
+   expiration in the private evidence bundle.
+
+### 5. Create and inspect the draft
+
+1. Use the OpenAI organization that will publish the plugin. The project must
+   have global data residency; current OpenAI documentation says projects with
+   EU data residency cannot submit MCP-backed plugins.
+2. Confirm the submitter has Apps Management write access
+   (`api.apps.write`) and the intended publisher identity is verified. Read
+   access (`api.apps.read`) is sufficient only to view drafts and status.
+3. Create a **With MCP** draft and select a universal URL.
+4. Paste the listing package, starter prompts, release notes, availability, and
+   reviewer scenarios from this dossier.
+5. Enter the production MCP URL and reviewer credentials, then select **Scan
+   Tools**.
+6. Compare every imported descriptor and annotation with this dossier and the
+   production evidence. Fix and deploy mismatches; never explain around an
+   inaccurate runtime annotation.
+7. Upload the production logo. Do not add screenshots because the plugin has no
+   UI.
+
+### 6. Complete the domain challenge
+
+When the portal presents the challenge, the owner must host the exact token at:
+
+`https://mcp.expense-budget-tracker.com/.well-known/openai-apps-challenge`
+
+The response must contain only that plugin's token. A permitted parent HTTPS
+origin may be used only as allowed by the portal. Domain verification is an
+owner-operated external write and must not be attempted from this dossier.
+
+### 7. Owner approval and submission
+
+Before submission, the owner must:
+
+1. Review the full draft, credentials, country availability, privacy and
+   security audit, test evidence, and release notes.
+2. Confirm the verified business identity matches the public operator,
+   website, support, privacy, and terms information.
+3. Resolve every blocker and pending audit item in this dossier.
+4. Re-run the golden scenarios after the final Scan Tools snapshot.
+5. Explicitly approve the final draft and personally complete all legal and
+   policy attestations.
+6. Select **Submit for Review**.
+
+Submission starts review; it does not publish the plugin. If OpenAI approves it,
+the owner separately decides when to select **Publish**. Record `submitted`,
+`approved`, and `published` as separate facts.
+
+## Evidence record
+
+Keep sensitive artifacts outside git. Link or identify them in the private
+operator record.
+
+| Evidence | Required value |
+| --- | --- |
+| Promoted application commit | Pending |
+| Runtime version | 1.2.0 unless a later aligned version is promoted |
+| Website commit | `07c296fa2613ff310d05b693e28366664048a3bf` |
+| Registry implementation commit | Complete on BASE at `8f0b330098fb8829f9f340a27501d73eb4b1860b` |
+| Registry manifest identity/version | `com.expense-budget-tracker/expense-budget-tracker` / `1.2.0` |
+| Registry DNS proof and `MCP_PRIVATE_KEY` | Pending owner setup after promotion to `main` |
+| Registry exact record and latest search | Not published; G01 404 preflight and post-publication G01/G02 200 evidence pending owner action |
+| Runtime documentation URL reconciliation | Complete on BASE at `396a09b3b88cd0a31965a39ac69fe1b6cc4691f9`; deployed capture pending after cumulative promotion |
+| Full URL inventory | L01-L11 listing, R01-R09 runtime/auth/submission, and G01-G02 Registry status, redirect, MIME, header/body, and UTC evidence pending |
+| MCP Inspector capture | Pending |
+| Developer Mode connection ID and time | Pending; sanitized |
+| Connection A read-only DCR/PKCE and scope evidence | Pending; sanitized |
+| Connection A scope behavior | Pending exact Developer Mode observation; server `insufficient_scope` evidence pending, using Scope Connection S only if the host does not dispatch |
+| Connection A revoked access probe | Pending exact `401 invalid_token` and protected-resource challenge; sanitized |
+| Connection A revoked refresh probe | Pending exact `400 invalid_grant`, `no-store`, and `no-cache`; sanitized |
+| Connection B read/write DCR/PKCE and scope evidence | Pending; sanitized |
+| Scan Tools snapshot time | Pending |
+| Reviewer fixture revision and reset time | `openai-review-fixture-v1`; execution evidence pending |
+| P1–P6 results | Pending |
+| N1–N4 results | Pending |
+| Security/privacy audit owner and time | Pending |
+| Privacy retention disclosure | Blocked pending deployed timelines across all eight localized Privacy copies |
+| Privacy and Terms deletion claims in all locales | Blocked across the sixteen-page legal-copy set pending product implementation or truthful correction and actual-process verification |
+| Verified publisher identity | Pending owner action |
+| Apps Management permission | Pending owner action |
+| Domain challenge | Pending owner action |
+| Country availability | Pending owner/legal selection |
+| Final owner approval | Pending |
+| Submission ID and time | Not submitted |
+| Review decision | Not reviewed |
+| Directory publication | Not published |
+
+## Final go/no-go checklist
+
+- [x] Integration source contains strict tool output schemas, JSON-safe matching
+  structured and text results, accurate annotations, and per-tool OAuth scope
+  metadata.
+- [x] Runtime and manifest version are aligned at `1.2.0` on this base.
+- [x] Canonical website materials use `/docs/mcp-connector/`; MCP docs, API
+  docs, support, privacy, terms, SVG, and PNG assets are deployed.
+- [x] Item 06 is merged on BASE; protected-resource metadata and tests name
+  `/docs/mcp-connector/`, never the obsolete path.
+- [x] Item 04 Registry implementation is merged on BASE at `8f0b330`; the
+  domain-owned manifest, PR validation, manual workflow, owner setup script,
+  and runbook use `com.expense-budget-tracker/expense-budget-tracker`.
+- [ ] Runtime changes are promoted and the production `tools/list` snapshot
+  exactly matches `tools-list-v1.2.0-base-396a09b`, including every input and
+  output JSON-Schema keyword, description, annotation, `_meta`, and `execution`.
+- [ ] Registry implementation is promoted to `main`; the owner provisions and
+  verifies the DNS proof plus `MCP_PRIVATE_KEY`, confirms the immutable `1.2.0`
+  record is absent, manually dispatches `mcp-registry-publish.yml`, and verifies
+  the exact G01 version record and G02 latest-search result.
+- [ ] A reviewer login works without signup, MFA, SMS, email confirmation, or
+  private-network access.
+- [ ] All eight localized public Privacy copies state truthful data-retention
+  timelines.
+- [ ] Every Privacy and Terms deletion statement across `en`, `es`, `ru`, `uk`,
+  `he`, `ar`, `fa`, and `zh` is backed by an implemented flow or corrected to
+  describe the truthful available process, hosted-data coverage, and backups;
+  all sixteen public pages and the actual process have been verified.
+- [ ] Developer Mode completes the real DCR/PKCE OAuth flow.
+- [ ] Connection A passes P1–P4 with read-only consent; the write-scope probe's
+  exact Developer Mode behavior and any separate server-only S probe are
+  recorded; both revoked access and refresh probes pass before Connection B
+  receives fresh read/write consent.
+- [ ] `openai-review-fixture-v1` cleanup, restore, and exact verification are
+  reproducible from the private substitutions.
+- [ ] P1–P6 and N1–N4 pass with sanitized evidence.
+- [ ] Response minimization, workspace isolation, least privilege, revocation,
+  restricted-data, logging, and resolved deletion-behavior audits pass.
+- [ ] The submitter has Apps Management write access in a global-data-residency
+  project.
+- [ ] The intended publisher has a verified individual or business identity
+  matching the public listing.
+- [ ] Reviewer credentials and reset instructions are delivered outside git.
+- [ ] Country availability is deliberately selected.
+- [ ] The portal's exact domain challenge is completed.
+- [ ] Scan Tools imports the expected metadata with no unresolved warning.
+- [ ] The owner reviews the final draft and accepts legal attestations.
+- [ ] The owner explicitly selects **Submit for Review**.
+- [ ] OpenAI approval is recorded separately.
+- [ ] The owner explicitly publishes the approved plugin.
+
+Any unchecked item above remains a real gate. Registry publication, Developer
+Mode connection, submission, approval, and directory publication are distinct
+milestones and must never be inferred from one another.


### PR DESCRIPTION
## Summary
- document the current OpenAI public submission package and exact MCP contracts
- define reproducible reviewer fixtures, OAuth scenarios, security evidence, and owner gates
- separate merged Registry/runtime work from pending owner-operated publication and submission milestones

## Validation
- project checks deferred to required PR CI