### PR TITLE
Bind Langfuse releases to the deployed web asset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,7 @@ OAUTH_RESOURCE=http://localhost:8082/mcp
 # LANGFUSE_PUBLIC_KEY=pk-lf-...
 # LANGFUSE_SECRET_KEY=sk-lf-...
 # LANGFUSE_BASE_URL=https://cloud.langfuse.com
+# LANGFUSE_RELEASE=<explicit 64-character lowercase hexadecimal release fingerprint>
 
 # --- Resend email delivery setup (local setup scripts only) ---
 
@@ -119,4 +120,5 @@ OAUTH_RESOURCE=http://localhost:8082/mcp
 # LANGFUSE_PUBLIC_KEY=<from Secrets Manager>
 # LANGFUSE_SECRET_KEY=<from Secrets Manager>
 # LANGFUSE_BASE_URL=https://cloud.langfuse.com
+# LANGFUSE_RELEASE=<from CDK: exact web Docker asset fingerprint>
 # NODE_EXTRA_CA_CERTS=/app/rds-global-bundle.pem

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@expense-budget-tracker/agent-shared": "1.4.0",
-    "@langfuse/client": "^5.10.1",
     "@langfuse/openai": "^5.10.1",
     "@langfuse/otel": "^5.10.1",
     "@langfuse/tracing": "^5.10.1",

--- a/apps/web/src/instrumentation.test.ts
+++ b/apps/web/src/instrumentation.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getLangfuseConfigValidationErrors } from "@/instrumentation";
+
+const LANGFUSE_CONNECTION_ENVIRONMENT: NodeJS.ProcessEnv = {
+  LANGFUSE_PUBLIC_KEY: "pk-lf-test",
+  LANGFUSE_SECRET_KEY: "sk-lf-test",
+  LANGFUSE_BASE_URL: "https://cloud.langfuse.com",
+};
+
+const LANGFUSE_ENVIRONMENT: NodeJS.ProcessEnv = {
+  ...LANGFUSE_CONNECTION_ENVIRONMENT,
+  LANGFUSE_RELEASE: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+};
+
+test("Langfuse configuration accepts disabled telemetry", (): void => {
+  assert.deepEqual(getLangfuseConfigValidationErrors({}), []);
+  assert.deepEqual(getLangfuseConfigValidationErrors({ LANGFUSE_RELEASE: "local" }), []);
+});
+
+test("Langfuse configuration rejects partial connection settings", (): void => {
+  assert.deepEqual(
+    getLangfuseConfigValidationErrors({
+      LANGFUSE_PUBLIC_KEY: "pk-lf-test",
+      LANGFUSE_RELEASE: LANGFUSE_ENVIRONMENT.LANGFUSE_RELEASE,
+    }),
+    [
+      "LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_BASE_URL must be configured together with non-empty values",
+    ],
+  );
+});
+
+test("Langfuse configuration requires a release when telemetry is enabled", (): void => {
+  assert.deepEqual(getLangfuseConfigValidationErrors(LANGFUSE_CONNECTION_ENVIRONMENT), [
+    "LANGFUSE_RELEASE must be an explicit 64-character lowercase hexadecimal release fingerprint when Langfuse telemetry is enabled",
+  ]);
+});
+
+test("Langfuse configuration rejects a non-fingerprint release", (): void => {
+  assert.deepEqual(
+    getLangfuseConfigValidationErrors({
+      ...LANGFUSE_CONNECTION_ENVIRONMENT,
+      LANGFUSE_RELEASE: "0123456789abcdef0123456789abcdef01234567",
+    }),
+    [
+      "LANGFUSE_RELEASE must be an explicit 64-character lowercase hexadecimal release fingerprint when Langfuse telemetry is enabled",
+    ],
+  );
+});
+
+test("Langfuse configuration accepts a complete telemetry contract", (): void => {
+  assert.deepEqual(getLangfuseConfigValidationErrors(LANGFUSE_ENVIRONMENT), []);
+});

