### PR TITLE
Promote OAuth consent safety and clarity

### DIFF
--- a/apps/auth/src/routes/oauth.test.ts
+++ b/apps/auth/src/routes/oauth.test.ts
@@ -72,19 +72,23 @@ const authorizationParamsForClient = (oauthClient: OAuthClient, state: string): 
 
 const authorizationParams = (): URLSearchParams => authorizationParamsForClient(client, "state-1");
 
-const consentRequest = (params: URLSearchParams, origin: string): Request => new Request(
-  `${issuer}/oauth/authorize`,
-  {
+const consentRequest = (
+  params: URLSearchParams,
+  origin: string | null,
+  secFetchSite: string | null,
+): Request => {
+  const headers = new Headers({
+    "Content-Type": "application/x-www-form-urlencoded",
+    Cookie: "session=valid-session",
+  });
+  if (origin !== null) headers.set("Origin", origin);
+  if (secFetchSite !== null) headers.set("Sec-Fetch-Site", secFetchSite);
+  return new Request(`${issuer}/oauth/authorize`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Cookie: "session=valid-session",
-      Origin: origin,
-      "Sec-Fetch-Site": origin === issuer ? "same-origin" : "cross-site",
-    },
+    headers,
     body: params.toString(),
-  },
-);
+  });
+};
 
 type BodyLimitCase = Readonly<{
   name: string;
@@ -390,6 +394,7 @@ test("consent is no-store, anti-clickjacking, and same-origin protected", async 
   assert.equal(consentPage.status, 200);
   assert.equal(consentPage.headers.get("cache-control"), "no-store");
   assert.equal(consentPage.headers.get("x-frame-options"), "DENY");
+  assert.equal(consentPage.headers.get("referrer-policy"), "strict-origin");
   assert.match(consentPage.headers.get("content-security-policy") ?? "", /frame-ancestors 'none'/u);
   const consentHtml = await consentPage.text();
   assert.match(consentHtml, /Desktop &lt;MCP&gt;/u);
@@ -402,14 +407,26 @@ test("consent is no-store, anti-clickjacking, and same-origin protected", async 
 
   const form = authorizationParams();
   form.set("decision", "allow");
-  const crossOrigin = await app.fetch(consentRequest(form, "https://attacker.example"));
-  assert.equal(crossOrigin.status, 403);
+  const rejectedSecurityHeaders: ReadonlyArray<readonly [string | null, string | null]> = [
+    ["https://attacker.example", "same-origin"],
+    ["null", "same-origin"],
+    [null, "same-origin"],
+    [issuer, "cross-site"],
+  ];
+  for (const [origin, secFetchSite] of rejectedSecurityHeaders) {
+    const rejected = await app.fetch(consentRequest(form, origin, secFetchSite));
+    assert.equal(rejected.status, 403);
+  }
   assert.equal(issueCount, 0);
 
-  const allowed = await app.fetch(consentRequest(form, issuer));
+  const allowed = await app.fetch(consentRequest(form, issuer, "same-origin"));
   assert.equal(allowed.status, 302);
   assert.match(allowed.headers.get("location") ?? "", /code=ebt_ac_issued-code/u);
   assert.equal(issueCount, 1);
+
+  const allowedWithoutFetchMetadata = await app.fetch(consentRequest(form, issuer, null));
+  assert.equal(allowedWithoutFetchMetadata.status, 302);
+  assert.equal(issueCount, 2);
 });
 
 test("authorization GET enforces its raw query ceiling and keeps nested login below its ceiling", async (): Promise<void> => {
@@ -476,7 +493,7 @@ test("consent renders only when both encoded decisions fit the POST byte limit",
   const denied = new URLSearchParams(exactBoundary);
   denied.set("decision", "deny");
   assert.ok(utf8Length(denied.toString()) <= MAX_CONSENT_REQUEST_BYTES);
-  const submission = await app.fetch(consentRequest(allowed, issuer));
+  const submission = await app.fetch(consentRequest(allowed, issuer, "same-origin"));
   assert.equal(submission.status, 302);
 
   const oversized = consentParametersWithEncodedSize(
@@ -503,7 +520,7 @@ test("authorization success appends parameters without rewriting the registered 
   const form = authorizationParamsForClient(exactRedirectClient, "state value/%");
   form.set("decision", "allow");
 
-  const response = await app.fetch(consentRequest(form, issuer));
+  const response = await app.fetch(consentRequest(form, issuer, "same-origin"));
 
   assert.equal(response.status, 302);
   assert.equal(
@@ -565,7 +582,7 @@ test("authorization POST logs and redirects code-persistence failures after call
   const form = authorizationParams();
   form.set("decision", "allow");
 
-  const response = await app.fetch(consentRequest(form, issuer));
+  const response = await app.fetch(consentRequest(form, issuer, "same-origin"));
 
   assert.equal(response.status, 302);
   assert.equal(
@@ -656,7 +673,7 @@ test("consent revalidates every submitted authorization field", async (): Promis
     const form = authorizationParams();
     form.set("decision", "allow");
     form.set(name, value);
-    const response = await app.fetch(consentRequest(form, issuer));
+    const response = await app.fetch(consentRequest(form, issuer, "same-origin"));
     const location = response.headers.get("location") ?? "";
     assert.equal(location.includes("code="), false, `${name} mutation must not issue a code`);
   }

--- a/apps/auth/src/routes/oauth.test.ts
+++ b/apps/auth/src/routes/oauth.test.ts
@@ -397,11 +397,19 @@ test("consent is no-store, anti-clickjacking, and same-origin protected", async 
   assert.equal(consentPage.headers.get("referrer-policy"), "strict-origin");
   assert.match(consentPage.headers.get("content-security-policy") ?? "", /frame-ancestors 'none'/u);
   const consentHtml = await consentPage.text();
+  assert.match(consentHtml, /<h1>Connect <bdi dir="auto">Desktop &lt;MCP&gt;<\/bdi> to Expense Budget Tracker\?<\/h1>/u);
   assert.match(consentHtml, /Desktop &lt;MCP&gt;/u);
   assert.equal(consentHtml.includes("Desktop <MCP>"), false);
-  assert.match(consentHtml, /Unverified client name/u);
+  assert.match(consentHtml, /connecting app supplied the displayed name/u);
+  assert.match(consentHtml, /Expense Budget Tracker has not verified who operates it/u);
+  assert.match(consentHtml, /Continue only if you started this connection and recognize the destination below/u);
+  assert.match(consentHtml, /After approval, you'll return to/u);
+  assert.match(consentHtml, /<p class="callback">https:\/\/client\.example<\/p>/u);
+  assert.match(consentHtml, /does not verify who operates the app/u);
+  assert.match(consentHtml, /<strong>Read access:<\/strong> View all financial data in the workspaces you can access\./u);
+  assert.match(consentHtml, /<strong>Write access:<\/strong> Create, change, and delete financial data\./u);
+  assert.match(consentHtml, /<details class="technical"><summary>Technical details<\/summary>/u);
   assert.match(consentHtml, /Client ID<\/dt><dd>ebt_cl_registered-client/u);
-  assert.match(consentHtml, /Callback origin<\/dt><dd>https:\/\/client\.example/u);
   assert.match(consentHtml, /Exact redirect URI<\/dt><dd>https:\/\/client\.example\/callback\?next=a&amp;source=b/u);
   assert.equal(consentHtml.includes("callback?next=a&source=b</dd>"), false);
 
@@ -427,6 +435,54 @@ test("consent is no-store, anti-clickjacking, and same-origin protected", async 
   const allowedWithoutFetchMetadata = await app.fetch(consentRequest(form, issuer, null));
   assert.equal(allowedWithoutFetchMetadata.status, 302);
   assert.equal(issueCount, 2);
+});
+
+test("consent isolates a bidi client name from trusted text", async (): Promise<void> => {
+  const hostileClient: OAuthClient = {
+    clientId: "ebt_cl_hostile-name",
+    clientName: "Reports <app>\u202EExpense Budget Tracker",
+    redirectUris: ["https://reports.example/callback"],
+  };
+  const app = createOAuthApp(createDependencies({
+    getOAuthClient: async (clientId) => clientId === hostileClient.clientId ? hostileClient : null,
+  }));
+  const query = authorizationParamsForClient(hostileClient, "state-hostile-name");
+  const response = await app.request(`${issuer}/oauth/authorize?${query.toString()}`);
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  const escapedClientName = "Reports &lt;app&gt;\u202EExpense Budget Tracker";
+  const isolatedClientName = `<bdi dir="auto">${escapedClientName}</bdi>`;
+  assert.equal(html.split(isolatedClientName).length - 1, 2);
+  assert.equal(html.includes(`<h1>Connect ${isolatedClientName} to Expense Budget Tracker?</h1>`), true);
+  assert.equal(html.includes(`displayed name <strong>${isolatedClientName}</strong>. Expense Budget Tracker has not verified who operates it.`), true);
+});
+
+test("consent displays destinations for supported callback shapes", async (): Promise<void> => {
+  const callbackCases: ReadonlyArray<Readonly<{ redirectUri: string; destination: string }>> = [
+    { redirectUri: "https://business.example/oauth/callback", destination: "https://business.example" },
+    { redirectUri: "http://127.0.0.1:49152/callback", destination: "http://127.0.0.1:49152" },
+    { redirectUri: "com.example.client:/callback", destination: "com.example.client:" },
+    { redirectUri: "expense-tracker://callback/path", destination: "expense-tracker://callback" },
+  ];
+
+  for (const [index, callbackCase] of callbackCases.entries()) {
+    const callbackClient: OAuthClient = {
+      clientId: `ebt_cl_callback-${index}`,
+      clientName: "Callback app",
+      redirectUris: [callbackCase.redirectUri],
+    };
+    const app = createOAuthApp(createDependencies({
+      getOAuthClient: async (clientId) => clientId === callbackClient.clientId ? callbackClient : null,
+    }));
+    const query = authorizationParamsForClient(callbackClient, `state-${index}`);
+    const response = await app.request(`${issuer}/oauth/authorize?${query.toString()}`);
+
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    assert.equal(html.includes(`<p class="callback">${callbackCase.destination}</p>`), true);
+    assert.equal(html.includes(`<dt>Exact redirect URI</dt><dd>${callbackCase.redirectUri}</dd>`), true);
+  }
 });
 
 test("authorization GET enforces its raw query ceiling and keeps nested login below its ceiling", async (): Promise<void> => {

--- a/apps/auth/src/routes/oauth.ts
+++ b/apps/auth/src/routes/oauth.ts
@@ -168,19 +168,26 @@ const validateConsentSubmissionSize = (request: AuthorizationRequest): void => {
   }
 };
 
+const getCallbackDestination = (redirectUri: string): string => {
+  const callbackUrl = new URL(redirectUri);
+  if (callbackUrl.origin !== "null") return callbackUrl.origin;
+  if (callbackUrl.host !== "") return `${callbackUrl.protocol}//${callbackUrl.host}`;
+  return callbackUrl.protocol;
+};
+
 const renderConsent = (client: OAuthClient, request: AuthorizationRequest): string => {
   const hidden = consentHiddenFields(request)
     .map(([name, value]) => `<input type="hidden" name="${name}" value="${escapeHtml(value)}">`)
     .join("");
-  const permissions = request.scopes.map((scope) => `<li>${scope === "expenses:read" ? "Read expenses and budgets" : "Create and update expenses and budgets"}</li>`).join("");
-  const callbackUrl = new URL(request.redirectUri);
-  const callbackOrigin = callbackUrl.origin === "null" ? callbackUrl.protocol : callbackUrl.origin;
+  const permissions = request.scopes.map((scope) => `<li>${scope === "expenses:read" ? "<strong>Read access:</strong> View all financial data in the workspaces you can access." : "<strong>Write access:</strong> Create, change, and delete financial data."}</li>`).join("");
+  const callbackDestination = getCallbackDestination(request.redirectUri);
+  const isolatedClientName = `<bdi dir="auto">${escapeHtml(client.clientName)}</bdi>`;
   const actions = CONSENT_DECISIONS
     .map((decision) => `<button name="decision" value="${decision}" type="submit">${decision === "allow" ? "Allow" : "Deny"}</button>`)
     .join("");
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Authorize MCP client</title><style>
-*{box-sizing:border-box}body{margin:0;min-height:100vh;display:grid;place-items:center;padding:16px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:#111;background:#fff}.card{width:100%;max-width:560px;border:1px solid #232323;padding:28px}h1{font-size:20px;margin:0 0 20px}p,li,dt,dd{font-size:14px;line-height:1.5}.client{font-weight:700;overflow-wrap:anywhere}.warning{padding:10px;border:1px solid #8a5a00;background:#fff8e6}.details{display:grid;grid-template-columns:max-content 1fr;gap:6px 12px}.details dt{font-weight:700}.details dd{margin:0;overflow-wrap:anywhere}.resource{color:#666;overflow-wrap:anywhere}.actions{display:flex;gap:10px;margin-top:24px}button{flex:1;padding:10px;border:1px solid #232323;background:#fff;color:#111;font:inherit;cursor:pointer}button[value=allow]{background:#232323;color:#fff}@media(max-width:540px){body{padding:0}.card{border:0;min-height:100vh;padding:24px 16px}.details{grid-template-columns:1fr}}
-</style></head><body><main class="card"><h1>Authorize MCP client</h1><p><span class="client">${escapeHtml(client.clientName)}</span> is requesting access to your Expense Budget Tracker data.</p><p class="warning"><strong>Unverified client name:</strong> this name was provided by the client and is not endorsed by Expense Budget Tracker.</p><dl class="details"><dt>Client ID</dt><dd>${escapeHtml(client.clientId)}</dd><dt>Callback origin</dt><dd>${escapeHtml(callbackOrigin)}</dd><dt>Exact redirect URI</dt><dd>${escapeHtml(request.redirectUri)}</dd></dl><ul>${permissions}</ul><p class="resource">Resource: ${escapeHtml(request.resource)}</p><form method="post" action="/oauth/authorize">${hidden}<div class="actions">${actions}</div></form></main></body></html>`;
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Connect an app | Expense Budget Tracker</title><style>
+*{box-sizing:border-box}body{margin:0;min-height:100vh;display:grid;place-items:center;padding:16px;font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#111;background:#fff}.card{width:100%;max-width:600px;border:1px solid #232323;padding:28px}h1{font-size:24px;line-height:1.25;margin:0 0 20px;overflow-wrap:anywhere}h2{font-size:16px;margin:24px 0 10px}p,li,dt,dd,summary{font-size:14px;line-height:1.5}.warning{padding:12px;border:1px solid #8a5a00;background:#fff8e6}.destination{padding:14px;border:2px solid #232323}.destination h2{margin:0 0 8px}.callback{font-size:18px;font-weight:700;margin:0;overflow-wrap:anywhere}.destination-note{color:#555;margin:8px 0 0}.permissions{padding-inline-start:22px}.permissions li+li{margin-top:8px}.technical{margin-top:24px}.technical summary{cursor:pointer;font-weight:700}.details{display:grid;grid-template-columns:max-content 1fr;gap:6px 12px;margin-top:10px}.details dt{font-weight:700}.details dd{margin:0;overflow-wrap:anywhere}.actions{display:flex;gap:10px;margin-top:24px}button{flex:1;padding:10px;border:1px solid #232323;background:#fff;color:#111;font:inherit;cursor:pointer}button[value=allow]{background:#232323;color:#fff}@media(max-width:540px){body{padding:0}.card{border:0;min-height:100vh;padding:24px 16px}.details{grid-template-columns:1fr}}
+</style></head><body><main class="card"><h1>Connect ${isolatedClientName} to Expense Budget Tracker?</h1><p class="warning"><strong>Before you continue:</strong> The connecting app supplied the displayed name <strong>${isolatedClientName}</strong>. Expense Budget Tracker has not verified who operates it. Continue only if you started this connection and recognize the destination below.</p><section class="destination" aria-labelledby="callback-heading"><h2 id="callback-heading">After approval, you'll return to</h2><p class="callback">${escapeHtml(callbackDestination)}</p><p class="destination-note">This destination is shown to help you recognize the connection. It does not verify who operates the app.</p></section><h2>Access in Expense Budget Tracker</h2><p>This app is asking for the following access:</p><ul class="permissions">${permissions}</ul><details class="technical"><summary>Technical details</summary><dl class="details"><dt>Client ID</dt><dd>${escapeHtml(client.clientId)}</dd><dt>Exact redirect URI</dt><dd>${escapeHtml(request.redirectUri)}</dd><dt>Requested resource</dt><dd>${escapeHtml(request.resource)}</dd></dl></details><form method="post" action="/oauth/authorize">${hidden}<div class="actions">${actions}</div></form></main></body></html>`;
 };
 
 const readSingleParameter = (params: URLSearchParams, name: string): string | undefined => {

--- a/apps/auth/src/routes/oauth.ts
+++ b/apps/auth/src/routes/oauth.ts
@@ -421,7 +421,7 @@ app.get("/oauth/authorize", async (c) => {
     if (identity instanceof Response) return identity;
     c.header("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'");
     c.header("X-Frame-Options", "DENY");
-    c.header("Referrer-Policy", "no-referrer");
+    c.header("Referrer-Policy", "strict-origin");
     return c.html(renderConsent(client, request));
   } catch (error) {
     if (isOAuthProtocolError(error)) {


### PR DESCRIPTION
## Summary
- preserve same-origin OAuth consent POST validation without weakening CSRF and origin protections
- make the OAuth consent page clearer for business users while preserving escaped, bidi-isolated client names
- retain supported redirect URI shapes and fail-closed security validation

## Review
- cumulative four-commit promotion review: no P0-P4 issues
- item PRs #242 and #243 passed fresh review, PR Quality Gate, and Extended Unit Tests

## Validation
- no local project checks run; GitHub CI owns promotion validation