### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-tracker-auth",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.1113.0",
-    "@expense-budget-tracker/agent-shared": "1.3.0",
+    "@expense-budget-tracker/agent-shared": "1.4.0",
     "@hono/node-server": "^2.1.1",
     "aws-jwt-verify": "^5.2.1",
     "hono": "^4.13.3",

--- a/apps/sql-api/package.json
+++ b/apps/sql-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-budget-tracker-sql-api",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.1113.0",
-    "@expense-budget-tracker/agent-shared": "1.3.0",
+    "@expense-budget-tracker/agent-shared": "1.4.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "hono": "^4.13.3",
     "pg": "^8.23.0",

--- a/apps/sql-api/src/mcp/server.test.ts
+++ b/apps/sql-api/src/mcp/server.test.ts
@@ -500,7 +500,7 @@ test("MCP server emits the public runtime contract and routes successful tool ca
 
       assert.deepEqual(client.getServerVersion(), {
         name: "expense-budget-tracker",
-        version: "1.3.0",
+        version: "1.4.0",
         title: "Expense Budget Tracker",
         websiteUrl: "https://expense-budget-tracker.com/",
         icons: [{

--- a/apps/sql-api/src/mcp/server.ts
+++ b/apps/sql-api/src/mcp/server.ts
@@ -26,7 +26,7 @@ import {
 } from "./results.js";
 
 const SERVER_NAME = "expense-budget-tracker";
-const SERVER_VERSION = "1.3.0";
+const SERVER_VERSION = "1.4.0";
 const LIST_WORKSPACES_TOOL_NAME = "list_workspaces";
 const GET_SCHEMA_TOOL_NAME = "get_schema";
 const SQL_QUERY_TOOL_NAME = "sql_query";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-budget-tracker-web",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "predev": "npm --prefix ../.. run build --workspace @expense-budget-tracker/agent-shared && node scripts/copy-pdfjs-assets.mjs",
@@ -16,7 +16,7 @@
     "test:e2e:local-demo": "npx playwright test --config=playwright.local-demo.config.ts"
   },
   "dependencies": {
-    "@expense-budget-tracker/agent-shared": "1.3.0",
+    "@expense-budget-tracker/agent-shared": "1.4.0",
     "@langfuse/client": "^5.10.1",
     "@langfuse/openai": "^5.10.1",
     "@langfuse/otel": "^5.10.1",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-budget-tracker-worker",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/docs/openai-mcp-submission.md
+++ b/docs/openai-mcp-submission.md
@@ -88,7 +88,7 @@ change.
 | Short description | Workspace-scoped expense and budget tools with OAuth read and write access. |
 | Category | Finance |
 | Intended publisher | SAMO DANNI EOOD |
-| Version under evaluation | 1.3.0 |
+| Version under evaluation | 1.4.0 |
 | Website | https://expense-budget-tracker.com/ |
 | Universal MCP URL | https://mcp.expense-budget-tracker.com/mcp |
 | MCP documentation | https://expense-budget-tracker.com/docs/mcp-connector/ |
@@ -175,8 +175,8 @@ assertion, with secrets redacted.
 | R07 | Authorization request, owner-controlled valid `GET`, then consent `POST` | `https://auth.expense-budget-tracker.com/oauth/authorize` | Without a session, same-origin `302` to login; after login, `200`, `text/html` consent with a same-origin form submission; approval returns `302` whose `Location` uses the exact registered `redirect_uri` and adds the authorization `code` plus the request's exact `state` | Pending controlled-client and Developer Mode evidence; record the complete sanitized chain |
 | R08 | Authorization-code or refresh exchange, URL-encoded `POST` | `https://auth.expense-budget-tracker.com/oauth/token` | Successful valid grant: `200`, `application/json`, no redirect, `Cache-Control: no-store`; revoked refresh probe: the exact `400 invalid_grant` result below | Pending controlled-client and Developer Mode evidence |
 | R09 | OpenAI domain challenge, owner-installed token `GET` | `https://mcp.expense-budget-tracker.com/.well-known/openai-apps-challenge` | Target after the portal supplies and the owner installs the token: `200`, `text/plain`, no redirect, body is only that exact token | **Pending and not provisioned.** Record the current pre-challenge result separately; it cannot satisfy this row |
-| G01 | Exact MCP Registry version, `GET` | `https://registry.modelcontextprotocol.io/v0.1/servers/com.expense-budget-tracker%2Fexpense-budget-tracker/versions/1.3.0` | Before publication: final `404`, record returned MIME, no redirect. After the one authorized publication: final `200`, `application/json`, no redirect, exact name/version and manifest metadata | Item-04 lookup contract complete on BASE; publication and timestamped before/after captures pending |
-| G02 | MCP Registry latest search, `GET` | `https://registry.modelcontextprotocol.io/v0.1/servers?search=com.expense-budget-tracker%2Fexpense-budget-tracker&version=latest` | Final `200`, `application/json`, no redirect. Before publication it must not contain this name/version; after publication it must contain the exact `1.3.0` record | Item-04 lookup contract complete on BASE; publication and timestamped before/after captures pending |
+| G01 | Exact MCP Registry version, `GET` | `https://registry.modelcontextprotocol.io/v0.1/servers/com.expense-budget-tracker%2Fexpense-budget-tracker/versions/1.4.0` | Before publication: final `404`, record returned MIME, no redirect. After the one authorized publication: final `200`, `application/json`, no redirect, exact name/version and manifest metadata | Item-04 lookup contract complete on BASE; publication and timestamped before/after captures pending |
+| G02 | MCP Registry latest search, `GET` | `https://registry.modelcontextprotocol.io/v0.1/servers?search=com.expense-budget-tracker%2Fexpense-budget-tracker&version=latest` | Final `200`, `application/json`, no redirect. Before publication it must not contain this name/version; after publication it must contain the exact `1.4.0` record | Item-04 lookup contract complete on BASE; publication and timestamped before/after captures pending |
 
 For L10, send a syntactically valid MCP request with `Accept: application/json,
 text/event-stream` and no `Authorization` header; retain the sanitized request
@@ -195,7 +195,7 @@ The initialized server advertises:
 | Field | Runtime value |
 | --- | --- |
 | `name` | `expense-budget-tracker` |
-| `version` | `1.3.0` |
+| `version` | `1.4.0` |
 | `title` | `Expense Budget Tracker` |
 | `websiteUrl` | `https://expense-budget-tracker.com/` |
 | Icon | `https://expense-budget-tracker.com/icon.svg`, `image/svg+xml`, size `any` |
@@ -1435,10 +1435,10 @@ operator record.
 | Evidence | Required value |
 | --- | --- |
 | Promoted application commit | Pending |
-| Runtime version | 1.3.0 unless a later aligned version is promoted |
+| Runtime version | 1.4.0 unless a later aligned version is promoted |
 | Website commit | `07c296fa2613ff310d05b693e28366664048a3bf` |
 | Registry implementation commit | Complete on BASE at `8f0b330098fb8829f9f340a27501d73eb4b1860b` |
-| Registry manifest identity/version | `com.expense-budget-tracker/expense-budget-tracker` / `1.3.0` |
+| Registry manifest identity/version | `com.expense-budget-tracker/expense-budget-tracker` / `1.4.0` |
 | Registry DNS proof and `MCP_PRIVATE_KEY` | Pending owner setup after promotion to `main` |
 | Registry exact record and latest search | Not published; G01 404 preflight and post-publication G01/G02 200 evidence pending owner action |
 | Runtime documentation URL reconciliation | Complete on BASE at `396a09b3b88cd0a31965a39ac69fe1b6cc4691f9`; deployed capture pending after cumulative promotion |

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-budget-tracker-aws",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "prebuild": "npm --prefix ../.. run build --workspace @expense-budget-tracker/agent-shared",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-crypto/client-node": "^5.0.2",
     "@aws-sdk/client-secrets-manager": "^3.1113.0",
-    "@expense-budget-tracker/agent-shared": "1.3.0",
+    "@expense-budget-tracker/agent-shared": "1.4.0",
     "aws-cdk-lib": "^2.265.0",
     "constructs": "^10.8.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,10 @@
     },
     "apps/auth": {
       "name": "expense-tracker-auth",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.1113.0",
-        "@expense-budget-tracker/agent-shared": "1.3.0",
+        "@expense-budget-tracker/agent-shared": "1.4.0",
         "@hono/node-server": "^2.1.1",
         "aws-jwt-verify": "^5.2.1",
         "hono": "^4.13.3",
@@ -37,10 +37,10 @@
     },
     "apps/sql-api": {
       "name": "expense-budget-tracker-sql-api",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1113.0",
-        "@expense-budget-tracker/agent-shared": "1.3.0",
+        "@expense-budget-tracker/agent-shared": "1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "hono": "^4.13.3",
         "pg": "^8.23.0",
@@ -58,9 +58,9 @@
     },
     "apps/web": {
       "name": "expense-budget-tracker-web",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
-        "@expense-budget-tracker/agent-shared": "1.3.0",
+        "@expense-budget-tracker/agent-shared": "1.4.0",
         "@langfuse/client": "^5.10.1",
         "@langfuse/openai": "^5.10.1",
         "@langfuse/otel": "^5.10.1",
@@ -97,7 +97,7 @@
     },
     "apps/worker": {
       "name": "expense-budget-tracker-worker",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1113.0",
         "fast-xml-parser": "^5.11.0",
@@ -116,11 +116,11 @@
     },
     "infra/aws": {
       "name": "expense-budget-tracker-aws",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@aws-crypto/client-node": "^5.0.2",
         "@aws-sdk/client-secrets-manager": "^3.1113.0",
-        "@expense-budget-tracker/agent-shared": "1.3.0",
+        "@expense-budget-tracker/agent-shared": "1.4.0",
         "aws-cdk-lib": "^2.265.0",
         "constructs": "^10.8.1"
       },
@@ -6710,7 +6710,7 @@
     },
     "packages/agent-shared": {
       "name": "@expense-budget-tracker/agent-shared",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "devDependencies": {
         "@types/node": "^24.13.3",
         "esbuild": "^0.28.2",

--- a/packages/agent-shared/package.json
+++ b/packages/agent-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expense-budget-tracker/agent-shared",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "files": [

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "com.expense-budget-tracker/expense-budget-tracker",
   "title": "Expense Budget Tracker",
   "description": "Track expenses, budgets, balances, transfers, and multi-currency reports with OAuth-secured tools.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "websiteUrl": "https://expense-budget-tracker.com",
   "icons": [
     {


### PR DESCRIPTION
Moves the shared product version from `1.3.0` to `1.4.0` across every surface listed in `docs/version-bump.md`, so the repository sits on the next minor version for the work that follows.

`1.3.0` is already tagged, released as [v1.3.0](https://github.com/kirill-markin/expense-budget-tracker/releases/tag/v1.3.0), and published to the MCP Registry, so nothing is left behind by moving on.

11 files, 29 version values: six workspace manifests, the matching `package-lock.json` workspace entries, the four exact `@expense-budget-tracker/agent-shared` pins and their lockfile counterparts, `server.json`, `SERVER_VERSION` and its test assertion, and the six current operational fields in `docs/openai-mcp-submission.md`.

Unchanged per the doc: the unversioned root manifests, the fixed historical evidence labels in the submission dossier, and every derived reference that reads the version instead of repeating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)