### PR TITLE
Block attribute-notation function calls in restricted SQL

### DIFF
--- a/packages/agent-shared/src/sql-policy.test.ts
+++ b/packages/agent-shared/src/sql-policy.test.ts
@@ -285,6 +285,75 @@ test("validateExpenseSql rejects non-allowlisted function calls in restricted SQ
   assertFunctionCallRejected("INSERT INTO ledger_entries (event_id, ts, account_id, amount, currency, kind, workspace_id) VALUES (gen_random_uuid(), now(), 'a-main-usd', 1, 'USD', 'income', 'workspace-1')");
 });
 
+test("validateExpenseSql rejects attribute-notation function calls on indirection expressions", (): void => {
+  const rejectedSql: ReadonlyArray<string> = [
+    "SELECT entry_id FROM ledger_entries WHERE (amount).pg_sleep IS NULL",
+    "UPDATE ledger_entries SET note = 'x' WHERE (amount).pg_sleep IS NULL",
+    "DELETE FROM ledger_entries WHERE (amount).pg_sleep IS NULL",
+    "SELECT entry_id FROM ledger_entries WHERE (currency).pg_get_viewdef IS NULL",
+    "SELECT entry_id FROM ledger_entries WHERE (currency).to_regclass IS NULL",
+    // Subscripted indirection terminates in `]` instead of `)`, but PostgreSQL
+    // resolves the trailing field name through the same function lookup.
+    "SELECT entry_id FROM ledger_entries WHERE (ARRAY[amount])[1].pg_sleep IS NULL",
+    "SELECT workspace_id FROM workspace_settings WHERE (filtered_categories)[1].to_regclass IS NULL",
+    // The construct is legal in every expression position, not only WHERE.
+    "SELECT account_id FROM ledger_entries GROUP BY account_id HAVING sum(amount) > (amount).pg_sleep",
+    "SELECT entry_id FROM ledger_entries ORDER BY entry_id, (amount).pg_sleep",
+    "UPDATE ledger_entries SET note = 'x' WHERE entry_id = 'e1' RETURNING entry_id, (amount).pg_sleep",
+    "WITH slow AS (SELECT entry_id FROM ledger_entries WHERE (amount).pg_sleep IS NULL) SELECT entry_id FROM slow",
+    "SELECT entry_id FROM ledger_entries; SELECT entry_id FROM ledger_entries WHERE (amount).pg_sleep IS NULL",
+  ];
+
+  for (const sql of rejectedSql) {
+    assert.throws(
+      () => validateExpenseSql(sql),
+      (error: unknown) =>
+        error instanceof SqlPolicyError
+        && error.code === "function_calls_not_allowed"
+        && error.message.includes("Attribute-notation function calls"),
+      sql,
+    );
+  }
+});
+
+test("validateExpenseSql still allows ordinary SQL without attribute notation", (): void => {
+  const acceptedSql: ReadonlyArray<Readonly<{
+    sql: string;
+    relations: ReadonlyArray<string>;
+  }>> = [
+    {
+      sql: "SELECT e.amount FROM ledger_entries e WHERE e.currency = 'EUR'",
+      relations: ["ledger_entries"],
+    },
+    {
+      sql: "SELECT entry_id FROM ledger_entries WHERE (amount) > 0",
+      relations: ["ledger_entries"],
+    },
+    { sql: "SELECT sum(amount) FROM ledger_entries", relations: ["ledger_entries"] },
+    // Plain subscripting and slices carry no field access, so the indirection
+    // guard must leave them alone.
+    {
+      sql: "SELECT workspace_id FROM workspace_settings WHERE filtered_categories[1] = 'food'",
+      relations: ["workspace_settings"],
+    },
+    {
+      sql: "SELECT workspace_id FROM workspace_settings WHERE filtered_categories[1:2] = ARRAY['food']",
+      relations: ["workspace_settings"],
+    },
+  ];
+
+  for (const { sql, relations } of acceptedSql) {
+    const validated = validateExpenseSql(sql);
+    assert.equal(validated.statements.length, 1, sql);
+    assert.deepEqual(validated.statements[0]?.referencedRelations, relations, sql);
+  }
+
+  const multiStatementCtes = validateReadOnlyExpenseSql(
+    "WITH totals AS (SELECT account_id, SUM(amount) AS balance FROM ledger_entries GROUP BY account_id) SELECT * FROM totals; WITH rows(value) AS (VALUES (1), (2)) SELECT value FROM rows",
+  );
+  assert.equal(multiStatementCtes.statements.length, 2);
+});
+
 test("validateExpenseSql still rejects set_config before function allowlist checks", (): void => {
   assert.throws(
     () => validateExpenseSql("SELECT set_config('app.user_id', 'user-1', true)"),

--- a/packages/agent-shared/src/sql-policy.ts
+++ b/packages/agent-shared/src/sql-policy.ts
@@ -1034,6 +1034,49 @@ const failFunctionCallNotAllowed = (functionName: string): never =>
     `Function ${functionName}() is not allowed in restricted SQL. Allowed functions: ${ALLOWED_SQL_FUNCTIONS_DESCRIPTION}`,
   );
 
+/**
+ * Tokens that can terminate a PostgreSQL indirection chain immediately before a
+ * `.` field access: `)` closes a parenthesized expression and `]` closes a
+ * subscript. PostgreSQL resolves the field name after either terminator through
+ * the same function lookup, so both spellings must be rejected.
+ *
+ * A bare identifier is deliberately absent: `relation.column` is ordinary SQL,
+ * and the paren-less `relation.func` form is an accepted, documented exception.
+ */
+const INDIRECTION_TERMINATORS: ReadonlySet<string> = new Set([")", "]"]);
+
+/**
+ * Rejects PostgreSQL attribute notation applied to an indirection expression,
+ * such as `(amount).pg_sleep` or `(ARRAY[amount])[1].pg_sleep`. Those forms are
+ * equivalent to `pg_sleep(amount)` but have no parenthesis after the function
+ * name, so the call allowlist, which only inspects identifiers followed by `(`,
+ * would never see them.
+ *
+ * The check stays anchored on the full `<terminator> . <word>` triple so that
+ * plain subscripting such as `filtered_categories[1] = 'food'`, slice syntax,
+ * and composite expansion via `.*` keep working; none of those resolve a
+ * function name.
+ */
+const assertNoIndirectionAttributeNotation = (
+  tokens: ReadonlyArray<SqlToken>,
+): void => {
+  for (let index = 2; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    const terminator = tokens[index - 2];
+    if (
+      token?.kind === "word"
+      && tokens[index - 1]?.value === "."
+      && terminator !== undefined
+      && INDIRECTION_TERMINATORS.has(terminator.value)
+    ) {
+      fail(
+        "function_calls_not_allowed",
+        `Attribute-notation function calls such as (column).${token.value} are not allowed in restricted SQL. Call an allowlisted function explicitly. Allowed functions: ${ALLOWED_SQL_FUNCTIONS_DESCRIPTION}`,
+      );
+    }
+  }
+};
+
 const assertOnlyAllowedFunctionCallsInSegment = (
   tokens: ReadonlyArray<SqlToken>,
   startIndex: number,
@@ -1424,6 +1467,7 @@ const validateExpenseSqlStatement = (sql: string): ValidatedExpenseSqlStatement 
   assertSupportedEffectiveStatementsInSegment(tokens, 0, tokens.length);
   assertMutationTargetsAreWritable(tokens, 0, tokens.length);
   assertOnlyAllowedFunctionCallsInSegment(tokens, 0, tokens.length, "statement");
+  assertNoIndirectionAttributeNotation(tokens);
 
   return {
     sql,


### PR DESCRIPTION
## Problem

The restricted SQL validator (`packages/agent-shared/src/sql-policy.ts`) only treated an identifier as a function call when the next token was `(`. PostgreSQL attribute notation `(expr).name` is equivalent to `name(expr)` and has no parenthesis after the name, so it bypassed the 6-function allowlist entirely.

Verified on real PostgreSQL 18.4 under a non-superuser role: the validator **accepted**

```sql
SELECT entry_id FROM ledger_entries WHERE (amount).pg_sleep IS NULL
```

and Postgres slept `amount` seconds per row, amplifying up to the 25 s statement timeout. Any authenticated user could hold database connections and exhaust the pool. `(currency).to_regclass` and `(currency).pg_get_viewdef` were reachable the same way.

Not a data-theft or privilege-escalation path: `api_sql_executor` grants already reject `pg_read_file` and the SECURITY DEFINER helpers, and RLS is unaffected.

## Fix

Reject the `<terminator> . <word>` triple for both indirection terminators, `)` and `]` — a subscript chain such as `(ARRAY[amount])[1].pg_sleep` reaches the same call, and `workspace_settings.filtered_categories` is a real `TEXT[]` column.

The trigger stays anchored on the full triple, so array subscripts, slices and `.*` composite expansion still validate. No new error code, no consumer changes.

## Scope

The paren-less `relation.func` form stays accepted on purpose: it can only pass a whole-row or `anyelement` argument. Guardrail: never add a PUBLIC function accepting an allowed relation's rowtype or `anyelement`.

## Tests

12 rejected cases (both cited payloads, plus `HAVING` / `ORDER BY` / `RETURNING` / CTE body / second statement of a script) and 5 accepted cases guarding against over-rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)