### PR TITLE
Enforce complete version consumer alignment

### DIFF
--- a/docs/mcp-registry-publishing.md
+++ b/docs/mcp-registry-publishing.md
@@ -96,11 +96,35 @@ intended content or authentication response. In particular, verify the MCP
 guide, API guide, support, privacy, terms, three icon URLs, and the hosted MCP
 endpoint.
 
-Confirm that the exact manifest version is still absent. For version `1.2.0`:
+Confirm that the exact manifest version is still absent. Read the version from
+`server.json`, require a valid SemVer string, and URL-encode it so the preflight
+always targets the manifest being published. The `&&` prevents `curl` from
+running when extraction or validation fails:
 
 ```sh
-curl -i \
-  'https://registry.modelcontextprotocol.io/v0.1/servers/com.expense-budget-tracker%2Fexpense-budget-tracker/versions/1.2.0'
+encoded_server_version="$(
+python3 <<'PY'
+import json
+import re
+from pathlib import Path
+from urllib.parse import quote
+
+semver_pattern = re.compile(
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+    r"(?:-(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+)
+manifest = json.loads(Path("server.json").read_text(encoding="utf-8"))
+if not isinstance(manifest, dict):
+    raise TypeError("server.json must contain a JSON object")
+version = manifest.get("version")
+if not isinstance(version, str) or semver_pattern.fullmatch(version) is None:
+    raise ValueError("server.json version must be a valid SemVer string")
+print(quote(version, safe=""))
+PY
+)" && curl -i \
+  "https://registry.modelcontextprotocol.io/v0.1/servers/com.expense-budget-tracker%2Fexpense-budget-tracker/versions/${encoded_server_version}"
 ```
 
 HTTP 404 is the publishable state. HTTP 200 means the immutable version already

--- a/docs/openai-mcp-submission.md
+++ b/docs/openai-mcp-submission.md
@@ -9,6 +9,14 @@ The current official OpenAI documentation calls this product a **plugin** and
 the public catalog the **Plugins Directory**. Older Apps SDK URLs redirect to
 the current plugin documentation.
 
+Version literals in the live listing package, Registry lookup inventory,
+current runtime identity, and pending evidence record follow the aligned
+repository version as described in `docs/version-bump.md`. Versions attached to
+a named commit, named descriptor snapshot, or completed base checklist item are
+historical evidence and must not be rewritten during a later version bump. Live
+immutable-version safety instructions refer to G01 instead of repeating its
+managed version.
+
 ## Current status
 
 | Milestone | Status | Evidence or remaining gate |
@@ -231,9 +239,9 @@ There is still no published Registry record. After cumulative promotion to
 root DNS ownership proof and store `MCP_PRIVATE_KEY`, confirm G01 returns 404,
 dispatch `mcp-registry-publish.yml` from `main`, and then require G01 and G02 to
 return the exact published record. Registry name/version pairs are immutable;
-if G01 already returns 200 before publication, do not republish or alter
-`1.2.0`. Do not use the README statement that the server “is listed in MCP
-registries” as publication evidence.
+if G01 already returns 200 before publication, do not republish or alter the
+version identified by G01. Do not use the README statement that the server “is
+listed in MCP registries” as publication evidence.
 
 ### OAuth discovery contract
 
@@ -1469,9 +1477,9 @@ operator record.
   exactly matches `tools-list-v1.2.0-base-396a09b`, including every input and
   output JSON-Schema keyword, description, annotation, `_meta`, and `execution`.
 - [ ] Registry implementation is promoted to `main`; the owner provisions and
-  verifies the DNS proof plus `MCP_PRIVATE_KEY`, confirms the immutable `1.2.0`
-  record is absent, manually dispatches `mcp-registry-publish.yml`, and verifies
-  the exact G01 version record and G02 latest-search result.
+  verifies the DNS proof plus `MCP_PRIVATE_KEY`, confirms the immutable G01
+  version record is absent, manually dispatches `mcp-registry-publish.yml`, and
+  verifies the exact G01 version record and G02 latest-search result.
 - [ ] A reviewer login works without signup, MFA, SMS, email confirmation, or
   private-network access.
 - [ ] All eight localized public Privacy copies state truthful data-retention

--- a/docs/version-bump.md
+++ b/docs/version-bump.md
@@ -1,6 +1,6 @@
 # Version bumps
 
