### PR TITLE
Keep chat working when the browser cannot resolve its timezone

### DIFF
--- a/apps/web/e2e/live-smoke.actions.ts
+++ b/apps/web/e2e/live-smoke.actions.ts
@@ -14,6 +14,15 @@ const VISIBILITY_MODE_STORAGE_KEY = "expense-tracker-visibility-mode";
 const LAST_ACTIVE_STORAGE_KEY = "expense-tracker-last-active-ts";
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
+/**
+ * Browser timezone for every E2E browser context.
+ *
+ * Contexts created manually from the `browser` fixture do not inherit
+ * `use.timezoneId` from the Playwright config, so each `browser.newContext()`
+ * call passes this constant explicitly to keep local runs identical to CI.
+ */
+export const E2E_TIMEZONE_ID = "UTC";
+
 export type LiveSmokeScenario = Readonly<{
   runId: string;
   workspaceName: string;

--- a/apps/web/e2e/live-smoke.spec.ts
+++ b/apps/web/e2e/live-smoke.spec.ts
@@ -13,6 +13,7 @@ import {
   createTestWorkspace,
   createTransaction,
   deleteTestWorkspace,
+  E2E_TIMEZONE_ID,
   ensureAllVisibilityMode,
   getBalancesSummary,
   getBudgetGrid,
@@ -51,7 +52,10 @@ test.describe.serial("live smoke: auth, transactions, balances, budget, and AI c
 
     sharedBaseUrl = baseURL;
     sharedScenario = buildScenario(runIdFromClock());
-    sharedContext = await browser.newContext({ ignoreHTTPSErrors: true });
+    sharedContext = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      timezoneId: E2E_TIMEZONE_ID,
+    });
     sharedPage = await sharedContext.newPage();
   });
 

