### PR TITLE
fix: close Registry publication trust boundary

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -37,9 +37,9 @@ jobs:
           echo "safe_deadline_epoch=${safe_job_deadline_epoch}" >> "${GITHUB_OUTPUT}"
           echo "Recorded a ${safe_job_budget_seconds}-second safe job budget from the first executable step: ${JOB_TIMEOUT_SECONDS}-second job limit minus ${JOB_DEADLINE_SAFETY_BUFFER_SECONDS}-second platform safety buffer."
 
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
 
@@ -52,9 +52,11 @@ jobs:
           fi
 
       - name: Validate MCP Registry manifest
+        id: manifest_validation
         run: |
           set -euo pipefail
           schema_path="${RUNNER_TEMP}/mcp-server-schema-2025-12-11.json"
+          schema_sha256="3fba09590c99f61735d234822279f4223fab9e300c0a81e81c91ab62a4114de0"
           schema_fetch_timeout_seconds=75
           set +e
           timeout \
@@ -77,26 +79,72 @@ jobs:
             exit 1
           fi
 
+          schema_checksum_timeout_seconds=15
+          set +e
+          printf '%s  %s\n' "${schema_sha256}" "${schema_path}" | timeout \
+            --signal=TERM \
+            --kill-after="${PREPUBLICATION_KILL_AFTER_SECONDS}s" \
+            "${schema_checksum_timeout_seconds}s" \
+            sha256sum --check --strict
+          schema_checksum_exit=$?
+          set -e
+          if [ "${schema_checksum_exit}" -eq 124 ] || [ "${schema_checksum_exit}" -eq 137 ]; then
+            echo "::error::Pinned MCP Registry schema verification exceeded its ${schema_checksum_timeout_seconds}-second execution deadline; timeout exit status: ${schema_checksum_exit}."
+            exit 1
+          fi
+          if [ "${schema_checksum_exit}" -ne 0 ]; then
+            echo "::error::MCP Registry schema SHA-256 verification failed with exit status ${schema_checksum_exit}; expected ${schema_sha256}."
+            exit 1
+          fi
+
           ajv_timeout_seconds=90
           set +e
           timeout \
             --signal=TERM \
             --kill-after="${PREPUBLICATION_KILL_AFTER_SECONDS}s" \
             "${ajv_timeout_seconds}s" \
-            npx --yes ajv-cli@5.0.0 validate \
-            -s "${schema_path}" \
-            -d server.json \
-            --strict=false
+            bash -c '
+              set -euo pipefail
+              npm ci --ignore-scripts --no-audit --no-fund
+              ./node_modules/.bin/ajv validate \
+                -s "$1" \
+                -d server.json \
+                --strict=false
+            ' bash "${schema_path}"
           ajv_exit=$?
           set -e
           if [ "${ajv_exit}" -eq 124 ] || [ "${ajv_exit}" -eq 137 ]; then
-            echo "::error::Pinned ajv-cli@5.0.0 installation or manifest validation exceeded its ${ajv_timeout_seconds}-second execution deadline; timeout exit status: ${ajv_exit}."
+            echo "::error::Integrity-locked dependency installation or manifest validation with ajv-cli@5.0.0 exceeded its ${ajv_timeout_seconds}-second execution deadline; timeout exit status: ${ajv_exit}."
             exit 1
           fi
           if [ "${ajv_exit}" -ne 0 ]; then
-            echo "::error::Pinned ajv-cli@5.0.0 manifest validation failed with exit status ${ajv_exit}."
+            echo "::error::Integrity-locked dependency installation or manifest validation with ajv-cli@5.0.0 failed with exit status ${ajv_exit}."
             exit 1
           fi
