### PR TITLE
Add gentle Luna chat routing

### DIFF
--- a/apps/web/src/lib/chatModels.ts
+++ b/apps/web/src/lib/chatModels.ts
@@ -1,11 +1,21 @@
 export const CHAT_VENDOR = "openai" as const;
 export const CHAT_MODEL_ID = "gpt-5.6-sol" as const;
 export const CHAT_MODEL_REASONING_EFFORT = "medium" as const;
+export const CHAT_FALLBACK_MODEL_ID = "gpt-5.6-luna" as const;
+export const CHAT_FALLBACK_MODEL_REASONING_EFFORT = "max" as const;
 export const CHAT_MODEL_REASONING_SUMMARY = "auto" as const;
 export const CHAT_MODEL_LABEL = "GPT-5.6 Sol" as const;
 export const CHAT_PROVIDER_LABEL = "OpenAI" as const;
 export const CHAT_MODEL_REASONING_LABEL = `${CHAT_MODEL_REASONING_EFFORT.slice(0, 1).toUpperCase()}${CHAT_MODEL_REASONING_EFFORT.slice(1)}` as const;
 export const CHAT_MODEL_BADGE_LABEL = `${CHAT_MODEL_LABEL} · ${CHAT_MODEL_REASONING_LABEL}` as const;
+
+export type ChatEffectiveModelId =
+  | typeof CHAT_MODEL_ID
+  | typeof CHAT_FALLBACK_MODEL_ID;
+
+export type ChatEffectiveReasoningEffort =
+  | typeof CHAT_MODEL_REASONING_EFFORT
+  | typeof CHAT_FALLBACK_MODEL_REASONING_EFFORT;
 
 export type ChatModelDef = Readonly<{
   id: typeof CHAT_MODEL_ID;

--- a/apps/web/src/server/chat/http/freshSessionRoute.test.ts
+++ b/apps/web/src/server/chat/http/freshSessionRoute.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { CHAT_MODEL_ID } from "@/lib/chatModels";
+import {
+  CHAT_FALLBACK_MODEL_ID,
+  CHAT_MODEL_ID,
+  CHAT_MODEL_REASONING_EFFORT,
+} from "@/lib/chatModels";
 import type { SupportedLocale } from "@/lib/locale";
 import {
   postFreshChatSessionRouteWithDeps,
@@ -14,6 +18,10 @@ import type {
   PersistedChatMessageItem,
   PreparedChatRun,
 } from "@/server/chat/store";
+import {
+  selectChatModelRouting,
+  type ChatModelRoutingLogEvent,
+} from "@/server/chat/modelRouting";
 import type { ChatStreamEvent, ContentPart } from "@/server/chat/types";
 
 const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
@@ -52,6 +60,7 @@ const createPreparedRun = (
   assistantItem: createAssistantItem(),
   localMessages: [],
   turnInput: content,
+  modelRouting: selectChatModelRouting(1, []),
 });
 
 const createReservation = (): ChatRunStartReservation => ({
@@ -117,6 +126,7 @@ test("POST /api/chat/new starts one prepared session and identifies it in the fi
     const content: ReadonlyArray<ContentPart> = [{ type: "text", text: "Hello" }];
     let prepareCallCount = 0;
     let startedSessionId: string | null = null;
+    const routingEvents: Array<ChatModelRoutingLogEvent> = [];
 
     const response = await postFreshChatSessionRouteWithDeps(
       createRequest({
@@ -138,6 +148,11 @@ test("POST /api/chat/new starts one prepared session and identifies it in the fi
             yield { type: "done" };
           })();
         },
+        log: (event) => {
+          if (event.domain === "chat" && event.action === "model_routing") {
+            routingEvents.push(event);
+          }
+        },
       }),
     );
 
@@ -146,6 +161,25 @@ test("POST /api/chat/new starts one prepared session and identifies it in the fi
     assert.equal(response.headers.get("X-Chat-Session-Id"), "session-1");
     assert.equal(prepareCallCount, 1);
     assert.equal(startedSessionId, "session-1");
+    assert.equal(routingEvents.length, 1);
+    assert.equal(routingEvents[0]?.requestedModel, CHAT_MODEL_ID);
+    assert.equal(routingEvents[0]?.defaultModel, CHAT_MODEL_ID);
+    assert.equal(routingEvents[0]?.effectiveModel, CHAT_MODEL_ID);
+    assert.equal(
+      routingEvents[0]?.effectiveReasoningEffort,
+      CHAT_MODEL_REASONING_EFFORT,
+    );
+    assert.equal(routingEvents[0]?.routingReason, "default");
+    assert.equal(routingEvents[0]?.rollingWindowHours, 24);
+    assert.equal(routingEvents[0]?.rolling24HourUserMessageCount, 1);
+    assert.equal(routingEvents[0]?.rollingUserMessageThreshold, 30);
+    assert.equal(routingEvents[0]?.sessionUserMessageCount, 0);
+    assert.equal(routingEvents[0]?.sessionUserMessageThreshold, 5);
+    assert.equal(routingEvents[0]?.sessionUniquePdfCount, 0);
+    assert.equal(routingEvents[0]?.sessionPdfThreshold, 4);
+    assert.equal(routingEvents[0]?.userId, "user-1");
+    assert.equal(routingEvents[0]?.workspaceId, "workspace-1");
+    assert.equal(routingEvents[0]?.sessionId, "session-1");
     assert.equal(
       await response.text(),
       [
@@ -209,6 +243,32 @@ test("POST /api/chat/new validation failures do not prepare or start a session",
     assert.equal(await response.text(), "content array is empty");
     assert.equal(prepareCallCount, 0);
     assert.equal(runtimeStartCallCount, 0);
+  });
+});
+
+test("POST /api/chat/new does not allow the browser to request the fallback model", async (): Promise<void> => {
+  await withOpenAiApiKey(async (): Promise<void> => {
+    let prepareCallCount = 0;
+    const response = await postFreshChatSessionRouteWithDeps(
+      createRequest({
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_FALLBACK_MODEL_ID,
+        timezone: "Europe/Madrid",
+      }),
+      createDependencies({
+        prepareFreshChatRun: async (_userId, _workspaceId, content) => {
+          prepareCallCount += 1;
+          return createPreparedRun(content);
+        },
+      }),
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(
+      await response.text(),
+      `Unsupported model: ${CHAT_FALLBACK_MODEL_ID}. Expected ${CHAT_MODEL_ID}`,
+    );
+    assert.equal(prepareCallCount, 0);
   });
 });
 
@@ -349,7 +409,9 @@ test("POST /api/chat/new preserves safe session identity when runtime start and 
           throw new Error("internal database persistence details");
         },
         log: (event) => {
-          loggedEvents.push(event);
+          if (event.domain === "chat" && event.action === "error") {
+            loggedEvents.push(event);
+          }
         },
       }),
     );