--- a/apps/web/e2e/public-monthly-share.spec.ts
+++ b/apps/web/e2e/public-monthly-share.spec.ts
@@ -5,6 +5,7 @@ import {
   createTestWorkspace,
   createTransaction,
   deleteTestWorkspace,
+  E2E_TIMEZONE_ID,
   runIdFromClock,
   setWorkspaceCookie,
   setupBrowserSession,
@@ -236,6 +237,7 @@ const createUnauthenticatedPage = async (
   const context = await browser.newContext({
     baseURL,
     ignoreHTTPSErrors: true,
+    timezoneId: E2E_TIMEZONE_ID,
   });
   return context.newPage();
 };

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -5,6 +5,8 @@ import {
   type VideoMode,
 } from "@playwright/test";
 
+import { E2E_TIMEZONE_ID } from "./e2e/live-smoke.actions";
+
 const appBaseUrl = process.env.EXPENSE_E2E_APP_BASE_URL ?? "https://app.expense-budget-tracker.com";
 
 const defaultTraceMode: TraceMode = "retain-on-failure";
@@ -89,6 +91,7 @@ export default defineConfig({
     headless: true,
     ignoreHTTPSErrors: true,
     navigationTimeout: liveSmokeNavigationTimeoutMs,
+    timezoneId: E2E_TIMEZONE_ID,
     trace: readTraceMode(),
     screenshot: readScreenshotMode(),
     video: readVideoMode(),

--- a/apps/web/src/lib/timezone.test.ts
+++ b/apps/web/src/lib/timezone.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isValidTimezone, listSupportedTimezones, listTimezoneOptions } from "./timezone";
+
+test("isValidTimezone accepts IANA zone names including link names", (): void => {
+  for (const timezone of [
+    "UTC",
+    "GMT",
+    "Europe/Madrid",
+    "US/Pacific",
+    "Asia/Calcutta",
+    "Europe/Kiev",
+    "Europe/Kyiv",
+    "Etc/GMT+5",
+  ]) {
+    assert.equal(isValidTimezone(timezone), true, timezone);
+  }
+});
+
+test("isValidTimezone rejects unusable values and numeric UTC offsets", (): void => {
+  for (const timezone of ["Etc/Unknown", "+05:30", "-08:00", "05:30", "", "   ", "not a timezone"]) {
+    assert.equal(isValidTimezone(timezone), false, timezone);
+  }
+});
+
+test("listTimezoneOptions offers every stored spelling exactly once", (): void => {
+  for (const timezone of ["US/Pacific", "Asia/Calcutta", "Asia/Kolkata", "Europe/Kiev", "Etc/GMT+5"]) {
+    const options = listTimezoneOptions(timezone);
+
+    assert.equal(options.includes(timezone), true, timezone);
+    assert.equal(new Set(options).size, options.length, timezone);
+  }
+});
+
+test("listTimezoneOptions keeps the supported list for a primary identifier", (): void => {
+  assert.deepEqual(listTimezoneOptions("UTC"), listSupportedTimezones());
+});

--- a/apps/web/src/lib/timezone.ts
+++ b/apps/web/src/lib/timezone.ts
@@ -10,18 +10,30 @@ const getIntlSupportedTimezones = (): ReadonlyArray<string> => {
   }
 };
 
+/**
+ * Shape of an IANA zone name: `/`-separated parts that each start with a letter.
+ *
+ * `Intl.DateTimeFormat` also accepts numeric UTC offsets such as `+05:30`, which
+ * are not zone names, carry no DST rules, and are not read the same way by
+ * Postgres, where a stored timezone is interpolated into `AT TIME ZONE` by the
+ * public share SQL functions. Link names such as `US/Pacific` and sign-carrying
+ * names such as `Etc/GMT+5` are IANA names and stay accepted.
+ */
+const IANA_TIMEZONE_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_+-]*(?:\/[A-Za-z][A-Za-z0-9_+-]*)*$/u;
+
+/**
+ * True when the value is an IANA zone name the runtime can format dates in.
+ *
+ * Acceptance is asked of Intl instead of matching
+ * `Intl.supportedValuesOf("timeZone")`, which lists one identifier per zone and
+ * omits the alternate spellings such as `US/Pacific`, `Asia/Calcutta`, and
+ * `Europe/Kiev` that browsers still report and every formatting path handles
+ * correctly.
+ */
 export const isValidTimezone = (value: string): boolean => {
   const normalizedValue = value.trim();
-  if (normalizedValue.length === 0) {
+  if (!IANA_TIMEZONE_NAME_PATTERN.test(normalizedValue)) {
     return false;
-  }
-  if (normalizedValue === UTC_TIMEZONE) {
-    return true;
-  }
-
-  const supportedTimezones = getIntlSupportedTimezones();
-  if (supportedTimezones.length > 0) {
-    return supportedTimezones.includes(normalizedValue);
   }
 
   try {
@@ -45,16 +57,61 @@ export const listSupportedTimezones = (): ReadonlyArray<string> => {
   return Array.from(timezones);
 };
 
+const resolveCanonicalTimezone = (value: string): string => {
+  try {
+    return new Intl.DateTimeFormat("en-US", { timeZone: value }).resolvedOptions().timeZone;
+  } catch {
+    return value;
+  }
+};
+
+/**
+ * Timezone choices for a picker, always containing the currently selected zone
+ * exactly once.
+ *
+ * `listSupportedTimezones()` carries the identifiers this engine chooses to
+ * list, so a stored link name such as `Asia/Calcutta` can match no choice and
+ * leave the picker blank. When the engine agrees that a listed identifier and
+ * the stored spelling name the same zone, the stored spelling takes that slot
+ * rather than being added next to it.
+ *
+ * Both sides are compared in canonical form because alias handling in
+ * `resolvedOptions().timeZone` is implementation-defined: engines may return the
+ * supplied identifier unchanged, and the listed identifier may itself be a
+ * legacy spelling. When an engine reports no relation between the two spellings,
+ * the stored value is appended, which is the only way to keep it selectable.
+ */
+export const listTimezoneOptions = (selectedTimezone: string): ReadonlyArray<string> => {
+  const supportedTimezones = listSupportedTimezones();
+  if (supportedTimezones.includes(selectedTimezone)) {
+    return supportedTimezones;
+  }
+
+  const canonicalTimezone = resolveCanonicalTimezone(selectedTimezone);
+  const canonicalIndex = supportedTimezones.findIndex(
+    (timezone): boolean => resolveCanonicalTimezone(timezone) === canonicalTimezone,
+  );
+  if (canonicalIndex === -1) {
+    return [...supportedTimezones, selectedTimezone];
+  }
+
+  return supportedTimezones.map((timezone, index): string =>
+    index === canonicalIndex ? selectedTimezone : timezone,
+  );
+};
+
+/**
+ * Browser timezone normalized to a valid IANA zone for server requests.
+ *
+ * Headless and hardened browsers can report a non-IANA value such as
+ * `Etc/Unknown`, meaning the browser cannot name its zone at all. UTC is the
+ * only value that can succeed for them, so it is used instead of failing.
+ */
 export const resolveBrowserTimezone = (): string => {
   const candidate = Intl.DateTimeFormat().resolvedOptions().timeZone;
   if (typeof candidate !== "string") {
-    throw new Error("Browser timezone is unavailable");
+    return UTC_TIMEZONE;
   }
 
-  const timezone = parseTimezone(candidate);
-  if (timezone === null) {
-    throw new Error(`Browser timezone is invalid: ${candidate}`);
-  }
-
-  return timezone;
+  return parseTimezone(candidate) ?? UTC_TIMEZONE;
 };

--- a/apps/web/src/server/chat/http/freshSessionRoute.ts
+++ b/apps/web/src/server/chat/http/freshSessionRoute.ts
@@ -4,6 +4,7 @@ import { handleRoute } from "@/server/api/handleRoute";
 import {
   buildChatRequestDiagnostics,
   extractChatRequestContext,
+  InvalidChatTimezoneError,
   parseFreshChatRequestBody,
   type ChatRequestContext,
   type FreshChatRequestBody,
@@ -151,6 +152,14 @@ export const postFreshChatSessionRouteWithDeps = async (
         body = parseFreshChatRequestBody(await request.json());
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+        if (error instanceof InvalidChatTimezoneError) {
+          dependencies.log({
+            domain: "chat",
+            action: "timezone_rejected",
+            route: "/api/chat/new",
+            timezone: error.timezone,
+          });
+        }
         return new Response(message, { status: 400 });
       }
 

--- a/apps/web/src/server/chat/http/request.test.ts
+++ b/apps/web/src/server/chat/http/request.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildChatRequestDiagnostics,
+  InvalidChatTimezoneError,
   parseChatRequestBody,
 } from "@/server/chat/http/request";
 import { LegacyPdfFileAttachmentError } from "@/server/chat/attachments/validation";
@@ -92,4 +93,42 @@ test("parseChatRequestBody rejects raw PDF file parts", (): void => {
       return true;
     },
   );
+});
+
+test("parseChatRequestBody rejects a timezone the browser could not resolve", (): void => {
+  assert.throws(
+    (): void => {
+      parseChatRequestBody({
+        ...createRequestBody([{ type: "text", text: "How much did I spend?" }]),
+        timezone: "Etc/Unknown",
+      });
+    },
+    (error: unknown): boolean => {
+      assert.ok(error instanceof InvalidChatTimezoneError);
+      assert.equal(error.timezone, "Etc/Unknown");
+      assert.match(
+        error.message,
+        /timezone must be UTC or a supported IANA timezone, received: Etc\/Unknown/u,
+      );
+      return true;
+    },
+  );
+});
+
+test("parseChatRequestBody accepts UTC sent by browsers without a resolvable timezone", (): void => {
+  const parsed = parseChatRequestBody({
+    ...createRequestBody([{ type: "text", text: "How much did I spend?" }]),
+    timezone: "UTC",
+  });
+
+  assert.equal(parsed.timezone, "UTC");
+});
+
+test("parseChatRequestBody preserves a legacy IANA alias timezone", (): void => {
+  const parsed = parseChatRequestBody({
+    ...createRequestBody([{ type: "text", text: "How much did I spend?" }]),
+    timezone: "US/Pacific",
+  });
+
+  assert.equal(parsed.timezone, "US/Pacific");
 });

--- a/apps/web/src/server/chat/http/request.ts
+++ b/apps/web/src/server/chat/http/request.ts
@@ -3,6 +3,7 @@ import type {
   ChatSessionSnapshot,
 } from "@/server/chat/store";
 import { z } from "zod";
+import { parseTimezone } from "@/lib/timezone";
 import { validateChatAttachments } from "@/server/chat/attachments/validation";
 import type { ContentPart } from "@/server/chat/types";
 import { extractUserId, extractWorkspaceId } from "@/server/userId";
@@ -60,6 +61,25 @@ export type ChatHistoryResponse = Readonly<{
     isStopped: boolean;
   }>>;
 }>;