+
+          manifest_digest_timeout_seconds=15
+          set +e
+          manifest_sha256_output="$(timeout \
+            --signal=TERM \
+            --kill-after="${PREPUBLICATION_KILL_AFTER_SECONDS}s" \
+            "${manifest_digest_timeout_seconds}s" \
+            sha256sum server.json)"
+          manifest_digest_exit=$?
+          set -e
+          if [ "${manifest_digest_exit}" -eq 124 ] || [ "${manifest_digest_exit}" -eq 137 ]; then
+            echo "::error::Validated server.json digest calculation exceeded its ${manifest_digest_timeout_seconds}-second execution deadline; timeout exit status: ${manifest_digest_exit}."
+            exit 1
+          fi
+          if [ "${manifest_digest_exit}" -ne 0 ]; then
+            echo "::error::Validated server.json digest calculation failed with exit status ${manifest_digest_exit}."
+            exit 1
+          fi
+          manifest_sha256="${manifest_sha256_output%% *}"
+          if [[ ! "${manifest_sha256}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::Validated server.json digest calculation returned an invalid SHA-256 value: ${manifest_sha256}."
+            exit 1
+          fi
+          echo "sha256=${manifest_sha256}" >> "${GITHUB_OUTPUT}"
 
       - name: Check version alignment
         run: |
@@ -312,6 +360,7 @@ jobs:
         id: publish
         env:
           SAFE_JOB_DEADLINE_EPOCH: ${{ steps.job_budget.outputs.safe_deadline_epoch }}
+          VALIDATED_MANIFEST_SHA256: ${{ steps.manifest_validation.outputs.sha256 }}
           MCP_PUBLISHER: ${{ steps.publisher.outputs.path }}
         run: |
           set -euo pipefail
@@ -332,6 +381,24 @@ jobs:
             exit 1
           fi
           echo "Publication budget accepted: ${remaining_job_budget_seconds} seconds remain before the conservative job deadline; ${required_publication_budget_seconds} seconds are required."
+
+          manifest_reverification_timeout_seconds=15
+          set +e
+          printf '%s  %s\n' "${VALIDATED_MANIFEST_SHA256}" server.json | timeout \
+            --signal=TERM \
+            --kill-after="${PREPUBLICATION_KILL_AFTER_SECONDS}s" \
+            "${manifest_reverification_timeout_seconds}s" \
+            sha256sum --check --strict
+          manifest_reverification_exit=$?
+          set -e
+          if [ "${manifest_reverification_exit}" -eq 124 ] || [ "${manifest_reverification_exit}" -eq 137 ]; then
+            echo "::error::Validated server.json digest reverification exceeded its ${manifest_reverification_timeout_seconds}-second execution deadline; timeout exit status: ${manifest_reverification_exit}. No publication was attempted."
+            exit 1
+          fi
+          if [ "${manifest_reverification_exit}" -ne 0 ]; then
+            echo "::error::server.json changed after validation; expected reviewed SHA-256 ${VALIDATED_MANIFEST_SHA256}. No publication was attempted."
+            exit 1
+          fi
           echo "attempted=true" >> "${GITHUB_OUTPUT}"
 
           set +e
@@ -383,19 +450,15 @@ jobs:
 
             if [ "${curl_exit}" -eq 0 ] && [ "${status}" = "200" ]; then
               if jq --exit-status \
-                --arg server_name "${SERVER_NAME}" \
-                --arg server_version "${SERVER_VERSION}" \
-                --arg server_remote_url "${SERVER_REMOTE_URL}" \
-                '.server.name == $server_name and
-                 .server.version == $server_version and
-                 any(.server.remotes[]?; .type == "streamable-http" and .url == $server_remote_url)' \
+                --slurpfile reviewed_manifest server.json \
+                '.server == $reviewed_manifest[0]' \
                 "${response_body}" > /dev/null; then
                 if [ "${PUBLISH_EXIT_STATUS}" -ne 0 ]; then
-                  echo "::warning::Reconciled successful publication after mcp-publisher exited with status ${PUBLISH_EXIT_STATUS}; the exact Registry record matches server.json."
-                  publication_outcome="Reconciled exact Registry record after non-zero publisher exit"
+                  echo "::warning::Reconciled successful publication after mcp-publisher exited with status ${PUBLISH_EXIT_STATUS}; the complete nested Registry server manifest matches server.json."
+                  publication_outcome="Reconciled complete Registry server manifest after non-zero publisher exit"
                 else
-                  echo "Exact Registry record matches server.json after mcp-publisher exited with status 0."
-                  publication_outcome="Publisher exited successfully and exact Registry record reconciled"
+                  echo "Complete nested Registry server manifest matches server.json after mcp-publisher exited with status 0."
+                  publication_outcome="Publisher exited successfully and complete Registry server manifest reconciled"
                 fi
                 {
                   echo "## MCP Registry publication"
@@ -421,7 +484,7 @@ jobs:
               elif [ "${status}" != "200" ]; then
                 echo "::warning::Registry reconciliation returned HTTP ${status}; retrying in ${retry_delay_seconds}s (${attempt}/${max_attempts})."
               else
-                echo "::warning::Registry reconciliation returned HTTP 200, but the nested server record did not match server.json name ${SERVER_NAME}, version ${SERVER_VERSION}, and streamable-http remote ${SERVER_REMOTE_URL}; retrying in ${retry_delay_seconds}s (${attempt}/${max_attempts})."
+                echo "::warning::Registry reconciliation returned HTTP 200, but the complete nested server manifest did not semantically equal the reviewed server.json; retrying in ${retry_delay_seconds}s (${attempt}/${max_attempts})."
               fi
               sleep "${retry_delay_seconds}"
               continue
@@ -433,7 +496,7 @@ jobs:
               echo "::error::Registry reconciliation failed after ${max_attempts} attempts for ${VERSION_ENDPOINT}; mcp-publisher exit status: ${PUBLISH_EXIT_STATUS}; last HTTP status: ${status}. Response body follows."
               cat "${response_body}"
             else
-              echo "::error::Registry reconciliation returned HTTP 200 after ${max_attempts} attempts, but the nested server record did not match server.json name ${SERVER_NAME}, version ${SERVER_VERSION}, and streamable-http remote ${SERVER_REMOTE_URL}; mcp-publisher exit status: ${PUBLISH_EXIT_STATUS}. Response body follows."
+              echo "::error::Registry reconciliation returned HTTP 200 after ${max_attempts} attempts, but the complete nested server manifest did not semantically equal the reviewed server.json; mcp-publisher exit status: ${PUBLISH_EXIT_STATUS}. Response body follows."
               cat "${response_body}"
             fi
             exit 1

--- a/docs/mcp-registry-publishing.md
+++ b/docs/mcp-registry-publishing.md
@@ -140,16 +140,21 @@ gh workflow run mcp-registry-publish.yml \
 
 The workflow rejects every non-`main` ref. Its first executable step records a
 conservative deadline 840 seconds later: the 900-second job limit minus a
-60-second platform safety buffer. Before reading the private key, it validates
-`server.json` with exactly `ajv-cli@5.0.0`, runs the shared version checker, and
-confirms that the exact name/version returns 404. The controlled
-pre-publication processes have explicit execution deadlines: 75 seconds for
-the schema download, 90 seconds for AJV installation and validation, 30 seconds
-for version alignment, 75 seconds for the publisher download, 15 seconds for
-its checksum verification, 30 seconds for extraction, and 60 seconds for DNS
-authentication. Each deadline allows a further five seconds for forced
-termination. The workflow then uses the official Linux ARM64 archive from the
-audited
+60-second platform safety buffer. The publication job pins checkout and Node
+setup actions to reviewed commit SHAs. Before reading the private key, it
+downloads the 2025-12-11 schema and verifies SHA-256
+`3fba09590c99f61735d234822279f4223fab9e300c0a81e81c91ab62a4114de0`, installs
+the exact integrity-locked dependencies with lifecycle scripts disabled, runs
+the repository-local `ajv-cli@5.0.0`, records the validated `server.json`
+SHA-256, runs the shared version checker, and confirms that the exact
+name/version returns 404. The controlled pre-publication processes have
+explicit execution deadlines: 75 seconds for the schema download, 15 seconds
+for its checksum verification, 90 seconds for locked dependency installation
+and AJV validation, 15 seconds for the manifest digest, 30 seconds for version
+alignment, 75 seconds for the publisher download, 15 seconds for its checksum
+verification, 30 seconds for extraction, and 60 seconds for DNS authentication.
+Each deadline allows a further five seconds for forced termination. The
+workflow then uses the official Linux ARM64 archive from the audited
 [`mcp-publisher` v1.8.1 release](https://github.com/modelcontextprotocol/registry/releases/tag/v1.8.1)
 and verifies its pinned SHA-256 digest
 `8dd75a6cf6845688b5d4e46df58d3ca26d5c8d233bb0626606e1db82c5e883e4`
@@ -160,23 +165,28 @@ reviewed tag and independently pinned digest. The workflow exposes
 
 The publish command has a five-minute execution deadline. The workflow sends
 `TERM` at the deadline and `KILL` ten seconds later if the process has not
-stopped. Immediately before invoking it, the workflow requires at least 540
-seconds before the conservative deadline: 300 seconds for the publisher, 10
-seconds for forced termination, 170 seconds for reconciliation (six 20-second
-requests and five 10-second retry delays), and a 60-second transition/reporting
-buffer. Insufficient budget fails before publication starts. The separate
-60-second platform safety buffer leaves 120 seconds beyond the 480-second
-publisher-and-reconciliation maximum.
+stopped. Before publication, the workflow requires at least 540 seconds before
+the conservative deadline: 300 seconds for the publisher, 10 seconds for
+forced termination, 170 seconds for reconciliation (six 20-second requests and
+five 10-second retry delays), and a 60-second transition/reporting buffer. It
+then reverifies the validated `server.json` SHA-256 under a 15-second deadline
+immediately before marking publication attempted and invoking the publisher.
+Insufficient budget or digest drift fails before publication starts. The
+separate 60-second platform safety buffer leaves 120 seconds beyond the
+480-second publisher-and-reconciliation maximum.
 
 The publisher's exit status, including a timeout status, is not treated as the
 final outcome because a network failure or timeout can happen after the
 Registry accepts the immutable record. Once publication starts, the workflow
 records that status and runs the exact-version reconciliation step even if the
 publisher step reports failure. It succeeds only when an HTTP 200 response
-contains a nested server record whose name, version, and Streamable HTTP remote
-URL match `server.json`. A matching record reconciles a non-zero or timed-out
-publisher exit; a missing or mismatched record fails with the publisher status
-and Registry response context. The resulting GitHub job summary is secret-free.
+contains a nested `.server` record that semantically equals the complete
+reviewed `server.json`. Object key order is irrelevant; array order and
+cardinality are exact. Registry-owned top-level `_meta` is outside the
+comparison, while publisher-provided `.server._meta` must match. A matching
+record reconciles a non-zero or timed-out publisher exit; a missing or
+mismatched record fails with the publisher status and Registry response
+context. The resulting GitHub job summary is secret-free.
 
 ## Successful verification
 
@@ -200,8 +210,8 @@ documentation, support, privacy, terms, and icon URLs. A successful workflow
 summary records the published commit, verified publisher version and digest,
 publisher exit status, exact verification endpoint, and reconciliation outcome
 without including credentials. HTTP 200 alone is insufficient: the response's
-nested server record must match the reviewed `server.json` identity, version,
-and Streamable HTTP remote URL.
+nested `.server` record must semantically equal the complete reviewed
+`server.json`.
 
 ## Immutable-version behavior
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
         "apps/*",
         "packages/*",
         "infra/*"
-      ]
+      ],
+      "devDependencies": {
+        "ajv-cli": "5.0.0"
+      }
     },
     "apps/auth": {
       "name": "expense-tracker-auth",
@@ -3803,6 +3806,33 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
+      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0",
+        "fast-json-patch": "^2.0.0",
+        "glob": "^7.1.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^2.0.0",
+        "json5": "^2.1.3",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "ajv": "dist/index.js"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
@@ -4037,6 +4067,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4139,6 +4176,17 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -4250,6 +4298,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/constructs": {
       "version": "10.8.1",
@@ -4951,6 +5006,20 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -5069,6 +5138,26 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-json-patch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -5178,6 +5267,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -5245,6 +5341,28 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -5387,6 +5505,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5468,6 +5598,30 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -5479,6 +5633,19 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -5654,6 +5821,29 @@
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mnemonist": {
       "version": "0.38.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "packages/*",
     "infra/*"
   ],
+  "devDependencies": {
+    "ajv-cli": "5.0.0"
+  },
   "allowScripts": {
     "esbuild@0.28.2": true,
     "fsevents@2.3.2": true,


### PR DESCRIPTION
## Summary
- pin publication-job actions, Registry schema bytes, and validator dependencies
- reverify the reviewed manifest immediately before publication
- reconcile the complete publisher-controlled Registry server manifest

## Validation
- clean behavioral/security review
- local project checks intentionally not run; required GitHub CI owns validation