### PR TITLE
docs: correct MCP Registry onboarding status

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Connect through either the hosted MCP server or the direct Agent API. Their cred
 
 ### MCP connector
 
-The hosted MCP server is available at `https://mcp.expense-budget-tracker.com/mcp` and is listed in MCP registries as `io.github.kirill-markin/expense-budget-tracker`. It exposes four workspace-scoped tools:
+The hosted MCP server is available directly at `https://mcp.expense-budget-tracker.com/mcp`. Its canonical MCP Registry identity is `com.expense-budget-tracker/expense-budget-tracker`; it will be available through the Registry only after the manual publication workflow succeeds and exact-version verification completes. It exposes four workspace-scoped tools:
 
 - `list_workspaces` — list workspaces available to the signed-in user
 - `get_schema` — inspect the allowed relations, columns, constraints, and limits


### PR DESCRIPTION
## Summary
- keep direct hosted MCP onboarding usable before Registry publication
- document the canonical MCP Registry identity
- make Registry availability conditional on manual publication and exact-version verification

## Validation
- not run locally; docs-only change and cloud CI owns validation