--- a/apps/web/src/instrumentation.test.ts
+++ b/apps/web/src/instrumentation.test.ts
@@ -2,13 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { getLangfuseConfigValidationErrors } from "@/instrumentation";
 
-const LANGFUSE_CONNECTION_ENVIRONMENT: NodeJS.ProcessEnv = {
+const LANGFUSE_CONNECTION_ENVIRONMENT = {
   LANGFUSE_PUBLIC_KEY: "pk-lf-test",
   LANGFUSE_SECRET_KEY: "sk-lf-test",
   LANGFUSE_BASE_URL: "https://cloud.langfuse.com",
 };
 
-const LANGFUSE_ENVIRONMENT: NodeJS.ProcessEnv = {
+const LANGFUSE_ENVIRONMENT = {
   ...LANGFUSE_CONNECTION_ENVIRONMENT,
   LANGFUSE_RELEASE: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 };

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -20,8 +20,15 @@ import { createLangfuseSpanProcessor } from "@/server/chat/openai/langfuse";
 let telemetrySdk: NodeSDK | null = null;
 let telemetryStarted = false;
 
+type LangfuseEnvironment = Readonly<{
+  LANGFUSE_PUBLIC_KEY?: string;
+  LANGFUSE_SECRET_KEY?: string;
+  LANGFUSE_BASE_URL?: string;
+  LANGFUSE_RELEASE?: string;
+}>;
+
 export const getLangfuseConfigValidationErrors = (
-  environment: NodeJS.ProcessEnv,
+  environment: LangfuseEnvironment,
 ): ReadonlyArray<string> => {
   const connectionValues = [
     environment.LANGFUSE_PUBLIC_KEY,

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -9,6 +9,7 @@
  * - AUTH_MODE=none is allowed only for explicit local dev/test
  * - DATABASE_URL is set (local) or DB_HOST+DB_PASSWORD are set (cognito/ECS)
  * - LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_BASE_URL are either all set or all absent
+ * - LANGFUSE_RELEASE is an explicit release fingerprint when Langfuse telemetry is enabled
  *
  * Throws with all collected errors on misconfiguration. Skipped in dev.
  */
@@ -19,21 +20,34 @@ import { createLangfuseSpanProcessor } from "@/server/chat/openai/langfuse";
 let telemetrySdk: NodeSDK | null = null;
 let telemetryStarted = false;
 
-const validateLangfuseConfig = (): ReadonlyArray<string> => {
-  const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
-  const secretKey = process.env.LANGFUSE_SECRET_KEY;
-  const baseUrl = process.env.LANGFUSE_BASE_URL;
-  const presentCount = [publicKey, secretKey, baseUrl]
-    .filter((value) => value !== undefined && value !== "")
-    .length;
-
-  if (presentCount === 0 || presentCount === 3) {
+export const getLangfuseConfigValidationErrors = (
+  environment: NodeJS.ProcessEnv,
+): ReadonlyArray<string> => {
+  const connectionValues = [
+    environment.LANGFUSE_PUBLIC_KEY,
+    environment.LANGFUSE_SECRET_KEY,
+    environment.LANGFUSE_BASE_URL,
+  ];
+  const connectionSettingsAbsent = connectionValues.every(
+    (value) => value === undefined || value === "",
+  );
+  if (connectionSettingsAbsent) {
     return [];
   }
 
-  return [
-    "LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_BASE_URL must be configured together",
-  ];
+  const errors: Array<string> = [];
+  if (connectionValues.some((value) => value === undefined || value.trim() === "")) {
+    errors.push(
+      "LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_BASE_URL must be configured together with non-empty values",
+    );
+  }
+  if (!/^[0-9a-f]{64}$/.test(environment.LANGFUSE_RELEASE ?? "")) {
+    errors.push(
+      "LANGFUSE_RELEASE must be an explicit 64-character lowercase hexadecimal release fingerprint when Langfuse telemetry is enabled",
+    );
+  }
+
+  return errors;
 };
 
 const startTelemetryIfConfigured = (): void => {
@@ -89,7 +103,7 @@ export const register = (): void => {
     if (!process.env.DATABASE_URL) errors.push("DATABASE_URL must be set in production");
   }
 
-  errors.push(...validateLangfuseConfig());
+  errors.push(...getLangfuseConfigValidationErrors(process.env));
 
   if (errors.length > 0) {
     throw new Error(

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -21,6 +21,7 @@ let telemetrySdk: NodeSDK | null = null;
 let telemetryStarted = false;
 
 type LangfuseEnvironment = Readonly<{
+  [name: string]: string | undefined;
   LANGFUSE_PUBLIC_KEY?: string;
   LANGFUSE_SECRET_KEY?: string;
   LANGFUSE_BASE_URL?: string;

--- a/apps/web/src/server/chat/openai/langfuse.ts
+++ b/apps/web/src/server/chat/openai/langfuse.ts
@@ -221,6 +221,7 @@ export const createLangfuseSpanProcessor = (): LangfuseSpanProcessor | null => {
   const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
   const secretKey = process.env.LANGFUSE_SECRET_KEY;
   const baseUrl = process.env.LANGFUSE_BASE_URL;
+  const release = process.env.LANGFUSE_RELEASE;
 
   if (
     publicKey === undefined
@@ -229,6 +230,8 @@ export const createLangfuseSpanProcessor = (): LangfuseSpanProcessor | null => {
     || secretKey === ""
     || baseUrl === undefined
     || baseUrl === ""
+    || release === undefined
+    || release === ""
   ) {
     return null;
   }
@@ -248,7 +251,7 @@ export const createLangfuseSpanProcessor = (): LangfuseSpanProcessor | null => {
     secretKey,
     baseUrl,
     environment: process.env.NODE_ENV,
-    release: process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA,
+    release,
     shouldExportSpan: ({ otelSpan }: Readonly<{ otelSpan: ReadableSpan }>): boolean =>
       isDefaultExportSpan(otelSpan),
     mask: ({ data }: Readonly<{ data: unknown }>): string =>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,7 +19,7 @@ This runs `docker compose -f infra/docker/compose.yml up -d`, which starts:
 3. **web** — Next.js app on `http://localhost:3000`.
 4. **worker** — TypeScript FX rate fetcher on a daily schedule.
 
-If you want Langfuse tracing in local Docker, set `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` together in `.env`. Leave all three unset if you do not want telemetry.
+If you want Langfuse tracing in local Docker, set `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`, and an explicit 64-character lowercase hexadecimal `LANGFUSE_RELEASE` together in `.env`. Leave the three connection values unset if you do not want telemetry; `LANGFUSE_RELEASE` alone does not enable it.
 
 ### Stop
 
@@ -46,7 +46,7 @@ Summary: CDK stack deploys VPC, ECS Fargate (web app), RDS Postgres (private), A
 
 ### Bootstrap and CI/CD
 
-Both bootstrap and CI/CD use the same method: `cdk deploy`. CDK builds Docker images, pushes them to the bootstrap ECR repo, and creates/updates all infrastructure in one pass. `/api/live` is used only for ECS/ALB liveness. Database migrations run as a one-off ECS task after deploy, and `/api/health` is checked after deploy to confirm DB readiness.
+Both bootstrap and CI/CD use the same method: `cdk deploy`. CDK builds Docker images, pushes them to the bootstrap ECR repo, and creates/updates all infrastructure in one pass. The web task receives the deterministic hash of its exact CDK Docker image asset as `LANGFUSE_RELEASE`. `/api/live` is used only for ECS/ALB liveness. Database migrations run as a one-off ECS task after deploy, and `/api/health` is checked after deploy to confirm DB readiness.
 
 **Bootstrap (first deploy, one-time):** `scripts/bootstrap.sh`
 

--- a/docs/langfuse-operations.md
+++ b/docs/langfuse-operations.md
@@ -22,8 +22,9 @@ The web container needs all of these values together:
 - `LANGFUSE_PUBLIC_KEY`
 - `LANGFUSE_SECRET_KEY`
 - `LANGFUSE_BASE_URL`
+- `LANGFUSE_RELEASE`
 
-If only part of the Langfuse config is present, production startup validation fails.
+If only part of the Langfuse config is present, or the release is not an explicit 64-character lowercase hexadecimal fingerprint, production startup validation fails. CDK sets the production release to the deterministic asset hash of the same web Docker image asset consumed by the ECS task definition, so it covers every file included in the staged image context, including included files ignored by Git.
 
 ## Export mode
 
@@ -41,6 +42,7 @@ Treat a trace that is missing for only a few seconds after a turn as normal batc
 For every user turn in the web chat, Langfuse should show:
 
 - trace name `chat_turn`
+- release equal to the deployed web Docker asset fingerprint
 - `sessionId` equal to the chat session id
 - `userId` equal to the authenticated app user id
 - tags `surface:web-chat`, `runtime:local-loop`, and `vendor:openai`
@@ -92,6 +94,7 @@ If no traces appear at all:
 - wait out the batch delay described in `## Export mode` before treating a missing trace as a configuration problem
 - if the web task was replaced or restarted right after the turn, expect the queued spans for that turn to be gone for good
 - confirm the ECS web task has all `LANGFUSE_*` environment values
+- confirm `LANGFUSE_RELEASE` matches the deployed web Docker asset fingerprint
 - confirm the web service was restarted after writing Secrets Manager values
 - check web container logs for startup validation failures about partial Langfuse configuration
 - check web container logs for `Langfuse telemetry failed:` errors

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -380,6 +380,8 @@ The script handles the full first-time deployment:
 5. Calls `/api/health` through the ALB DNS name until DB readiness succeeds
 6. Seeds exchange rates
 
+CDK injects the deterministic hash of the exact staged web Docker image asset as `LANGFUSE_RELEASE`. The same asset object supplies the ECS container image, so the release changes with every included image-context input, including included files ignored by Git.
+
 After this one-time bootstrap, all subsequent deploys happen automatically via CI/CD on push to `main`.
 
 Infrastructure liveness and database readiness are intentionally separate:
@@ -464,7 +466,7 @@ The canonical MCP transport is `https://mcp.yourdomain.com/mcp`, and its protect
      --secret-string 'sk-lf-...' \
      --profile expense-tracker
    ```
-   `langfuseBaseUrl` is injected as a regular ECS environment variable and defaults to `https://cloud.langfuse.com`. Then restart the ECS service to pick up the new values:
+   `langfuseBaseUrl` is injected as a regular ECS environment variable and defaults to `https://cloud.langfuse.com`. CDK injects the exact web Docker asset fingerprint as `LANGFUSE_RELEASE`. Then restart the ECS service to pick up the new values:
    ```bash
    aws ecs update-service \
      --cluster <EcsClusterName from output> \
@@ -510,7 +512,7 @@ After first deploy:
 
 3. Every push to `main` will automatically:
    - `cdk deploy` — update infrastructure, Lambda, and IAM permissions
-   - Build and push Docker images to ECR (tagged with git SHA + `latest`)
+   - Build and push content-addressed Docker image assets to ECR
    - Run migration ECS task (one-off Fargate task)
    - Restart ECS service (`force-new-deployment` picks up the new `latest` image)
 

--- a/infra/aws/lib/compute.test.ts
+++ b/infra/aws/lib/compute.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import test from "node:test";
+
+const COMPUTE_SOURCE_PATH = path.join(__dirname, "compute.ts");
+
+test("the web Docker asset supplies both the ECS image and Langfuse release", (): void => {
+  const source = fs.readFileSync(COMPUTE_SOURCE_PATH, "utf8");
+  const assetDeclaration = /const ([A-Za-z][A-Za-z0-9]*) = new DockerImageAsset\(scope, "WebDockerImageAsset",/.exec(source);
+
+  assert.ok(assetDeclaration, "Expected compute.ts to construct one explicit web Docker image asset");
+  const assetName = assetDeclaration[1];
+  assert.match(
+    source,
+    new RegExp(`image: ecs\\.ContainerImage\\.fromDockerImageAsset\\(${assetName}\\)`),
+  );
+  assert.match(
+    source,
+    new RegExp(`LANGFUSE_RELEASE: ${assetName}\\.assetHash`),
+  );
+});

--- a/infra/aws/lib/compute.ts
+++ b/infra/aws/lib/compute.ts
@@ -1,7 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecs from "aws-cdk-lib/aws-ecs";
-import { Platform } from "aws-cdk-lib/aws-ecr-assets";
+import { DockerImageAsset, Platform } from "aws-cdk-lib/aws-ecr-assets";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as rds from "aws-cdk-lib/aws-rds";
 import * as logs from "aws-cdk-lib/aws-logs";
@@ -126,6 +126,14 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
   ];
   const cluster = new ecs.Cluster(scope, "Cluster", { vpc: props.vpc });
 
+  const webDockerImageAsset = new DockerImageAsset(scope, "WebDockerImageAsset", {
+    directory: path.join(__dirname, "../../.."),
+    file: "apps/web/Dockerfile",
+    exclude: webDockerAssetExclude,
+    ignoreMode: cdk.IgnoreMode.DOCKER,
+    platform: Platform.LINUX_ARM64,
+  });
+
   const webTaskDef = new ecs.FargateTaskDefinition(scope, "WebTask", {
     cpu: 1024,
     memoryLimitMiB: 2048,
@@ -142,12 +150,7 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
   });
 
   const webContainer = webTaskDef.addContainer("web", {
-    image: ecs.ContainerImage.fromAsset(path.join(__dirname, "../../.."), {
-      file: "apps/web/Dockerfile",
-      exclude: webDockerAssetExclude,
-      ignoreMode: cdk.IgnoreMode.DOCKER,
-      platform: Platform.LINUX_ARM64,
-    }),
+    image: ecs.ContainerImage.fromDockerImageAsset(webDockerImageAsset),
     portMappings: [{ containerPort: 8080 }],
     // Full list of ECS env vars is also documented in .env.example
     environment: {
@@ -163,6 +166,7 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
       DB_NAME: "tracker",
       DB_USER: "app",
       LANGFUSE_BASE_URL: props.langfuseBaseUrl,
+      LANGFUSE_RELEASE: webDockerImageAsset.assetHash,
       // RDS certs are signed by Amazon's CA, not in the Node.js trust store.
       // Points to the CA bundle downloaded in apps/web/Dockerfile.
       NODE_EXTRA_CA_CERTS: "/app/rds-global-bundle.pem",

--- a/infra/docker/compose.yml
+++ b/infra/docker/compose.yml
@@ -57,6 +57,7 @@ services:
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
       LANGFUSE_BASE_URL: ${LANGFUSE_BASE_URL:-}
+      LANGFUSE_RELEASE: ${LANGFUSE_RELEASE:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
       "version": "1.4.0",
       "dependencies": {
         "@expense-budget-tracker/agent-shared": "1.4.0",
-        "@langfuse/client": "^5.10.1",
         "@langfuse/openai": "^5.10.1",
         "@langfuse/otel": "^5.10.1",
         "@langfuse/tracing": "^5.10.1",
@@ -1819,20 +1818,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
-      }
-    },
-    "node_modules/@langfuse/client": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@langfuse/client/-/client-5.10.1.tgz",
-      "integrity": "sha512-isfMUbb55mXnp5EjIKnKmdB6aVxy+jPYK65RkaLdi2xveUbifVeov9kAwHQN6lWtzkR/ssSk6+JwvTCLaPcvTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@langfuse/core": "^5.10.1",
-        "@langfuse/tracing": "^5.10.1",
-        "mustache": "^4.2.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
       }
     },
     "node_modules/@langfuse/core": {
@@ -5360,15 +5345,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.18",


### PR DESCRIPTION
Binds each configured Langfuse release to the exact staged CDK web Docker asset, enforces explicit startup and local release configuration, removes the unused Langfuse client dependency, and synchronizes tests and operations documentation. Cloud CI owns executable validation.