### PR TITLE
Promote Registry DER validation fix

### DIFF
--- a/scripts/cloudflare/setup-mcp-registry-credential.sh
+++ b/scripts/cloudflare/setup-mcp-registry-credential.sh
@@ -435,12 +435,13 @@ is_ed25519_private_key = (
     outer_tag == 0x30
     and outer_end == len(der)
     and version_tag == 0x02
-    and version in (b"\\x00", b"\\x01")
+    and version == b"\x00"
     and algorithm_tag == 0x30
     and oid_tag == 0x06
     and oid == bytes.fromhex("2b6570")
     and algorithm_end == len(algorithm)
     and private_key_tag == 0x04
+    and field_offset == len(private_key_info)
     and seed_tag == 0x04
     and seed_end == len(wrapped_seed)
     and len(seed) == 32


### PR DESCRIPTION
Promotes the already reviewed Registry PKCS#8 DER validation fix from `integration-mcp-publication` to `main`.

Source head: 23adb857b40e91de2ad2cb986e0f301fc57a3824
Included item: PR #240
Content diff against current main: only `scripts/cloudflare/setup-mcp-registry-credential.sh` (2 additions, 1 deletion).

This PR must merge with a merge commit after every required or started GitHub check completes successfully.