-All deployed workspace packages, exact internal dependency pins, lockfile metadata, the MCP runtime, and the MCP Registry manifest share one SemVer version. MCP Registry versions are immutable after publication, so the repository must be aligned before publication.
+All deployed workspace packages, exact internal dependency pins, lockfile metadata, the MCP runtime and its integration assertion, the MCP Registry manifest, and current operational submission fields share one SemVer version. MCP Registry versions are immutable after publication, so the repository must be aligned before publication.
 
 The root `package.json` and the root `package-lock.json` package entry are orchestration metadata and remain unversioned.
 
@@ -28,6 +28,21 @@ Update these MCP surfaces to the same version:
 
 - `server.json`: `version`
 - `apps/sql-api/src/mcp/server.ts`: the literal `SERVER_VERSION`
+- `apps/sql-api/src/mcp/server.test.ts`: the `getServerVersion()` assertion's `version`
+
+Update only these current operational fields in `docs/openai-mcp-submission.md`:
+
+- Public listing package: `Version under evaluation`
+- Public URL verification inventory: the G01 exact Registry version URL and the G02 expected exact record
+- MCP server identity: `version`
+- Evidence record: `Runtime version` and `Registry manifest identity/version`
+
+Other live publication instructions derive or reference a managed field instead of repeating its version:
+
+- `docs/openai-mcp-submission.md`: immutable-version safety and the pending publication checklist refer to G01
+- `docs/mcp-registry-publishing.md`: the exact-version preflight validates and URL-encodes the SemVer read from `server.json` before calling `curl`
+
+Do not replace those references with a version literal. Do not bulk-replace version literals in the dossier. Its only unmanaged product-version literals are historical evidence: the Item 04 `server.json` summary attached to commit `8f0b330098fb8829f9f340a27501d73eb4b1860b`, the named `tools-list-v1.2.0-base-396a09b` snapshot wherever referenced, and the completed base-alignment checklist item. Keep those labels unchanged and add new evidence for a later version when needed.
 
 ## Procedure
 
@@ -36,7 +51,7 @@ Update these MCP surfaces to the same version:
    - Minor: `x.y.z` becomes `x.(y + 1).0`.
    - Major: `x.y.z` becomes `(x + 1).0.0`.
 2. Treat “bump the minor version” as the normal request. For example, `1.2.0` becomes `1.3.0`.
-3. Update every managed manifest version, exact internal pin, lockfile field, `SERVER_VERSION`, and `server.json` together in one pull request.
+3. Update every managed manifest version, exact internal pin, lockfile field, MCP runtime and test assertion, `server.json`, and current operational dossier field together in one pull request.
 4. Let the required `PR Quality Gate` run `scripts/checks/pr/check-version-alignment.mjs` and confirm that every managed value is the same valid SemVer version.
 5. Review and merge the version-bump pull request before manually dispatching the MCP Registry publication workflow for that version.
 

--- a/scripts/checks/pr/check-version-alignment.mjs
+++ b/scripts/checks/pr/check-version-alignment.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 /** @typedef {null | boolean | number | string | ReadonlyArray<JsonValue> | JsonObject} JsonValue */
 /** @typedef {Readonly<Record<string, JsonValue | undefined>>} JsonObject */
 /** @typedef {{ readonly file: string, readonly fields: ReadonlyArray<string> }} JsonSurfaceSpec */
+/** @typedef {{ readonly file: string, readonly label: string, readonly prefix: string, readonly suffix: string }} SourceSurfaceSpec */
 /** @typedef {{ readonly path: string, readonly value: string }} VersionSurface */
 
 const VERSIONED_PACKAGE_PATHS = [
@@ -22,7 +23,8 @@ const SHARED_DEPENDENCY_PACKAGE_PATHS = [
 const SHARED_DEPENDENCY_NAME = "@expense-budget-tracker/agent-shared";
 const PACKAGE_LOCK_PATH = "package-lock.json";
 const MCP_SERVER_PATH = "apps/sql-api/src/mcp/server.ts";
-const SERVER_VERSION_PATTERN = /^const SERVER_VERSION = "([^"\r\n]+)";$/gm;
+const MCP_SERVER_TEST_PATH = "apps/sql-api/src/mcp/server.test.ts";
+const OPENAI_DOSSIER_PATH = "docs/openai-mcp-submission.md";
 const SEMVER_PATTERN = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 /** @type {ReadonlyArray<JsonSurfaceSpec>} */
@@ -42,6 +44,58 @@ const JSON_SURFACE_SPECS = [
     },
   ]),
   { file: "server.json", fields: ["version"] },
