### PR TITLE
Close the ALB to Cloudflare-only ingress

### DIFF
--- a/infra/aws/lib/ingress.ts
+++ b/infra/aws/lib/ingress.ts
@@ -445,9 +445,15 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
   });
   props.webService.attachToApplicationTargetGroup(webTargetGroup);
 
-  // ALB listeners: HTTPS forwards to app, HTTP → HTTPS redirect
+  // ALB listeners: HTTPS forwards to app, HTTP → HTTPS redirect.
+  // open: false on every listener. The CDK default (open: true) adds an anyIpv4
+  // ingress rule for the listener port to the ALB security group, which reopens the
+  // load balancer to the whole internet next to the Cloudflare-only rules built in
+  // networking.ts. Bypassing Cloudflare that way defeats every Cloudflare-side
+  // control and the WAF rate limits keyed on CF-Connecting-IP.
   const httpsListener = alb.addListener("HttpsListener", {
     port: 443,
+    open: false,
     certificates: [props.certificate],
     defaultAction: elbv2.ListenerAction.forward([webTargetGroup]),
   });
@@ -486,6 +492,7 @@ export function ingress(scope: Construct, props: IngressProps): IngressResult {
 
   alb.addListener("HttpRedirect", {
     port: 80,
+    open: false,
     defaultAction: elbv2.ListenerAction.redirect({
       protocol: "HTTPS",
       port: "443",


### PR DESCRIPTION
## Problem

`infra/aws/lib/networking.ts` builds `AlbSg` with one ingress rule per Cloudflare CIDR, and both the README and `docs/architecture.md` describe the ALB as Cloudflare-only. The deployed security group `sg-0998d6f80dfcfc5af` nevertheless carries **`0.0.0.0/0` on ports 80 and 443** next to the 15 Cloudflare ranges.

The cause is in code, not manual drift: both `alb.addListener(...)` calls rely on the CDK default `open: true`, which adds an `anyIpv4` ingress rule per listener port.

So the load balancer answers the whole internet on its own DNS name. That bypasses Cloudflare completely — every Cloudflare-side control, and the WAF rate limits keyed on `CF-Connecting-IP`, can be skipped without even owning a Cloudflare zone. The CI readiness probe demonstrated it accidentally: it reached `https://<alb-dns>/api/health` from a GitHub-hosted runner in under a second, until a merged change repointed it through Cloudflare.

## Fix

`open: false` on both listeners. `albSg` is created in the same stack, so the rules render into the security group resource's `SecurityGroupIngress` list and CloudFormation removes them in place on the next deploy — only the Cloudflare ranges remain.

## Safety

- The ALB is **ipv4-only**, so the absence of IPv6 ranges in `infra/aws/cloudflare-ips.json` is not a gap. That file is current (15 CIDRs, refreshed 2026-08-22).
- Health checks are ALB→target traffic governed by egress and the ECS SG, not by client ingress, so they are unaffected.
- Every hostname resolving to the ALB (`app`, `auth`, apex) is Cloudflare-proxied, and all CI probes use the public domains.
- `scripts/bootstrap.sh` keeps a direct-ALB probe used only during a first-time bootstrap that predates Cloudflare DNS. It will no longer succeed against a closed group — an accepted trade-off, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)