### PR TITLE
fix(auth): allow OAuth callback redirects

### DIFF
--- a/apps/auth/src/routes/oauth.test.ts
+++ b/apps/auth/src/routes/oauth.test.ts
@@ -395,7 +395,10 @@ test("consent is no-store, anti-clickjacking, and same-origin protected", async 
   assert.equal(consentPage.headers.get("cache-control"), "no-store");
   assert.equal(consentPage.headers.get("x-frame-options"), "DENY");
   assert.equal(consentPage.headers.get("referrer-policy"), "strict-origin");
-  assert.match(consentPage.headers.get("content-security-policy") ?? "", /frame-ancestors 'none'/u);
+  assert.equal(
+    consentPage.headers.get("content-security-policy"),
+    "default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'",
+  );
   const consentHtml = await consentPage.text();
   assert.match(consentHtml, /<h1>Connect <bdi dir="auto">Desktop &lt;MCP&gt;<\/bdi> to Expense Budget Tracker\?<\/h1>/u);
   assert.match(consentHtml, /Desktop &lt;MCP&gt;/u);

--- a/apps/auth/src/routes/oauth.ts
+++ b/apps/auth/src/routes/oauth.ts
@@ -426,7 +426,7 @@ app.get("/oauth/authorize", async (c) => {
     validateConsentSubmissionSize(request);
     const identity = await requireBrowserIdentity(c, buildLoginRedirect(config.issuer, request), dependencies);
     if (identity instanceof Response) return identity;
-    c.header("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'");
+    c.header("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'");
     c.header("X-Frame-Options", "DENY");
     c.header("Referrer-Policy", "strict-origin");
     return c.html(renderConsent(client, request));


### PR DESCRIPTION
## Summary

- remove the consent document `form-action 'self'` restriction so Chromium can follow the server-issued 302 to the exact registered OAuth callback after Allow or Deny
- assert the complete remaining consent CSP contract in the focused server test

## Preserved protections

The hotfix retains the restrictive default/style/frame/base CSP directives, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin`, the hardcoded same-origin form action, exact Origin and Fetch Metadata validation, URL-encoded request enforcement, exact registered redirect validation, and PKCE. It adds no client-specific allowlist.

## Validation

Local project checks were not run; required GitHub Actions checks own executable validation.