+
+/**
+ * Raised when a chat request carries a timezone the runtime cannot format dates
+ * in, such as the `Etc/Unknown` reported by browsers that cannot name their own
+ * zone.
+ *
+ * The rejected value is kept as a field so the route can log it as a structured
+ * CloudWatch property; the request itself only ever returns a bare 400, which
+ * would otherwise leave this class of failure with no server-side signal.
+ */
+export class InvalidChatTimezoneError extends Error {
+  public readonly timezone: string;
+
+  public constructor(timezone: string) {
+    super(`timezone must be UTC or a supported IANA timezone, received: ${timezone}`);
+    this.name = "InvalidChatTimezoneError";
+    this.timezone = timezone;
+  }
+}
 
 const LEGACY_CHAT_REQUEST_FIELDS = [
   "chatSessionId",
@@ -191,6 +211,10 @@ const parseChatMessageRequestBody = (body: unknown): FreshChatRequestBody => {
   if (typeof candidate.timezone !== "string" || candidate.timezone.length === 0) {
     throw new Error("timezone must be a non-empty string");
   }
+  const timezone = parseTimezone(candidate.timezone);
+  if (timezone === null) {
+    throw new InvalidChatTimezoneError(candidate.timezone);
+  }
 
   const content = candidate.content.map(normalizeParsedContentPart);
   validateChatAttachments(content);
@@ -198,7 +222,7 @@ const parseChatMessageRequestBody = (body: unknown): FreshChatRequestBody => {
   return {
     content,
     model: candidate.model,
-    timezone: candidate.timezone,
+    timezone,
   };
 };
 

--- a/apps/web/src/server/chat/http/routeHandlers.test.ts
+++ b/apps/web/src/server/chat/http/routeHandlers.test.ts
@@ -159,6 +159,30 @@ test("postChatRouteWithDeps returns 400 for invalid request bodies", async (): P
   });
 });
 