--- a/apps/web/src/server/chat/http/freshSessionRoute.ts
+++ b/apps/web/src/server/chat/http/freshSessionRoute.ts
@@ -16,6 +16,7 @@ import {
 import {
   CHAT_STREAM_INTERRUPTED_ERROR,
 } from "@/server/chat/http/sessionRecovery";
+import { createChatModelRoutingLogEvent } from "@/server/chat/modelRouting";
 import {
   releaseChatRunStartReservation,
   reserveChatRunStart,
@@ -226,6 +227,15 @@ export const postFreshChatSessionRouteWithDeps = async (
           }
           reservation = reservationResult.reservation;
 
+          dependencies.log(createChatModelRoutingLogEvent({
+            requestedModel: body.model,
+            decision: preparedRun.modelRouting,
+            requestId,
+            userId: context.userId,
+            workspaceId: context.workspaceId,
+            sessionId: preparedRun.sessionId,
+          }));
+
           const startedEvents = dependencies.startPersistedChatRun({
             requestId,
             userId: context.userId,
@@ -237,12 +247,13 @@ export const postFreshChatSessionRouteWithDeps = async (
             assistantItemId: preparedRun.assistantItem.itemId,
             localMessages: preparedRun.localMessages,
             turnInput: preparedRun.turnInput,
+            modelRouting: preparedRun.modelRouting,
             diagnostics: {
               requestId,
               userId: context.userId,
               workspaceId: context.workspaceId,
               sessionId: preparedRun.sessionId,
-              model: body.model,
+              model: preparedRun.modelRouting.effectiveModel,
               messageCount: diagnostics.messageCount,
               hasAttachments: diagnostics.hasAttachments,
               attachmentFileNames: diagnostics.attachmentFileNames,

--- a/apps/web/src/server/chat/http/routeHandlers.test.ts
+++ b/apps/web/src/server/chat/http/routeHandlers.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { CHAT_MODEL_ID } from "@/lib/chatModels";
+import { CHAT_FALLBACK_MODEL_ID, CHAT_MODEL_ID } from "@/lib/chatModels";
 import type { SupportedLocale } from "@/lib/locale";
 import {
   deleteChatRouteWithDeps,
@@ -14,6 +14,7 @@ import {
   ChatSessionNotFoundError,
   ChatTurnCancelledError,
 } from "@/server/chat/store";
+import { selectChatModelRouting } from "@/server/chat/modelRouting";
 import {
   clearActiveChatRunForTests,
   createActiveChatRunForTests,
@@ -69,6 +70,7 @@ const createPreparedRun = (
   },
   localMessages: [],
   turnInput: [{ type: "text", text: "Hello" }],
+  modelRouting: selectChatModelRouting(1, []),
 });
 
 const createReservation = (
@@ -437,19 +439,22 @@ test("postChatRouteWithDeps rejects generic HEIC signatures before persistence",
   });
 });
 
-test("postChatRouteWithDeps returns 400 for unsupported models", async (): Promise<void> => {
+test("postChatRouteWithDeps does not allow the browser to request the fallback model", async (): Promise<void> => {
   const response = await postChatRouteWithDeps(
     createChatRequest({
       sessionId: "session-1",
       content: [{ type: "text", text: "Hello" }],
-      model: "wrong-model",
+      model: CHAT_FALLBACK_MODEL_ID,
       timezone: "Europe/Madrid",
     }),
     createPostDependencies(),
   );
 
   assert.equal(response.status, 400);
-  assert.equal(await response.text(), `Unsupported model: wrong-model. Expected ${CHAT_MODEL_ID}`);
+  assert.equal(
+    await response.text(),
+    `Unsupported model: ${CHAT_FALLBACK_MODEL_ID}. Expected ${CHAT_MODEL_ID}`,
+  );
 });
 
 test("postChatRouteWithDeps returns 500 when OPENAI_API_KEY is missing", async (): Promise<void> => {

--- a/apps/web/src/server/chat/http/routeHandlers.ts
+++ b/apps/web/src/server/chat/http/routeHandlers.ts
@@ -20,6 +20,7 @@ import {
   CHAT_STREAM_HEARTBEAT_INTERVAL_MS,
   createChatEventStream,
 } from "@/server/chat/http/sse";
+import { createChatModelRoutingLogEvent } from "@/server/chat/modelRouting";
 import {
   releaseChatRunStartReservation,
   reserveChatRunStart,
@@ -239,12 +240,20 @@ export const postChatRouteWithDeps = async (
         preparedRun.activeRunId,
       );
       const locale = dependencies.getLocaleFromRequest(request);
+      dependencies.log(createChatModelRoutingLogEvent({
+        requestedModel: body.model,
+        decision: preparedRun.modelRouting,
+        requestId,
+        userId: context.userId,
+        workspaceId: context.workspaceId,
+        sessionId: preparedRun.sessionId,
+      }));
       const runtimeParams = {
         requestId,
         userId: context.userId,
         workspaceId: context.workspaceId,
         sessionId: preparedRun.sessionId,
-        model: body.model,
+        model: preparedRun.modelRouting.effectiveModel,
         messageCount: diagnostics.messageCount,
         hasAttachments: diagnostics.hasAttachments,
         attachmentFileNames: diagnostics.attachmentFileNames,
@@ -260,6 +269,7 @@ export const postChatRouteWithDeps = async (
         assistantItemId: preparedRun.assistantItem.itemId,
         localMessages: preparedRun.localMessages,
         turnInput: preparedRun.turnInput,
+        modelRouting: preparedRun.modelRouting,
         diagnostics: runtimeParams,
       }, reservation);
       runtimeStarted = true;

--- a/apps/web/src/server/chat/modelRouting.test.ts
+++ b/apps/web/src/server/chat/modelRouting.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CHAT_FALLBACK_MODEL_ID,
+  CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+  CHAT_MODEL_ID,
+  CHAT_MODEL_REASONING_EFFORT,
+} from "@/lib/chatModels";
+import {
+  countUniquePdfAttachments,
+  getChatModelRollingWindowStart,
+  selectChatModelRouting,
+} from "@/server/chat/modelRouting";
+import type { ServerChatMessage } from "@/server/chat/openai/responses/replayItems";
+import type { ContentPart } from "@/server/chat/types";
+
+const createUserMessage = (
+  content: ReadonlyArray<ContentPart>,
+): ServerChatMessage => ({
+  role: "user",
+  content,
+});
+
+const createPdf = (
+  fileName: string,
+  content: string,
+): Extract<ContentPart, { type: "file" }> => ({
+  type: "file",
+  fileName,
+  mediaType: "application/pdf",
+  base64Data: Buffer.from(content).toString("base64"),
+});
+
+test("selectChatModelRouting keeps Sol Medium below both routing thresholds", (): void => {
+  const messages: ReadonlyArray<ServerChatMessage> = [
+    createUserMessage([createPdf("one.pdf", "pdf-one")]),
+    createUserMessage([createPdf("two.pdf", "pdf-two")]),
+    createUserMessage([createPdf("three.pdf", "pdf-three")]),
+    createUserMessage([createPdf("four.pdf", "pdf-four")]),
+  ];
+
+  const decision = selectChatModelRouting(29, messages);
+
+  assert.equal(decision.effectiveModel, CHAT_MODEL_ID);
+  assert.equal(decision.effectiveReasoningEffort, CHAT_MODEL_REASONING_EFFORT);
+  assert.equal(decision.reason, "default");
+  assert.equal(decision.sessionUserMessageCount, 4);
+  assert.equal(decision.sessionUniquePdfCount, 4);
+});
+
+test("selectChatModelRouting switches to Luna Max at the rolling user-message threshold", (): void => {
+  const decision = selectChatModelRouting(30, [
+    createUserMessage([{ type: "text", text: "Current turn" }]),
+  ]);
+
+  assert.equal(decision.effectiveModel, CHAT_FALLBACK_MODEL_ID);
+  assert.equal(
+    decision.effectiveReasoningEffort,
+    CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+  );
+  assert.equal(decision.reason, "rolling_24h_user_messages");
+});
+
+test("persisted PDF-heavy history activates Luna on the fifth user message", (): void => {
+  const messages: ReadonlyArray<ServerChatMessage> = [
+    createUserMessage([createPdf("one.pdf", "pdf-one")]),
+    createUserMessage([createPdf("two.pdf", "pdf-two")]),
+    createUserMessage([createPdf("three.pdf", "pdf-three")]),
+    createUserMessage([createPdf("four.pdf", "pdf-four")]),
+    createUserMessage([{ type: "text", text: "Use the existing PDFs" }]),
+  ];
+
+  const decision = selectChatModelRouting(5, messages);
+
+  assert.equal(decision.effectiveModel, CHAT_FALLBACK_MODEL_ID);
+  assert.equal(
+    decision.effectiveReasoningEffort,
+    CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+  );
+  assert.equal(decision.reason, "pdf_heavy_session");
+  assert.equal(decision.sessionUserMessageCount, 5);
+  assert.equal(decision.sessionUniquePdfCount, 4);
+});
+
+test("unique PDF counting uses content and excludes images and non-PDF files", (): void => {
+  const firstPdf = createPdf("first-name.pdf", "same-pdf-content");
+  const messages: ReadonlyArray<ServerChatMessage> = [
+    createUserMessage([firstPdf]),
+    createUserMessage([{ ...firstPdf, fileName: "reattached.pdf" }]),
+    createUserMessage([createPdf("other.pdf", "other-pdf-content")]),
+    createUserMessage([{
+      type: "file",
+      fileName: "not-really-a-pdf.pdf",
+      mediaType: "application/octet-stream",
+      base64Data: Buffer.from("opaque-file").toString("base64"),
+    }]),
+    createUserMessage([{
+      type: "image",
+      mediaType: "image/png",
+      base64Data: Buffer.from("image-content").toString("base64"),
+    }]),
+  ];
+  const originalMessages = structuredClone(messages);
+
+  assert.equal(countUniquePdfAttachments(messages), 2);
+  assert.equal(selectChatModelRouting(5, messages).reason, "default");
+  assert.deepEqual(messages, originalMessages);
+});
+
+test("rolling model routing starts exactly 24 hours before evaluation", (): void => {
+  const evaluatedAt = new Date("2026-05-02T13:00:00.000Z");
+
+  assert.equal(
+    getChatModelRollingWindowStart(evaluatedAt).toISOString(),
+    "2026-05-01T13:00:00.000Z",
+  );
+});

--- a/apps/web/src/server/chat/modelRouting.ts
+++ b/apps/web/src/server/chat/modelRouting.ts
@@ -1,0 +1,175 @@
+import { createHash } from "node:crypto";
+import {
+  CHAT_FALLBACK_MODEL_ID,
+  CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+  CHAT_MODEL_ID,
+  CHAT_MODEL_REASONING_EFFORT,
+  type ChatEffectiveModelId,
+  type ChatEffectiveReasoningEffort,
+} from "@/lib/chatModels";
+import type { ServerChatMessage } from "@/server/chat/openai/responses/replayItems";
+import type { FileContentPart } from "@/server/chat/types";
+
+export const CHAT_MODEL_ROLLING_WINDOW_HOURS = 24;
+export const CHAT_MODEL_ROLLING_USER_MESSAGE_THRESHOLD = 30;
+export const CHAT_MODEL_SESSION_PDF_THRESHOLD = 4;
+export const CHAT_MODEL_SESSION_USER_MESSAGE_THRESHOLD = 5;
+
+export type ChatModelRoutingReason =
+  | "default"
+  | "rolling_24h_user_messages"
+  | "pdf_heavy_session"
+  | "rolling_24h_user_messages_and_pdf_heavy_session";
+
+export type ChatModelRoutingDecision = Readonly<{
+  effectiveModel: ChatEffectiveModelId;
+  effectiveReasoningEffort: ChatEffectiveReasoningEffort;
+  reason: ChatModelRoutingReason;
+  rolling24HourUserMessageCount: number;
+  sessionUserMessageCount: number;
+  sessionUniquePdfCount: number;
+}>;
+
+export type ChatModelRoutingLogEvent = Readonly<{
+  domain: "chat";
+  action: "model_routing";
+  vendor: "openai";
+  requestedModel: string;
+  defaultModel: typeof CHAT_MODEL_ID;
+  effectiveModel: ChatEffectiveModelId;
+  effectiveReasoningEffort: ChatEffectiveReasoningEffort;
+  routingReason: ChatModelRoutingReason;
+  rollingWindowHours: typeof CHAT_MODEL_ROLLING_WINDOW_HOURS;
+  rolling24HourUserMessageCount: number;
+  rollingUserMessageThreshold: typeof CHAT_MODEL_ROLLING_USER_MESSAGE_THRESHOLD;
+  sessionUserMessageCount: number;
+  sessionUserMessageThreshold: typeof CHAT_MODEL_SESSION_USER_MESSAGE_THRESHOLD;
+  sessionUniquePdfCount: number;
+  sessionPdfThreshold: typeof CHAT_MODEL_SESSION_PDF_THRESHOLD;
+  requestId: string;
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+}>;
+
+const isValidatedPdfAttachment = (
+  part: FileContentPart,
+): boolean =>
+  part.mediaType.trim().toLowerCase() === "application/pdf";
+
+const getPdfContentFingerprint = (
+  part: FileContentPart,
+): string =>
+  createHash("sha256")
+    .update(Buffer.from(part.base64Data, "base64"))
+    .digest("hex");
+
+export const countUniquePdfAttachments = (
+  messages: ReadonlyArray<ServerChatMessage>,
+): number => {
+  const fingerprints = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== "user") {
+      continue;
+    }
+    for (const part of message.content) {
+      if (part.type === "file" && isValidatedPdfAttachment(part)) {
+        fingerprints.add(getPdfContentFingerprint(part));
+      }
+    }
+  }
+  return fingerprints.size;
+};
+
+export const getChatModelRollingWindowStart = (
+  evaluatedAt: Date,
+): Date => {
+  const evaluatedAtMs = evaluatedAt.getTime();
+  if (!Number.isFinite(evaluatedAtMs)) {
+    throw new TypeError("Chat model routing evaluation time must be a valid date");
+  }
+
+  return new Date(
+    evaluatedAtMs - CHAT_MODEL_ROLLING_WINDOW_HOURS * 60 * 60 * 1000,
+  );
+};
+
+const requireMessageCount = (
+  count: number,
+  countName: string,
+): number => {
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new TypeError(`Chat model routing ${countName} must be a non-negative safe integer: ${String(count)}`);
+  }
+  return count;
+};
+
+export const selectChatModelRouting = (
+  rolling24HourUserMessageCount: number,
+  messages: ReadonlyArray<ServerChatMessage>,
+): ChatModelRoutingDecision => {
+  const validatedRollingMessageCount = requireMessageCount(
+    rolling24HourUserMessageCount,
+    "rolling 24-hour user message count",
+  );
+  const sessionUserMessageCount = messages.filter(
+    (message) => message.role === "user",
+  ).length;
+  const sessionUniquePdfCount = countUniquePdfAttachments(messages);
+  const reachedRollingThreshold = validatedRollingMessageCount
+    >= CHAT_MODEL_ROLLING_USER_MESSAGE_THRESHOLD;
+  const reachedPdfSessionThreshold = sessionUserMessageCount
+    >= CHAT_MODEL_SESSION_USER_MESSAGE_THRESHOLD
+    && sessionUniquePdfCount >= CHAT_MODEL_SESSION_PDF_THRESHOLD;
+
+  const reason: ChatModelRoutingReason = reachedRollingThreshold
+    ? reachedPdfSessionThreshold
+      ? "rolling_24h_user_messages_and_pdf_heavy_session"
+      : "rolling_24h_user_messages"
+    : reachedPdfSessionThreshold
+      ? "pdf_heavy_session"
+      : "default";
+  const useFallback = reachedRollingThreshold || reachedPdfSessionThreshold;
+
+  return {
+    effectiveModel: useFallback ? CHAT_FALLBACK_MODEL_ID : CHAT_MODEL_ID,
+    effectiveReasoningEffort: useFallback
+      ? CHAT_FALLBACK_MODEL_REASONING_EFFORT
+      : CHAT_MODEL_REASONING_EFFORT,
+    reason,
+    rolling24HourUserMessageCount: validatedRollingMessageCount,
+    sessionUserMessageCount,
+    sessionUniquePdfCount,
+  };
+};
+
+export const createChatModelRoutingLogEvent = (
+  params: Readonly<{
+    requestedModel: string;
+    decision: ChatModelRoutingDecision;
+    requestId: string;
+    userId: string;
+    workspaceId: string;
+    sessionId: string;
+  }>,
+): ChatModelRoutingLogEvent => ({
+  domain: "chat",
+  action: "model_routing",
+  vendor: "openai",
+  requestedModel: params.requestedModel,
+  defaultModel: CHAT_MODEL_ID,
+  effectiveModel: params.decision.effectiveModel,
+  effectiveReasoningEffort: params.decision.effectiveReasoningEffort,
+  routingReason: params.decision.reason,
+  rollingWindowHours: CHAT_MODEL_ROLLING_WINDOW_HOURS,
+  rolling24HourUserMessageCount: params.decision.rolling24HourUserMessageCount,
+  rollingUserMessageThreshold: CHAT_MODEL_ROLLING_USER_MESSAGE_THRESHOLD,
+  sessionUserMessageCount: params.decision.sessionUserMessageCount,
+  sessionUserMessageThreshold: CHAT_MODEL_SESSION_USER_MESSAGE_THRESHOLD,
+  sessionUniquePdfCount: params.decision.sessionUniquePdfCount,
+  sessionPdfThreshold: CHAT_MODEL_SESSION_PDF_THRESHOLD,
+  requestId: params.requestId,
+  userId: params.userId,
+  workspaceId: params.workspaceId,
+  sessionId: params.sessionId,
+});

--- a/apps/web/src/server/chat/openai/loop.test.ts
+++ b/apps/web/src/server/chat/openai/loop.test.ts
@@ -2,6 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import OpenAI from "openai";
 import {
+  CHAT_FALLBACK_MODEL_ID,
+  CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+  CHAT_MODEL_ID,
+  CHAT_MODEL_REASONING_EFFORT,
+} from "@/lib/chatModels";
+import {
   CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS,
   runOpenAILoopWithDeps,
   type OpenAILoopEventHandler,
@@ -29,6 +35,8 @@ const createLoopParams = (): StartOpenAILoopParams => ({
   timezone: "Europe/Madrid",
   localMessages: [],
   turnInput: [{ type: "text", text: "Hello" }],
+  model: CHAT_MODEL_ID,
+  reasoningEffort: CHAT_MODEL_REASONING_EFFORT,
   rootObservation: null,
 });
 
@@ -148,6 +156,36 @@ const createStartedToolStates = (
   Date.now(),
 ).toolStates;
 
+test("runOpenAILoop propagates the default model policy to an ordinary call", async (): Promise<void> => {
+  const params = createLoopParams();
+  const observedRequests: Array<OpenAIResponsesRequest> = [];
+
+  await runOpenAILoopWithDeps(
+    params,
+    async (): Promise<void> => {},
+    createTestLoopDeps({
+      runOneModelCall: async (
+        _client: OpenAI,
+        _callParams: StartOpenAILoopParams,
+        _emitEvent: OpenAILoopEventHandler,
+        request: OpenAIResponsesRequest,
+      ) => {
+        observedRequests.push(request);
+        return {
+          finalResponse: createFinalResponse("Done"),
+          functionCalls: [],
+          replayItems: [createAssistantReplayItem("Done")],
+          streamedText: "Done",
+          toolStates: createToolCallStateMap(),
+        };
+      },
+    }),
+  );
+
+  assert.equal(observedRequests[0]?.model, CHAT_MODEL_ID);
+  assert.equal(observedRequests[0]?.reasoning.effort, CHAT_MODEL_REASONING_EFFORT);
+});
+
 test("runOpenAILoop waits for async event handling before resolving completion", async (): Promise<void> => {
   const params = createLoopParams();
   const observedEvents: Array<ChatStreamEvent> = [];
@@ -218,7 +256,11 @@ test("runOpenAILoop waits for async event handling before resolving completion",
 });
 
 test("runOpenAILoop executes tool calls and returns replay items from the full continuation", async (): Promise<void> => {
-  const params = createLoopParams();
+  const params: StartOpenAILoopParams = {
+    ...createLoopParams(),
+    model: CHAT_FALLBACK_MODEL_ID,
+    reasoningEffort: CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+  };
   const observedEvents: Array<ChatStreamEvent> = [];
   const toolCall = createFunctionCall("call-1", "query_database", "{\"sql\":\"select 1\"}");
   const toolOutput = "{\"ok\":true}";
@@ -300,6 +342,16 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
     openAIRequests.map((request) => request.prompt_cache_key),
     ["session-1", "session-1"],
   );
+  assert.equal(
+    openAIRequests.every((request) => request.model === CHAT_FALLBACK_MODEL_ID),
+    true,
+  );
+  assert.equal(
+    openAIRequests.every(
+      (request) => request.reasoning.effort === CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+    ),
+    true,
+  );
   assert.deepEqual(observedEvents, [
     {
       type: "tool_call",
@@ -324,7 +376,11 @@ test("runOpenAILoop executes tool calls and returns replay items from the full c
 });
 
 test("runOpenAILoop emits a synthetic final delta and returns the summary replay item after the tool-call limit", async (): Promise<void> => {
-  const params = createLoopParams();
+  const params: StartOpenAILoopParams = {
+    ...createLoopParams(),
+    model: CHAT_FALLBACK_MODEL_ID,
+    reasoningEffort: CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+  };
   const observedEvents: Array<ChatStreamEvent> = [];
   let modelCallCount = 0;
   const openAIRequests: Array<OpenAIResponsesRequest> = [];
@@ -381,6 +437,16 @@ test("runOpenAILoop emits a synthetic final delta and returns the summary replay
   assert.equal(modelCallCount, CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS + 1);
   assert.equal(
     openAIRequests.every((request) => request.safety_identifier === EXPECTED_USER_1_SAFETY_IDENTIFIER),
+    true,
+  );
+  assert.equal(
+    openAIRequests.every((request) => request.model === CHAT_FALLBACK_MODEL_ID),
+    true,
+  );
+  assert.equal(
+    openAIRequests.every(
+      (request) => request.reasoning.effort === CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+    ),
     true,
   );
   assert.deepEqual(openAIRequests.at(-1)?.tools, []);

--- a/apps/web/src/server/chat/openai/loop.ts
+++ b/apps/web/src/server/chat/openai/loop.ts
@@ -1,5 +1,9 @@
 import type OpenAI from "openai";
 import type { LangfuseObservation } from "@langfuse/tracing";
+import type {
+  ChatEffectiveModelId,
+  ChatEffectiveReasoningEffort,
+} from "@/lib/chatModels";
 import type { SupportedLocale } from "@/lib/locale";
 import { ti } from "@/i18n/serverT";
 import {
@@ -107,6 +111,8 @@ export type StartOpenAILoopParams = Readonly<{
   timezone: string;
   localMessages: ReadonlyArray<ServerChatMessage>;
   turnInput: ReadonlyArray<ContentPart>;
+  model: ChatEffectiveModelId;
+  reasoningEffort: ChatEffectiveReasoningEffort;
   signal?: AbortSignal;
   rootObservation: LangfuseObservation | null;
 }>;
@@ -333,6 +339,8 @@ const completeToolLimitSummaryTurn = async (
       params.timezone,
       [],
       [buildToolLimitSummaryInstruction(CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS)],
+      params.model,
+      params.reasoningEffort,
     ),
     promptCacheKey,
     callIndex: summaryCallIndex,
@@ -394,6 +402,8 @@ const runLoopWithDeps = async (
         params.userId,
         params.sessionId,
         params.timezone,
+        params.model,
+        params.reasoningEffort,
       ),
       promptCacheKey,
       callIndex,

--- a/apps/web/src/server/chat/openai/responses/modelCall.ts
+++ b/apps/web/src/server/chat/openai/responses/modelCall.ts
@@ -255,6 +255,7 @@ export const runOneModelCall = async (
       callIndex,
       promptCacheKey,
       durationMs: Date.now() - modelCallStartedAt,
+      model: request.model,
       response: finalResponse,
     }));
     return {

--- a/apps/web/src/server/chat/openai/responses/request.test.ts
+++ b/apps/web/src/server/chat/openai/responses/request.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type OpenAI from "openai";
+import {
+  CHAT_FALLBACK_MODEL_ID,
+  CHAT_MODEL_ID,
+} from "@/lib/chatModels";
+import { buildChatResponseLogEvent } from "@/server/chat/openai/responses/request";
+
+test("buildChatResponseLogEvent records the effective request model", (): void => {
+  const response = {
+    id: "response-1",
+    model: CHAT_MODEL_ID,
+    status: "completed",
+    output: [],
+    usage: {
+      input_tokens: 10,
+      input_tokens_details: { cached_tokens: 4 },
+      output_tokens: 3,
+      output_tokens_details: { reasoning_tokens: 1 },
+      total_tokens: 13,
+    },
+  } as unknown as OpenAI.Responses.Response;
+
+  const event = buildChatResponseLogEvent({
+    requestId: "request-1",
+    sessionId: "session-1",
+    callIndex: 1,
+    promptCacheKey: "session-1",
+    durationMs: 100,
+    model: CHAT_FALLBACK_MODEL_ID,
+    response,
+  });
+
+  assert.equal(event.model, CHAT_FALLBACK_MODEL_ID);
+});

--- a/apps/web/src/server/chat/openai/responses/request.ts
+++ b/apps/web/src/server/chat/openai/responses/request.ts
@@ -1,8 +1,8 @@
 import type OpenAI from "openai";
 import {
-  CHAT_MODEL_ID,
-  CHAT_MODEL_REASONING_EFFORT,
   CHAT_MODEL_REASONING_SUMMARY,
+  type ChatEffectiveModelId,
+  type ChatEffectiveReasoningEffort,
 } from "@/lib/chatModels";
 import {
   toOpenAIResponseInputItem,
@@ -12,13 +12,13 @@ import { buildOpenAISafetyIdentifier } from "@/server/chat/openai/safetyIdentifi
 import { OPENAI_CHAT_TOOLS } from "@/server/chat/openai/tooling/tools";
 
 export type OpenAIResponsesRequest = Readonly<{
-  model: typeof CHAT_MODEL_ID;
+  model: ChatEffectiveModelId;
   store: false;
   include: ["reasoning.encrypted_content"];
   tools: Array<OpenAI.Responses.Tool>;
   input: Array<OpenAI.Responses.ResponseInputItem>;
   reasoning: Readonly<{
-    effort: typeof CHAT_MODEL_REASONING_EFFORT;
+    effort: ChatEffectiveReasoningEffort;
     summary: typeof CHAT_MODEL_REASONING_SUMMARY;
   }>;
   prompt_cache_key: string;
@@ -64,14 +64,16 @@ export const buildOpenAIResponsesRequest = (
   userId: string,
   sessionId: string,
   timezone: string,
+  model: ChatEffectiveModelId,
+  reasoningEffort: ChatEffectiveReasoningEffort,
 ): OpenAIResponsesRequest => ({
-  model: CHAT_MODEL_ID,
+  model,
   store: false,
   include: ["reasoning.encrypted_content"],
   tools: [...OPENAI_CHAT_TOOLS],
   input: buildOpenAIInput(baseInput, continuationItems, []),
   reasoning: {
-    effort: CHAT_MODEL_REASONING_EFFORT,
+    effort: reasoningEffort,
     summary: CHAT_MODEL_REASONING_SUMMARY,
   },
   prompt_cache_key: buildPromptCacheKey(sessionId),
@@ -86,14 +88,16 @@ export const buildOpenAIResponsesRequestWithOptions = (
   timezone: string,
   tools: ReadonlyArray<OpenAI.Responses.Tool>,
   extraInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
+  model: ChatEffectiveModelId,
+  reasoningEffort: ChatEffectiveReasoningEffort,
 ): OpenAIResponsesRequest => ({
-  model: CHAT_MODEL_ID,
+  model,
   store: false,
   include: ["reasoning.encrypted_content"],
   tools: [...tools],
   input: buildOpenAIInput(baseInput, continuationItems, extraInput),
   reasoning: {
-    effort: CHAT_MODEL_REASONING_EFFORT,
+    effort: reasoningEffort,
     summary: CHAT_MODEL_REASONING_SUMMARY,
   },
   prompt_cache_key: buildPromptCacheKey(sessionId),
@@ -128,6 +132,7 @@ export const buildChatResponseLogEvent = (
     callIndex: number;
     promptCacheKey: string;
     durationMs: number;
+    model: ChatEffectiveModelId;
     response: OpenAI.Responses.Response;
   }>,
 ): ChatResponseLogEvent => {
@@ -141,7 +146,7 @@ export const buildChatResponseLogEvent = (
     vendor: "openai",
     requestId: params.requestId,
     sessionId: params.sessionId,
-    model: params.response.model,
+    model: params.model,
     callIndex: params.callIndex,
     promptCacheKey: params.promptCacheKey,
     stopReason: getResponseStopReason(params.response),

--- a/apps/web/src/server/chat/runtime/runtime.test.ts
+++ b/apps/web/src/server/chat/runtime/runtime.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { LangfuseObservation } from "@langfuse/tracing";
+import {
+  CHAT_FALLBACK_MODEL_ID,
+  CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+  CHAT_MODEL_ID,
+} from "@/lib/chatModels";
 import { prependSessionEvent } from "@/server/chat/http/freshSessionRoute";
 import { createChatEventStream } from "@/server/chat/http/sse";
 import { buildChatCompletionInput } from "@/server/chat/openai/responses/input";
@@ -21,6 +26,7 @@ import {
   type StartPersistedChatRunParams,
 } from "./runtime";
 import { ChatSessionRunTransitionError } from "@/server/chat/store";
+import { selectChatModelRouting } from "@/server/chat/modelRouting";
 import type { PersistedChatMessageItem } from "@/server/chat/store/shared";
 import type { ChatStreamEvent } from "@/server/chat/types";
 
@@ -94,12 +100,13 @@ const createRunParams = (
   assistantItemId: "assistant-1",
   localMessages: [],
   turnInput: [{ type: "text", text: "Hello" }],
+  modelRouting: selectChatModelRouting(1, []),
   diagnostics: {
     requestId: `req-${sessionId}`,
     userId: "user-1",
     workspaceId: "workspace-1",
     sessionId,
-    model: "gpt-test",
+    model: CHAT_MODEL_ID,
     messageCount: 1,
     hasAttachments: false,
     attachmentFileNames: [],
@@ -198,6 +205,61 @@ const createRuntimeDependencies = (
     }),
   beginTaskProtection: overrides.beginTaskProtection ?? (async (): Promise<void> => undefined),
   endTaskProtection: overrides.endTaskProtection ?? (async (): Promise<void> => undefined),
+});
+
+test("runPersistedChatSessionWithDeps reports and runs the effective fallback model", async (): Promise<void> => {
+  const baseParams = createRunParams("session-fallback-model");
+  const modelRouting = selectChatModelRouting(30, []);
+  const params: StartPersistedChatRunParams = {
+    ...baseParams,
+    modelRouting,
+    diagnostics: {
+      ...baseParams.diagnostics,
+      model: modelRouting.effectiveModel,
+    },
+  };
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  let observedTraceModel: string | null = null;
+  let observedLoopModel: string | null = null;
+  let observedLoopReasoningEffort: string | null = null;
+
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+  try {
+    await runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          startChatTurnObservation: async (observationParams, fn): Promise<void> => {
+            observedTraceModel = observationParams.model;
+            await fn(null);
+          },
+          runOpenAILoop: async (loopParams): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            observedLoopModel = loopParams.model;
+            observedLoopReasoningEffort = loopParams.reasoningEffort;
+            return { openaiItems: [] };
+          },
+        },
+        recorded,
+      ),
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+  }
+
+  assert.equal(observedTraceModel, CHAT_FALLBACK_MODEL_ID);
+  assert.equal(observedLoopModel, CHAT_FALLBACK_MODEL_ID);
+  assert.equal(
+    observedLoopReasoningEffort,
+    CHAT_FALLBACK_MODEL_REASONING_EFFORT,
+  );
 });
 
 test("runPersistedChatSessionWithDeps persists stopped state for user aborts without completing the run", async (): Promise<void> => {

--- a/apps/web/src/server/chat/runtime/runtime.ts
+++ b/apps/web/src/server/chat/runtime/runtime.ts
@@ -31,6 +31,7 @@ import {
   endChatTaskProtection,
 } from "./taskProtection";
 import { createChatErrorLogEvent } from "@/server/chat/logging";
+import type { ChatModelRoutingDecision } from "@/server/chat/modelRouting";
 import type {
   ChatStreamEvent,
   ContentPart,
@@ -65,6 +66,7 @@ export type StartPersistedChatRunParams = Readonly<{
   assistantItemId: string;
   localMessages: ReadonlyArray<ServerChatMessage>;
   turnInput: ReadonlyArray<ContentPart>;
+  modelRouting: ChatModelRoutingDecision;
   diagnostics: ChatRunDiagnostics;
 }>;
 
@@ -612,7 +614,7 @@ export const runPersistedChatSessionWithDeps = async (
         userId: params.userId,
         workspaceId: params.workspaceId,
         sessionId: params.sessionId,
-        model: params.diagnostics.model,
+        model: params.modelRouting.effectiveModel,
         turnIndex: params.diagnostics.messageCount,
         runState: "running",
         turnInput: params.turnInput,
@@ -693,6 +695,8 @@ export const runPersistedChatSessionWithDeps = async (
           timezone: params.timezone,
           localMessages: params.localMessages,
           turnInput: params.turnInput,
+          model: params.modelRouting.effectiveModel,
+          reasoningEffort: params.modelRouting.effectiveReasoningEffort,
           rootObservation,
           signal: getCurrentActiveChatRun(params.sessionId, params.activeRunId)?.abortController.signal,
         }, handleOpenAILoopEvent);

--- a/apps/web/src/server/chat/store/lifecycleStore.test.ts
+++ b/apps/web/src/server/chat/store/lifecycleStore.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { QueryResult } from "pg";
+import { CHAT_MODEL_ID, CHAT_MODEL_REASONING_EFFORT } from "@/lib/chatModels";
 import {
   admitChatRunStartWithQuery,
   cancelActiveChatRunByUserWithQuery,
@@ -211,6 +212,10 @@ const createFreshRunQueryFn = (
     }]);
   }
 
+  if (text.includes("COUNT(*)::text AS user_message_count")) {
+    return createQueryResult([{ user_message_count: "1" }]);
+  }
+
   if (text.includes("FROM public.chat_items")) {
     return createQueryResult([{
       item_id: "user-1",
@@ -268,12 +273,18 @@ test("prepareFreshChatRunWithQuery creates one running session and the two requi
   assert.equal(preparedRun.assistantItem.role, "assistant");
   assert.equal(preparedRun.assistantItem.state, "in_progress");
   assert.equal(preparedRun.localMessages.length, 1);
-  assert.equal(recordedQueries.length, 4);
+  assert.equal(preparedRun.modelRouting.effectiveModel, CHAT_MODEL_ID);
+  assert.equal(
+    preparedRun.modelRouting.effectiveReasoningEffort,
+    CHAT_MODEL_REASONING_EFFORT,
+  );
+  assert.equal(recordedQueries.length, 5);
   assert.equal(recordedQueries[0].text.includes("INSERT INTO public.chat_sessions"), true);
   assert.equal(recordedQueries[0].params[3], "Hello world");
   assert.equal(recordedQueries[1].text.includes("INSERT INTO public.chat_items"), true);
   assert.equal(recordedQueries[2].text.includes("FROM public.chat_items"), true);
-  assert.equal(recordedQueries[3].text.includes("INSERT INTO public.chat_items"), true);
+  assert.equal(recordedQueries[3].text.includes("COUNT(*)::text"), true);
+  assert.equal(recordedQueries[4].text.includes("INSERT INTO public.chat_items"), true);
 });
 
 test("prepareFreshChatRunWithQuery propagates item failures to the enclosing transaction", async (): Promise<void> => {

--- a/apps/web/src/server/chat/store/lifecycleStore.ts
+++ b/apps/web/src/server/chat/store/lifecycleStore.ts
@@ -2,8 +2,14 @@ import { randomUUID } from "node:crypto";
 import { finalizePendingToolCallContent } from "@/lib/chatHistory";
 import { withUserContext } from "@/server/db";
 import type { QueryFn } from "@/server/db/contextRunner";
+import type { ServerChatMessage } from "@/server/chat/openai/responses/replayItems";
 import type { ContentPart } from "@/server/chat/types";
 import { log } from "@/server/logger";
+import {
+  getChatModelRollingWindowStart,
+  selectChatModelRouting,
+  type ChatModelRoutingDecision,
+} from "@/server/chat/modelRouting";
 import {
   ChatSessionConflictError,
   ChatSessionRunTransitionError,
@@ -23,6 +29,7 @@ import {
   type UserStoppedChatRunUpdatePlan,
 } from "./shared";
 import {
+  countWorkspaceUserMessagesSinceWithQuery,
   hasChatUserTurnWithQuery,
   insertChatItemWithQuery,
   listChatMessagesWithQuery,
@@ -47,6 +54,22 @@ import {
   hasChatTurnCancellationWithQuery,
   insertChatTurnCancellationWithQuery,
 } from "./turnCancellationStore";
+
+const resolvePreparedChatModelRouting = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  localMessages: ReadonlyArray<ServerChatMessage>,
+): Promise<ChatModelRoutingDecision> => {
+  const rollingWindowStart = getChatModelRollingWindowStart(new Date());
+  const rollingUserMessageCount = await countWorkspaceUserMessagesSinceWithQuery(
+    queryFn,
+    userId,
+    workspaceId,
+    rollingWindowStart,
+  );
+  return selectChatModelRouting(rollingUserMessageCount, localMessages);
+};
 
 export const buildUserStoppedAssistantContent = (
   content: ReadonlyArray<ContentPart>,
@@ -124,6 +147,13 @@ export const prepareChatRunWithQuery = async (
   });
 
   const persistedMessages = await listChatMessagesWithQuery(queryFn, sessionRow.session_id);
+  const localMessages = buildLocalChatMessages(persistedMessages);
+  const modelRouting = await resolvePreparedChatModelRouting(
+    queryFn,
+    userId,
+    workspaceId,
+    localMessages,
+  );
   const assistantItem = await insertChatItemWithQuery(queryFn, {
     itemId: null,
     sessionId: sessionRow.session_id,
@@ -140,8 +170,9 @@ export const prepareChatRunWithQuery = async (
       sessionId: sessionRow.session_id,
       activeRunId: turnId,
       assistantItem,
-      localMessages: buildLocalChatMessages(persistedMessages),
+      localMessages,
       turnInput: content,
+      modelRouting,
     },
   };
 };
@@ -297,6 +328,13 @@ export const prepareFreshChatRunWithQuery = async (
   });
 
   const persistedMessages = await listChatMessagesWithQuery(queryFn, sessionRow.session_id);
+  const localMessages = buildLocalChatMessages(persistedMessages);
+  const modelRouting = await resolvePreparedChatModelRouting(
+    queryFn,
+    userId,
+    workspaceId,
+    localMessages,
+  );
   const assistantItem = await insertChatItemWithQuery(queryFn, {
     itemId: null,
     sessionId: sessionRow.session_id,
@@ -309,8 +347,9 @@ export const prepareFreshChatRunWithQuery = async (
     sessionId: sessionRow.session_id,
     activeRunId,
     assistantItem,
-    localMessages: buildLocalChatMessages(persistedMessages),
+    localMessages,
     turnInput: content,
+    modelRouting,
   };
 };
 

--- a/apps/web/src/server/chat/store/messageStore.test.ts
+++ b/apps/web/src/server/chat/store/messageStore.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { QueryResult } from "pg";
 import {
+  countWorkspaceUserMessagesSinceWithQuery,
   insertChatItemWithQuery,
   updateChatItemAndInvalidateMainContentWithQuery,
   updateChatItemWithQuery,
@@ -71,6 +72,37 @@ test("insertChatItemWithQuery records user activity but not an empty assistant p
   assert.equal(recordedQueries[1].params[0], null);
   assert.equal(recordedQueries[1].params[4], false);
   assert.equal(recordedQueries.some((query) => query.text.includes("title =")), false);
+});
+
+test("countWorkspaceUserMessagesSinceWithQuery includes the supplied rolling-window boundary", async (): Promise<void> => {
+  const boundary = new Date("2026-05-01T13:00:00.000Z");
+  const recordedQueries: Array<Readonly<{
+    text: string;
+    params: ReadonlyArray<unknown>;
+  }>> = [];
+  const queryFn: QueryFn = async (text, params): Promise<QueryResult> => {
+    recordedQueries.push({ text, params });
+    return {
+      command: "SELECT",
+      rowCount: 1,
+      oid: 0,
+      fields: [],
+      rows: [{ user_message_count: "30" }],
+    };
+  };
+
+  const count = await countWorkspaceUserMessagesSinceWithQuery(
+    queryFn,
+    "user-1",
+    "workspace-1",
+    boundary,
+  );
+
+  assert.equal(count, 30);
+  assert.match(recordedQueries[0]?.text ?? "", /item\.created_at >= \$3::timestamptz/u);
+  assert.match(recordedQueries[0]?.text ?? "", /session\.user_id = \$1/u);
+  assert.match(recordedQueries[0]?.text ?? "", /session\.workspace_id = \$2/u);
+  assert.deepEqual(recordedQueries[0]?.params, ["user-1", "workspace-1", boundary]);
 });
 
 test("assistant progress and final updates advance visible session activity", async (): Promise<void> => {

--- a/apps/web/src/server/chat/store/messageStore.ts
+++ b/apps/web/src/server/chat/store/messageStore.ts
@@ -33,6 +33,10 @@ type ChatItemWithInvalidationRow = ChatItemRow & Readonly<{
   main_content_invalidation_version: string;
 }>;
 
+type UserMessageCountRow = Readonly<{
+  user_message_count: string;
+}>;
+
 const LIST_CHAT_ITEMS_SQL = `
   SELECT
     item_id,
@@ -81,6 +85,18 @@ const HAS_CHAT_USER_TURN_SQL = `
     AND session_id = $2
     AND item_kind = 'message'
     AND payload->>'role' = 'user'
+`;
+
+const COUNT_WORKSPACE_USER_MESSAGES_SINCE_SQL = `
+  SELECT COUNT(*)::text AS user_message_count
+  FROM public.chat_items AS item
+  INNER JOIN public.chat_sessions AS session
+    ON session.session_id = item.session_id
+  WHERE session.user_id = $1
+    AND session.workspace_id = $2
+    AND item.item_kind = 'message'
+    AND item.payload->>'role' = 'user'
+    AND item.created_at >= $3::timestamptz
 `;
 
 const UPDATE_CHAT_ITEM_SQL = `
@@ -219,6 +235,31 @@ export const hasChatUserTurnWithQuery = async (
 ): Promise<boolean> => {
   const result = await queryFn(HAS_CHAT_USER_TURN_SQL, [turnId, sessionId]);
   return result.rows.length > 0;
+};
+
+export const countWorkspaceUserMessagesSinceWithQuery = async (
+  queryFn: QueryFn,
+  userId: string,
+  workspaceId: string,
+  since: Date,
+): Promise<number> => {
+  const result = await queryFn(COUNT_WORKSPACE_USER_MESSAGES_SINCE_SQL, [
+    userId,
+    workspaceId,
+    since,
+  ]);
+  const rawCount = (result.rows[0] as UserMessageCountRow | undefined)
+    ?.user_message_count;
+  const count = typeof rawCount === "string" && /^(?:0|[1-9]\d*)$/u.test(rawCount)
+    ? Number(rawCount)
+    : Number.NaN;
+  if (!Number.isSafeInteger(count)) {
+    throw new Error(
+      `Count workspace chat user messages failed: invalid user_message_count=${String(rawCount)}, userId=${userId}, workspaceId=${workspaceId}, since=${since.toISOString()}`,
+    );
+  }
+
+  return count;
 };
 
 export const updateChatItemWithQuery = async (

--- a/apps/web/src/server/chat/store/shared.ts
+++ b/apps/web/src/server/chat/store/shared.ts
@@ -2,6 +2,7 @@ import type {
   ServerChatMessage,
   StoredOpenAIReplayItem,
 } from "@/server/chat/openai/responses/replayItems";
+import type { ChatModelRoutingDecision } from "@/server/chat/modelRouting";
 import type { ContentPart } from "@/server/chat/types";
 
 export type ChatSessionRunState = "idle" | "running" | "interrupted";
@@ -89,6 +90,7 @@ export type PreparedChatRun = Readonly<{
   assistantItem: PersistedChatMessageItem;
   localMessages: ReadonlyArray<ServerChatMessage>;
   turnInput: ReadonlyArray<ContentPart>;
+  modelRouting: ChatModelRoutingDecision;
 }>;
 
 export type PrepareChatRunResult =

--- a/apps/web/src/server/logger.ts
+++ b/apps/web/src/server/logger.ts
@@ -1,3 +1,5 @@
+import type { ChatModelRoutingLogEvent } from "@/server/chat/modelRouting";
+
 type ChatVendor = "openai";
 type ToolStatus = "started" | "completed" | "error";
 export type ChatErrorStage = "config" | "auth" | "stream" | "agent";
@@ -32,6 +34,7 @@ type ChatAttemptMetadata = Readonly<{
 }>;
 
 type ChatEvent =
+  | ChatModelRoutingLogEvent
   | Readonly<{
     domain: "chat";
     action: "request";


### PR DESCRIPTION
## Summary
- select a server-owned effective chat model from rolling workspace usage and PDF-heavy session history
- propagate Luna Max routing through ordinary, continuation, and tool-limit summary calls
- record effective-model telemetry and add focused routing coverage

## Validation
- not run locally; required cloud CI owns executable validation