### PR TITLE
Follow up on the origin-secret rule: docs, alarm, apex warning

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -59,7 +59,7 @@ The script runs `cdk bootstrap` (prepares the AWS account), then `cdk deploy` (c
 
 **CI/CD (all subsequent deploys):** `.github/workflows/deploy.yml`
 
-Triggered on every push to `main`. Runs the same `cdk deploy` to update infrastructure and images, then runs migrations when needed, then checks `/api/health` through the ALB DNS name to confirm DB readiness, then invokes the FX fetcher Lambda when worker code changes.
+Triggered on every push to `main`. Runs the same `cdk deploy` to update infrastructure and images, then runs migrations when needed, then checks `https://app.<domain>/api/health` through Cloudflare to confirm DB readiness, then invokes the FX fetcher Lambda when worker code changes.
 
 Schema changes in this pipeline must remain backward-compatible for at least one deploy. If a change requires “migrate before new web code serves traffic”, use a separate two-phase rollout instead of the default pipeline.
 

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -508,13 +508,13 @@ The ALB security group only accepts Cloudflare edge ranges, which proves a reque
 - Once the value is set (surrounding whitespace is stripped), the WAF rule `BlockRequestsWithoutOriginSharedSecret` (priority 9, metric `expense-tracker-origin-secret-block`) blocks every request whose `x-origin-auth` header is missing or not exactly equal to the secret
 - The same value is also required inside the scope-down of both `CF-Connecting-IP` rate-limit rules. A rate-based rule aggregates every request it evaluates and a later block does not un-count it, so without this a forged `CF-Connecting-IP` from a foreign zone could still exhaust a victim IP's registration or token budget before being blocked. Existing rule priorities are unchanged
 - ALB target health checks reach the targets directly without traversing the web ACL, so they are unaffected
-- The `WafOriginSecretBlockedAlarm` CloudWatch alarm notifies the alert topic when this rule blocks more than 50 requests in 5 minutes — target health checks stay green during a secret mismatch, so this alarm is the signal that the zone and the ACL diverged
+- The `WafOriginSecretBlockedAlarm` CloudWatch alarm notifies the alert topic, and notifies again on recovery, when this rule blocks 3 or more requests in each of 3 out of the last 5 minutes — target health checks stay green during a secret mismatch, so this alarm is the signal that the zone and the ACL diverged
 
 Generate the value with a shell-safe generator, for example `openssl rand -hex 32`.
 
-> **Warning:** activate in this order. Setting the secret before the Cloudflare Transform Rule exists blocks all public traffic to `app.*` and `auth.*` and takes the whole site down.
+> **Warning:** activate in this order. Setting the secret before the Cloudflare Transform Rule exists blocks all public traffic and takes the whole site down. The WAF rule is host-agnostic, so the Transform Rule must cover every proxied hostname routed to the ALB: `app.*`, `auth.*` and the apex `domain.com` itself. Leaving the apex out makes the root domain return 403 instead of redirecting to `app.*`.
 
-1. **First**, create a Transform Rule (Rules → Transform Rules → Modify Request Header) in the Cloudflare zone that sets `x-origin-auth` to the secret on every request to the proxied hostnames, and confirm it is live.
+1. **First**, create a Transform Rule (Rules → Transform Rules → Modify Request Header) in the Cloudflare zone that sets `x-origin-auth` to the secret on every request to every proxied hostname, apex included, and confirm it is live.
 2. **Second**, store the same value as the `CDK_ORIGIN_SHARED_SECRET` GitHub Actions secret (and in `cdk.context.local.json` for local deploys) and deploy.
 
 To roll back, clear the GitHub Actions secret and deploy: the rule disappears from the web ACL. The secret is part of the synthesized CloudFormation template — that is accepted, because it only authenticates the Cloudflare-to-ALB hop and grants no access to user data.

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -138,26 +138,32 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
   // The rule is absent until originSharedSecret is configured, so the metric simply
   // never reports while the feature is inert. Once it is on, a secret that diverges
   // from the Cloudflare Transform Rule blocks all public traffic while ALB target
-  // health checks keep passing, because they never traverse the web ACL. The
-  // threshold sits above the background noise of scanners hitting the ALB directly.
-  new cloudwatch.Alarm(scope, "WafOriginSecretBlockedAlarm", {
-    metric: new cloudwatch.Metric({
-      namespace: "AWS/WAFV2",
-      metricName: "BlockedRequests",
-      dimensionsMap: {
-        WebACL: props.webAclName,
-        Region: cdk.Aws.REGION,
-        Rule: "expense-tracker-origin-secret-block",
-      },
-      period: cdk.Duration.minutes(5),
-      statistic: "Sum",
+  // health checks keep passing, because they never traverse the web ACL, so this
+  // alarm is the only signal of a total outage and must fire even on a quiet night.
+  // The ALB accepts Cloudflare ranges only, so nothing else reaches the web ACL and
+  // background noise on this rule is near zero: a low per-minute threshold is safe,
+  // and short bursts are absorbed by requiring 3 breaching minutes out of 5 instead.
+  notifyOnAlarmAndRecovery(
+    new cloudwatch.Alarm(scope, "WafOriginSecretBlockedAlarm", {
+      metric: new cloudwatch.Metric({
+        namespace: "AWS/WAFV2",
+        metricName: "BlockedRequests",
+        dimensionsMap: {
+          WebACL: props.webAclName,
+          Region: cdk.Aws.REGION,
+          Rule: "expense-tracker-origin-secret-block",
+        },
+        period: cdk.Duration.minutes(1),
+        statistic: "Sum",
+      }),
+      threshold: 3,
+      evaluationPeriods: 5,
+      datapointsToAlarm: 3,
+      alarmDescription:
+        "WAF blocked requests missing the Cloudflare origin shared secret in 3 of the last 5 minutes — the deployed secret may not match the Cloudflare Transform Rule",
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     }),
-    threshold: 50,
-    evaluationPeriods: 1,
-    alarmDescription:
-      "WAF blocked many requests missing the Cloudflare origin shared secret — the deployed secret may not match the Cloudflare Transform Rule",
-    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+  );
 
   const webErrorMetricFilter = new logs.MetricFilter(scope, "WebErrorMetricFilter", {
     logGroup: props.webLogGroup,


### PR DESCRIPTION
Three non-blocking follow-ups queued from the review of the origin-secret change ([#259](https://github.com/kirill-markin/expense-budget-tracker/pull/259)).

**`docs/deployment.md`** — the CI/CD readiness line still described a probe through the ALB DNS name; that change repointed it at `https://app.<domain>/api/health` through Cloudflare. The bootstrap line above it is untouched, because `scripts/bootstrap.sh` really does still probe the ALB directly on a first deploy.

**`infra/aws/lib/monitoring.ts`** — `WafOriginSecretBlockedAlarm` now reports recovery too, through the existing `notifyOnAlarmAndRecovery` helper, like the other availability-critical alarms. It is also sensitive enough to catch the outage it exists for: a divergence between the Cloudflare Transform Rule and the web ACL blocks 100% of traffic while target health checks stay green, and the previous `50 in one 5-minute period` needed roughly 10 blocked req/min sustained — a quiet night could miss a full outage.

New shape: `≥3 blocked requests in 3 of the last 5 one-minute periods`. Once the ALB accepts Cloudflare ranges only ([#261](https://github.com/kirill-markin/expense-budget-tracker/pull/261)), almost nothing but real traffic reaches the web ACL, so background noise on this rule is near zero and burst tolerance comes from M-of-N evaluation rather than a high threshold. Dimensions and `NOT_BREACHING` are unchanged, so the alarm stays quiet while the feature is inert.

**`infra/aws/README.md`** — the activation warning named only `app.*` and `auth.*`, but the apex domain is routed to the ALB as well and the WAF rule is host-agnostic. A Transform Rule that omits the apex turns the root domain into a 403 instead of a redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)