### PR TITLE
Persist MCP Cloudflare rate limit

### DIFF
--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -87,6 +87,7 @@ MCP client → Cloudflare → API Gateway (HTTP API v2) → MCP Lambda → RDS
 - Public ACM certificates for the regional `api.*` and `mcp.*` API Gateway domains
 - Proxied DNS CNAMEs for `api.*` and `mcp.*`
 - Cache bypass for root, `app.*`, `auth.*`, and `mcp.*`
+- Per-IP MCP rate limiting at 20 requests per 10 seconds with a 10-second block
 - Edge SSL, DDoS protection (automatic with proxied DNS)
 
 ## Step-by-step setup
@@ -161,12 +162,13 @@ Go to https://dash.cloudflare.com/profile/api-tokens → **Create Token**:
 
 - Template: **"Edit zone DNS"**
 - Zone Resources: Include → Specific zone → your domain
-- **Important:** click "+ Add more" and add three more permissions:
+- **Important:** click "+ Add more" and add four more permissions:
   - **Zone → SSL and Certificates → Edit** (for Origin Certificate creation)
   - **Zone → Zone Settings → Edit** (for setting SSL mode to Full Strict)
   - **Zone → Cache Rules → Edit** (for disabling edge cache on dynamic hosts)
+  - **Zone → Zone WAF → Edit** (for the MCP rate-limit rule)
 
-The token needs all four permissions (DNS + SSL + Zone Settings + Cache Rules). Missing any will cause script failures.
+The token needs all five permissions (DNS + SSL + Zone Settings + Cache Rules + Zone WAF). Missing any will cause script failures.
 
 Copy the token and save it in your password manager along with the Zone ID from step 3c.
 