+];
+
+/** @type {ReadonlyArray<SourceSurfaceSpec>} */
+const OPERATIONAL_SOURCE_SURFACE_SPECS = [
+  {
+    file: MCP_SERVER_PATH,
+    label: "SERVER_VERSION",
+    prefix: "const SERVER_VERSION = \"",
+    suffix: "\";",
+  },
+  {
+    file: MCP_SERVER_TEST_PATH,
+    label: "getServerVersion assertion",
+    prefix: "        version: \"",
+    suffix: "\",",
+  },
+  {
+    file: OPENAI_DOSSIER_PATH,
+    label: "Version under evaluation",
+    prefix: "| Version under evaluation | ",
+    suffix: " |",
+  },
+  {
+    file: OPENAI_DOSSIER_PATH,
+    label: "G01 Registry lookup version",
+    prefix: "| G01 | Exact MCP Registry version, `GET` | `https://registry.modelcontextprotocol.io/v0.1/servers/com.expense-budget-tracker%2Fexpense-budget-tracker/versions/",
+    suffix: "` |",
+  },
+  {
+    file: OPENAI_DOSSIER_PATH,
+    label: "G02 expected Registry record version",
+    prefix: "| G02 | MCP Registry latest search, `GET` | `https://registry.modelcontextprotocol.io/v0.1/servers?search=com.expense-budget-tracker%2Fexpense-budget-tracker&version=latest` | Final `200`, `application/json`, no redirect. Before publication it must not contain this name/version; after publication it must contain the exact `",
+    suffix: "` record",
+  },
+  {
+    file: OPENAI_DOSSIER_PATH,
+    label: "MCP server identity version",
+    prefix: "| `version` | `",
+    suffix: "` |",
+  },
+  {
+    file: OPENAI_DOSSIER_PATH,
+    label: "Evidence record runtime version",
+    prefix: "| Runtime version | ",
+    suffix: " unless a later aligned version is promoted |",
+  },
+  {
+    file: OPENAI_DOSSIER_PATH,
+    label: "Evidence record Registry manifest version",
+    prefix: "| Registry manifest identity/version | `com.expense-budget-tracker/expense-budget-tracker` / `",
+    suffix: "` |",
+  },
 ];
 
 /**
@@ -109,22 +163,31 @@ const readJsonVersionSurface = (document, spec) => {
 };
 
 /**
- * @param {string} path
+ * @param {SourceSurfaceSpec} spec
  * @returns {VersionSurface}
  */
-const readRuntimeVersionSurface = (path) => {
-  const matches = [...readFileSync(path, "utf8").matchAll(SERVER_VERSION_PATTERN)];
-  if (matches.length !== 1) {
+const readOperationalSourceVersionSurface = (spec) => {
+  const matchingLines = readFileSync(spec.file, "utf8")
+    .split(/\r?\n/u)
+    .filter((line) => line.startsWith(spec.prefix));
+  if (matchingLines.length !== 1) {
     throw new Error(
-      `${path} must contain exactly one literal matching 'const SERVER_VERSION = "<version>";', found ${matches.length}`,
+      `${spec.file} must contain exactly one ${spec.label} literal matching ${JSON.stringify(`${spec.prefix}<version>${spec.suffix}`)}, found ${matchingLines.length}`,
     );
   }
 
-  const value = matches[0]?.[1];
-  if (value === undefined || value === "") {
-    throw new Error(`${path} SERVER_VERSION must be a non-empty string`);
+  const line = matchingLines[0];
+  const suffixIndex = line?.indexOf(spec.suffix, spec.prefix.length) ?? -1;
+  if (suffixIndex === -1) {
+    throw new Error(
+      `${spec.file} ${spec.label} literal must contain ${JSON.stringify(spec.suffix)} after the version`,
+    );
   }
-  return { path: `${path}#SERVER_VERSION`, value };
+  const value = line?.slice(spec.prefix.length, suffixIndex);
+  if (value === undefined || value === "") {
+    throw new Error(`${spec.file} ${spec.label} must be a non-empty string`);
+  }
+  return { path: `${spec.file}#${spec.label}`, value };
 };
 
 const jsonDocuments = new Map(
@@ -140,7 +203,7 @@ const jsonVersionSurfaces = JSON_SURFACE_SPECS.map((spec) => {
 });
 const versionSurfaces = [
   ...jsonVersionSurfaces,
-  readRuntimeVersionSurface(MCP_SERVER_PATH),
+  ...OPERATIONAL_SOURCE_SURFACE_SPECS.map(readOperationalSourceVersionSurface),
 ];
 
 const invalidSurfaces = versionSurfaces.filter(


### PR DESCRIPTION
Align every operational version consumer with the shared release version, keep immutable evidence fixed, and make the Registry preflight derive and validate the manifest version safely.