### PR TITLE
Add inert Cloudflare origin-secret WAF rule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,7 +113,10 @@ jobs:
       - name: CDK deploy
         working-directory: infra/aws
         run: |
-          cat > cdk.context.local.json <<CTXEOF
+          # Quoted delimiter: GitHub expands the expressions before the shell runs,
+          # so an unquoted heredoc would let the shell mangle secrets containing
+          # $, backticks or backslashes and deploy a secret nobody can reproduce.
+          cat > cdk.context.local.json <<'CTXEOF'
           {
             "region": "${{ vars.AWS_REGION }}",
             "domainName": "${{ vars.CDK_DOMAIN_NAME }}",
@@ -125,7 +128,8 @@ jobs:
             "langfuseBaseUrl": "${{ vars.CDK_LANGFUSE_BASE_URL }}",
             "alertEmail": "${{ vars.CDK_ALERT_EMAIL }}",
             "githubRepo": "${{ vars.CDK_GITHUB_REPO }}",
-            "demoEmailDostip": "${{ vars.CDK_DEMO_EMAIL_DOSTIP }}"
+            "demoEmailDostip": "${{ vars.CDK_DEMO_EMAIL_DOSTIP }}",
+            "originSharedSecret": "${{ secrets.CDK_ORIGIN_SHARED_SECRET }}"
           }
           CTXEOF
           npx cdk deploy --all --require-approval never
@@ -143,7 +147,6 @@ jobs:
           echo "service=$(get_output EcsServiceName)" >> "$GITHUB_OUTPUT"
           echo "migrate_task=$(get_output MigrateTaskDefArn)" >> "$GITHUB_OUTPUT"
           echo "migrate_sg=$(get_output MigrateSecurityGroupId)" >> "$GITHUB_OUTPUT"
-          echo "alb_dns=$(get_output AlbDns)" >> "$GITHUB_OUTPUT"
           echo "fx_function=$(get_output FxFetcherFunctionName)" >> "$GITHUB_OUTPUT"
 
       # Run database migrations as a one-off ECS task after every deploy.
@@ -158,10 +161,12 @@ jobs:
           MIGRATE_TASK: ${{ steps.outputs.outputs.migrate_task }}
           MIGRATE_SG: ${{ steps.outputs.outputs.migrate_sg }}
 
+      # Probe the public app origin through Cloudflare, like every other post-deploy
+      # check: a direct-to-ALB probe cannot carry the Cloudflare origin shared secret.
       - name: Confirm web readiness
         run: bash scripts/check-web-readiness.sh
         env:
-          ALB_DNS: ${{ steps.outputs.outputs.alb_dns }}
+          READINESS_URL: https://app.${{ vars.CDK_DOMAIN_NAME }}/api/health
 
       # Ensure exchange rates are up to date (idempotent — ON CONFLICT DO NOTHING)
       - name: Seed exchange rates

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -66,7 +66,7 @@ MCP client → Cloudflare → API Gateway (HTTP API v2) → MCP Lambda → RDS
 - **ECS Fargate** — web service (0.5 vCPU / 1 GB ARM64, 1–3 tasks, CPU-based auto-scaling with alert on scale-out) + one-off migration task definition
 - **ALB** with HTTPS (Cloudflare Origin Certificate), forwards traffic to ECS and uses `/api/live` for liveness checks
 - **Cognito User Pool** (Essentials tier) — passwordless Email OTP auth with a CustomEmailSender Lambda through Resend, managed by the app directly (no Hosted UI)
