### PR TITLE
Log Postgres pool errors instead of crashing the process

### DIFF
--- a/apps/auth/src/server/db.ts
+++ b/apps/auth/src/server/db.ts
@@ -5,6 +5,7 @@
  * schema and narrow helper functions. It must not reuse the main app role.
  */
 import pg from "pg";
+import { log } from "./logger.js";
 
 const getConnectionString = (): string => {
   const directUrl = process.env.AUTH_DATABASE_URL ?? "";
@@ -35,6 +36,12 @@ const getPool = (): pg.Pool => {
   pool = new pg.Pool({
     connectionString: getConnectionString(),
     ssl: useSsl ? true : false,
+  });
+  // The server can close a pooled connection while it is idle (RDS maintenance,
+  // restart, failover). Without this listener the pool emits an unhandled
+  // 'error' event and Node terminates the process.
+  pool.on("error", (error: Error): void => {
+    log({ domain: "auth", action: "db_pool_error", error: error.message });
   });
   return pool;
 };

--- a/apps/auth/src/server/logger.ts
+++ b/apps/auth/src/server/logger.ts
@@ -71,6 +71,7 @@ type AuthEvent =
   | Readonly<{ domain: "auth"; action: "verify_code_challenge_expired"; transport: "browser" | "agent"; maskedEmail: string }>
   | Readonly<{ domain: "auth"; action: "verify_code_error"; error: string }>
   | Readonly<{ domain: "auth"; action: "otp_sweep_error"; error: string }>
+  | Readonly<{ domain: "auth"; action: "db_pool_error"; error: string }>
   | CognitoRefreshRetryEvent
   | CognitoOAuthOwnerRetryEvent
   | OAuthAuthorizationServerErrorEvent

--- a/apps/sql-api/src/dbPool.test.ts
+++ b/apps/sql-api/src/dbPool.test.ts
@@ -45,7 +45,7 @@ const createManualRuntime = (
   };
 };
 
