### PR TITLE
Migrate Langfuse tracing to v4 observation lifecycle

### DIFF
--- a/apps/web/src/app/api/chat/transcriptions/route.test.ts
+++ b/apps/web/src/app/api/chat/transcriptions/route.test.ts
@@ -49,10 +49,12 @@ test("transcription succeeds without a persisted chat session", async (): Promis
   }]);
   assert.equal(telemetryContexts[0]?.userId, "user-1");
   assert.equal(telemetryContexts[0]?.workspaceId, "workspace-1");
+  assert.equal(telemetryContexts[0]?.sessionId, null);
   assert.equal(typeof telemetryContexts[0]?.requestId, "string");
 });
 
-test("transcription echoes a legacy client session id without validating it", async (): Promise<void> => {
+test("transcription echoes a valid legacy client session id", async (): Promise<void> => {
+  const telemetryContexts: Array<ChatTranscriptionTelemetryContext> = [];
   const response = await transcribeChatRouteWithDeps(
     createTranscriptionRequest(),
     {
@@ -62,7 +64,10 @@ test("transcription echoes a legacy client session id without validating it", as
         source: "web",
         sessionId: "session-legacy",
       }),
-      transcribeChatAudioUpload: async () => "legacy transcription",
+      transcribeChatAudioUpload: async (_upload, context) => {
+        telemetryContexts.push(context);
+        return "legacy transcription";
+      },
     },
   );
 
@@ -71,6 +76,60 @@ test("transcription echoes a legacy client session id without validating it", as
     text: "legacy transcription",
     sessionId: "session-legacy",
   });
+  assert.equal(telemetryContexts[0]?.sessionId, "session-legacy");
+});
+
+test("transcription accepts and propagates a 200-character session id", async (): Promise<void> => {
+  const sessionId = "s".repeat(200);
+  const telemetryContexts: Array<ChatTranscriptionTelemetryContext> = [];
+  const response = await transcribeChatRouteWithDeps(
+    createTranscriptionRequest(),
+    {
+      ensureUserProvisioned: async () => undefined,
+      parseChatTranscriptionUpload: async () => ({
+        file: new File(["audio"], "audio.webm", { type: "audio/webm" }),
+        source: "web",
+        sessionId,
+      }),
+      transcribeChatAudioUpload: async (_upload, context) => {
+        telemetryContexts.push(context);
+        return "limit transcription";
+      },
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    text: "limit transcription",
+    sessionId,
+  });
+  assert.equal(telemetryContexts[0]?.sessionId, sessionId);
+});
+
+test("transcription rejects session ids longer than the Langfuse limit", async (): Promise<void> => {
+  let providerCalled = false;
+  const response = await transcribeChatRouteWithDeps(
+    createTranscriptionRequest(),
+    {
+      ensureUserProvisioned: async () => undefined,
+      parseChatTranscriptionUpload: async () => ({
+        file: new File(["audio"], "audio.webm", { type: "audio/webm" }),
+        source: "web",
+        sessionId: "s".repeat(201),
+      }),
+      transcribeChatAudioUpload: async () => {
+        providerCalled = true;
+        return "must not transcribe";
+      },
+    },
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(
+    await response.text(),
+    "sessionId must contain at most 200 characters for audio transcription",
+  );
+  assert.equal(providerCalled, false);
 });
 
 test("transcription still rejects missing workspace authentication", async (): Promise<void> => {

--- a/apps/web/src/app/api/chat/transcriptions/route.ts
+++ b/apps/web/src/app/api/chat/transcriptions/route.ts
@@ -18,6 +18,8 @@ type ChatTranscriptionsRouteDependencies = Readonly<{
   transcribeChatAudioUpload: typeof transcribeChatAudioUpload;
 }>;
 
+const LANGFUSE_SESSION_ID_MAX_LENGTH = 200;
+
 const DEFAULT_CHAT_TRANSCRIPTIONS_ROUTE_DEPENDENCIES: ChatTranscriptionsRouteDependencies = {
   ensureUserProvisioned,
   parseChatTranscriptionUpload,
@@ -31,6 +33,15 @@ const assertAuthenticatedChatRequest = (request: Request): void => {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new ApiRouteError(401, message);
+  }
+};
+
+const assertSupportedTranscriptionSessionId = (sessionId: string | null): void => {
+  if (sessionId !== null && sessionId.length > LANGFUSE_SESSION_ID_MAX_LENGTH) {
+    throw new ApiRouteError(
+      400,
+      `sessionId must contain at most ${String(LANGFUSE_SESSION_ID_MAX_LENGTH)} characters for audio transcription`,
+    );
   }
 };
 
@@ -50,10 +61,12 @@ export const transcribeChatRouteWithDeps = async (
       const workspaceId = extractWorkspaceId(request);
       await dependencies.ensureUserProvisioned(userId, workspaceId);
       const upload = await dependencies.parseChatTranscriptionUpload(request);
+      assertSupportedTranscriptionSessionId(upload.sessionId);
       const text = await dependencies.transcribeChatAudioUpload(upload, {
         requestId: randomUUID(),
         userId,
         workspaceId,
+        sessionId: upload.sessionId,
         source: upload.source,
         fileName: upload.file.name,
         mediaType: upload.file.type.trim().toLowerCase(),

--- a/apps/web/src/server/chat/openai/langfuse.test.ts
+++ b/apps/web/src/server/chat/openai/langfuse.test.ts
@@ -1,11 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { propagateAttributes, type LangfuseObservation } from "@langfuse/tracing";
+import {
+  propagateAttributes,
+  type LangfuseObservation,
+  type PropagateAttributesParams,
+} from "@langfuse/tracing";
 import {
   sanitizeLangfuseSerializedTelemetry,
   startChatTranscriptionObservationWithDeps,
   startChatTurnObservationWithDeps,
+  type ChatTurnObservationOutcome,
 } from "@/server/chat/openai/langfuse";
+import type { ContentPart } from "@/server/chat/types";
 
 const MEDIA_DATA_URI = "data:image/png;base64,1234567890123456";
 const UNPADDED_MEDIA_DATA_URI_MOD_2 = "data:application/octet-stream;base64,12345678901234";
@@ -15,9 +21,15 @@ const PADDED_MEDIA_DATA_URI_TWO = "data:application/octet-stream;base64,12345678
 const TRACE_ID = "0123456789abcdef0123456789abcdef";
 
 type StartObservationDependencies = Parameters<typeof startChatTurnObservationWithDeps>[2];
+type StartActiveObservationDependency = StartObservationDependencies["startActiveObservation"];
+type StartActiveObservationName = Parameters<StartActiveObservationDependency>[0];
+type StartActiveObservationRoot = Parameters<
+  Parameters<StartActiveObservationDependency>[1]
+>[0];
+type StartActiveObservationOptions = Parameters<StartActiveObservationDependency>[2];
 type ObservationUpdate = Parameters<LangfuseObservation["updateOtelSpanAttributes"]>[0];
 type LangfuseLogEvent = Parameters<StartObservationDependencies["log"]>[0];
-type RootTelemetryOperation = "success update" | "error update" | "end";
+type RootTelemetryOperation = "initial update" | "outcome update" | "error update" | "end";
 
 type ObservationErrors = Readonly<{
   update: Error | null;
@@ -92,6 +104,7 @@ const createExpectedTranscriptionTelemetryLog = (
   requestId: "request-1",
   userId: "user-1",
   workspaceId: "workspace-1",
+  sessionId: "session-1",
 });
 
 const createObservationDependencies = (
@@ -100,7 +113,10 @@ const createObservationDependencies = (
 ): StartObservationDependencies => ({
   createTraceId: async (): Promise<string> => TRACE_ID,
   propagateAttributes,
-  startObservation: (() => observation) as StartObservationDependencies["startObservation"],
+  startActiveObservation: <Result>(
+    _name: StartActiveObservationName,
+    fn: (rootObservation: StartActiveObservationRoot) => Result,
+  ): Result => fn(observation),
   log: logger,
 });
 
@@ -119,29 +135,183 @@ const CHAT_TRANSCRIPTION_PARAMS: Parameters<typeof startChatTranscriptionObserva
   requestId: "request-1",
   userId: "user-1",
   workspaceId: "workspace-1",
+  sessionId: "session-1",
   source: "web",
   fileName: "recording.webm",
   mediaType: "audio/webm",
   fileSize: 1024,
 };
 
+const CHAT_TURN_OUTPUT: ReadonlyArray<ContentPart> = [{
+  type: "text",
+  text: "Goodbye",
+}];
+
+const CHAT_TURN_COMPLETED_OUTCOME: ChatTurnObservationOutcome = {
+  kind: "completed",
+  assistantContent: CHAT_TURN_OUTPUT,
+};
+
+const CHAT_TURN_INITIAL_UPDATE: ObservationUpdate = {
+  input: {
+    turnInput: [{
+      type: "text",
+      text: "Hello",
+    }],
+  },
+  metadata: {
+    requestId: "request-1",
+    workspaceId: "workspace-1",
+    model: "gpt-5",
+    attempt: "1",
+    turnIndex: "1",
+    hasAttachments: "false",
+    attachmentCount: "0",
+    runState: "running",
+  },
+};
+
+const CHAT_TRANSCRIPTION_INITIAL_UPDATE: ObservationUpdate = {
+  input: {
+    upload: {
+      workspaceId: "workspace-1",
+      source: "web",
+      fileName: "recording.webm",
+      mediaType: "audio/webm",
+      fileSize: 1024,
+    },
+  },
+  metadata: {
+    requestId: "request-1",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    source: "web",
+    fileName: "recording.webm",
+    mediaType: "audio/webm",
+    fileSize: "1024",
+    sessionId: "session-1",
+  },
+};
+
+test("startChatTurnObservationWithDeps propagates attributes before starting the active root", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  const lifecycle: Array<string> = [];
+  const dependencies: StartObservationDependencies = {
+    createTraceId: async (): Promise<string> => TRACE_ID,
+    propagateAttributes: <
+      Args extends unknown[],
+      Callback extends (...args: Args) => ReturnType<Callback>,
+    >(
+      attributes: PropagateAttributesParams,
+      fn: Callback,
+    ): ReturnType<Callback> => {
+      lifecycle.push("propagate");
+      assert.equal(attributes.traceName, "chat_turn");
+      assert.equal(attributes.userId, "user-1");
+      assert.equal(attributes.sessionId, "session-1");
+      return propagateAttributes<Args, Callback>(attributes, fn);
+    },
+    startActiveObservation: <Result>(
+      name: StartActiveObservationName,
+      fn: (rootObservation: StartActiveObservationRoot) => Result,
+      options: StartActiveObservationOptions,
+    ): Result => {
+      lifecycle.push("active-root");
+      assert.equal(name, "chat_turn");
+      assert.deepEqual(options, {
+        asType: "agent",
+        endOnExit: false,
+        parentSpanContext: {
+          traceId: TRACE_ID,
+          spanId: TRACE_ID.slice(0, 16),
+          traceFlags: 1,
+        },
+      });
+      return fn(recording.observation);
+    },
+    log: ignoreLog,
+  };
+
+  await startChatTurnObservationWithDeps(
+    CHAT_TURN_PARAMS,
+    async (): Promise<ChatTurnObservationOutcome> => {
+      lifecycle.push("callback");
+      assert.deepEqual(recording.updates, [CHAT_TURN_INITIAL_UPDATE]);
+      return CHAT_TURN_COMPLETED_OUTCOME;
+    },
+    dependencies,
+  );
+
+  assert.deepEqual(lifecycle, ["propagate", "active-root", "callback"]);
+});
+
 test("startChatTurnObservationWithDeps leaves successful roots at the default level", async (): Promise<void> => {
   const recording = createRecordingObservation();
 
   await startChatTurnObservationWithDeps(
     CHAT_TURN_PARAMS,
-    async (rootObservation): Promise<void> => {
+    async (rootObservation): Promise<ChatTurnObservationOutcome> => {
       assert.equal(rootObservation, recording.observation);
+      return CHAT_TURN_COMPLETED_OUTCOME;
     },
     createObservationDependencies(recording.observation, ignoreLog),
   );
 
-  assert.deepEqual(recording.updates, [{
-    output: {
-      result: "success",
+  assert.deepEqual(recording.updates, [
+    CHAT_TURN_INITIAL_UPDATE,
+    {
+      output: {
+        result: "success",
+        assistantContent: CHAT_TURN_OUTPUT,
+      },
     },
-  }]);
+  ]);
   assert.equal(recording.getEndCount(), 1);
+});
+
+test("startChatTurnObservationWithDeps records every non-success outcome explicitly", async (): Promise<void> => {
+  const scenarios: ReadonlyArray<Readonly<{
+    outcome: ChatTurnObservationOutcome;
+    expectedUpdate: ObservationUpdate;
+  }>> = [
+    {
+      outcome: { kind: "cancelled", assistantContent: CHAT_TURN_OUTPUT },
+      expectedUpdate: {
+        output: { result: "cancelled", assistantContent: CHAT_TURN_OUTPUT },
+      },
+    },
+    {
+      outcome: { kind: "invalidated" },
+      expectedUpdate: { output: { result: "invalidated" } },
+    },
+    {
+      outcome: {
+        kind: "failed",
+        assistantContent: CHAT_TURN_OUTPUT,
+        message: "Provider failed",
+      },
+      expectedUpdate: {
+        level: "ERROR",
+        statusMessage: "Provider failed",
+        output: {
+          result: "error",
+          message: "Provider failed",
+          assistantContent: CHAT_TURN_OUTPUT,
+        },
+      },
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const recording = createRecordingObservation();
+    await startChatTurnObservationWithDeps(
+      CHAT_TURN_PARAMS,
+      async (): Promise<ChatTurnObservationOutcome> => scenario.outcome,
+      createObservationDependencies(recording.observation, ignoreLog),
+    );
+    assert.deepEqual(recording.updates, [CHAT_TURN_INITIAL_UPDATE, scenario.expectedUpdate]);
+    assert.equal(recording.getEndCount(), 1);
+  }
 });
 
 test("startChatTurnObservationWithDeps preserves success when the success telemetry update throws", async (): Promise<void> => {
@@ -156,9 +326,10 @@ test("startChatTurnObservationWithDeps preserves success when the success teleme
 
   await startChatTurnObservationWithDeps(
     CHAT_TURN_PARAMS,
-    async (rootObservation): Promise<void> => {
+    async (rootObservation): Promise<ChatTurnObservationOutcome> => {
       callbackCount += 1;
       assert.equal(rootObservation, recording.observation);
+      return CHAT_TURN_COMPLETED_OUTCOME;
     },
     createObservationDependencies(
       recording.observation,
@@ -169,14 +340,19 @@ test("startChatTurnObservationWithDeps preserves success when the success teleme
   );
 
   assert.equal(callbackCount, 1);
-  assert.deepEqual(recording.updates, [{
-    output: {
-      result: "success",
+  assert.deepEqual(recording.updates, [
+    CHAT_TURN_INITIAL_UPDATE,
+    {
+      output: {
+        result: "success",
+        assistantContent: CHAT_TURN_OUTPUT,
+      },
     },
-  }]);
+  ]);
   assert.equal(recording.getEndCount(), 1);
   assert.deepEqual(logEvents, [
-    createExpectedChatTurnTelemetryLog("success update", updateError),
+    createExpectedChatTurnTelemetryLog("initial update", updateError),
+    createExpectedChatTurnTelemetryLog("outcome update", updateError),
     createExpectedChatTurnTelemetryLog("end", endError),
   ]);
 });
@@ -192,7 +368,7 @@ test("startChatTurnObservationWithDeps marks failed roots as errors and rethrows
   const callbackError = new Error("Chat turn failed");
   const propagatedError = await startChatTurnObservationWithDeps(
     CHAT_TURN_PARAMS,
-    async (): Promise<void> => {
+    async (): Promise<ChatTurnObservationOutcome> => {
       throw callbackError;
     },
     createObservationDependencies(
@@ -207,23 +383,76 @@ test("startChatTurnObservationWithDeps marks failed roots as errors and rethrows
   );
 
   assert.equal(propagatedError, callbackError);
-  assert.deepEqual(recording.updates, [{
-    level: "ERROR",
-    statusMessage: "Chat turn failed",
-    output: {
-      result: "error",
-      message: "Chat turn failed",
+  assert.deepEqual(recording.updates, [
+    CHAT_TURN_INITIAL_UPDATE,
+    {
+      level: "ERROR",
+      statusMessage: "Chat turn failed",
+      output: {
+        result: "error",
+        message: "Chat turn failed",
+      },
     },
-  }]);
+  ]);
   assert.equal(recording.getEndCount(), 1);
   assert.deepEqual(logEvents, [
+    createExpectedChatTurnTelemetryLog("initial update", updateError),
     createExpectedChatTurnTelemetryLog("error update", updateError),
     createExpectedChatTurnTelemetryLog("end", endError),
   ]);
 });
 
+test("startChatTurnObservationWithDeps rethrows a null callback rejection exactly once", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  let callbackCount = 0;
+  let rejectionObserved = false;
+
+  try {
+    await startChatTurnObservationWithDeps(
+      CHAT_TURN_PARAMS,
+      async (): Promise<ChatTurnObservationOutcome> => {
+        callbackCount += 1;
+        return Promise.reject(null);
+      },
+      createObservationDependencies(recording.observation, ignoreLog),
+    );
+  } catch (error) {
+    rejectionObserved = true;
+    assert.equal(error, null);
+  }
+
+  assert.equal(rejectionObserved, true);
+  assert.equal(callbackCount, 1);
+  assert.deepEqual(recording.updates, [
+    CHAT_TURN_INITIAL_UPDATE,
+    {
+      level: "ERROR",
+      statusMessage: "null",
+      output: {
+        result: "error",
+        message: "null",
+      },
+    },
+  ]);
+  assert.equal(recording.getEndCount(), 1);
+});
+
 test("startChatTranscriptionObservationWithDeps leaves successful roots at the default level", async (): Promise<void> => {
   const recording = createRecordingObservation();
+  const baseDependencies = createObservationDependencies(recording.observation, ignoreLog);
+  const dependencies: StartObservationDependencies = {
+    ...baseDependencies,
+    propagateAttributes: <
+      Args extends unknown[],
+      Callback extends (...args: Args) => ReturnType<Callback>,
+    >(
+      attributes: PropagateAttributesParams,
+      fn: Callback,
+    ): ReturnType<Callback> => {
+      assert.equal(attributes.sessionId, "session-1");
+      return propagateAttributes<Args, Callback>(attributes, fn);
+    },
+  };
 
   const result = await startChatTranscriptionObservationWithDeps(
     CHAT_TRANSCRIPTION_PARAMS,
@@ -231,15 +460,19 @@ test("startChatTranscriptionObservationWithDeps leaves successful roots at the d
       assert.equal(rootObservation, recording.observation);
       return "transcript";
     },
-    createObservationDependencies(recording.observation, ignoreLog),
+    dependencies,
   );
 
   assert.equal(result, "transcript");
-  assert.deepEqual(recording.updates, [{
-    output: {
-      result: "success",
+  assert.deepEqual(recording.updates, [
+    CHAT_TRANSCRIPTION_INITIAL_UPDATE,
+    {
+      output: {
+        result: "success",
+        transcription: "transcript",
+      },
     },
-  }]);
+  ]);
   assert.equal(recording.getEndCount(), 1);
 });
 
@@ -270,14 +503,19 @@ test("startChatTranscriptionObservationWithDeps preserves success when the succe
 
   assert.equal(result, "transcript");
   assert.equal(callbackCount, 1);
-  assert.deepEqual(recording.updates, [{
-    output: {
-      result: "success",
+  assert.deepEqual(recording.updates, [
+    CHAT_TRANSCRIPTION_INITIAL_UPDATE,
+    {
+      output: {
+        result: "success",
+        transcription: "transcript",
+      },
     },
-  }]);
+  ]);
   assert.equal(recording.getEndCount(), 1);
   assert.deepEqual(logEvents, [
-    createExpectedTranscriptionTelemetryLog("success update", updateError),
+    createExpectedTranscriptionTelemetryLog("initial update", updateError),
+    createExpectedTranscriptionTelemetryLog("outcome update", updateError),
     createExpectedTranscriptionTelemetryLog("end", endError),
   ]);
 });
@@ -308,19 +546,58 @@ test("startChatTranscriptionObservationWithDeps marks failed roots as errors and
   );
 
   assert.equal(propagatedError, callbackError);
-  assert.deepEqual(recording.updates, [{
-    level: "ERROR",
-    statusMessage: "Transcription failed",
-    output: {
-      result: "error",
-      message: "Transcription failed",
+  assert.deepEqual(recording.updates, [
+    CHAT_TRANSCRIPTION_INITIAL_UPDATE,
+    {
+      level: "ERROR",
+      statusMessage: "Transcription failed",
+      output: {
+        result: "error",
+        message: "Transcription failed",
+      },
     },
-  }]);
+  ]);
   assert.equal(recording.getEndCount(), 1);
   assert.deepEqual(logEvents, [
+    createExpectedTranscriptionTelemetryLog("initial update", updateError),
     createExpectedTranscriptionTelemetryLog("error update", updateError),
     createExpectedTranscriptionTelemetryLog("end", endError),
   ]);
+});
+
+test("startChatTranscriptionObservationWithDeps rethrows a null callback rejection exactly once", async (): Promise<void> => {
+  const recording = createRecordingObservation();
+  let callbackCount = 0;
+  let rejectionObserved = false;
+
+  try {
+    await startChatTranscriptionObservationWithDeps(
+      CHAT_TRANSCRIPTION_PARAMS,
+      async (): Promise<string> => {
+        callbackCount += 1;
+        return Promise.reject(null);
+      },
+      createObservationDependencies(recording.observation, ignoreLog),
+    );
+  } catch (error) {
+    rejectionObserved = true;
+    assert.equal(error, null);
+  }
+
+  assert.equal(rejectionObserved, true);
+  assert.equal(callbackCount, 1);
+  assert.deepEqual(recording.updates, [
+    CHAT_TRANSCRIPTION_INITIAL_UPDATE,
+    {
+      level: "ERROR",
+      statusMessage: "null",
+      output: {
+        result: "error",
+        message: "null",
+      },
+    },
+  ]);
+  assert.equal(recording.getEndCount(), 1);
 });
 
 test("sanitizeLangfuseSerializedTelemetry masks nested text while preserving media", (): void => {

--- a/apps/web/src/server/chat/openai/langfuse.test.ts
+++ b/apps/web/src/server/chat/openai/langfuse.test.ts
@@ -1,10 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
-  propagateAttributes,
-  type LangfuseObservation,
-  type PropagateAttributesParams,
-} from "@langfuse/tracing";
+import { propagateAttributes, type LangfuseObservation } from "@langfuse/tracing";
 import {
   sanitizeLangfuseSerializedTelemetry,
   startChatTranscriptionObservationWithDeps,
@@ -198,18 +194,12 @@ test("startChatTurnObservationWithDeps propagates attributes before starting the
   const lifecycle: Array<string> = [];
   const dependencies: StartObservationDependencies = {
     createTraceId: async (): Promise<string> => TRACE_ID,
-    propagateAttributes: <
-      Args extends unknown[],
-      Callback extends (...args: Args) => ReturnType<Callback>,
-    >(
-      attributes: PropagateAttributesParams,
-      fn: Callback,
-    ): ReturnType<Callback> => {
+    propagateAttributes: (attributes, fn) => {
       lifecycle.push("propagate");
       assert.equal(attributes.traceName, "chat_turn");
       assert.equal(attributes.userId, "user-1");
       assert.equal(attributes.sessionId, "session-1");
-      return propagateAttributes<Args, Callback>(attributes, fn);
+      return propagateAttributes(attributes, fn);
     },
     startActiveObservation: <Result>(
       name: StartActiveObservationName,
@@ -442,15 +432,9 @@ test("startChatTranscriptionObservationWithDeps leaves successful roots at the d
   const baseDependencies = createObservationDependencies(recording.observation, ignoreLog);
   const dependencies: StartObservationDependencies = {
     ...baseDependencies,
-    propagateAttributes: <
-      Args extends unknown[],
-      Callback extends (...args: Args) => ReturnType<Callback>,
-    >(
-      attributes: PropagateAttributesParams,
-      fn: Callback,
-    ): ReturnType<Callback> => {
+    propagateAttributes: (attributes, fn) => {
       assert.equal(attributes.sessionId, "session-1");
-      return propagateAttributes<Args, Callback>(attributes, fn);
+      return propagateAttributes(attributes, fn);
     },
   };
 

--- a/apps/web/src/server/chat/openai/langfuse.ts
+++ b/apps/web/src/server/chat/openai/langfuse.ts
@@ -1,6 +1,10 @@
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import { LangfuseSpanProcessor, isDefaultExportSpan } from "@langfuse/otel";
-import type { LangfuseObservation, StartActiveObservationOpts } from "@langfuse/tracing";
+import type {
+  LangfuseObservation,
+  PropagateAttributesParams,
+  StartActiveObservationOpts,
+} from "@langfuse/tracing";
 import { createTraceId, propagateAttributes, startActiveObservation } from "@langfuse/tracing";
 import type { ContentPart } from "@/server/chat/types";
 import { log } from "@/server/logger";
@@ -66,9 +70,14 @@ type StartActiveAgentObservation = <Result>(
   options: StartActiveObservationOpts & { asType: "agent" },
 ) => Result;
 
+type PropagateAttributesDependency = <Result>(
+  attributes: PropagateAttributesParams,
+  fn: () => Result,
+) => Result;
+
 type StartObservationDependencies = Readonly<{
   createTraceId: typeof createTraceId;
-  propagateAttributes: typeof propagateAttributes;
+  propagateAttributes: PropagateAttributesDependency;
   startActiveObservation: StartActiveAgentObservation;
   log: typeof log;
 }>;

--- a/apps/web/src/server/chat/openai/langfuse.ts
+++ b/apps/web/src/server/chat/openai/langfuse.ts
@@ -1,7 +1,7 @@
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import { LangfuseSpanProcessor, isDefaultExportSpan } from "@langfuse/otel";
-import type { LangfuseObservation } from "@langfuse/tracing";
-import { createTraceId, propagateAttributes, startObservation } from "@langfuse/tracing";
+import type { LangfuseObservation, StartActiveObservationOpts } from "@langfuse/tracing";
+import { createTraceId, propagateAttributes, startActiveObservation } from "@langfuse/tracing";
 import type { ContentPart } from "@/server/chat/types";
 import { log } from "@/server/logger";
 import { sanitizeContentPartsForTelemetry } from "./responses/input";
@@ -21,11 +21,30 @@ export type ChatTranscriptionTraceMetadata = Readonly<{
   requestId: string;
   userId: string;
   workspaceId: string;
+  sessionId: string | null;
   source: "web";
   fileName: string;
   mediaType: string;
   fileSize: number;
 }>;
+
+export type ChatTurnObservationOutcome =
+  | Readonly<{
+    kind: "completed";
+    assistantContent: ReadonlyArray<ContentPart>;
+  }>
+  | Readonly<{
+    kind: "cancelled";
+    assistantContent: ReadonlyArray<ContentPart>;
+  }>
+  | Readonly<{
+    kind: "invalidated";
+  }>
+  | Readonly<{
+    kind: "failed";
+    assistantContent: ReadonlyArray<ContentPart>;
+    message: string;
+  }>;
 
 type TelemetryMetadata = Readonly<Record<string, string>>;
 
@@ -41,28 +60,55 @@ type JsonContainer =
   | ReadonlyArray<JsonValue>
   | Readonly<{ [key: string]: JsonValue }>;
 
+type StartActiveAgentObservation = <Result>(
+  name: string,
+  fn: (observation: LangfuseObservation) => Result,
+  options: StartActiveObservationOpts & { asType: "agent" },
+) => Result;
+
 type StartObservationDependencies = Readonly<{
   createTraceId: typeof createTraceId;
   propagateAttributes: typeof propagateAttributes;
-  startObservation: typeof startObservation;
+  startActiveObservation: StartActiveAgentObservation;
   log: typeof log;
 }>;
 
-type RootObservationTelemetryOperation = "success update" | "error update" | "end";
+type RootObservationTelemetryOperation =
+  | "initial update"
+  | "outcome update"
+  | "error update"
+  | "end";
 
-type RootObservationTelemetryContext =
+type RootObservationTelemetryContext = Readonly<{
+  observationName: "chat turn" | "chat transcription";
+  requestId: string;
+  userId: string;
+  workspaceId: string;
+  sessionId: string | null;
+}>;
+
+type CallbackFailure =
+  | Readonly<{ failed: false }>
+  | Readonly<{ failed: true; error: unknown }>;
+
+type SanitizedContentParts = Awaited<ReturnType<typeof sanitizeContentPartsForTelemetry>>;
+
+type ChatTurnTelemetryOutput =
   | Readonly<{
-    observationName: "chat turn";
-    requestId: string;
-    userId: string;
-    workspaceId: string;
-    sessionId: string;
+    result: "success";
+    assistantContent: SanitizedContentParts;
   }>
   | Readonly<{
-    observationName: "chat transcription";
-    requestId: string;
-    userId: string;
-    workspaceId: string;
+    result: "cancelled";
+    assistantContent: SanitizedContentParts;
+  }>
+  | Readonly<{
+    result: "invalidated";
+  }>
+  | Readonly<{
+    result: "error";
+    message: string;
+    assistantContent: SanitizedContentParts;
   }>;
 
 const MASK_PATTERNS: ReadonlyArray<Readonly<{
@@ -115,6 +161,9 @@ const buildChatTranscriptionTraceMetadata = (
   fileName: metadataValue(params.fileName),
   mediaType: metadataValue(params.mediaType),
   fileSize: metadataValue(params.fileSize),
+  ...(params.sessionId === null
+    ? {}
+    : { sessionId: metadataValue(params.sessionId) }),
 });
 
 const isValidBase64Payload = (payload: string): boolean => {
@@ -262,8 +311,27 @@ export const createLangfuseSpanProcessor = (): LangfuseSpanProcessor | null => {
 const DEFAULT_START_OBSERVATION_DEPENDENCIES: StartObservationDependencies = {
   createTraceId,
   propagateAttributes,
-  startObservation,
+  startActiveObservation,
   log,
+};
+
+const logRootObservationTelemetryError = (
+  context: RootObservationTelemetryContext,
+  operation: RootObservationTelemetryOperation,
+  error: unknown,
+  logger: typeof log,
+): void => {
+  logger({
+    domain: "chat",
+    action: "error",
+    vendor: "openai",
+    stage: "agent",
+    error: `Langfuse ${context.observationName} ${operation} failed: ${error instanceof Error ? error.message : String(error)}`,
+    requestId: context.requestId,
+    userId: context.userId,
+    workspaceId: context.workspaceId,
+    ...(context.sessionId === null ? {} : { sessionId: context.sessionId }),
+  });
 };
 
 const runRootObservationTelemetryOperation = (
@@ -275,18 +343,36 @@ const runRootObservationTelemetryOperation = (
   try {
     telemetryOperation();
   } catch (error) {
-    logger({
-      domain: "chat",
-      action: "error",
-      vendor: "openai",
-      stage: "agent",
-      error: `Langfuse ${context.observationName} ${operation} failed: ${error instanceof Error ? error.message : String(error)}`,
-      requestId: context.requestId,
-      userId: context.userId,
-      workspaceId: context.workspaceId,
-      ...("sessionId" in context ? { sessionId: context.sessionId } : {}),
-    });
+    logRootObservationTelemetryError(context, operation, error, logger);
   }
+};
+
+const buildChatTurnTelemetryOutput = async (
+  outcome: ChatTurnObservationOutcome,
+): Promise<ChatTurnTelemetryOutput> => {
+  if (outcome.kind === "invalidated") {
+    return { result: "invalidated" } as const;
+  }
+
+  const assistantContent = await sanitizeContentPartsForTelemetry(outcome.assistantContent);
+  if (outcome.kind === "completed") {
+    return {
+      result: "success",
+      assistantContent,
+    } as const;
+  }
+  if (outcome.kind === "cancelled") {
+    return {
+      result: "cancelled",
+      assistantContent,
+    } as const;
+  }
+
+  return {
+    result: "error",
+    message: outcome.message,
+    assistantContent,
+  } as const;
 };
 
 export const sanitizeChatTranscriptionForTelemetry = (
@@ -311,15 +397,11 @@ export const sanitizeChatTranscriptionForTelemetry = (
 
 export const startChatTurnObservationWithDeps = async (
   params: ChatTraceMetadata,
-  fn: (rootObservation: LangfuseObservation | null) => Promise<void>,
+  fn: (
+    rootObservation: LangfuseObservation | null,
+  ) => Promise<ChatTurnObservationOutcome>,
   dependencies: StartObservationDependencies,
 ): Promise<void> => {
-  const traceId = await dependencies.createTraceId(params.requestId);
-  const parentSpanContext = {
-    traceId,
-    spanId: traceId.slice(0, 16),
-    traceFlags: 1,
-  };
   const telemetryContext: RootObservationTelemetryContext = {
     observationName: "chat turn",
     requestId: params.requestId,
@@ -328,9 +410,16 @@ export const startChatTurnObservationWithDeps = async (
     sessionId: params.sessionId,
   };
   let callbackStarted = false;
-  let callbackError: unknown | null = null;
+  let callbackFailure: CallbackFailure = { failed: false };
+  const getCallbackFailure = (): CallbackFailure => callbackFailure;
 
   try {
+    const traceId = await dependencies.createTraceId(params.requestId);
+    const parentSpanContext = {
+      traceId,
+      spanId: traceId.slice(0, 16),
+      traceFlags: 1,
+    };
     await dependencies.propagateAttributes(
       {
         traceName: "chat_turn",
@@ -340,64 +429,100 @@ export const startChatTurnObservationWithDeps = async (
         metadata: buildTraceMetadata(params),
       },
       async (): Promise<void> => {
-        callbackStarted = true;
-        const rootObservation = dependencies.startObservation(
+        await dependencies.startActiveObservation(
           "chat_turn",
-          {
-            input: {
-              turnInput: await sanitizeContentPartsForTelemetry(params.turnInput),
-            },
-            metadata: buildTraceMetadata(params),
+          async (rootObservation): Promise<void> => {
+            callbackStarted = true;
+
+            try {
+              try {
+                const telemetryInput = await sanitizeContentPartsForTelemetry(params.turnInput);
+                runRootObservationTelemetryOperation(
+                  telemetryContext,
+                  "initial update",
+                  (): void => rootObservation.updateOtelSpanAttributes({
+                    input: {
+                      turnInput: telemetryInput,
+                    },
+                    metadata: buildTraceMetadata(params),
+                  }),
+                  dependencies.log,
+                );
+              } catch (error) {
+                logRootObservationTelemetryError(
+                  telemetryContext,
+                  "initial update",
+                  error,
+                  dependencies.log,
+                );
+              }
+
+              let outcome: ChatTurnObservationOutcome;
+              try {
+                outcome = await fn(rootObservation);
+              } catch (error) {
+                callbackFailure = { failed: true, error };
+                runRootObservationTelemetryOperation(
+                  telemetryContext,
+                  "error update",
+                  (): void => rootObservation.updateOtelSpanAttributes({
+                    level: "ERROR",
+                    statusMessage: error instanceof Error ? error.message : String(error),
+                    output: {
+                      result: "error",
+                      message: error instanceof Error ? error.message : String(error),
+                    },
+                  }),
+                  dependencies.log,
+                );
+                throw error;
+              }
+
+              try {
+                const telemetryOutput = await buildChatTurnTelemetryOutput(outcome);
+                runRootObservationTelemetryOperation(
+                  telemetryContext,
+                  "outcome update",
+                  (): void => rootObservation.updateOtelSpanAttributes({
+                    ...(outcome.kind === "failed"
+                      ? {
+                        level: "ERROR" as const,
+                        statusMessage: outcome.message,
+                      }
+                      : {}),
+                    output: telemetryOutput,
+                  }),
+                  dependencies.log,
+                );
+              } catch (error) {
+                logRootObservationTelemetryError(
+                  telemetryContext,
+                  "outcome update",
+                  error,
+                  dependencies.log,
+                );
+              }
+            } finally {
+              runRootObservationTelemetryOperation(
+                telemetryContext,
+                "end",
+                (): void => rootObservation.end(),
+                dependencies.log,
+              );
+            }
           },
           {
             asType: "agent",
+            endOnExit: false,
             parentSpanContext,
           },
         );
-
-        try {
-          try {
-            await fn(rootObservation);
-          } catch (error) {
-            callbackError = error;
-            runRootObservationTelemetryOperation(
-              telemetryContext,
-              "error update",
-              (): void => rootObservation.updateOtelSpanAttributes({
-                level: "ERROR",
-                statusMessage: error instanceof Error ? error.message : String(error),
-                output: {
-                  result: "error",
-                  message: error instanceof Error ? error.message : String(error),
-                },
-              }),
-              dependencies.log,
-            );
-            throw error;
-          }
-          runRootObservationTelemetryOperation(
-            telemetryContext,
-            "success update",
-            (): void => rootObservation.updateOtelSpanAttributes({
-              output: {
-                result: "success",
-              },
-            }),
-            dependencies.log,
-          );
-        } finally {
-          runRootObservationTelemetryOperation(
-            telemetryContext,
-            "end",
-            (): void => rootObservation.end(),
-            dependencies.log,
-          );
-        }
       },
     );
   } catch (error) {
-    if (callbackError !== null) {
-      throw callbackError;
+    const recordedCallbackFailure = getCallbackFailure();
+    if (recordedCallbackFailure.failed) {
+      throw recordedCallbackFailure.error;
     }
 
     if (callbackStarted) {
@@ -432,7 +557,9 @@ export const startChatTurnObservationWithDeps = async (
 
 export const startChatTurnObservation = async (
   params: ChatTraceMetadata,
-  fn: (rootObservation: LangfuseObservation | null) => Promise<void>,
+  fn: (
+    rootObservation: LangfuseObservation | null,
+  ) => Promise<ChatTurnObservationOutcome>,
 ): Promise<void> =>
   startChatTurnObservationWithDeps(
     params,
@@ -440,102 +567,119 @@ export const startChatTurnObservation = async (
     DEFAULT_START_OBSERVATION_DEPENDENCIES,
   );
 
-export const startChatTranscriptionObservationWithDeps = async <TResult>(
+export const startChatTranscriptionObservationWithDeps = async (
   params: ChatTranscriptionTraceMetadata,
-  fn: (rootObservation: LangfuseObservation | null) => Promise<TResult>,
+  fn: (rootObservation: LangfuseObservation | null) => Promise<string>,
   dependencies: StartObservationDependencies,
-): Promise<TResult> => {
-  const traceId = await dependencies.createTraceId(params.requestId);
-  const parentSpanContext = {
-    traceId,
-    spanId: traceId.slice(0, 16),
-    traceFlags: 1,
-  };
+): Promise<string> => {
   const telemetryContext: RootObservationTelemetryContext = {
     observationName: "chat transcription",
     requestId: params.requestId,
     userId: params.userId,
     workspaceId: params.workspaceId,
+    sessionId: params.sessionId,
   };
   let callbackStarted = false;
   let callbackCompleted = false;
-  let callbackError: unknown | null = null;
-  let callbackResult: TResult | undefined;
+  let callbackFailure: CallbackFailure = { failed: false };
+  let callbackResult: string | undefined;
+  const getCallbackFailure = (): CallbackFailure => callbackFailure;
 
   try {
+    const traceId = await dependencies.createTraceId(params.requestId);
+    const parentSpanContext = {
+      traceId,
+      spanId: traceId.slice(0, 16),
+      traceFlags: 1,
+    };
     await dependencies.propagateAttributes(
       {
         traceName: "chat_transcription",
         userId: params.userId,
+        ...(params.sessionId === null ? {} : { sessionId: params.sessionId }),
         tags: ["surface:chat-transcription", "runtime:backend-route", "vendor:openai"],
         metadata: buildChatTranscriptionTraceMetadata(params),
       },
-      async (): Promise<TResult> => {
-        callbackStarted = true;
-        const rootObservation = dependencies.startObservation(
+      async (): Promise<string> =>
+        await dependencies.startActiveObservation(
           "chat_transcription",
-          {
-            input: sanitizeChatTranscriptionForTelemetry(params),
-            metadata: buildChatTranscriptionTraceMetadata(params),
-          },
-          {
-            asType: "agent",
-            parentSpanContext,
-          },
-        );
-
-        try {
-          try {
-            callbackResult = await fn(rootObservation);
-            callbackCompleted = true;
-          } catch (error) {
-            callbackError = error;
+          async (rootObservation): Promise<string> => {
+            callbackStarted = true;
             runRootObservationTelemetryOperation(
               telemetryContext,
-              "error update",
+              "initial update",
               (): void => rootObservation.updateOtelSpanAttributes({
-                level: "ERROR",
-                statusMessage: error instanceof Error ? error.message : String(error),
-                output: {
-                  result: "error",
-                  message: error instanceof Error ? error.message : String(error),
-                },
+                input: sanitizeChatTranscriptionForTelemetry(params),
+                metadata: buildChatTranscriptionTraceMetadata(params),
               }),
               dependencies.log,
             );
-            throw error;
-          }
-          runRootObservationTelemetryOperation(
-            telemetryContext,
-            "success update",
-            (): void => rootObservation.updateOtelSpanAttributes({
-              output: {
-                result: "success",
-              },
-            }),
-            dependencies.log,
-          );
-          return callbackResult;
-        } finally {
-          runRootObservationTelemetryOperation(
-            telemetryContext,
-            "end",
-            (): void => rootObservation.end(),
-            dependencies.log,
-          );
-        }
-      },
+
+            try {
+              let transcription: string;
+              try {
+                transcription = await fn(rootObservation);
+                callbackResult = transcription;
+                callbackCompleted = true;
+              } catch (error) {
+                callbackFailure = { failed: true, error };
+                runRootObservationTelemetryOperation(
+                  telemetryContext,
+                  "error update",
+                  (): void => rootObservation.updateOtelSpanAttributes({
+                    level: "ERROR",
+                    statusMessage: error instanceof Error ? error.message : String(error),
+                    output: {
+                      result: "error",
+                      message: error instanceof Error ? error.message : String(error),
+                    },
+                  }),
+                  dependencies.log,
+                );
+                throw error;
+              }
+              runRootObservationTelemetryOperation(
+                telemetryContext,
+                "outcome update",
+                (): void => rootObservation.updateOtelSpanAttributes({
+                  output: {
+                    result: "success",
+                    transcription,
+                  },
+                }),
+                dependencies.log,
+              );
+              return transcription;
+            } finally {
+              runRootObservationTelemetryOperation(
+                telemetryContext,
+                "end",
+                (): void => rootObservation.end(),
+                dependencies.log,
+              );
+            }
+          },
+          {
+            asType: "agent",
+            endOnExit: false,
+            parentSpanContext,
+          },
+        ),
     );
-    if (!callbackCompleted) {
+    if (!callbackCompleted || callbackResult === undefined) {
       throw new Error("Chat transcription completed without returning a result");
     }
-    return callbackResult as TResult;
+    return callbackResult;
   } catch (error) {
-    if (callbackError !== null) {
-      throw callbackError;
+    const recordedCallbackFailure = getCallbackFailure();
+    if (recordedCallbackFailure.failed) {
+      throw recordedCallbackFailure.error;
     }
 
-    if (callbackStarted && callbackCompleted) {
+    if (callbackStarted) {
+      if (!callbackCompleted) {
+        throw error;
+      }
       dependencies.log({
         domain: "chat",
         action: "error",
@@ -544,12 +688,13 @@ export const startChatTranscriptionObservationWithDeps = async <TResult>(
         requestId: params.requestId,
         userId: params.userId,
         workspaceId: params.workspaceId,
+        ...(params.sessionId === null ? {} : { sessionId: params.sessionId }),
         error: `Langfuse telemetry failed after the chat transcription finished: ${error instanceof Error ? error.message : String(error)}`,
       });
-      if (!callbackCompleted) {
+      if (callbackResult === undefined) {
         throw new Error("Chat transcription completed without returning a result");
       }
-      return callbackResult as TResult;
+      return callbackResult;
     }
 
     dependencies.log({
@@ -560,16 +705,17 @@ export const startChatTranscriptionObservationWithDeps = async <TResult>(
       requestId: params.requestId,
       userId: params.userId,
       workspaceId: params.workspaceId,
+      ...(params.sessionId === null ? {} : { sessionId: params.sessionId }),
       error: `Langfuse telemetry failed: ${error instanceof Error ? error.message : String(error)}`,
     });
     return await fn(null);
   }
 };
 
-export const startChatTranscriptionObservation = async <TResult>(
+export const startChatTranscriptionObservation = async (
   params: ChatTranscriptionTraceMetadata,
-  fn: (rootObservation: LangfuseObservation | null) => Promise<TResult>,
-): Promise<TResult> =>
+  fn: (rootObservation: LangfuseObservation | null) => Promise<string>,
+): Promise<string> =>
   startChatTranscriptionObservationWithDeps(
     params,
     fn,

--- a/apps/web/src/server/chat/runtime/runtime.test.ts
+++ b/apps/web/src/server/chat/runtime/runtime.test.ts
@@ -10,6 +10,7 @@ import { prependSessionEvent } from "@/server/chat/http/freshSessionRoute";
 import { createChatEventStream } from "@/server/chat/http/sse";
 import { buildChatCompletionInput } from "@/server/chat/openai/responses/input";
 import type { StoredOpenAIReplayItem } from "@/server/chat/openai/responses/replayItems";
+import type { ChatTurnObservationOutcome } from "@/server/chat/openai/langfuse";
 import {
   clearActiveChatRunForTests,
   createActiveChatRunForTests,
@@ -28,7 +29,7 @@ import {
 import { ChatSessionRunTransitionError } from "@/server/chat/store";
 import { selectChatModelRouting } from "@/server/chat/modelRouting";
 import type { PersistedChatMessageItem } from "@/server/chat/store/shared";
-import type { ChatStreamEvent } from "@/server/chat/types";
+import type { ChatStreamEvent, ContentPart } from "@/server/chat/types";
 
 type ActiveRunPayload = Readonly<{ activeRunId: string }>;
 
@@ -125,6 +126,19 @@ const createDeltaEvent = (
   sequenceNumber: 0,
 });
 
+const createStartedToolCallEvent = (): Extract<ChatStreamEvent, { type: "tool_call" }> => ({
+  type: "tool_call",
+  id: "call-1",
+  itemId: "tool-item-1",
+  name: "query_database",
+  status: "started",
+  responseIndex: 0,
+  outputIndex: 0,
+  sequenceNumber: 0,
+  providerStatus: "in_progress",
+  input: "{}",
+});
+
 const createRuntimeDependencies = (
   overrides: Readonly<Partial<ChatRuntimeDependencies>>,
   recorded: {
@@ -142,7 +156,9 @@ const createRuntimeDependencies = (
   })),
   startChatTurnObservation: overrides.startChatTurnObservation ?? (async (
     _params,
-    fn: (rootObservation: LangfuseObservation | null) => Promise<void>,
+    fn: (
+      rootObservation: LangfuseObservation | null,
+    ) => Promise<ChatTurnObservationOutcome>,
   ): Promise<void> => {
     await fn(null);
   }),
@@ -272,6 +288,8 @@ test("runPersistedChatSessionWithDeps persists stopped state for user aborts wit
     terminalErrorPayload: null as unknown,
     completedPayload: null as unknown,
   };
+  const lifecycle: Array<string> = [];
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
 
   createActiveChatRunForTests(sessionId, params.activeRunId);
 
@@ -280,6 +298,19 @@ test("runPersistedChatSessionWithDeps persists stopped state for user aborts wit
       params,
       createRuntimeDependencies(
         {
+          startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+            lifecycle.push("root-start");
+            rootOutcome = await fn(null);
+            lifecycle.push("root-outcome");
+          },
+          persistAssistantCancelled: async (
+            _userId,
+            _workspaceId,
+            payload,
+          ): Promise<void> => {
+            lifecycle.push("cancel-persisted");
+            recorded.cancelledPayload = payload;
+          },
           runOpenAILoop: async (
             loopParams,
             onEvent,
@@ -310,6 +341,592 @@ test("runPersistedChatSessionWithDeps persists stopped state for user aborts wit
   assert.equal((recorded.cancelledPayload as ActiveRunPayload).activeRunId, params.activeRunId);
   assert.equal(recorded.terminalErrorPayload, null);
   assert.equal(recorded.completedPayload, null);
+  assert.deepEqual(lifecycle, ["root-start", "cancel-persisted", "root-outcome"]);
+  assert.deepEqual(rootOutcome, {
+    kind: "cancelled",
+    assistantContent: (recorded.cancelledPayload as { assistantContent: ReadonlyArray<ContentPart> })
+      .assistantContent,
+  });
+});
+
+test("runPersistedChatSessionWithDeps classifies persisted cancellation before a concurrent non-abort loop rejection", async (): Promise<void> => {
+  const params = createRunParams("session-persisted-cancellation-loop-error-race");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const loopError = new Error("Provider failed after cancellation persisted");
+  const logLines: Array<string> = [];
+  const originalLog = console.log;
+  console.log = (message?: unknown): void => {
+    if (typeof message === "string") {
+      logLines.push(message);
+    }
+  };
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+            rootOutcome = await fn(null);
+          },
+          runOpenAILoop: async (): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            assert.deepEqual(stopActiveChatRun(params.sessionId, params.activeRunId), {
+              stopped: true,
+              activeRunId: params.activeRunId,
+            });
+            markActiveChatRunCancellationPersisted(params.sessionId, params.activeRunId);
+            throw loopError;
+          },
+        },
+        recorded,
+      ),
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.equal(recorded.cancelledPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.completedPayload, null);
+  assert.deepEqual(rootOutcome, { kind: "cancelled", assistantContent: [] });
+  assert.deepEqual(logLines.map((line) => JSON.parse(line)), [
+    {
+      domain: "chat",
+      action: "run_cancelled",
+      vendor: "openai",
+      requestId: params.requestId,
+      sessionId: params.sessionId,
+      userId: params.userId,
+      workspaceId: params.workspaceId,
+    },
+    {
+      domain: "chat",
+      action: "error",
+      vendor: "openai",
+      stage: "agent",
+      error: loopError.message,
+      requestId: params.requestId,
+      userId: params.userId,
+      workspaceId: params.workspaceId,
+      sessionId: params.sessionId,
+      model: params.diagnostics.model,
+      messageCount: params.diagnostics.messageCount,
+      hasAttachments: params.diagnostics.hasAttachments,
+      attachmentFileNames: params.diagnostics.attachmentFileNames,
+      errorClass: "Error",
+    },
+  ]);
+});
+
+test("runPersistedChatSessionWithDeps retries requested cancellation after stop persistence fails and the loop rejects", async (): Promise<void> => {
+  const params = createRunParams("session-requested-cancellation-loop-error-race");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const initialStopPersistenceError = new Error("Stop route cancellation persistence failed");
+  const loopError = new Error("Provider failed after the stop request");
+  const loopStarted = createDeferred();
+  const releaseLoopRejection = createDeferred();
+  const lifecycle: Array<string> = [];
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  const runPromise = runPersistedChatSessionWithDeps(
+    params,
+    createRuntimeDependencies(
+      {
+        startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+          lifecycle.push("root-start");
+          rootOutcome = await fn(null);
+          lifecycle.push("root-outcome");
+        },
+        persistAssistantCancelled: async (
+          _userId,
+          _workspaceId,
+          payload,
+        ): Promise<void> => {
+          lifecycle.push("runtime-cancel-persisted");
+          recorded.cancelledPayload = payload;
+        },
+        runOpenAILoop: async (): Promise<Readonly<{
+          openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+        }>> => {
+          lifecycle.push("loop-started");
+          loopStarted.resolve();
+          await releaseLoopRejection.promise;
+          lifecycle.push("loop-rejected");
+          throw loopError;
+        },
+      },
+      recorded,
+    ),
+  );
+
+  try {
+    await loopStarted.promise;
+    await assert.rejects(
+      (async (): Promise<void> => {
+        try {
+          lifecycle.push("stop-route-persist-failed");
+          throw initialStopPersistenceError;
+        } finally {
+          lifecycle.push("runtime-stop-requested");
+          assert.deepEqual(stopActiveChatRun(params.sessionId, params.activeRunId), {
+            stopped: true,
+            activeRunId: params.activeRunId,
+          });
+        }
+      })(),
+      (error: unknown): boolean => error === initialStopPersistenceError,
+    );
+    releaseLoopRejection.resolve();
+    await runPromise;
+  } finally {
+    releaseLoopRejection.resolve();
+    await runPromise.catch((): void => undefined);
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.notEqual(recorded.cancelledPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.completedPayload, null);
+  assert.deepEqual(lifecycle, [
+    "root-start",
+    "loop-started",
+    "stop-route-persist-failed",
+    "runtime-stop-requested",
+    "loop-rejected",
+    "runtime-cancel-persisted",
+    "root-outcome",
+  ]);
+  assert.deepEqual(rootOutcome, {
+    kind: "cancelled",
+    assistantContent: (recorded.cancelledPayload as {
+      assistantContent: ReadonlyArray<ContentPart>;
+    }).assistantContent,
+  });
+});
+
+test("runPersistedChatSessionWithDeps stops post-event work after cancellation persistence", async (): Promise<void> => {
+  const params = createRunParams("session-event-cancellation-stop");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  let postEventWorkRan = false;
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+            rootOutcome = await fn(null);
+          },
+          runOpenAILoop: async (_loopParams, onEvent): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            assert.deepEqual(stopActiveChatRun(params.sessionId, params.activeRunId), {
+              stopped: true,
+              activeRunId: params.activeRunId,
+            });
+            await onEvent(createDeltaEvent("Must not be processed"));
+            postEventWorkRan = true;
+            return { openaiItems: [] };
+          },
+        },
+        recorded,
+      ),
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+  }
+
+  assert.equal(postEventWorkRan, false);
+  assert.equal(recorded.updatePayloads.length, 0);
+  assert.notEqual(recorded.cancelledPayload, null);
+  assert.equal(recorded.completedPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.deepEqual(rootOutcome, {
+    kind: "cancelled",
+    assistantContent: (recorded.cancelledPayload as {
+      assistantContent: ReadonlyArray<ContentPart>;
+    }).assistantContent,
+  });
+});
+
+test("runPersistedChatSessionWithDeps stops tool work when a pending event write is cancelled or replaced", async (): Promise<void> => {
+  const scenarios: ReadonlyArray<"cancelled" | "replaced"> = ["cancelled", "replaced"];
+
+  for (const scenario of scenarios) {
+    const params = createRunParams(`session-pending-tool-${scenario}`);
+    const recorded = {
+      updatePayloads: [] as Array<unknown>,
+      heartbeatPayloads: [] as Array<unknown>,
+      cancelledPayload: null as unknown,
+      terminalErrorPayload: null as unknown,
+      completedPayload: null as unknown,
+    };
+    const progressWriteStarted = createDeferred();
+    const releaseProgressWrite = createDeferred();
+    let postEventToolExecutionAttempted = false;
+    let rootOutcome: ChatTurnObservationOutcome | null = null;
+    const baseDependencies = createRuntimeDependencies({}, recorded);
+    createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+    const runPromise = runPersistedChatSessionWithDeps(
+      params,
+      createRuntimeDependencies(
+        {
+          startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+            rootOutcome = await fn(null);
+          },
+          updateAssistantMessageItem: async (
+            userId,
+            workspaceId,
+            payload,
+          ): Promise<PersistedChatMessageItem> => {
+            progressWriteStarted.resolve();
+            await releaseProgressWrite.promise;
+            return baseDependencies.updateAssistantMessageItem(userId, workspaceId, payload);
+          },
+          runOpenAILoop: async (_loopParams, onEvent): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            await onEvent(createStartedToolCallEvent());
+            postEventToolExecutionAttempted = true;
+            return { openaiItems: [] };
+          },
+        },
+        recorded,
+      ),
+    );
+
+    try {
+      await progressWriteStarted.promise;
+      assert.deepEqual(stopActiveChatRun(params.sessionId, params.activeRunId), {
+        stopped: true,
+        activeRunId: params.activeRunId,
+      });
+      if (scenario === "replaced") {
+        markActiveChatRunCancellationPersisted(params.sessionId, params.activeRunId);
+        clearActiveChatRunForTests(params.sessionId);
+        createActiveChatRunForTests(params.sessionId, `${params.activeRunId}-replacement`);
+      }
+      releaseProgressWrite.resolve();
+      await runPromise;
+    } finally {
+      releaseProgressWrite.resolve();
+      await runPromise.catch((): void => undefined);
+      clearActiveChatRunForTests(params.sessionId);
+    }
+
+    assert.equal(postEventToolExecutionAttempted, false);
+    assert.equal(recorded.updatePayloads.length, 1);
+    assert.equal(recorded.completedPayload, null);
+    assert.equal(recorded.terminalErrorPayload, null);
+    if (scenario === "cancelled") {
+      assert.notEqual(recorded.cancelledPayload, null);
+      assert.deepEqual(rootOutcome, {
+        kind: "cancelled",
+        assistantContent: (recorded.cancelledPayload as {
+          assistantContent: ReadonlyArray<ContentPart>;
+        }).assistantContent,
+      });
+    } else {
+      assert.equal(recorded.cancelledPayload, null);
+      assert.deepEqual(rootOutcome, { kind: "invalidated" });
+    }
+  }
+});
+
+test("runPersistedChatSessionWithDeps keeps persisted cancellation when an in-flight progress write loses its transition", async (): Promise<void> => {
+  const params = createRunParams("session-persisted-cancellation-progress-write-race");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const progressWriteStarted = createDeferred();
+  const releaseProgressWrite = createDeferred();
+  const lifecycle: Array<string> = [];
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  let postEventWorkRan = false;
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  const runPromise = runPersistedChatSessionWithDeps(
+    params,
+    createRuntimeDependencies(
+      {
+        startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+          lifecycle.push("root-start");
+          rootOutcome = await fn(null);
+          lifecycle.push("root-outcome");
+        },
+        updateAssistantMessageItem: async (): Promise<PersistedChatMessageItem> => {
+          lifecycle.push("progress-write-started");
+          progressWriteStarted.resolve();
+          await releaseProgressWrite.promise;
+          lifecycle.push("progress-write-transition-lost");
+          throw new ChatSessionRunTransitionError({
+            sessionId: params.sessionId,
+            activeRunId: params.activeRunId,
+            operation: "update assistant progress",
+          });
+        },
+        runOpenAILoop: async (_loopParams, onEvent): Promise<Readonly<{
+          openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+        }>> => {
+          await onEvent(createDeltaEvent("Partial answer"));
+          postEventWorkRan = true;
+          return { openaiItems: [] };
+        },
+      },
+      recorded,
+    ),
+  );
+
+  try {
+    await progressWriteStarted.promise;
+    assert.deepEqual(stopActiveChatRun(params.sessionId, params.activeRunId), {
+      stopped: true,
+      activeRunId: params.activeRunId,
+    });
+    markActiveChatRunCancellationPersisted(params.sessionId, params.activeRunId);
+    lifecycle.push("stop-route-cancelled");
+    releaseProgressWrite.resolve();
+    await runPromise;
+  } finally {
+    releaseProgressWrite.resolve();
+    await runPromise.catch((): void => undefined);
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.equal(postEventWorkRan, false);
+  assert.equal(recorded.cancelledPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.completedPayload, null);
+  assert.deepEqual(lifecycle, [
+    "root-start",
+    "progress-write-started",
+    "stop-route-cancelled",
+    "progress-write-transition-lost",
+    "root-outcome",
+  ]);
+  assert.deepEqual(rootOutcome, {
+    kind: "cancelled",
+    assistantContent: [{
+      type: "text",
+      text: "Partial answer",
+      streamPosition: {
+        itemId: "assistant-item",
+        responseIndex: 0,
+        outputIndex: 0,
+        contentIndex: 0,
+        sequenceNumber: 0,
+      },
+    }],
+  });
+});
+
+test("runPersistedChatSessionWithDeps rejects abort cancellation persistence through the active root", async (): Promise<void> => {
+  const params = createRunParams("session-abort-cancellation-store-error");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const storeError = new Error("cancellation store unavailable after abort");
+  const lifecycle: Array<string> = [];
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await assert.rejects(
+      runPersistedChatSessionWithDeps(
+        params,
+        createRuntimeDependencies(
+          {
+            startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+              lifecycle.push("root-start");
+              try {
+                await fn(null);
+              } catch (error) {
+                lifecycle.push("root-error");
+                throw error;
+              }
+            },
+            persistAssistantCancelled: async (): Promise<void> => {
+              lifecycle.push("cancel-persist");
+              throw storeError;
+            },
+            runOpenAILoop: async (): Promise<Readonly<{
+              openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+            }>> => {
+              assert.deepEqual(stopActiveChatRun(params.sessionId, params.activeRunId), {
+                stopped: true,
+                activeRunId: params.activeRunId,
+              });
+              const abortError = new Error("User aborted");
+              abortError.name = "AbortError";
+              throw abortError;
+            },
+          },
+          recorded,
+        ),
+      ),
+      (error: unknown): boolean => error === storeError,
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+  }
+
+  assert.deepEqual(lifecycle, ["root-start", "cancel-persist", "root-error"]);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.completedPayload, null);
+});
+
+test("runPersistedChatSessionWithDeps rejects event cancellation persistence through the active root", async (): Promise<void> => {
+  const params = createRunParams("session-event-cancellation-store-error");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const storeError = new Error("cancellation store unavailable during event");
+  const lifecycle: Array<string> = [];
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await assert.rejects(
+      runPersistedChatSessionWithDeps(
+        params,
+        createRuntimeDependencies(
+          {
+            startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+              lifecycle.push("root-start");
+              try {
+                await fn(null);
+              } catch (error) {
+                lifecycle.push("root-error");
+                throw error;
+              }
+            },
+            persistAssistantCancelled: async (): Promise<void> => {
+              lifecycle.push("cancel-persist");
+              throw storeError;
+            },
+            runOpenAILoop: async (_loopParams, onEvent): Promise<Readonly<{
+              openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+            }>> => {
+              assert.deepEqual(stopActiveChatRun(params.sessionId, params.activeRunId), {
+                stopped: true,
+                activeRunId: params.activeRunId,
+              });
+              await onEvent(createDeltaEvent("Ignored after cancellation"));
+              return { openaiItems: [] };
+            },
+          },
+          recorded,
+        ),
+      ),
+      (error: unknown): boolean => error === storeError,
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+  }
+
+  assert.deepEqual(lifecycle, ["root-start", "cancel-persist", "root-error"]);
+  assert.equal(recorded.updatePayloads.length, 0);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.completedPayload, null);
+});
+
+test("runPersistedChatSessionWithDeps rejects resolved-loop cancellation persistence through the active root", async (): Promise<void> => {
+  const params = createRunParams("session-resolved-cancellation-store-error");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const storeError = new Error("cancellation store unavailable after loop completion");
+  const lifecycle: Array<string> = [];
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await assert.rejects(
+      runPersistedChatSessionWithDeps(
+        params,
+        createRuntimeDependencies(
+          {
+            startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+              lifecycle.push("root-start");
+              try {
+                await fn(null);
+              } catch (error) {
+                lifecycle.push("root-error");
+                throw error;
+              }
+            },
+            persistAssistantCancelled: async (): Promise<void> => {
+              lifecycle.push("cancel-persist");
+              throw storeError;
+            },
+            runOpenAILoop: async (): Promise<Readonly<{
+              openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+            }>> => {
+              assert.deepEqual(stopActiveChatRun(params.sessionId, params.activeRunId), {
+                stopped: true,
+                activeRunId: params.activeRunId,
+              });
+              return { openaiItems: [] };
+            },
+          },
+          recorded,
+        ),
+      ),
+      (error: unknown): boolean => error === storeError,
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+  }
+
+  assert.deepEqual(lifecycle, ["root-start", "cancel-persist", "root-error"]);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.completedPayload, null);
 });
 
 test("runPersistedChatSessionWithDeps persists terminal errors when the provider loop rejects", async (): Promise<void> => {
@@ -321,13 +938,27 @@ test("runPersistedChatSessionWithDeps persists terminal errors when the provider
     terminalErrorPayload: null as unknown,
     completedPayload: null as unknown,
   };
-
+  const lifecycle: Array<string> = [];
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
   createActiveChatRunForTests(params.sessionId, params.activeRunId);
   try {
     await runPersistedChatSessionWithDeps(
       params,
       createRuntimeDependencies(
         {
+          startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+            lifecycle.push("root-start");
+            rootOutcome = await fn(null);
+            lifecycle.push("root-outcome");
+          },
+          persistAssistantTerminalError: async (
+            _userId,
+            _workspaceId,
+            payload,
+          ): Promise<void> => {
+            lifecycle.push("terminal-persisted");
+            recorded.terminalErrorPayload = payload;
+          },
           runOpenAILoop: async (
             _loopParams,
             onEvent,
@@ -352,6 +983,157 @@ test("runPersistedChatSessionWithDeps persists terminal errors when the provider
   assert.notEqual(recorded.terminalErrorPayload, null);
   assert.equal((recorded.terminalErrorPayload as ActiveRunPayload).activeRunId, params.activeRunId);
   assert.equal(recorded.completedPayload, null);
+  assert.deepEqual(lifecycle, ["root-start", "terminal-persisted", "root-outcome"]);
+  assert.deepEqual(rootOutcome, {
+    kind: "failed",
+    assistantContent: (recorded.terminalErrorPayload as {
+      assistantContent: ReadonlyArray<ContentPart>;
+    }).assistantContent,
+    message: (recorded.terminalErrorPayload as { errorMessage: string }).errorMessage,
+  });
+});
+
+test("runPersistedChatSessionWithDeps retries requested cancellation after terminal failure persistence", async (): Promise<void> => {
+  const params = createRunParams("session-terminal-failure-cancellation-race");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const terminalPersistenceStarted = createDeferred();
+  const releaseTerminalPersistence = createDeferred();
+  const lifecycle: Array<string> = [];
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  const runPromise = runPersistedChatSessionWithDeps(
+    params,
+    createRuntimeDependencies(
+      {
+        startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+          lifecycle.push("root-start");
+          rootOutcome = await fn(null);
+          lifecycle.push("root-outcome");
+        },
+        persistAssistantTerminalError: async (
+          _userId,
+          _workspaceId,
+          payload,
+        ): Promise<void> => {
+          lifecycle.push("terminal-persistence-started");
+          terminalPersistenceStarted.resolve();
+          await releaseTerminalPersistence.promise;
+          recorded.terminalErrorPayload = payload;
+          lifecycle.push("terminal-persisted");
+        },
+        persistAssistantCancelled: async (
+          _userId,
+          _workspaceId,
+          payload,
+        ): Promise<void> => {
+          recorded.cancelledPayload = payload;
+          lifecycle.push("cancellation-persisted");
+        },
+        runOpenAILoop: async (): Promise<Readonly<{
+          openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+        }>> => {
+          throw new Error("Provider stream failed");
+        },
+      },
+      recorded,
+    ),
+  );
+
+  try {
+    await terminalPersistenceStarted.promise;
+    assert.deepEqual(stopActiveChatRun(params.sessionId, params.activeRunId), {
+      stopped: true,
+      activeRunId: params.activeRunId,
+    });
+    lifecycle.push("stop-requested");
+    releaseTerminalPersistence.resolve();
+    await runPromise;
+  } finally {
+    releaseTerminalPersistence.resolve();
+    await runPromise.catch((): void => undefined);
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.notEqual(recorded.terminalErrorPayload, null);
+  assert.notEqual(recorded.cancelledPayload, null);
+  assert.equal(recorded.completedPayload, null);
+  assert.deepEqual(lifecycle, [
+    "root-start",
+    "terminal-persistence-started",
+    "stop-requested",
+    "terminal-persisted",
+    "cancellation-persisted",
+    "root-outcome",
+  ]);
+  assert.deepEqual(rootOutcome, {
+    kind: "cancelled",
+    assistantContent: (recorded.cancelledPayload as {
+      assistantContent: ReadonlyArray<ContentPart>;
+    }).assistantContent,
+  });
+});
+
+test("runPersistedChatSessionWithDeps rejects terminal failure persistence through the active root", async (): Promise<void> => {
+  const params = createRunParams("session-terminal-store-error");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const storeError = new Error("terminal error store unavailable");
+  const lifecycle: Array<string> = [];
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await assert.rejects(
+      runPersistedChatSessionWithDeps(
+        params,
+        createRuntimeDependencies(
+          {
+            startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+              lifecycle.push("root-start");
+              try {
+                await fn(null);
+              } catch (error) {
+                lifecycle.push("root-error");
+                throw error;
+              }
+            },
+            persistAssistantTerminalError: async (): Promise<void> => {
+              lifecycle.push("terminal-persist");
+              throw storeError;
+            },
+            runOpenAILoop: async (): Promise<Readonly<{
+              openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+            }>> => {
+              throw new Error("Provider stream failed");
+            },
+          },
+          recorded,
+        ),
+      ),
+      (error: unknown): boolean => error === storeError,
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+  }
+
+  assert.deepEqual(lifecycle, ["root-start", "terminal-persist", "root-error"]);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.completedPayload, null);
+  assert.equal(recorded.cancelledPayload, null);
 });
 
 test("startPersistedChatRunWithDeps persists and streams recovery for poisoned HEIC history", async (): Promise<void> => {
@@ -434,6 +1216,7 @@ test("runPersistedChatSessionWithDeps skips terminal error persistence when prov
     terminalErrorPayload: null as unknown,
     completedPayload: null as unknown,
   };
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
   const originalLog = console.log;
   console.log = (): void => undefined;
   createActiveChatRunForTests(params.sessionId, params.activeRunId);
@@ -443,6 +1226,9 @@ test("runPersistedChatSessionWithDeps skips terminal error persistence when prov
       params,
       createRuntimeDependencies(
         {
+          startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+            rootOutcome = await fn(null);
+          },
           runOpenAILoop: async (): Promise<Readonly<{
             openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
           }>> => {
@@ -468,6 +1254,7 @@ test("runPersistedChatSessionWithDeps skips terminal error persistence when prov
   assert.equal(recorded.terminalErrorPayload, null);
   assert.equal(recorded.completedPayload, null);
   assert.equal(recorded.cancelledPayload, null);
+  assert.deepEqual(rootOutcome, { kind: "invalidated" });
 });
 
 test("runPersistedChatSessionWithDeps skips cancellation persistence when user abort lost the active-run race", async (): Promise<void> => {
@@ -480,6 +1267,7 @@ test("runPersistedChatSessionWithDeps skips cancellation persistence when user a
     terminalErrorPayload: null as unknown,
     completedPayload: null as unknown,
   };
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
   const originalLog = console.log;
   console.log = (): void => undefined;
   createActiveChatRunForTests(sessionId, params.activeRunId);
@@ -489,6 +1277,9 @@ test("runPersistedChatSessionWithDeps skips cancellation persistence when user a
       params,
       createRuntimeDependencies(
         {
+          startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+            rootOutcome = await fn(null);
+          },
           runOpenAILoop: async (
             _loopParams,
             _onEvent,
@@ -523,6 +1314,7 @@ test("runPersistedChatSessionWithDeps skips cancellation persistence when user a
   assert.equal(recorded.cancelledPayload, null);
   assert.equal(recorded.terminalErrorPayload, null);
   assert.equal(recorded.completedPayload, null);
+  assert.deepEqual(rootOutcome, { kind: "invalidated" });
 });
 
 test("hasActiveChatRun matches the stored active run id", (): void => {
@@ -680,6 +1472,194 @@ test("cancelling the session-prefixed SSE stream unsubscribes a pending read wit
     await reader.cancel().catch((): void => undefined);
     clearActiveChatRunForTests(sessionId);
   }
+});
+
+test("startPersistedChatRunWithDeps emits done only after completion persistence", async (): Promise<void> => {
+  const params = createRunParams("session-deferred-completion");
+  const completionStarted = createDeferred();
+  const releaseCompletion = createDeferred();
+  const backendRunFinished = createDeferred();
+  const finalDelta = createDeltaEvent("Final answer");
+  const lifecycle: Array<string> = [];
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const events = startPersistedChatRunWithDeps(
+    params,
+    requireReservation(params.sessionId, params.activeRunId),
+    createRuntimeDependencies(
+      {
+        runOpenAILoop: async (_loopParams, onEvent): Promise<Readonly<{
+          openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+        }>> => {
+          await onEvent(finalDelta);
+          await onEvent({ type: "done" });
+          lifecycle.push("loop-done-returned");
+          return { openaiItems: [] };
+        },
+        completeChatRun: async (_userId, _workspaceId, payload): Promise<void> => {
+          lifecycle.push("complete-started");
+          completionStarted.resolve();
+          await releaseCompletion.promise;
+          recorded.completedPayload = payload;
+          lifecycle.push("complete-persisted");
+        },
+        endTaskProtection: async (): Promise<void> => {
+          backendRunFinished.resolve();
+        },
+      },
+      recorded,
+    ),
+  );
+
+  try {
+    assert.deepEqual(await events.next(), {
+      done: false,
+      value: finalDelta,
+    });
+    const pendingDoneEvent = events.next();
+    await completionStarted.promise;
+    assert.equal(await resolvesWithin(pendingDoneEvent, 20), false);
+    assert.equal(recorded.completedPayload, null);
+
+    releaseCompletion.resolve();
+    assert.deepEqual(await pendingDoneEvent, {
+      done: false,
+      value: { type: "done" },
+    });
+    assert.deepEqual(lifecycle, [
+      "loop-done-returned",
+      "complete-started",
+      "complete-persisted",
+    ]);
+    assert.notEqual(recorded.completedPayload, null);
+    assert.deepEqual(await events.next(), { done: true, value: undefined });
+    await backendRunFinished.promise;
+  } finally {
+    releaseCompletion.resolve();
+    await events.return(undefined).catch((): void => undefined);
+    clearActiveChatRunForTests(params.sessionId);
+  }
+});
+
+test("startPersistedChatRunWithDeps logs rejected background persistence", async (): Promise<void> => {
+  const params = createRunParams("session-background-persistence-error");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const storeError = new Error("background completion store unavailable");
+  const logLines: Array<string> = [];
+  const originalLog = console.log;
+  console.log = (message?: unknown): void => {
+    if (typeof message === "string") {
+      logLines.push(message);
+    }
+  };
+
+  try {
+    const events = startPersistedChatRunWithDeps(
+      params,
+      requireReservation(params.sessionId, params.activeRunId),
+      createRuntimeDependencies(
+        {
+          runOpenAILoop: async (_loopParams, onEvent): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            await onEvent({ type: "done" });
+            return { openaiItems: [] };
+          },
+          completeChatRun: async (): Promise<void> => {
+            throw storeError;
+          },
+        },
+        recorded,
+      ),
+    );
+
+    assert.deepEqual(await events.next(), { done: true, value: undefined });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.equal(recorded.completedPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.cancelledPayload, null);
+  assert.deepEqual(logLines.map((line) => JSON.parse(line)), [{
+    domain: "chat",
+    action: "error",
+    vendor: "openai",
+    stage: "agent",
+    error: storeError.message,
+    requestId: params.requestId,
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    sessionId: params.sessionId,
+    model: params.diagnostics.model,
+    messageCount: params.diagnostics.messageCount,
+    hasAttachments: params.diagnostics.hasAttachments,
+    attachmentFileNames: params.diagnostics.attachmentFileNames,
+    errorClass: "Error",
+  }]);
+});
+
+test("startPersistedChatRunWithDeps suppresses done when completion loses its transition", async (): Promise<void> => {
+  const params = createRunParams("session-completion-transition-loss");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+
+  try {
+    const events = startPersistedChatRunWithDeps(
+      params,
+      requireReservation(params.sessionId, params.activeRunId),
+      createRuntimeDependencies(
+        {
+          runOpenAILoop: async (_loopParams, onEvent): Promise<Readonly<{
+            openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
+          }>> => {
+            await onEvent({ type: "done" });
+            return { openaiItems: [] };
+          },
+          completeChatRun: async (): Promise<void> => {
+            throw new ChatSessionRunTransitionError({
+              sessionId: params.sessionId,
+              activeRunId: params.activeRunId,
+              operation: "complete chat run",
+              targetState: "idle",
+            });
+          },
+        },
+        recorded,
+      ),
+    );
+
+    assert.deepEqual(await events.next(), { done: true, value: undefined });
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.equal(recorded.completedPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.cancelledPayload, null);
 });
 
 test("separate session ids keep independent active backend runs", (): void => {
@@ -852,6 +1832,7 @@ test("late done from a replaced run does not close the newer stream", async (): 
   const oldLoopStarted = createDeferred();
   const oldEmitDone = createDeferred();
   const newRelease = createDeferred();
+  let oldPostEventWorkRan = false;
   const oldRecorded = {
     updatePayloads: [] as Array<unknown>,
     heartbeatPayloads: [] as Array<unknown>,
@@ -883,6 +1864,7 @@ test("late done from a replaced run does not close the newer stream", async (): 
             oldLoopStarted.resolve();
             await oldEmitDone.promise;
             await onEvent({ type: "done" });
+            oldPostEventWorkRan = true;
             return { openaiItems: [] };
           },
         },
@@ -920,6 +1902,7 @@ test("late done from a replaced run does not close the newer stream", async (): 
     const nextEvent = newEvents.next();
     oldEmitDone.resolve();
     await oldRun;
+    assert.equal(oldPostEventWorkRan, false);
     assert.equal(oldRecorded.completedPayload, null);
     assert.equal(oldRecorded.terminalErrorPayload, null);
 
@@ -943,8 +1926,15 @@ test("late done from a replaced run does not close the newer stream", async (): 
   }
 });
 
-test("runPersistedChatSessionWithDeps passes the same active run id to heartbeat and completion", async (): Promise<void> => {
+test("runPersistedChatSessionWithDeps persists finalized output before resolving the root observation", async (): Promise<void> => {
   const params = createRunParams("session-success");
+  const replayItems: ReadonlyArray<StoredOpenAIReplayItem> = [{
+    type: "function_call",
+    call_id: "call-1",
+    name: "query_database",
+    arguments: "{}",
+    status: "completed",
+  }];
   const recorded = {
     updatePayloads: [] as Array<unknown>,
     heartbeatPayloads: [] as Array<unknown>,
@@ -952,6 +1942,8 @@ test("runPersistedChatSessionWithDeps passes the same active run id to heartbeat
     terminalErrorPayload: null as unknown,
     completedPayload: null as unknown,
   };
+  const lifecycle: Array<string> = [];
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
 
   createActiveChatRunForTests(params.sessionId, params.activeRunId);
   try {
@@ -959,6 +1951,15 @@ test("runPersistedChatSessionWithDeps passes the same active run id to heartbeat
       params,
       createRuntimeDependencies(
         {
+          startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+            lifecycle.push("root-start");
+            rootOutcome = await fn(null);
+            lifecycle.push("root-outcome");
+          },
+          completeChatRun: async (_userId, _workspaceId, payload): Promise<void> => {
+            lifecycle.push("complete");
+            recorded.completedPayload = payload;
+          },
           runOpenAILoop: async (
             _loopParams,
             onEvent,
@@ -966,7 +1967,7 @@ test("runPersistedChatSessionWithDeps passes the same active run id to heartbeat
             openaiItems: ReadonlyArray<StoredOpenAIReplayItem>;
           }>> => {
             await onEvent(createDeltaEvent("Done"));
-            return { openaiItems: [] };
+            return { openaiItems: replayItems };
           },
         },
         recorded,
@@ -988,6 +1989,19 @@ test("runPersistedChatSessionWithDeps passes the same active run id to heartbeat
   assert.notEqual(recorded.completedPayload, null);
   assert.equal((recorded.completedPayload as ActiveRunPayload).activeRunId, params.activeRunId);
   assert.equal((recorded.completedPayload as { sessionId: string }).sessionId, params.sessionId);
+  assert.deepEqual(
+    (recorded.completedPayload as {
+      assistantOpenAIItems: ReadonlyArray<StoredOpenAIReplayItem>;
+    }).assistantOpenAIItems,
+    replayItems,
+  );
+  assert.deepEqual(lifecycle, ["root-start", "complete", "root-outcome"]);
+  assert.deepEqual(rootOutcome, {
+    kind: "completed",
+    assistantContent: (recorded.completedPayload as {
+      assistantContent: ReadonlyArray<ContentPart>;
+    }).assistantContent,
+  });
   assert.equal(recorded.cancelledPayload, null);
   assert.equal(recorded.terminalErrorPayload, null);
 });
@@ -1106,6 +2120,8 @@ test("runPersistedChatSessionWithDeps skips terminal error persistence when comp
     terminalErrorPayload: null as unknown,
     completedPayload: null as unknown,
   };
+  const lifecycle: Array<string> = [];
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
   const originalLog = console.log;
   console.log = (): void => undefined;
   createActiveChatRunForTests(params.sessionId, params.activeRunId);
@@ -1115,7 +2131,13 @@ test("runPersistedChatSessionWithDeps skips terminal error persistence when comp
       params,
       createRuntimeDependencies(
         {
+          startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+            lifecycle.push("root-start");
+            rootOutcome = await fn(null);
+            lifecycle.push("root-outcome");
+          },
           completeChatRun: async (): Promise<void> => {
+            lifecycle.push("complete");
             throw new ChatSessionRunTransitionError({
               sessionId: params.sessionId,
               activeRunId: params.activeRunId,
@@ -1132,6 +2154,136 @@ test("runPersistedChatSessionWithDeps skips terminal error persistence when comp
     console.log = originalLog;
   }
 
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.equal(recorded.cancelledPayload, null);
+  assert.deepEqual(lifecycle, ["root-start", "complete", "root-outcome"]);
+  assert.deepEqual(rootOutcome, { kind: "invalidated" });
+});
+
+test("runPersistedChatSessionWithDeps keeps persisted cancellation when completion loses its transition", async (): Promise<void> => {
+  const params = createRunParams("session-completion-persisted-cancellation-race");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const completionPersistenceStarted = createDeferred();
+  const releaseCompletionPersistence = createDeferred();
+  const lifecycle: Array<string> = [];
+  const originalLog = console.log;
+  console.log = (): void => undefined;
+  let rootOutcome: ChatTurnObservationOutcome | null = null;
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  const runPromise = runPersistedChatSessionWithDeps(
+    params,
+    createRuntimeDependencies(
+      {
+        startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+          lifecycle.push("root-start");
+          rootOutcome = await fn(null);
+          lifecycle.push("root-outcome");
+        },
+        completeChatRun: async (): Promise<void> => {
+          lifecycle.push("completion-persistence-started");
+          completionPersistenceStarted.resolve();
+          await releaseCompletionPersistence.promise;
+          lifecycle.push("completion-transition-lost");
+          throw new ChatSessionRunTransitionError({
+            sessionId: params.sessionId,
+            activeRunId: params.activeRunId,
+            operation: "complete chat run",
+            targetState: "idle",
+          });
+        },
+      },
+      recorded,
+    ),
+  );
+
+  try {
+    await completionPersistenceStarted.promise;
+    assert.deepEqual(stopActiveChatRun(params.sessionId, params.activeRunId), {
+      stopped: true,
+      activeRunId: params.activeRunId,
+    });
+    markActiveChatRunCancellationPersisted(params.sessionId, params.activeRunId);
+    lifecycle.push("stop-route-cancelled");
+    releaseCompletionPersistence.resolve();
+    await runPromise;
+  } finally {
+    releaseCompletionPersistence.resolve();
+    await runPromise.catch((): void => undefined);
+    clearActiveChatRunForTests(params.sessionId);
+    console.log = originalLog;
+  }
+
+  assert.equal(recorded.completedPayload, null);
+  assert.equal(recorded.cancelledPayload, null);
+  assert.equal(recorded.terminalErrorPayload, null);
+  assert.deepEqual(lifecycle, [
+    "root-start",
+    "completion-persistence-started",
+    "stop-route-cancelled",
+    "completion-transition-lost",
+    "root-outcome",
+  ]);
+  assert.deepEqual(rootOutcome, {
+    kind: "cancelled",
+    assistantContent: [],
+  });
+});
+
+test("runPersistedChatSessionWithDeps rejects completion persistence through the active root", async (): Promise<void> => {
+  const params = createRunParams("session-completion-store-error");
+  const recorded = {
+    updatePayloads: [] as Array<unknown>,
+    heartbeatPayloads: [] as Array<unknown>,
+    cancelledPayload: null as unknown,
+    terminalErrorPayload: null as unknown,
+    completedPayload: null as unknown,
+  };
+  const storeError = new Error("completion store unavailable");
+  const lifecycle: Array<string> = [];
+  createActiveChatRunForTests(params.sessionId, params.activeRunId);
+
+  try {
+    await assert.rejects(
+      runPersistedChatSessionWithDeps(
+        params,
+        createRuntimeDependencies(
+          {
+            startChatTurnObservation: async (_observationParams, fn): Promise<void> => {
+              lifecycle.push("root-start");
+              try {
+                await fn(null);
+              } catch (error) {
+                lifecycle.push("root-error");
+                throw error;
+              }
+            },
+            completeChatRun: async (): Promise<void> => {
+              lifecycle.push("complete");
+              throw storeError;
+            },
+            persistAssistantTerminalError: async (): Promise<void> => {
+              lifecycle.push("terminalize");
+              throw new Error("must not terminalize a completion persistence failure");
+            },
+          },
+          recorded,
+        ),
+      ),
+      (error: unknown): boolean => error === storeError,
+    );
+  } finally {
+    clearActiveChatRunForTests(params.sessionId);
+  }
+
+  assert.deepEqual(lifecycle, ["root-start", "complete", "root-error"]);
+  assert.equal(recorded.completedPayload, null);
   assert.equal(recorded.terminalErrorPayload, null);
   assert.equal(recorded.cancelledPayload, null);
 });

--- a/apps/web/src/server/chat/runtime/runtime.ts
+++ b/apps/web/src/server/chat/runtime/runtime.ts
@@ -14,7 +14,10 @@ import type {
 import { UnsupportedStoredChatAttachmentError } from "@/server/chat/openai/responses/input";
 import { runOpenAILoop } from "@/server/chat/openai/loop";
 import { isOpenAITransientError } from "@/server/chat/logging";
-import { startChatTurnObservation } from "@/server/chat/openai/langfuse";
+import {
+  startChatTurnObservation,
+  type ChatTurnObservationOutcome,
+} from "@/server/chat/openai/langfuse";
 import {
   buildUserStoppedAssistantContent,
   ChatSessionRunTransitionError,
@@ -43,6 +46,7 @@ import { log, type ChatErrorStage } from "@/server/logger";
 export const CHAT_RUN_HEARTBEAT_INTERVAL_MS = 5_000;
 export const CHAT_RUN_STALE_HEARTBEAT_MS = 30_000;
 const INCOMPLETE_TOOL_CALL_PROVIDER_STATUS = "incomplete";
+const CHAT_RUN_LOOP_STOP_SIGNAL = Symbol("chat_run_loop_stop");
 
 type ChatRunDiagnostics = Readonly<{
   requestId: string;
@@ -54,6 +58,21 @@ type ChatRunDiagnostics = Readonly<{
   hasAttachments: boolean;
   attachmentFileNames: ReadonlyArray<string>;
 }>;
+
+type ChatInvalidatedObservationOutcome = Extract<
+  ChatTurnObservationOutcome,
+  { kind: "invalidated" }
+>;
+
+type ChatCancellationObservationOutcome = Extract<
+  ChatTurnObservationOutcome,
+  { kind: "cancelled" | "invalidated" }
+>;
+
+type ChatFailureObservationOutcome = Extract<
+  ChatTurnObservationOutcome,
+  { kind: "failed" | "invalidated" }
+>;
 
 export type StartPersistedChatRunParams = Readonly<{
   requestId: string;
@@ -546,8 +565,15 @@ export const runPersistedChatSessionWithDeps = async (
 ): Promise<void> => {
   let assistantContent: ReadonlyArray<ContentPart> = [];
   let assistantOpenAIItems: ReadonlyArray<StoredOpenAIReplayItem> | undefined;
-  let isFinalized = false;
+  let pendingObservationOutcome: ChatTurnObservationOutcome | null = null;
+  let pendingCancellationOutcome: ChatCancellationObservationOutcome | null = null;
+  let activeRootPersistenceError: unknown | null = null;
+  let activeRootPersistenceFailed = false;
+  let cancellationLogged = false;
+  let doneEventPending = false;
   const seenInvalidationVersions = new Map<string, number>();
+  const getPendingObservationOutcome = (): ChatTurnObservationOutcome | null =>
+    pendingObservationOutcome;
   const heartbeatTimer = setInterval(() => {
     void dependencies.touchChatSessionHeartbeat(
       params.userId,
@@ -559,31 +585,125 @@ export const runPersistedChatSessionWithDeps = async (
     });
   }, CHAT_RUN_HEARTBEAT_INTERVAL_MS);
 
-  const persistUserCancellationIfNeeded = async (): Promise<boolean> => {
+  const classifyPersistenceFailure = (
+    error: unknown,
+  ): ChatInvalidatedObservationOutcome => {
+    if (error instanceof ChatSessionRunTransitionError) {
+      logRunTransitionSkipped(error, params);
+      return { kind: "invalidated" };
+    }
+
+    activeRootPersistenceFailed = true;
+    activeRootPersistenceError = error;
+    throw error;
+  };
+
+  const stopOpenAILoop = (outcome: ChatTurnObservationOutcome): never => {
+    pendingObservationOutcome = outcome;
+    throw CHAT_RUN_LOOP_STOP_SIGNAL;
+  };
+
+  const logUserCancellation = (): void => {
+    if (cancellationLogged) {
+      return;
+    }
+
+    cancellationLogged = true;
+    log({
+      domain: "chat",
+      action: "run_cancelled",
+      vendor: "openai",
+      requestId: params.requestId,
+      sessionId: params.sessionId,
+      userId: params.userId,
+      workspaceId: params.workspaceId,
+    });
+  };
+
+  const persistUserCancellationIfNeeded = async (): Promise<
+    ChatCancellationObservationOutcome | null
+  > => {
     const activeRun = getActiveChatRun(params.sessionId);
     if (
       activeRun === undefined
       || activeRun.activeRunId !== params.activeRunId
       || activeRun.stopRequestedByUser !== true
     ) {
-      return false;
+      return null;
     }
-
-    if (activeRun.cancellationState === "persisted") {
-      isFinalized = true;
-      return true;
+    if (pendingCancellationOutcome?.kind === "invalidated") {
+      return pendingCancellationOutcome;
     }
 
     assistantContent = buildUserStoppedAssistantContent(assistantContent);
-    await dependencies.persistAssistantCancelled(params.userId, params.workspaceId, {
-      sessionId: params.sessionId,
-      activeRunId: params.activeRunId,
-      assistantItemId: params.assistantItemId,
-      assistantContent,
-    });
+    if (activeRun.cancellationState === "persisted") {
+      logUserCancellation();
+      pendingCancellationOutcome = {
+        kind: "cancelled",
+        assistantContent,
+      };
+      return pendingCancellationOutcome;
+    }
+
+    try {
+      await dependencies.persistAssistantCancelled(params.userId, params.workspaceId, {
+        sessionId: params.sessionId,
+        activeRunId: params.activeRunId,
+        assistantItemId: params.assistantItemId,
+        assistantContent,
+      });
+    } catch (error) {
+      pendingCancellationOutcome = classifyPersistenceFailure(error);
+      return pendingCancellationOutcome;
+    }
     activeRun.cancellationState = "persisted";
-    isFinalized = true;
-    return true;
+    logUserCancellation();
+    pendingCancellationOutcome = {
+      kind: "cancelled",
+      assistantContent,
+    };
+    return pendingCancellationOutcome;
+  };
+
+  const stopOpenAILoopIfInterrupted = (
+    cancellationOutcome: ChatCancellationObservationOutcome | null,
+  ): void => {
+    const existingObservationOutcome = getPendingObservationOutcome();
+    if (existingObservationOutcome !== null) {
+      stopOpenAILoop(existingObservationOutcome);
+    }
+
+    if (cancellationOutcome !== null) {
+      stopOpenAILoop(cancellationOutcome);
+    }
+
+    if (!isCurrentActiveChatRun(params.sessionId, params.activeRunId)) {
+      stopOpenAILoop({ kind: "invalidated" });
+    }
+  };
+
+  const persistTerminalFailure = async (
+    errorMessage: string,
+  ): Promise<ChatFailureObservationOutcome> => {
+    assistantContent = finalizeAssistantToolCalls(assistantContent);
+    try {
+      await dependencies.persistAssistantTerminalError(params.userId, params.workspaceId, {
+        sessionId: params.sessionId,
+        activeRunId: params.activeRunId,
+        assistantItemId: params.assistantItemId,
+        assistantContent,
+        errorMessage,
+        sessionState: "idle",
+      });
+    } catch (error) {
+      return classifyPersistenceFailure(error);
+    }
+
+    return {
+      kind: "failed",
+      assistantContent,
+      message: errorMessage,
+    };
   };
 
   try {
@@ -619,27 +739,38 @@ export const runPersistedChatSessionWithDeps = async (
         runState: "running",
         turnInput: params.turnInput,
       },
-      async (rootObservation): Promise<void> => {
+      async (rootObservation): Promise<ChatTurnObservationOutcome> => {
         const handleOpenAILoopEvent = async (event: ChatStreamEvent): Promise<void> => {
-          if (await persistUserCancellationIfNeeded()) {
-            return;
+          const existingObservationOutcome = getPendingObservationOutcome();
+          if (existingObservationOutcome !== null) {
+            stopOpenAILoop(existingObservationOutcome);
           }
 
-          if (!isCurrentActiveChatRun(params.sessionId, params.activeRunId)) {
+          const initialCancellationOutcome = await persistUserCancellationIfNeeded();
+          stopOpenAILoopIfInterrupted(initialCancellationOutcome);
+
+          if (event.type === "done") {
+            doneEventPending = true;
             return;
           }
 
           if (event.type === "delta") {
             assistantContent = applyAssistantDelta(assistantContent, event);
-            await updateAssistantInProgress(
-              dependencies,
-              params.userId,
-              params.workspaceId,
-              params.sessionId,
-              params.activeRunId,
-              params.assistantItemId,
-              assistantContent,
-            );
+            try {
+              await updateAssistantInProgress(
+                dependencies,
+                params.userId,
+                params.workspaceId,
+                params.sessionId,
+                params.activeRunId,
+                params.assistantItemId,
+                assistantContent,
+              );
+            } catch (error) {
+              stopOpenAILoop(classifyPersistenceFailure(error));
+            }
+            const postPersistenceCancellationOutcome = await persistUserCancellationIfNeeded();
+            stopOpenAILoopIfInterrupted(postPersistenceCancellationOutcome);
           } else if (event.type === "tool_call") {
             assistantContent = upsertToolCallContent(assistantContent, createToolCallContentPart(event));
             const eventToBroadcast = await persistToolCallProgress(
@@ -652,7 +783,11 @@ export const runPersistedChatSessionWithDeps = async (
               assistantContent,
               event,
               seenInvalidationVersions,
+            ).catch((error: unknown): never =>
+              stopOpenAILoop(classifyPersistenceFailure(error)),
             );
+            const postPersistenceCancellationOutcome = await persistUserCancellationIfNeeded();
+            stopOpenAILoopIfInterrupted(postPersistenceCancellationOutcome);
             broadcastChatEvent(params.sessionId, params.activeRunId, eventToBroadcast);
             return;
           } else if (event.type === "reasoning_summary") {
@@ -660,101 +795,179 @@ export const runPersistedChatSessionWithDeps = async (
               assistantContent,
               createReasoningSummaryContentPart(event),
             );
-            await updateAssistantInProgress(
-              dependencies,
-              params.userId,
-              params.workspaceId,
-              params.sessionId,
-              params.activeRunId,
-              params.assistantItemId,
-              assistantContent,
-            );
+            try {
+              await updateAssistantInProgress(
+                dependencies,
+                params.userId,
+                params.workspaceId,
+                params.sessionId,
+                params.activeRunId,
+                params.assistantItemId,
+                assistantContent,
+              );
+            } catch (error) {
+              stopOpenAILoop(classifyPersistenceFailure(error));
+            }
+            const postPersistenceCancellationOutcome = await persistUserCancellationIfNeeded();
+            stopOpenAILoopIfInterrupted(postPersistenceCancellationOutcome);
           } else if (event.type === "error") {
-            assistantContent = finalizeAssistantToolCalls(assistantContent);
-            await dependencies.persistAssistantTerminalError(params.userId, params.workspaceId, {
-              sessionId: params.sessionId,
-              activeRunId: params.activeRunId,
-              assistantItemId: params.assistantItemId,
-              assistantContent,
-              errorMessage: event.message,
-              sessionState: "idle",
-            });
-            isFinalized = true;
+            const failureOutcome = await persistTerminalFailure(event.message);
+            const cancellationOutcome = await persistUserCancellationIfNeeded();
+            if (cancellationOutcome !== null) {
+              stopOpenAILoop(cancellationOutcome);
+            }
+            if (
+              failureOutcome.kind === "invalidated"
+              || !isCurrentActiveChatRun(params.sessionId, params.activeRunId)
+            ) {
+              stopOpenAILoop(failureOutcome);
+            }
+            broadcastChatEvent(params.sessionId, params.activeRunId, event);
+            stopOpenAILoop(failureOutcome);
           }
 
           broadcastChatEvent(params.sessionId, params.activeRunId, event);
         };
 
-        const completion = await dependencies.runOpenAILoop({
-          requestId: params.requestId,
-          userId: params.userId,
-          workspaceId: params.workspaceId,
-          sessionId: params.sessionId,
-          turnId: params.activeRunId,
-          locale: params.locale,
-          timezone: params.timezone,
-          localMessages: params.localMessages,
-          turnInput: params.turnInput,
-          model: params.modelRouting.effectiveModel,
-          reasoningEffort: params.modelRouting.effectiveReasoningEffort,
-          rootObservation,
-          signal: getCurrentActiveChatRun(params.sessionId, params.activeRunId)?.abortController.signal,
-        }, handleOpenAILoopEvent);
+        let completion: Awaited<ReturnType<ChatRuntimeDependencies["runOpenAILoop"]>>;
+        try {
+          completion = await dependencies.runOpenAILoop({
+            requestId: params.requestId,
+            userId: params.userId,
+            workspaceId: params.workspaceId,
+            sessionId: params.sessionId,
+            turnId: params.activeRunId,
+            locale: params.locale,
+            timezone: params.timezone,
+            localMessages: params.localMessages,
+            turnInput: params.turnInput,
+            model: params.modelRouting.effectiveModel,
+            reasoningEffort: params.modelRouting.effectiveReasoningEffort,
+            rootObservation,
+            signal: getCurrentActiveChatRun(params.sessionId, params.activeRunId)?.abortController.signal,
+          }, handleOpenAILoopEvent);
+        } catch (error) {
+          if (activeRootPersistenceFailed && error === activeRootPersistenceError) {
+            throw error;
+          }
 
-        if (await persistUserCancellationIfNeeded()) {
-          return;
+          const activeRun = getActiveChatRun(params.sessionId);
+          const stoppedByUser = activeRun?.activeRunId === params.activeRunId
+            && activeRun.stopRequestedByUser === true;
+
+          if (stoppedByUser) {
+            const cancellationOutcome = await persistUserCancellationIfNeeded();
+            if (error !== CHAT_RUN_LOOP_STOP_SIGNAL && !isUserAbortError(error)) {
+              logChatRunError(params.diagnostics, "agent", error);
+            }
+            if (cancellationOutcome === null) {
+              return { kind: "invalidated" };
+            }
+            return cancellationOutcome;
+          }
+
+          if (error === CHAT_RUN_LOOP_STOP_SIGNAL) {
+            const stoppedObservationOutcome = getPendingObservationOutcome();
+            if (stoppedObservationOutcome === null) {
+              throw new Error("Chat loop stopped without a pending observation outcome");
+            }
+            return stoppedObservationOutcome;
+          }
+
+          const emittedObservationOutcome = getPendingObservationOutcome();
+          if (emittedObservationOutcome !== null) {
+            return emittedObservationOutcome;
+          }
+
+          if (error instanceof ChatSessionRunTransitionError) {
+            logRunTransitionSkipped(error, params);
+            return { kind: "invalidated" };
+          }
+
+          if (!isCurrentActiveChatRun(params.sessionId, params.activeRunId)) {
+            return { kind: "invalidated" };
+          }
+
+          const userFacingMessage = buildUserFacingChatErrorMessage(params.locale, error);
+          const failureOutcome = await persistTerminalFailure(userFacingMessage);
+          const cancellationOutcome = await persistUserCancellationIfNeeded();
+          if (cancellationOutcome !== null) {
+            return cancellationOutcome;
+          }
+          if (failureOutcome.kind === "invalidated") {
+            return failureOutcome;
+          }
+          broadcastChatEvent(params.sessionId, params.activeRunId, {
+            type: "error",
+            message: userFacingMessage,
+          });
+          logChatRunError(params.diagnostics, "agent", error);
+          return failureOutcome;
+        }
+
+        const loopObservationOutcome = getPendingObservationOutcome();
+        if (loopObservationOutcome?.kind === "invalidated") {
+          return loopObservationOutcome;
+        }
+
+        const cancellationOutcome = await persistUserCancellationIfNeeded();
+        if (cancellationOutcome !== null) {
+          return cancellationOutcome;
+        }
+
+        const persistedObservationOutcome = getPendingObservationOutcome();
+        if (persistedObservationOutcome !== null) {
+          return persistedObservationOutcome;
         }
 
         if (!isCurrentActiveChatRun(params.sessionId, params.activeRunId)) {
-          isFinalized = true;
-          return;
+          return { kind: "invalidated" };
         }
 
-        if (!isFinalized) {
-          assistantOpenAIItems = completion.openaiItems;
+        assistantOpenAIItems = completion.openaiItems;
+        assistantContent = finalizeAssistantToolCalls(assistantContent);
+        let completionInvalidationOutcome: ChatInvalidatedObservationOutcome | null = null;
+        try {
+          await dependencies.completeChatRun(
+            params.userId,
+            params.workspaceId,
+            {
+              sessionId: params.sessionId,
+              activeRunId: params.activeRunId,
+              assistantItemId: params.assistantItemId,
+              assistantContent,
+              assistantOpenAIItems,
+            },
+          );
+        } catch (error) {
+          completionInvalidationOutcome = classifyPersistenceFailure(error);
         }
+        const postCompletionCancellationOutcome = await persistUserCancellationIfNeeded();
+        if (postCompletionCancellationOutcome !== null) {
+          return postCompletionCancellationOutcome;
+        }
+        if (completionInvalidationOutcome !== null) {
+          return completionInvalidationOutcome;
+        }
+        if (doneEventPending) {
+          broadcastChatEvent(params.sessionId, params.activeRunId, { type: "done" });
+        }
+        return {
+          kind: "completed",
+          assistantContent,
+        };
       },
     );
-
-    if (!isFinalized) {
-      assistantContent = finalizeAssistantToolCalls(assistantContent);
-      await dependencies.completeChatRun(
-        params.userId,
-        params.workspaceId,
-        {
-          sessionId: params.sessionId,
-          activeRunId: params.activeRunId,
-          assistantItemId: params.assistantItemId,
-          assistantContent,
-          assistantOpenAIItems,
-        },
-      );
-      isFinalized = true;
-    }
   } catch (error) {
+    if (activeRootPersistenceFailed && error === activeRootPersistenceError) {
+      throw error;
+    }
+
     const activeRun = getActiveChatRun(params.sessionId);
     const stoppedByUser = activeRun?.activeRunId === params.activeRunId && activeRun.stopRequestedByUser === true;
 
     if (stoppedByUser && isUserAbortError(error)) {
-      try {
-        await persistUserCancellationIfNeeded();
-      } catch (persistError) {
-        if (persistError instanceof ChatSessionRunTransitionError) {
-          logRunTransitionSkipped(persistError, params);
-          return;
-        }
-
-        throw persistError;
-      }
-      log({
-        domain: "chat",
-        action: "run_cancelled",
-        vendor: "openai",
-        requestId: params.requestId,
-        sessionId: params.sessionId,
-        userId: params.userId,
-        workspaceId: params.workspaceId,
-      });
+      await persistUserCancellationIfNeeded();
       return;
     }
 
@@ -891,7 +1104,9 @@ export const startPersistedChatRunWithDeps = (
     cancellationState: "active",
   });
 
-  void runPersistedChatSessionWithDeps(params, dependencies);
+  void runPersistedChatSessionWithDeps(params, dependencies).catch((error) => {
+    logChatRunError(params.diagnostics, "agent", error);
+  });
 
   return subscriber.createIterator();
 };

--- a/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
+++ b/apps/web/src/ui/chat/shell/panel/ChatPanel.tsx
@@ -1427,14 +1427,21 @@ export const ChatPanel = (props: Props): ReactElement => {
         }
         return ownership.target;
       };
-      if (readCurrentOperationTarget() === null) {
+      const transcriptionTarget = readCurrentOperationTarget();
+      if (transcriptionTarget === null) {
         return;
       }
       if (audioBlob.size <= 0) {
         return;
       }
 
-      const transcription = await transcribeChatAudio(audioBlob, t);
+      const transcription = await transcribeChatAudio(
+        audioBlob,
+        transcriptionTarget.kind === "session"
+          ? transcriptionTarget.sessionId
+          : null,
+        t,
+      );
       const currentTarget = readCurrentOperationTarget();
       if (currentTarget === null) {
         return;

--- a/apps/web/src/ui/chat/stream/hooks/chatDictation.test.ts
+++ b/apps/web/src/ui/chat/stream/hooks/chatDictation.test.ts
@@ -110,7 +110,7 @@ test("a delayed transcription cannot overwrite a newer operation", async (): Pro
   assert.equal(selectedDraftText, "newer target");
 });
 
-test("transcribeChatAudio sends audio without creating or naming a chat session", async (): Promise<void> => {
+test("transcribeChatAudio sends an owned session id and keeps drafts sessionless", async (): Promise<void> => {
   const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
   const originalFetch = Object.getOwnPropertyDescriptor(globalThis, "fetch");
   const submittedForms: Array<FormData> = [];
@@ -129,14 +129,23 @@ test("transcribeChatAudio sends audio without creating or naming a chat session"
   });
 
   try {
-    const result = await transcribeChatAudio(
+    const draftResult = await transcribeChatAudio(
       new Blob(["audio"], { type: "audio/webm" }),
+      null,
+      t,
+    );
+    const sessionResult = await transcribeChatAudio(
+      new Blob(["audio"], { type: "audio/webm" }),
+      "session-existing",
       t,
     );
 
-    assert.deepEqual(result, { text: "hello" });
+    assert.deepEqual(draftResult, { text: "hello" });
+    assert.deepEqual(sessionResult, { text: "hello" });
     assert.equal(submittedForms[0]?.get("sessionId"), null);
     assert.equal(submittedForms[0]?.get("source"), "web");
+    assert.equal(submittedForms[1]?.get("sessionId"), "session-existing");
+    assert.equal(submittedForms[1]?.get("source"), "web");
   } finally {
     if (originalDocument === undefined) {
       Reflect.deleteProperty(globalThis, "document");

--- a/apps/web/src/ui/chat/stream/hooks/chatDictation.ts
+++ b/apps/web/src/ui/chat/stream/hooks/chatDictation.ts
@@ -153,6 +153,7 @@ export const sanitizeChatTranscriptionErrorText = (
 
 export const transcribeChatAudio = async (
   blob: Blob,
+  sessionId: string | null,
   t: ChatTranslation,
 ): Promise<ChatTranscriptionResponse> => {
   const mediaType = normalizeAudioMediaType(blob.type === "" ? "audio/webm" : blob.type);
@@ -162,6 +163,9 @@ export const transcribeChatAudio = async (
   const formData = new FormData();
   formData.append("file", file);
   formData.append("source", "web");
+  if (sessionId !== null) {
+    formData.append("sessionId", sessionId);
+  }
 
   const response = await fetchWithCsrf("/api/chat/transcriptions", {
     method: "POST",

--- a/docs/langfuse-operations.md
+++ b/docs/langfuse-operations.md
@@ -11,6 +11,10 @@ The web chat now runs with fully app-managed state:
 - Langfuse receives one trace per user turn
 - trace name is `chat_turn`
 - Langfuse `sessionId` matches the chat session id
+- the active root `agent` observation stores the sanitized turn input and terminal assistant outcome
+- OpenAI generations and local tool observations run inside that root observation
+
+Audio transcription uses a separate active `chat_transcription` root. Its root stores the upload summary and transcription output. When the client supplies a chat session id of at most 200 characters, the root and observed OpenAI generation inherit that `sessionId`.
 
 OpenAI Conversations, hosted code interpreter containers, and provider-managed recovery are not part of the runtime anymore.
 
@@ -33,7 +37,9 @@ Spans are exported in batches, not one by one:
 - the span processor uses the `@langfuse/otel` default `batched` export mode
 - the OpenTelemetry batch processor schedules a flush every 5 seconds by default, so a finished turn can take a few seconds to appear in Langfuse
 - batching keeps OTLP serialization and the export request off the chat request path, so telemetry competes less with request handling for the event loop
+- exporter retry behavior uses the SDK and OpenTelemetry defaults; the app does not add another retry layer
 - spans still queued when a web task stops are lost, because nothing flushes the SDK on exit; this is an accepted trade-off, not a misconfiguration
+- observation update and end failures are logged without changing the chat result; background exporter failures are not propagated into the chat request
 
 Treat a trace that is missing for only a few seconds after a turn as normal batching latency.
 
@@ -52,6 +58,15 @@ For a plain text turn, expect:
 
 - one root `agent` observation for `chat_turn`
 - one nested OpenAI generation observation
+- sanitized `turnInput` on the root before the generation starts
+- a terminal root output written after the application outcome is known
+
+The chat root output uses these result values:
+
+- `success` only after final assistant tool normalization and `completeChatRun` persistence; the client `done` event is emitted only after that write succeeds
+- `cancelled` only after user-cancellation persistence
+- `invalidated` when the run was discarded or lost its active-run transition
+- `error` for a persisted stream terminal error or a thrown failure
 
 For a turn that uses `query_database`, expect:
 
@@ -59,6 +74,13 @@ For a turn that uses `query_database`, expect:
 - at least one nested OpenAI generation observation
 - one nested tool observation for `query_database`
 - if the tool result causes a follow-up model call, another nested generation observation under the same trace
+
+For an audio transcription with a chat session id, expect:
+
+- one root `agent` observation for `chat_transcription`
+- one nested OpenAI generation observation
+- the same `sessionId` on both observations so session cost includes the generation
+- the upload summary on the root input and transcription text on the root output
 
 ## How to filter traces
 
@@ -74,7 +96,7 @@ Useful metadata for narrowing a trace:
 
 - `requestId` for one exact server request
 - `model` for model-specific regressions
-- `runState` to separate successful turns from interrupted or failed ones
+- root output `result` to separate completed, cancelled, invalidated, and failed turns
 - `turnIndex` to understand where in the chat history the problem happened
 
 ## First production smoke check
@@ -125,4 +147,14 @@ If a chat works but no Langfuse data is exported:
 
 ## Current non-goals
 
-The cutover does not include a Langfuse dataset workflow yet. There is currently no admin or job flow in this repo that creates dataset items from `sourceTraceId` or `sourceObservationId`. Treat that as phase 2 observability work, not as a blocker for the runtime migration.
+The repository uses the GA Langfuse JS/TS SDK v5 with OpenTelemetry ingestion. It has no direct Langfuse read API, raw ingestion request, generated client, evaluator job, dataset experiment, or export integration. The only code-derived observation-evaluator candidates are the `chat_turn` and `chat_transcription` roots described above; this does not establish that any evaluator exists in the Langfuse project.
+
+`LANGFUSE_BASE_URL` can point to Langfuse Cloud or a self-hosted deployment. The application does not discover the server major; self-hosted operators must confirm the target is on Langfuse v4 before completing the project cutover.
+
+Project-dependent migration checks remain blocked until access to the confirmed target project is configured. That includes project reads or writes, representative non-production ingestion, evaluator and export cutovers, and rollback verification. Check these project surfaces separately:
+
+- [Migration status](https://cloud.langfuse.com/v4-migration)
+- [Evaluators](https://cloud.langfuse.com/project/~/evals), including active Legacy rows
+- [Integrations](https://cloud.langfuse.com/project/~/settings/integrations), including export sources and downstream cutover state
+
+Do not enable or cut over evaluators or exports until a representative non-production trace has been inspected. Keep disabled legacy evaluators for rollback. Repository behavior follows the official [v4 overview](https://langfuse.com/docs/v4), [compatibility matrix](https://langfuse.com/docs/compatibility), [JS/TS upgrade path](https://langfuse.com/docs/observability/sdk/upgrade-path/js-v4-to-v5), [OpenAI integration](https://langfuse.com/integrations/model-providers/openai-js), and [batching lifecycle](https://langfuse.com/docs/observability/features/queuing-batching).


### PR DESCRIPTION
## Summary
- migrate chat-turn and transcription telemetry to the Langfuse v4 observation lifecycle
- propagate trace, session, metadata, and cost-correlating attributes before child observations
- preserve cancellation, failure, completion, dictation, replay, broadcast, post-commit, and telemetry-isolation behavior
- use sound Langfuse 5.10.1 generic adapters in the dependency tests

## Supersession
This replacement supersedes #268 after that item exhausted its review rounds.

## Cloud evidence
- Prior Extended Unit Tests passed.
- The final two tsc errors were isolated to the propagateAttributes test adapters.
- They are resolved with explicit Langfuse 5.10.1 <Args, Callback> relationships that preserve the full variadic tuple and ReturnType correlation.
- Fresh static review round 1 found no P0-P4 issues and no additional notes.
- No local project checks were run; this PR cloud suite owns executable validation.