-- **AWS WAF** on ALB — SQLi/XSS protection, common threat rules, and approximate anonymous `POST auth.*/oauth/register` throttling with a 10-request threshold over AWS's native 60-second evaluation window per real client IP from `CF-Connecting-IP`; malformed values match the block action, while AWS WAF omits missing headers, which is accepted because the ALB only accepts Cloudflare edges that supply the header
+- **AWS WAF** on ALB — SQLi/XSS protection, common threat rules, and approximate anonymous `POST auth.*/oauth/register` throttling with a 10-request threshold over AWS's native 60-second evaluation window per real client IP from `CF-Connecting-IP`; malformed values match the block action, while AWS WAF omits missing headers, which is accepted because the ALB only accepts Cloudflare edges that supply the header. Cloudflare edge ingress proves only *some* Cloudflare zone, so the rate limits trust `CF-Connecting-IP` fully only once the optional `x-origin-auth` origin shared secret is configured: it both blocks requests that did not pass through our own zone and confines the rate-limit scope to requests carrying it (see [Origin shared secret](#origin-shared-secret-cloudflare--alb))
 - **Lambda** (Node.js 24) for daily FX rate fetching + EventBridge schedule at 08:00 UTC, and Cognito custom email delivery through Resend
 - **API Gateway** — one REST API with authorizer + executor Lambdas for ApiKey machine SQL, plus an independent HTTP API v2 and Lambda for stateless Streamable HTTP MCP at `/mcp`; the MCP default `execute-api` endpoint is disabled
 - **MCP capacity budget** — the HTTP API accepts a burst of 20 and then 10 requests/second, enough for five concurrent clients to each send the normal four-request `initialize`, `notifications/initialized`, `tools/list`, first `tools/call` sequence without exhausting the stage token bucket. Database safety is enforced independently: five reserved Lambda executions × the explicit 10-connection SQL API pool ceiling reserve at most 50 of the t4g.micro's roughly 85 connections, leaving about 35 for web, auth, worker, and the machine SQL API; excess Lambda load may be throttled without expanding that database budget
@@ -333,6 +333,7 @@ Edit `cdk.context.local.json` with your values:
 | `langfuseBaseUrl` | Langfuse base URL, defaults to `https://cloud.langfuse.com` |
 | `alertEmail` | Email for CloudWatch alarm notifications |
 | `githubRepo` | GitHub repo for CI/CD, e.g. `user/expense-budget-tracker` |
