### PR TITLE
Add chat turn rate counter table and demo email config for web

### DIFF
--- a/db/migrations/0072_chat_turn_rate_events.sql
+++ b/db/migrations/0072_chat_turn_rate_events.sql
@@ -1,0 +1,33 @@
+-- Per-user chat turn counter used to rate limit demo accounts.
+--
+-- Deliberately scoped by user only, with no workspace_id column and no
+-- workspace predicate in its policy. chat_sessions_self_access requires
+-- workspace_id = current_setting('app.workspace_id', true), so a client that
+-- creates a fresh workspace per run never sees its own earlier turns. A
+-- workspace-scoped counter would therefore be trivially bypassable.
+
+CREATE TABLE public.chat_turn_rate_events (
+  id          BIGSERIAL   PRIMARY KEY,
+  user_id     TEXT        NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX chat_turn_rate_events_user_created_idx
+  ON public.chat_turn_rate_events (user_id, created_at DESC);
+
+ALTER TABLE public.chat_turn_rate_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chat_turn_rate_events FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY chat_turn_rate_events_self_access
+  ON public.chat_turn_rate_events
+  FOR ALL
+  USING (user_id = current_setting('app.user_id', true))
+  WITH CHECK (user_id = current_setting('app.user_id', true));
+
+REVOKE ALL ON TABLE public.chat_turn_rate_events FROM PUBLIC;
+REVOKE ALL ON TABLE public.chat_turn_rate_events FROM api_sql_executor;
+GRANT SELECT, INSERT, DELETE ON TABLE public.chat_turn_rate_events TO app;
+
+REVOKE ALL ON SEQUENCE public.chat_turn_rate_events_id_seq FROM PUBLIC;
+REVOKE ALL ON SEQUENCE public.chat_turn_rate_events_id_seq FROM api_sql_executor;
+GRANT USAGE ON SEQUENCE public.chat_turn_rate_events_id_seq TO app;

--- a/infra/aws/lib/compute.ts
+++ b/infra/aws/lib/compute.ts
@@ -166,6 +166,7 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
       // RDS certs are signed by Amazon's CA, not in the Node.js trust store.
       // Points to the CA bundle downloaded in apps/web/Dockerfile.
       NODE_EXTRA_CA_CERTS: "/app/rds-global-bundle.pem",
+      ...(props.demoEmailDostip !== "" ? { DEMO_EMAIL_DOSTIP: props.demoEmailDostip } : {}),
     },
     secrets: {
       DB_PASSWORD: ecs.Secret.fromSecretsManager(props.appDbSecret, "password"),


### PR DESCRIPTION
## Why

The demo sign-in at `apps/auth/src/routes/sendCode.ts:72` mints a session for anyone who knows an allowlisted `@example.com` email, and that email is committed in this public repository. Rather than rotate it, we cap demo/review accounts at a fixed number of chat turns per hour.

This PR ships **only the prerequisites**: schema and configuration, with no caller. `CLAUDE.md` notes the deploy may update the web service before running migrations, so shipping the table and the code that queries it in one release could leave the web service hitting a table that does not exist yet. This deploys green on its own.

## What

- `db/migrations/0072_chat_turn_rate_events.sql`: counter table with `ENABLE` + `FORCE ROW LEVEL SECURITY`, one self-access policy, and grants limited to the `app` role. Revoked from `PUBLIC` and `api_sql_executor` following `0029`/`0065`.
- `infra/aws/lib/compute.ts`: pass the already-threaded `props.demoEmailDostip` to the web container, mirroring the auth container's existing conditional. No new stack prop, no new secret.

## Design note

The counter is scoped **by user alone and deliberately not by workspace**. `chat_sessions_self_access` (`db/migrations/0029_chat_sessions.sql:47`) forces `workspace_id = current_setting('app.workspace_id', true)`, which is exactly why the existing per-workspace message counter never accumulates for a client that creates a fresh workspace on every run — production logs show its rolling count stuck at 1 then 2 across eight runs in sixteen minutes. A workspace-scoped policy here would make the cap bypassable, so the divergence is intentional and recorded in a comment at the top of the migration.

Enforcement, the demo-account predicate, the log event, the i18n strings and the tests are a separate follow-up PR that lands after this one is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)