-const createPool = (): pg.Pool => ({}) as pg.Pool;
+const createPool = (): pg.Pool => ({ on: (): void => undefined }) as unknown as pg.Pool;
 
 test("pool initialization is shared and configures bounded PostgreSQL connection establishment", async (): Promise<void> => {
   let resolveDatabaseUrl: ((databaseUrl: string) => void) | undefined;
@@ -104,6 +104,25 @@ test("pool initialization clears failed shared state without creating a pool", a
   assert.equal(await provider.getPool(), expectedPool);
   assert.equal(databaseUrlRequestCount, 2);
   assert.equal(poolCreationCount, 1);
+});
+
+test("shared pool initialization listens for errors on connections the server closes", async (): Promise<void> => {
+  const poolErrorListeners: Array<(error: Error) => void> = [];
+  const expectedPool = {
+    on: (event: string, listener: (error: Error) => void): void => {
+      assert.equal(event, "error");
+      poolErrorListeners.push(listener);
+    },
+  } as unknown as pg.Pool;
+  const provider = createDatabasePoolProvider({
+    createPool: () => expectedPool,
+    getDatabaseUrl: async () => "postgresql://database.example.internal/expense_tracker",
+    useTls: () => false,
+  });
+
+  assert.equal(await provider.getPool(), expectedPool);
+  assert.equal(poolErrorListeners.length, 1);
+  poolErrorListeners[0]?.(new Error("terminating connection due to administrator command"));
 });
 
 test("a short first SQL caller does not shorten shared pool initialization for a longer caller", async (): Promise<void> => {

--- a/apps/sql-api/src/dbPool.ts
+++ b/apps/sql-api/src/dbPool.ts
@@ -10,6 +10,7 @@ import {
   getDatabaseUrl,
 } from "./config.js";
 import type { DeadlineRuntime } from "./dbDeadline.js";
+import { getSafeErrorType, log } from "./logger.js";
 
 export const POSTGRES_CONNECTION_TIMEOUT_MS = 5_000;
 
@@ -38,12 +39,25 @@ export const createDatabasePoolProvider = (
     }
 
     const startedInitialization = dependencies.getDatabaseUrl(DATABASE_SECRET_TIMEOUT_MS).then(
-      (connectionString): pg.Pool => dependencies.createPool({
-        connectionString,
-        ssl: dependencies.useTls(),
-        max: SQL_API_DB_POOL_MAX_CONNECTIONS,
-        connectionTimeoutMillis: POSTGRES_CONNECTION_TIMEOUT_MS,
-      }),
+      (connectionString): pg.Pool => {
+        const createdPool = dependencies.createPool({
+          connectionString,
+          ssl: dependencies.useTls(),
+          max: SQL_API_DB_POOL_MAX_CONNECTIONS,
+          connectionTimeoutMillis: POSTGRES_CONNECTION_TIMEOUT_MS,
+        });
+        // The server can close a pooled connection while it is idle (RDS
+        // maintenance, restart, failover). Without this listener the pool emits
+        // an unhandled 'error' event and the Lambda runtime exits.
+        createdPool.on("error", (error: Error): void => {
+          log({
+            domain: "sql_api",
+            action: "database_pool_error",
+            errorType: getSafeErrorType(error),
+          });
+        });
+        return createdPool;
+      },
     );
     initialization = startedInitialization;
     void startedInitialization.then(

--- a/apps/sql-api/src/logger.ts
+++ b/apps/sql-api/src/logger.ts
@@ -7,13 +7,19 @@ export const getSafeErrorType = (error: unknown): SafeErrorType => {
   return "non_error";
 };
 
-export type SqlApiLogEvent = Readonly<{
-  domain: "sql_api";
-  action: "mcp_unexpected_error";
-  boundary: "authentication" | "tool" | "transport";
-  operation: string;
-  errorType: SafeErrorType;
-}>;
+export type SqlApiLogEvent =
+  | Readonly<{
+    domain: "sql_api";
+    action: "mcp_unexpected_error";
+    boundary: "authentication" | "tool" | "transport";
+    operation: string;
+    errorType: SafeErrorType;
+  }>
+  | Readonly<{
+    domain: "sql_api";
+    action: "database_pool_error";
+    errorType: SafeErrorType;
+  }>;
 
 export const log = (event: SqlApiLogEvent): void => {
   console.log(JSON.stringify(event));

--- a/apps/web/src/server/db/pool.ts
+++ b/apps/web/src/server/db/pool.ts
@@ -1,4 +1,5 @@
 import pg from "pg";
+import { log } from "@/server/logger";
 
 // AUTH_MODE=cognito means production behind ALB -> always RDS -> always SSL.
 // In cognito mode, construct the URL from individual env vars (ECS injects DB_PASSWORD from Secrets Manager).
@@ -20,6 +21,13 @@ const connectionString = process.env.AUTH_MODE === "cognito"
 const ssl = process.env.AUTH_MODE === "cognito" ? true : false;
 
 const pool = new pg.Pool({ connectionString, ssl });
+
+// The server can close a pooled connection while it is idle (RDS maintenance,
+// restart, failover). Without this listener the pool emits an unhandled
+// 'error' event and Node terminates the process.
+pool.on("error", (error: Error): void => {
+  log({ domain: "db", action: "pool_error", error: error.message });
+});
 
 /** Execute a query without RLS context (global tables only). */
 export const query = (text: string, params: ReadonlyArray<unknown>): Promise<pg.QueryResult> =>

--- a/apps/web/src/server/logger.ts
+++ b/apps/web/src/server/logger.ts
@@ -221,7 +221,15 @@ type AuthEvent =
   | Readonly<{ domain: "auth"; action: "proxy_auth_error"; error: string }>
   | Readonly<{ domain: "auth"; action: "error"; error: string }>;
 
-type LogEvent = ChatEvent | ChatTranscriptionEvent | ApiEvent | SqlApiEvent | AuthEvent;
+/**
+ * A pooled Postgres connection failed while idle, usually because the server
+ * closed it (RDS maintenance, restart, or failover). node-postgres discards the
+ * broken client on its own, so the action is deliberately kept out of the
+ * `error` family that the CloudWatch web error alarm pages on.
+ */
+type DbEvent = Readonly<{ domain: "db"; action: "pool_error"; error: string }>;
+
+type LogEvent = ChatEvent | ChatTranscriptionEvent | ApiEvent | SqlApiEvent | AuthEvent | DbEvent;
 
 export const log = (event: LogEvent): void => {
   console.log(JSON.stringify(event));

--- a/apps/worker/src/db.ts
+++ b/apps/worker/src/db.ts
@@ -18,6 +18,12 @@ async function getPool(): Promise<pg.Pool> {
     // to the RDS CA bundle (set in CDK, bundle downloaded during Lambda bundling).
     const ssl = process.env.DB_SECRET_ARN ? true : false;
     pool = new pg.Pool({ connectionString, ssl });
+    // The server can close a pooled connection while it is idle (RDS maintenance,
+    // restart, failover). Without this listener the pool emits an unhandled
+    // 'error' event and Node terminates the process.
+    pool.on("error", (error: Error): void => {
+      console.error("Postgres pool error:", error);
+    });
   }
   return pool;
 }


### PR DESCRIPTION
## Problem

On 2026-08-26 RDS ran an automatic minor-version upgrade (18.4.R1 → 18.6.R1, downtime 05:42:03Z–05:43:07Z UTC). Postgres closed live connections with `FATAL 57P01: terminating connection due to administrator command`.

The MCP Lambda's pooled idle socket delivered that error on its next invocation at 05:44:59Z. No `pg.Pool` in the repository had an `error` listener, so Node threw `Unhandled 'error' event`, the invocation died with `Runtime.ExitError`, and `McpLambdaErrorAlarm` fired.

## Change

Attach an `error` listener to every long-lived pool — `apps/web`, `apps/worker`, `apps/auth`, `apps/sql-api` (which backs both the SQL API and MCP Lambdas). Each handler only logs through its app's existing contract; node-postgres already removes the broken idle client from the pool.

The web event is deliberately not named `error`, so a self-healing maintenance disconnect does not page `WebErrorEventsAlarm`.

## Out of scope

`scripts/publicMonthlyShareDbSmoke.ts` (short-lived script), `idleTimeoutMillis`/`keepAlive` tuning, CDK/alarm changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)