+| `originSharedSecret` | Optional. Cloudflare-to-ALB shared secret — leave empty until the Transform Rule exists (see [Origin shared secret](#origin-shared-secret-cloudflare--alb)) |
 
 #### 5a. Create the MCP domain certificate and complete the context (~5-30 min wait)
 
@@ -478,6 +479,7 @@ After first deploy:
    - `CDK_CERTIFICATE_ARN` — ACM certificate ARN (Cloudflare Origin Cert, from step 3d)
    - `CDK_API_CERTIFICATE_ARN` — ACM certificate ARN (public cert for API domain, from step 3e)
    - `CDK_MCP_CERTIFICATE_ARN` — ACM certificate ARN (public cert for MCP domain, from step 5a)
+   - `CDK_ORIGIN_SHARED_SECRET` — optional Cloudflare-to-ALB shared secret; see [Origin shared secret](#origin-shared-secret-cloudflare--alb) before setting it
 
    **Variables** (Settings → Secrets and variables → Actions → Variables):
    - `AWS_REGION` — target region (e.g. `eu-central-1`)
@@ -495,6 +497,29 @@ After first deploy:
    - Restart ECS service (`force-new-deployment` picks up the new `latest` image)
 
 No AWS keys stored in GitHub — uses OIDC federation.
+
+## Origin shared secret (Cloudflare → ALB)
+
+The ALB security group only accepts Cloudflare edge ranges, which proves a request came from *some* Cloudflare zone. An attacker can point their own Cloudflare zone at the ALB, bypass this zone's rules, and send an arbitrary `CF-Connecting-IP`, which defeats the WAF rate limits keyed on that header. A shared secret injected by a Transform Rule proves the request came from *our* zone, because Transform Rules are per-zone.
+
+- Header: `x-origin-auth` (lowercase — AWS WAF `singleHeader` names must be lowercase)
+- CDK context key: `originSharedSecret`; GitHub Actions secret: `CDK_ORIGIN_SHARED_SECRET`
+- While the value is empty, absent, or whitespace-only, the web ACL is byte-for-byte unchanged and no request is blocked
+- Once the value is set (surrounding whitespace is stripped), the WAF rule `BlockRequestsWithoutOriginSharedSecret` (priority 9, metric `expense-tracker-origin-secret-block`) blocks every request whose `x-origin-auth` header is missing or not exactly equal to the secret
+- The same value is also required inside the scope-down of both `CF-Connecting-IP` rate-limit rules. A rate-based rule aggregates every request it evaluates and a later block does not un-count it, so without this a forged `CF-Connecting-IP` from a foreign zone could still exhaust a victim IP's registration or token budget before being blocked. Existing rule priorities are unchanged
+- ALB target health checks reach the targets directly without traversing the web ACL, so they are unaffected
+- The `WafOriginSecretBlockedAlarm` CloudWatch alarm notifies the alert topic when this rule blocks more than 50 requests in 5 minutes — target health checks stay green during a secret mismatch, so this alarm is the signal that the zone and the ACL diverged
+
+Generate the value with a shell-safe generator, for example `openssl rand -hex 32`.
+
+> **Warning:** activate in this order. Setting the secret before the Cloudflare Transform Rule exists blocks all public traffic to `app.*` and `auth.*` and takes the whole site down.
+
+1. **First**, create a Transform Rule (Rules → Transform Rules → Modify Request Header) in the Cloudflare zone that sets `x-origin-auth` to the secret on every request to the proxied hostnames, and confirm it is live.
+2. **Second**, store the same value as the `CDK_ORIGIN_SHARED_SECRET` GitHub Actions secret (and in `cdk.context.local.json` for local deploys) and deploy.
+
+To roll back, clear the GitHub Actions secret and deploy: the rule disappears from the web ACL. The secret is part of the synthesized CloudFormation template — that is accepted, because it only authenticates the Cloudflare-to-ALB hop and grants no access to user data.
+
+The rule accepts exactly one value, so rotation needs the same two-phase discipline as activation, in reverse: change the Cloudflare Transform Rule to the new value first, then update `CDK_ORIGIN_SHARED_SECRET` and deploy. Traffic is blocked for the window between the two steps, so rotate during a maintenance window, or turn the secret off, rotate, and turn it back on.
 
 ## Domain routing
 

--- a/infra/aws/bin/app.ts
+++ b/infra/aws/bin/app.ts
@@ -53,6 +53,10 @@ if (!resendSenderEmail) {
   throw new Error("Missing required context: 'resendSenderEmail'. Set it in cdk.context.local.json (e.g. \"no-reply@mail.yourdomain.com\")");
 }
 
+// Optional context: "originSharedSecret" is the shared secret our Cloudflare zone
+// injects as the x-origin-auth header. It is deliberately not required — an absent
+// or empty value keeps the WAF origin-secret rule out of the web ACL.
+
 new ExpenseBudgetTrackerStack(app, "ExpenseBudgetTracker", {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,

--- a/infra/aws/cdk.context.local.example.json
+++ b/infra/aws/cdk.context.local.example.json
@@ -8,5 +8,6 @@
   "resendSenderEmail": "no-reply@mail.example.com",
   "langfuseBaseUrl": "https://cloud.langfuse.com",
   "alertEmail": "your-email@gmail.com",
-  "githubRepo": "your-github-user/expense-budget-tracker"
+  "githubRepo": "your-github-user/expense-budget-tracker",
+  "originSharedSecret": ""
 }

--- a/infra/aws/lib/ingress.test.ts
+++ b/infra/aws/lib/ingress.test.ts
@@ -155,7 +155,7 @@ const assertBoundedGetRoute = (
 };
 
 test("WAF counts the managed query-size rule and re-blocks outside exact bounded auth GETs", (): void => {
-  const rules = buildIngressWafRules("app.example.com", "auth.example.com");
+  const rules = buildIngressWafRules("app.example.com", "auth.example.com", "");
   const managedRule = getRule(rules, "AWSManagedCommonRules");
   const managedStatement = requireStatement(managedRule.statement);
   const managedRuleGroup = requireManagedRuleGroupStatement(
@@ -203,7 +203,7 @@ test("WAF counts the managed query-size rule and re-blocks outside exact bounded
 });
 
 test("WAF re-blocks managed loopback body matches outside exact JSON client registration", (): void => {
-  const rules = buildIngressWafRules("app.example.com", "auth.example.com");
+  const rules = buildIngressWafRules("app.example.com", "auth.example.com", "");
   assert.deepEqual(
     rules.map((rule) => [rule.name, rule.priority]),
     [
@@ -318,7 +318,7 @@ test("WAF re-blocks managed loopback body matches outside exact JSON client regi
 });
 
 test("WAF rate limits exact dynamic client registration requests by trusted Cloudflare client IP", (): void => {
-  const rules = buildIngressWafRules("app.example.com", "auth.example.com");
+  const rules = buildIngressWafRules("app.example.com", "auth.example.com", "");
   const rule = getRule(rules, "RateLimitDynamicClientRegistration");
   assert.equal(rule.priority, 7);
   assert.deepEqual(rule.action, { block: {} });
@@ -358,7 +358,7 @@ test("WAF rate limits exact dynamic client registration requests by trusted Clou
 });
 
 test("WAF separately rate limits exact OAuth token exchanges by trusted Cloudflare client IP", (): void => {
-  const rules = buildIngressWafRules("app.example.com", "auth.example.com");
+  const rules = buildIngressWafRules("app.example.com", "auth.example.com", "");
   const rule = getRule(rules, "RateLimitOAuthTokenExchanges");
   assert.equal(rule.priority, 8);
   assert.deepEqual(rule.action, { block: {} });
@@ -399,5 +399,102 @@ test("WAF separately rate limits exact OAuth token exchanges by trusted Cloudfla
     sampledRequestsEnabled: true,
     cloudWatchMetricsEnabled: true,
     metricName: "expense-tracker-oauth-token-rate-limit",
+  });
+});
+
+test("WAF omits the origin-secret rule when no shared secret is configured", (): void => {
+  const rules = buildIngressWafRules("app.example.com", "auth.example.com", "");
+  assert.equal(
+    rules.some((rule) => rule.name === "BlockRequestsWithoutOriginSharedSecret"),
+    false,
+  );
+});
+
+test("WAF stays byte-for-byte unchanged for a blank or whitespace-only origin secret", (): void => {
+  const unset = buildIngressWafRules("app.example.com", "auth.example.com", "");
+  for (const blank of ["   ", "\n", "\t "]) {
+    assert.deepEqual(
+      buildIngressWafRules("app.example.com", "auth.example.com", blank),
+      unset,
+    );
+  }
+});
+
+test("WAF trims padding around the configured origin secret", (): void => {
+  const padded = buildIngressWafRules(
+    "app.example.com",
+    "auth.example.com",
+    "  s3cret-value\n",
+  );
+  const rule = getRule(padded, "BlockRequestsWithoutOriginSharedSecret");
+  const negation = requireNotStatement(requireStatement(rule.statement).notStatement);
+  assert.equal(
+    requireByteMatchStatement(
+      requireStatement(negation.statement).byteMatchStatement,
+    ).searchString,
+    "s3cret-value",
+  );
+  assert.deepEqual(
+    padded,
+    buildIngressWafRules("app.example.com", "auth.example.com", "s3cret-value"),
+  );
+});
+
+// Rate-based rules aggregate every request they evaluate, and a later terminating
+// rule does not un-count it. Requests that did not come through our Cloudflare zone
+// must therefore be excluded from the scope-down, not merely blocked afterwards.
+test("WAF rate limits only requests carrying the configured origin secret", (): void => {
+  const rules = buildIngressWafRules(
+    "app.example.com",
+    "auth.example.com",
+    "s3cret-value",
+  );
+  for (const name of [
+    "RateLimitDynamicClientRegistration",
+    "RateLimitOAuthTokenExchanges",
+  ]) {
+    const rule = getRule(rules, name);
+    const rateBasedStatement = requireRateBasedStatement(
+      requireStatement(rule.statement).rateBasedStatement,
+    );
+    const scopeDown = requireAndStatement(
+      requireStatement(rateBasedStatement.scopeDownStatement).andStatement,
+    );
+    const conditions = requireStatements(scopeDown.statements);
+    assert.deepEqual(
+      requireByteMatchStatement(conditions.at(-1)?.byteMatchStatement),
+      {
+        fieldToMatch: { singleHeader: { Name: "x-origin-auth" } },
+        positionalConstraint: "EXACTLY",
+        searchString: "s3cret-value",
+        textTransformations: [{ priority: 0, type: "NONE" }],
+      },
+    );
+  }
+});
+
+test("WAF blocks requests without the exact configured origin secret header", (): void => {
+  const rules = buildIngressWafRules(
+    "app.example.com",
+    "auth.example.com",
+    "s3cret-value",
+  );
+  const rule = getRule(rules, "BlockRequestsWithoutOriginSharedSecret");
+  assert.equal(rule.priority, 9);
+  assert.deepEqual(rule.action, { block: {} });
+
+  const statement = requireStatement(rule.statement);
+  const negation = requireNotStatement(statement.notStatement);
+  const byteMatch = requireByteMatchStatement(
+    requireStatement(negation.statement).byteMatchStatement,
+  );
+  assert.deepEqual(byteMatch.fieldToMatch, { singleHeader: { Name: "x-origin-auth" } });
+  assert.equal(byteMatch.positionalConstraint, "EXACTLY");
+  assert.equal(byteMatch.searchString, "s3cret-value");
+  assert.deepEqual(byteMatch.textTransformations, [{ priority: 0, type: "NONE" }]);
+  assert.deepEqual(rule.visibilityConfig, {
+    sampledRequestsEnabled: true,
+    cloudWatchMetricsEnabled: true,
+    metricName: "expense-tracker-origin-secret-block",
   });
 });

--- a/infra/aws/lib/ingress.ts
+++ b/infra/aws/lib/ingress.ts
@@ -20,6 +20,7 @@ export interface IngressProps {
   baseDomain: string;
   appDomain: string;
   authDomain: string;
+  originSharedSecret: string;
 }
 
 export interface IngressResult {
@@ -36,6 +37,16 @@ const DYNAMIC_CLIENT_REGISTRATION_RATE_LIMIT = 10;
 const DYNAMIC_CLIENT_REGISTRATION_EVALUATION_WINDOW_SECONDS = 60;
 const OAUTH_TOKEN_EXCHANGE_RATE_LIMIT = 60;
 const OAUTH_TOKEN_EXCHANGE_EVALUATION_WINDOW_SECONDS = 60;
+
+// Injected by a Transform Rule in our own Cloudflare zone. AWS WAF singleHeader
+// names must be lowercase. Requests reaching the ALB through any other Cloudflare
+// zone cannot carry it, so they are rejected once the secret is configured.
+const ORIGIN_SHARED_SECRET_HEADER = "x-origin-auth";
+// Priorities 0-8 are taken and AWS WAF priorities are non-negative integers, so the
+// lowest free slot is after the rate-based rules. Evaluation order is irrelevant for
+// this rule because the rate limiters scope themselves down to requests carrying the
+// same secret, so a foreign-zone request is never aggregated before it is blocked.
+const ORIGIN_SHARED_SECRET_RULE_PRIORITY = 9;
 
 const noneTextTransformation = (): wafv2.CfnWebACL.TextTransformationProperty => ({
   priority: 0,
@@ -154,6 +165,32 @@ const blockLabeledRequestUnless = (
   },
 });
 
+const originSharedSecretMatches = (
+  originSharedSecret: string,
+): wafv2.CfnWebACL.StatementProperty =>
+  byteMatchStatement(
+    singleHeaderField(ORIGIN_SHARED_SECRET_HEADER),
+    "EXACTLY",
+    originSharedSecret,
+    noneTextTransformation(),
+  );
+
+// Blocks every request whose origin secret header is absent or different.
+// A missing header does not match the byte comparison, so the negation matches.
+const blockRequestsWithoutOriginSharedSecret = (
+  originSharedSecret: string,
+): wafv2.CfnWebACL.RuleProperty => ({
+  name: "BlockRequestsWithoutOriginSharedSecret",
+  priority: ORIGIN_SHARED_SECRET_RULE_PRIORITY,
+  action: { block: {} },
+  statement: notStatement(originSharedSecretMatches(originSharedSecret)),
+  visibilityConfig: {
+    sampledRequestsEnabled: true,
+    cloudWatchMetricsEnabled: true,
+    metricName: "expense-tracker-origin-secret-block",
+  },
+});
+
 const postRequestToApp = (
   appDomain: string,
   path: string,
@@ -170,7 +207,23 @@ const postRequestToApp = (
 export const buildIngressWafRules = (
   appDomain: string,
   authDomain: string,
+  originSharedSecret: string,
 ): ReadonlyArray<wafv2.CfnWebACL.RuleProperty> => {
+  // A blank or whitespace-only context value means "not configured": it must leave
+  // the web ACL untouched instead of producing a live rule matching a literal that
+  // Cloudflare never sends. Padding around a real secret is stripped for the same
+  // reason, so the rule always matches exactly what the Transform Rule injects.
+  const sharedSecret = originSharedSecret.trim();
+
+  // Rate-based rules aggregate every request they evaluate, and a terminating action
+  // in a later rule does not un-count it. A request that did not come through our
+  // Cloudflare zone therefore must never enter a CF-Connecting-IP rate-limit scope,
+  // or a forged CF-Connecting-IP can still exhaust a victim IP's budget before the
+  // origin-secret rule blocks it. Requiring the secret inside every scope-down keeps
+  // the rate limits keyed on IPs we actually trust, without renumbering any rule.
+  const fromTrustedZone: ReadonlyArray<wafv2.CfnWebACL.StatementProperty> =
+    sharedSecret === "" ? [] : [originSharedSecretMatches(sharedSecret)];
+
   const chatJsonRequest = postRequestToApp(appDomain, "/api/chat", "application/json");
   const newChatJsonRequest = postRequestToApp(
     appDomain,
@@ -203,7 +256,7 @@ export const buildIngressWafRules = (
     ]),
   ]);
 
-  return [
+  const rules: ReadonlyArray<wafv2.CfnWebACL.RuleProperty> = [
     {
       name: "AWSManagedCommonRules",
       priority: 0,
@@ -316,6 +369,7 @@ export const buildIngressWafRules = (
             headerIs("host", authDomain),
             methodIs("POST"),
             uriPathIs("/oauth/register"),
+            ...fromTrustedZone,
           ]),
         },
       },
@@ -342,6 +396,7 @@ export const buildIngressWafRules = (
             headerIs("host", authDomain),
             methodIs("POST"),
             uriPathIs("/oauth/token"),
+            ...fromTrustedZone,
           ]),
         },
       },
@@ -352,6 +407,12 @@ export const buildIngressWafRules = (
       },
     },
   ];
+
+  if (sharedSecret === "") {
+    return rules;
+  }
+
+  return [...rules, blockRequestsWithoutOriginSharedSecret(sharedSecret)];
 };
 
 export function ingress(scope: Construct, props: IngressProps): IngressResult {
@@ -437,6 +498,9 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
   // the trusted real-client boundary for the OAuth rate rules. AWS WAF ignores these
   // rules if that header is absent; Cloudflare supplies it on every origin request.
   // A present malformed value uses MATCH and is blocked instead of bypassing a rule.
+  // "Some Cloudflare edge" is a weaker claim than "our Cloudflare zone": once
+  // originSharedSecret is configured, the rate rules additionally require the
+  // x-origin-auth header, so only requests from our own zone are ever aggregated.
   const waf = new wafv2.CfnWebACL(scope, "Waf", {
     scope: "REGIONAL",
     defaultAction: { allow: {} },
@@ -445,7 +509,13 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
       cloudWatchMetricsEnabled: true,
       metricName: "expense-tracker-waf",
     },
-    rules: [...buildIngressWafRules(props.appDomain, props.authDomain)],
+    rules: [
+      ...buildIngressWafRules(
+        props.appDomain,
+        props.authDomain,
+        props.originSharedSecret,
+      ),
+    ],
   });
   const webAclName = cdk.Fn.select(0, cdk.Fn.split("|", waf.ref));
 

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -134,6 +134,31 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
 
+  // WAF blocks by the Cloudflare origin-secret rule.
+  // The rule is absent until originSharedSecret is configured, so the metric simply
+  // never reports while the feature is inert. Once it is on, a secret that diverges
+  // from the Cloudflare Transform Rule blocks all public traffic while ALB target
+  // health checks keep passing, because they never traverse the web ACL. The
+  // threshold sits above the background noise of scanners hitting the ALB directly.
+  new cloudwatch.Alarm(scope, "WafOriginSecretBlockedAlarm", {
+    metric: new cloudwatch.Metric({
+      namespace: "AWS/WAFV2",
+      metricName: "BlockedRequests",
+      dimensionsMap: {
+        WebACL: props.webAclName,
+        Region: cdk.Aws.REGION,
+        Rule: "expense-tracker-origin-secret-block",
+      },
+      period: cdk.Duration.minutes(5),
+      statistic: "Sum",
+    }),
+    threshold: 50,
+    evaluationPeriods: 1,
+    alarmDescription:
+      "WAF blocked many requests missing the Cloudflare origin shared secret — the deployed secret may not match the Cloudflare Transform Rule",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+
   const webErrorMetricFilter = new logs.MetricFilter(scope, "WebErrorMetricFilter", {
     logGroup: props.webLogGroup,
     filterPattern: logs.FilterPattern.any(

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -40,6 +40,7 @@ export class ExpenseBudgetTrackerStack extends cdk.Stack {
     const langfuseBaseUrl = this.node.tryGetContext("langfuseBaseUrl") as string | undefined
       ?? "https://cloud.langfuse.com";
     const demoEmailDostip = this.node.tryGetContext("demoEmailDostip") as string | undefined ?? "";
+    const originSharedSecret = this.node.tryGetContext("originSharedSecret") as string | undefined ?? "";
     const resendApiKeySecretArn = getOptionalContextValue(this, "resendApiKeySecretArn");
     const resendSenderEmail = getOptionalContextValue(this, "resendSenderEmail");
 
@@ -89,6 +90,7 @@ export class ExpenseBudgetTrackerStack extends cdk.Stack {
       baseDomain,
       appDomain,
       authDomain,
+      originSharedSecret,
     });
 
     const fx = fxFetcher(this, {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -94,7 +94,10 @@ CLUSTER="$CLUSTER" SERVICE="$SERVICE" MIGRATE_TASK="$MIGRATE_TASK" MIGRATE_SG="$
 # --- Step 6: Confirm web readiness ---
 echo ""
 echo "=== Confirm web readiness ==="
-ALB_DNS="$ALB_DNS" bash "${SCRIPT_DIR}/check-web-readiness.sh"
+# First deploy: Cloudflare DNS does not exist yet (README step 6), so this probes
+# the ALB directly and skips verification of its Cloudflare Origin Certificate.
+READINESS_URL="https://${ALB_DNS}/api/health" READINESS_INSECURE=true \
+  bash "${SCRIPT_DIR}/check-web-readiness.sh"
 
 # --- Step 7: Seed exchange rates ---
 # Invoke the FX fetcher Lambda so the currency dropdown is populated immediately

--- a/scripts/check-web-readiness.sh
+++ b/scripts/check-web-readiness.sh
@@ -3,26 +3,36 @@
 #
 # Used after AWS deploys because /api/live only confirms the process is up.
 #
+# Prefer the public app URL, which reaches the origin through Cloudflare and so
+# carries the origin shared secret the WAF may require. Only the first-deploy
+# bootstrap, which runs before Cloudflare DNS exists, probes the ALB directly.
+#
 # Required env vars:
-#   ALB_DNS — ALB DNS name from CloudFormation outputs
+#   READINESS_URL — full readiness URL to poll, e.g. https://app.example.com/api/health
 #
 # Optional env vars:
+#   READINESS_INSECURE         — "true" skips TLS verification (raw ALB origin cert)
 #   READINESS_TIMEOUT_SECONDS  — total wait time (default: 300)
 #   READINESS_INTERVAL_SECONDS — delay between checks (default: 10)
 
 set -euo pipefail
 
-: "${ALB_DNS:?ALB_DNS env var is required}"
+: "${READINESS_URL:?READINESS_URL env var is required}"
 
 TIMEOUT_SECONDS="${READINESS_TIMEOUT_SECONDS:-300}"
 INTERVAL_SECONDS="${READINESS_INTERVAL_SECONDS:-10}"
-URL="https://${ALB_DNS}/api/health"
+URL="$READINESS_URL"
 ELAPSED=0
+
+CURL_ARGS=(--fail --silent --show-error)
+if [ "${READINESS_INSECURE:-false}" = "true" ]; then
+  CURL_ARGS+=(--insecure)
+fi
 
 echo "Waiting for web readiness at ${URL} ..."
 
 while true; do
-  if curl --fail --silent --show-error --insecure "$URL" > /dev/null; then
+  if curl "${CURL_ARGS[@]}" "$URL" > /dev/null; then
     echo "Web readiness check passed."
     exit 0
   fi


### PR DESCRIPTION
## Problem

The ALB security group is meant to accept Cloudflare edges only, which proves *some* Cloudflare zone, not ours. An attacker can front the ALB with their own Cloudflare zone: our zone's rules are bypassed and `CF-Connecting-IP` becomes attacker-controlled, defeating the WAF rate limits keyed on it.

## Change

Block requests whose `x-origin-auth` header does not match a shared secret that a Transform Rule injects in our own zone. Transform Rules are per-zone, so a foreign zone cannot produce the header.

The check lives in the existing web ACL rather than in `proxy.ts`: it covers both `app.*` and `auth.*`, and ALB target health checks reach targets directly without traversing the ACL, so they cannot break.

**The secret is also required inside the `scopeDownStatement` of both rate-based rules.** That is what actually restores their integrity — a foreign-zone request is never aggregated against a victim's budget, rather than being counted at priority 7/8 and blocked at 9. Existing rule priorities are unchanged.

## Inert by default

An unset or whitespace-only `originSharedSecret` leaves the synthesized ACL byte-for-byte identical, asserted by tests. **Merging and deploying this changes nothing in production.**

Activation is operational and strictly ordered:
1. create the Cloudflare Transform Rule injecting `x-origin-auth`;
2. then set `CDK_ORIGIN_SHARED_SECRET`.

The reverse order blocks all public traffic. Documented in `infra/aws/README.md`, with `openssl rand -hex 32` as the generator.

## Collateral fixes

- The CI/CD readiness probe hit the raw ALB DNS and would have failed once the secret is active — repointed at the Cloudflare-fronted app domain. First-time bootstrap keeps the direct-ALB probe behind an explicit opt-in, since Cloudflare DNS does not exist yet at that point.
- Quoted the deploy heredoc delimiter, so a secret containing `$`, a backtick or a backslash is not silently mangled into a site-wide outage.
- Added `WafOriginSecretBlockedAlarm`: a zone/ACL divergence blocks all traffic while target health checks stay green, so this metric is the only signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)