+test("postChatRouteWithDeps logs the rejected timezone value", async (): Promise<void> => {
+  await withOpenAiApiKey("test-key", async (): Promise<void> => {
+    const rejectedTimezones: Array<string> = [];
+    const response = await postChatRouteWithDeps(
+      createChatRequest({
+        sessionId: "session-1",
+        content: [{ type: "text", text: "Hello" }],
+        model: CHAT_MODEL_ID,
+        timezone: "Etc/Unknown",
+      }),
+      createPostDependencies({
+        log: (event) => {
+          if (event.domain === "chat" && event.action === "timezone_rejected") {
+            rejectedTimezones.push(event.timezone);
+          }
+        },
+      }),
+    );
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(rejectedTimezones, ["Etc/Unknown"]);
+  });
+});
+
 test("postChatRouteWithDeps rejects non-UUID turn identities before persistence", async (): Promise<void> => {
   await withOpenAiApiKey("test-key", async (): Promise<void> => {
     const response = await postChatRouteWithDeps(

--- a/apps/web/src/server/chat/http/routeHandlers.ts
+++ b/apps/web/src/server/chat/http/routeHandlers.ts
@@ -7,6 +7,7 @@ import {
 import {
   buildChatRequestDiagnostics,
   extractChatRequestContext,
+  InvalidChatTimezoneError,
   parseChatRequestBody,
   toChatHistoryResponse,
   type ChatRequestBody,
@@ -154,6 +155,14 @@ export const postChatRouteWithDeps = async (
     body = parseChatRequestBody(await request.json());
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (error instanceof InvalidChatTimezoneError) {
+      dependencies.log({
+        domain: "chat",
+        action: "timezone_rejected",
+        route: "/api/chat",
+        timezone: error.timezone,
+      });
+    }
     return new Response(message, { status: 400 });
   }
 

--- a/apps/web/src/server/logger.ts
+++ b/apps/web/src/server/logger.ts
@@ -134,6 +134,19 @@ type ChatEvent =
     lastMessageRole?: "user" | "assistant";
     lastMessageState?: "in_progress" | "completed" | "error" | "cancelled";
   }>
+  /**
+   * A chat request was refused because its `timezone` field is not a zone the
+   * runtime can format dates in. This is invalid client input, not a server
+   * failure, so the action is deliberately kept out of the `error` family that
+   * the CloudWatch web error alarm pages on; it exists so the rejected value
+   * stays searchable in logs.
+   */
+  | Readonly<{
+    domain: "chat";
+    action: "timezone_rejected";
+    route: string;
+    timezone: string;
+  }>
   | Readonly<{
     domain: "chat";
     action: "run_transition_skipped";

--- a/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
+++ b/apps/web/src/ui/chat/session/controller/chatSessionControllerRuntime.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/chatImageFormats";
 import { CHAT_MODEL_ID } from "@/lib/chatModels";
 import type { StoredMessage } from "@/lib/chatHistory";
+import { resolveBrowserTimezone } from "@/lib/timezone";
 import type { ContentPart } from "@/server/chat/types";
 import type { PendingAttachment } from "../../shell/panel/FileAttachment";
 import type { ChatSessionSnapshot } from "../bootstrap/chatSessionSnapshot";
@@ -1058,7 +1059,7 @@ export const prepareChatSendRequest = (
     turnId: "00000000-0000-4000-8000-000000000000",
     model: CHAT_MODEL_ID,
     content: contentParts,
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    timezone: resolveBrowserTimezone(),
   } satisfies ExistingChatSendRequestBody);
 
   if (requestBody.length > MAX_BODY_BYTES) {
@@ -1087,7 +1088,7 @@ export const buildChatSendRequestBody = (
     turnId,
     model: CHAT_MODEL_ID,
     content,
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    timezone: resolveBrowserTimezone(),
   } satisfies ExistingChatSendRequestBody);
 
 export const buildFreshChatSendRequestBody = (
@@ -1096,7 +1097,7 @@ export const buildFreshChatSendRequestBody = (
   JSON.stringify({
     model: CHAT_MODEL_ID,
     content,
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    timezone: resolveBrowserTimezone(),
   } satisfies ChatMessageRequestBody);
 
 export const createChatSendTransport = (

--- a/apps/web/src/ui/settings/WorkspaceSettings.tsx
+++ b/apps/web/src/ui/settings/WorkspaceSettings.tsx
@@ -4,7 +4,7 @@ import { type ReactElement, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { fetchWithCsrf } from "@/lib/csrf";
-import { listSupportedTimezones } from "@/lib/timezone";
+import { listTimezoneOptions } from "@/lib/timezone";
 
 import styles from "./SettingsForm.module.css";
 
@@ -33,8 +33,8 @@ export const WorkspaceSettings = (props: Props): ReactElement => {
   const dirty = selected !== reportingCurrency || firstDayOfWeek !== props.firstDayOfWeek || timezone !== props.timezone;
 
   const timezones = useMemo<ReadonlyArray<string>>(() => {
-    return listSupportedTimezones();
-  }, []);
+    return listTimezoneOptions(props.timezone);
+  }, [props.timezone]);
 
   const handleSave = useCallback(async (): Promise<void> => {
     setSaving(true);


### PR DESCRIPTION
## Why

The `ExpenseBudgetTracker-WebErrorEventsAlarm` alarm fired on 19 and 20 Aug. Every error event was `RangeError: Invalid time zone specified: Etc/Unknown` from the chat agent stage.

Browsers that cannot map their host zone report `Etc/Unknown` from `Intl.DateTimeFormat().resolvedOptions().timeZone`. The client sent it verbatim, the server accepted it after only a non-empty-string check, and `formatDatetime()` threw before the first model call. The user saw the generic chat error and every retry failed, so chat was permanently dead for that browser. `resolveBrowserTimezone()` threw on the same input, so those browsers could not create a workspace either.

The account in the logs was the live-smoke suite, but the code path is reachable by real hardened and privacy browsers, so this is a product fix rather than only a test-config change.

## What

- `resolveBrowserTimezone()` returns `UTC` instead of throwing when no usable IANA zone is available; the three raw reads in the chat controller now go through it.
- The server validates the chat timezone with `parseTimezone()` and rejects an unusable value with an explicit error naming it, so nothing invalid reaches `Intl`. No server-side fallback.
- `isValidTimezone` now accepts IANA link names such as `US/Pacific` and `Asia/Calcutta`, which `supportedValuesOf()` membership rejected, while still refusing numeric offset forms that would reach `AT TIME ZONE` in the public share SQL (`db/migrations/0047…`, `0050…`).
- The workspace settings select offers the stored zone, so a link name is no longer displayed as blank.
- A structured `chat` / `timezone_rejected` event keeps a rejected zone visible in CloudWatch. It deliberately does not match `WebErrorMetricFilter`, so invalid client input does not page the on-call.
- Playwright pins the live-smoke browser timezone to `UTC`, including the manually created contexts that `use.*` does not reach — the reason local runs failed while CI stayed green.

## Notes

Open verification action, not addressed here: confirm the deployed Postgres carries tzdb `backward` link names, since link names can now be stored and are interpolated into `AT TIME ZONE`.

```sql
SELECT name FROM pg_timezone_names
WHERE name IN ('US/Pacific','Asia/Calcutta','Europe/Kiev','Etc/GMT+5');
```

Reviewed across four fresh review rounds; the final round returned no P0-P4 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)