### PR TITLE
Fix Registry PKCS#8 version validation

### DIFF
--- a/scripts/cloudflare/setup-mcp-registry-credential.sh
+++ b/scripts/cloudflare/setup-mcp-registry-credential.sh
@@ -435,12 +435,13 @@ is_ed25519_private_key = (
     outer_tag == 0x30
     and outer_end == len(der)
     and version_tag == 0x02
-    and version in (b"\\x00", b"\\x01")
+    and version == b"\x00"
     and algorithm_tag == 0x30
     and oid_tag == 0x06
     and oid == bytes.fromhex("2b6570")
     and algorithm_end == len(algorithm)
     and private_key_tag == 0x04
+    and field_offset == len(private_key_info)
     and seed_tag == 0x04
     and seed_end == len(wrapped_seed)
     and len(seed) == 32


### PR DESCRIPTION
## Summary

- compare the decoded PKCS#8 version with the actual one-byte version emitted by OpenSSL
- reject trailing fields in the generated `PrivateKeyInfo` structure
- preserve the existing strict Ed25519 and secret-safety checks

## Validation

- Fresh behavioral/security static review passed
- Local tests and the credential helper were not run; GitHub Actions owns executable validation