@@ -405,6 +407,22 @@ After deploy completes, **create the DNS record** pointing to the ALB and config
 ```
 
 The script creates proxied CNAMEs for the ALB, `api.*`, and `mcp.*`; sets SSL/TLS to Full (Strict); and bypasses cache for dynamic hosts. The AWS WAF attached to the auth ALB separately rate-limits the exact anonymous `POST auth.*/oauth/register` endpoint by the real client IP supplied in `CF-Connecting-IP`.
+
+Configure the Cloudflare Free rate-limit rule for the public MCP endpoint:
+
+```bash
+(
+  set -euo pipefail
+  set -a
+  source scripts/cloudflare/.env
+  set +a
+
+  bash scripts/cloudflare/setup-mcp-rate-limit.sh \
+    --domain yourdomain.com
+)
+```
+
+The script reconciles the repository contract in `scripts/cloudflare/mcp-rate-limit-rule.json`: requests to `/mcp` are counted per Cloudflare data center and source IP, with a limit of 20 requests per 10 seconds and a 10-second block. Cloudflare Free supports one rate-limit rule and path-only matching, so the script stops instead of replacing an unrelated existing rule. The local token needs `Zone WAF Edit` for the target zone.
 
 Verify Cloudflare resources and their CloudFormation targets after DNS propagation:
 

--- a/scripts/cloudflare/.env.example
+++ b/scripts/cloudflare/.env.example
@@ -2,7 +2,7 @@
 # Copy to .env and fill in both values.
 #
 # Get a token: Cloudflare Dashboard > My Profile > API Tokens > Create Token
-# Required permissions: Zone:DNS:Edit, Zone:SSL and Certificates:Edit, Zone:Zone Settings:Edit, Zone:Cache Rules:Edit
+# Required permissions: Zone:DNS:Edit, Zone:SSL and Certificates:Edit, Zone:Zone Settings:Edit, Zone:Cache Rules:Edit, Zone:Zone WAF:Edit
 # Get Zone ID: see infra/aws/README.md step 3c
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_ZONE_ID=

--- a/scripts/cloudflare/assert-mcp-rate-limit.py
+++ b/scripts/cloudflare/assert-mcp-rate-limit.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import json
+import pathlib
+import sys
+from typing import TypeAlias
+
+JsonPrimitive: TypeAlias = None | bool | int | float | str
+JsonValue: TypeAlias = JsonPrimitive | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+def load_json_object(path: pathlib.Path) -> dict[str, JsonValue]:
+    value: JsonValue = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def is_expected_subset(actual: JsonValue, expected: JsonValue) -> bool:
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict):
+            return False
+        return all(
+            key in actual and is_expected_subset(actual[key], expected_value)
+            for key, expected_value in expected.items()
+        )
+    return actual == expected
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit(f"Usage: {sys.argv[0]} <expected-rule.json>")
+
+    expected_path = pathlib.Path(sys.argv[1])
+    expected_rule = load_json_object(expected_path)
+    response: JsonValue = json.load(sys.stdin)
+    if not isinstance(response, dict) or response.get("success") is not True:
+        raise ValueError("Cloudflare rate-limit response is not successful")
+
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise ValueError("Cloudflare rate-limit response has no ruleset object")
+    rules = result.get("rules")
+    if not isinstance(rules, list) or any(not isinstance(rule, dict) for rule in rules):
+        raise ValueError("Cloudflare rate-limit ruleset has no valid rules array")
+
+    description = expected_rule.get("description")
+    expression = expected_rule.get("expression")
+    if not isinstance(description, str) or not description:
+        raise ValueError("Repository MCP rate-limit contract has no description")
+    if not isinstance(expression, str) or not expression:
+        raise ValueError("Repository MCP rate-limit contract has no expression")
+    candidates = [
+        rule
+        for rule in rules
+        if isinstance(rule, dict)
+        and (
+            rule.get("description") == description
+            or rule.get("expression") == expression
+        )
+    ]
+    if len(candidates) != 1:
+        raise ValueError(
+            "Cloudflare must contain exactly one managed MCP rate-limit rule; "
+            f"found {len(candidates)}"
+        )
+    if not is_expected_subset(candidates[0], expected_rule):
+        raise ValueError(
+            "Cloudflare MCP rate-limit rule differs from the repository contract: "
+            f"{json.dumps(candidates[0], sort_keys=True)}"
+        )
+
+    ratelimit = expected_rule.get("ratelimit")
+    if not isinstance(ratelimit, dict):
+        raise ValueError("Repository MCP rate-limit contract has no ratelimit object")
+    requests_per_period = ratelimit.get("requests_per_period")
+    period = ratelimit.get("period")
+    mitigation_timeout = ratelimit.get("mitigation_timeout")
+    for field_name, value in {
+        "requests_per_period": requests_per_period,
+        "period": period,
+        "mitigation_timeout": mitigation_timeout,
+    }.items():
+        if type(value) is not int or value <= 0:
+            raise ValueError(
+                f"Repository MCP rate-limit contract field {field_name} must be a positive integer"
+            )
+    print(
+        "Verified MCP rate limit: "
+        f"{requests_per_period} requests per {period} seconds "
+        f"per IP, block for {mitigation_timeout} seconds."
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/cloudflare/mcp-rate-limit-rule.json
+++ b/scripts/cloudflare/mcp-rate-limit-rule.json
@@ -1,0 +1,15 @@
+{
+  "description": "Rate limit MCP requests per client IP",
+  "expression": "(http.request.uri.path eq \"/mcp\")",
+  "action": "block",
+  "enabled": true,
+  "ratelimit": {
+    "characteristics": [
+      "cf.colo.id",
+      "ip.src"
+    ],
+    "period": 10,
+    "requests_per_period": 20,
+    "mitigation_timeout": 10
+  }
+}

--- a/scripts/cloudflare/setup-mcp-rate-limit.sh
+++ b/scripts/cloudflare/setup-mcp-rate-limit.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Reconcile the zone-level Cloudflare Free rate-limit rule for the public MCP endpoint.
+# Requires CLOUDFLARE_API_TOKEN with Zone WAF Edit and CLOUDFLARE_ZONE_ID.
+# Usage from the repository root; the parent shell never receives the token:
+#   (
+#     set -euo pipefail
+#     set -a
+#     source scripts/cloudflare/.env
+#     set +a
+#     bash scripts/cloudflare/setup-mcp-rate-limit.sh --domain expense-budget-tracker.com
+#   )
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXPECTED_RULE_FILE="${SCRIPT_DIR}/mcp-rate-limit-rule.json"
+source "${SCRIPT_DIR}/cloudflare-api.sh"
+
+DOMAIN=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --domain) DOMAIN="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$DOMAIN" ]]; then
+  echo "Usage: $0 --domain <domain>" >&2
+  exit 1
+fi
+
+cloudflare_require_api_token
+: "${CLOUDFLARE_ZONE_ID:?Set CLOUDFLARE_ZONE_ID env var}"
+
+ZONE_RESPONSE=$(cloudflare_api_request \
+  "read MCP rate-limit zone" \
+  "GET" \
+  "/zones/${CLOUDFLARE_ZONE_ID}" \
+  "")
+ZONE_NAME=$(echo "$ZONE_RESPONSE" | python3 -c '
+import json
+import sys
+
+response = json.load(sys.stdin)
+result = response.get("result")
+name = result.get("name") if response.get("success") is True and isinstance(result, dict) else None
+if not isinstance(name, str) or not name:
+    print("ERROR: Cloudflare zone lookup returned no domain name.", file=sys.stderr)
+    raise SystemExit(1)
+print(name)
+')
+if [[ "$ZONE_NAME" != "$DOMAIN" ]]; then
+  echo "ERROR: Cloudflare zone ${ZONE_NAME} does not match requested domain ${DOMAIN}." >&2
+  exit 1
+fi
+
+build_rate_limit_ruleset_payload() {
+  local expected_rule_file="$1"
+  python3 -c '
+import json
+import pathlib
+import sys
+
+expected_rule = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if not isinstance(expected_rule, dict):
+    print("ERROR: MCP rate-limit contract must contain a JSON object.", file=sys.stderr)
+    raise SystemExit(1)
+
+response = json.load(sys.stdin)
+if not isinstance(response, dict):
+    print("ERROR: Cloudflare rate-limit response must contain a JSON object.", file=sys.stderr)
+    raise SystemExit(1)
+if response.get("success") is True:
+    result = response.get("result")
+    existing_rules = result.get("rules", []) if isinstance(result, dict) else []
+else:
+    errors = response.get("errors", [])
+    not_found = any(
+        "not found" in str(error.get("message", "")).lower()
+        for error in errors
+        if isinstance(error, dict)
+    )
+    if not not_found:
+        print("ERROR: Could not fetch the Cloudflare rate-limit ruleset.", file=sys.stderr)
+        print("ACTION: Grant the token Zone WAF Edit for the requested zone.", file=sys.stderr)
+        print(json.dumps(errors if errors else response, indent=2), file=sys.stderr)
+        raise SystemExit(1)
+    existing_rules = []
+
+if not isinstance(existing_rules, list) or any(not isinstance(rule, dict) for rule in existing_rules):
+    print("ERROR: Cloudflare returned an invalid rate-limit rules array.", file=sys.stderr)
+    raise SystemExit(1)
+
+description = expected_rule.get("description")
+expression = expected_rule.get("expression")
+if not isinstance(description, str) or not description:
+    print("ERROR: MCP rate-limit contract has no description.", file=sys.stderr)
+    raise SystemExit(1)
+if not isinstance(expression, str) or not expression:
+    print("ERROR: MCP rate-limit contract has no expression.", file=sys.stderr)
+    raise SystemExit(1)
+managed_rules = [
+    rule
+    for rule in existing_rules
+    if rule.get("description") == description or rule.get("expression") == expression
+]
+unmanaged_rules = [
+    rule
+    for rule in existing_rules
+    if rule.get("description") != description and rule.get("expression") != expression
+]
+if unmanaged_rules and not managed_rules:
+    descriptions = [str(rule.get("description") or "<unnamed>") for rule in unmanaged_rules]
+    print(
+        "ERROR: The Cloudflare Free plan has an existing unrelated rate-limit rule: "
+        + ", ".join(descriptions),
+        file=sys.stderr,
+    )
+    print("ACTION: Decide which single Free-plan rate-limit rule should own the zone before rerunning.", file=sys.stderr)
+    raise SystemExit(1)
+
+read_only_rule_fields = {"id", "version", "last_updated"}
+preserved_rules = [
+    {
+        key: value
+        for key, value in rule.items()
+        if key not in read_only_rule_fields
+    }
+    for rule in unmanaged_rules
+]
+print(json.dumps({"rules": [*preserved_rules, expected_rule]}))
+' "$expected_rule_file"
+}
+
+RATE_LIMIT_RULESET=$(cloudflare_optional_get_request \
+  "read MCP rate-limit ruleset" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_ratelimit/entrypoint")
+RATE_LIMIT_PAYLOAD=$(echo "$RATE_LIMIT_RULESET" | build_rate_limit_ruleset_payload "$EXPECTED_RULE_FILE")
+RATE_LIMIT_RESULT=$(cloudflare_api_request \
+  "replace MCP rate-limit ruleset" \
+  "PUT" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_ratelimit/entrypoint" \
+  "$RATE_LIMIT_PAYLOAD")
+
+echo "$RATE_LIMIT_RESULT" | python3 "${SCRIPT_DIR}/assert-mcp-rate-limit.py" "$EXPECTED_RULE_FILE"

--- a/scripts/cloudflare/verify.sh
+++ b/scripts/cloudflare/verify.sh
@@ -3,7 +3,7 @@
 # Drift detection for Cloudflare resources that live outside IaC.
 #
 # Required env vars:
-#   CLOUDFLARE_API_TOKEN  — API token with Zone, DNS, SSL, and Cache Rules read access
+#   CLOUDFLARE_API_TOKEN  — API token with Zone, DNS, SSL, Cache Rules, and Zone WAF read access
 #   CLOUDFLARE_ZONE_ID    — Zone ID from Cloudflare dashboard
 #   AWS_PROFILE           — explicit AWS CLI profile for the deployment account
 #   AWS_REGION            — explicit AWS region for the deployed stack
@@ -314,6 +314,17 @@ if [[ "$CACHE_RULE_COUNT" -eq 0 ]]; then
   ERRORS=$((ERRORS + 1))
 else
   echo "  OK: Cache bypass rule active (${CACHE_RULE_COUNT} rule(s))"
+fi
+
+# --- MCP rate limit ---
+echo ""
+echo "Checking MCP rate-limit rule..."
+MCP_RATE_LIMIT_RULESET=$(cloudflare_optional_get_request \
+  "read MCP rate-limit ruleset" \
+  "/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_ratelimit/entrypoint")
+if ! echo "$MCP_RATE_LIMIT_RULESET" \
+  | python3 "${SCRIPT_DIR}/assert-mcp-rate-limit.py" "${SCRIPT_DIR}/mcp-rate-limit-rule.json"; then
+  ERRORS=$((ERRORS + 1))
 fi
 
 # --- Summary ---


### PR DESCRIPTION
## Summary
- define the MCP Cloudflare rate-limit rule as a repository JSON contract
- add an idempotent setup script that preserves unrelated rules and refuses unsafe Free-plan replacement
- verify the live rule in the existing Cloudflare drift check
- document the required Zone WAF permission and setup command

## Validation
- CI owns repository checks per project instructions
- live Cloudflare reconciliation will run from merged `main` after the token permission is confirmed