### PR TITLE
Fix CSV attachment handling in chat

### DIFF
--- a/apps/web/src/lib/chatAttachments.ts
+++ b/apps/web/src/lib/chatAttachments.ts
@@ -7,8 +7,9 @@ import type { FileContentPart, ImageContentPart } from "@/server/chat/types";
  * markdown export generation.
  *
  * Runtime / model-input behavior:
- * - Plain text-like files are decoded as UTF-8 and sent both as `input_text`
- *   and as the original `input_file`.
+ * - CSV files are decoded as UTF-8 and sent as `input_text` only.
+ * - Other plain text-like files are decoded as UTF-8 and sent both as
+ *   `input_text` and as the original `input_file`.
  * - XLS/XLSX workbooks are converted to per-sheet CSV text and sent both as
  *   `input_text` and as the original `input_file`.
  * - DOCX files are deterministically converted to raw text and sent both as
@@ -38,15 +39,24 @@ export const BINARY_DATA_PLACEHOLDER = "[binary-data]";
 export const PDF_OPENAI_NATIVE_PLACEHOLDER = "[pdf-openai-native-attached]";
 export const DOCX_OPENAI_NATIVE_PLACEHOLDER = "[docx-openai-native-attached]";
 
-const TEXT_MEDIA_TYPES = new Set([
+const CSV_MEDIA_TYPES = new Set([
   "application/csv",
+  "text/csv",
+]);
+
+const CSV_FILE_EXTENSIONS = new Set([
+  ".csv",
+]);
+
+const TEXT_MEDIA_TYPES = new Set([
+  ...CSV_MEDIA_TYPES,
   "application/json",
   "application/sql",
   "application/xml",
 ]);
 
 const TEXT_FILE_EXTENSIONS = new Set([
-  ".csv",
+  ...CSV_FILE_EXTENSIONS,
   ".html",
   ".js",
   ".json",
@@ -179,6 +189,12 @@ export const isDocxAttachment = (
 ): boolean =>
   DOCX_MEDIA_TYPES.has(part.mediaType.toLowerCase())
   || DOCX_EXTENSIONS.has(getFileExtension(part.fileName));
+
+export const isCsvAttachment = (
+  part: FileContentPart,
+): boolean =>
+  CSV_MEDIA_TYPES.has(part.mediaType.toLowerCase())
+  || CSV_FILE_EXTENSIONS.has(getFileExtension(part.fileName));
 
 export const isTextFileAttachment = (
   part: FileContentPart,

--- a/apps/web/src/server/chat/openai/responses/input.test.ts
+++ b/apps/web/src/server/chat/openai/responses/input.test.ts
@@ -10,6 +10,10 @@ import type { ContentPart } from "@/server/chat/types";
 
 const HEIC_BASE64_PREFIX = "AAAAGGZ0eXBoZWljAAAAAA==";
 const JPEG_BASE64_PREFIX = "/9j/4AAQSkZJRg==";
+const CSV_BASE64 = Buffer.from(
+  "date,amount\n2026-08-16,-844.82",
+  "utf8",
+).toString("base64");
 
 test("buildChatCompletionInput rejects a legacy HEIC attachment without mutating history", async (): Promise<void> => {
   const localMessages: ReadonlyArray<ServerChatMessage> = [{
@@ -65,6 +69,55 @@ test("buildChatCompletionInput replays a prepared JPEG as a native input image",
       type: "input_image",
       detail: "auto",
       image_url: `data:image/jpeg;base64,${JPEG_BASE64_PREFIX}`,
+    }],
+  });
+});
+
+test("buildChatCompletionInput replays CSV content identified by MIME without a native input file", async (): Promise<void> => {
+  const localMessages: ReadonlyArray<ServerChatMessage> = [{
+    role: "user",
+    content: [{
+      type: "file",
+      fileName: "statement.data",
+      mediaType: "text/csv",
+      base64Data: CSV_BASE64,
+    }],
+  }];
+
+  const input = await buildChatCompletionInput(
+    localMessages,
+    [{ type: "text", text: "Continue" }],
+    "Europe/Madrid",
+  );
+
+  assert.deepEqual(input[1], {
+    role: "user",
+    type: "message",
+    content: [{
+      type: "input_text",
+      text: "Attached file: statement.data\n```text\ndate,amount\n2026-08-16,-844.82\n```",
+    }],
+  });
+});
+
+test("buildChatCompletionInput sends current CSV content identified by uppercase extension without a native input file", async (): Promise<void> => {
+  const input = await buildChatCompletionInput(
+    [],
+    [{
+      type: "file",
+      fileName: "statement.CSV",
+      mediaType: "application/octet-stream",
+      base64Data: CSV_BASE64,
+    }],
+    "Europe/Madrid",
+  );
+
+  assert.deepEqual(input[1], {
+    role: "user",
+    type: "message",
+    content: [{
+      type: "input_text",
+      text: "Attached file: statement.CSV\n```csv\ndate,amount\n2026-08-16,-844.82\n```",
     }],
   });
 });

--- a/apps/web/src/server/chat/openai/responses/input.ts
+++ b/apps/web/src/server/chat/openai/responses/input.ts
@@ -8,6 +8,7 @@ import {
   buildDocxPromptText,
   buildTextFilePromptText,
   buildWorkbookPromptText,
+  isCsvAttachment,
   isDocxAttachment,
   isTextFileAttachment,
   isWorkbookAttachment,
@@ -83,7 +84,8 @@ const buildFileDataUrl = (
  * resend to the model on later turns.
  *
  * The policy is intentionally format-aware:
- * - text-like files -> `input_text` + original `input_file`
+ * - CSV files -> `input_text` only
+ * - other text-like files -> `input_text` + original `input_file`
  * - workbooks -> extracted CSV text + original `input_file`
  * - DOCX -> extracted raw text + original `input_file`
  * - images -> native `input_image`
@@ -100,6 +102,13 @@ const mapAttachmentPart = async (
         image_url: `data:${part.mediaType};base64,${part.base64Data}`,
       }];
     case "file":
+      if (isCsvAttachment(part)) {
+        return [{
+          type: "input_text",
+          text: buildTextFilePromptText(part),
+        }];
+      }
+
       if (isTextFileAttachment(part)) {
         return [
           {


### PR DESCRIPTION
## Summary

- send CSV attachments to the OpenAI Responses API as decoded input_text only
- detect CSV independently through supported MIME types or a case-insensitive .csv extension
- preserve existing native attachment behavior for other text files, workbooks, DOCX, PDFs, and images

## Root cause

The chat mapper injected the complete strict UTF-8 decoded CSV as input_text and also transmitted the same CSV as a native input_file. The deployed Responses API runtime has no Code Interpreter/container tool, so the native CSV input_file was rejected with invalid_file. Stored attachments are replayed through this mapper, which made later turns fail as well.

## Coverage

- replayed CSV identified by MIME only emits one exact input_text part
- current-turn CSV identified by uppercase .CSV extension only emits one exact input_text part
- both assertions preserve the complete decoded CSV text and exclude input_file