### PR TITLE
Alarm on sustained Postgres pool errors

### DIFF
--- a/apps/worker/src/db.ts
+++ b/apps/worker/src/db.ts
@@ -22,6 +22,8 @@ async function getPool(): Promise<pg.Pool> {
     // restart, failover). Without this listener the pool emits an unhandled
     // 'error' event and Node terminates the process.
     pool.on("error", (error: Error): void => {
+      // "Postgres pool error" is a CloudWatch contract: FxDbPoolErrorMetricFilter in
+      // infra/aws/lib/monitoring.ts matches this literal text. Keep it if logging changes.
       console.error("Postgres pool error:", error);
     });
   }

--- a/infra/aws/lib/compute.ts
+++ b/infra/aws/lib/compute.ts
@@ -35,6 +35,7 @@ export interface ComputeResult {
   webContainer: ecs.ContainerDefinition;
   webLogGroup: logs.LogGroup;
   authService: ecs.FargateService;
+  authLogGroup: logs.LogGroup;
   migrateTaskDef: ecs.FargateTaskDefinition;
   migrateLogGroup: logs.LogGroup;
 }
@@ -340,5 +341,5 @@ export function compute(scope: Construct, props: ComputeProps): ComputeResult {
     }),
   });
 
-  return { cluster, webService, webContainer, webLogGroup, authService, migrateTaskDef, migrateLogGroup };
+  return { cluster, webService, webContainer, webLogGroup, authService, authLogGroup, migrateTaskDef, migrateLogGroup };
 }

--- a/infra/aws/lib/monitoring.test.ts
+++ b/infra/aws/lib/monitoring.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import * as cdk from "aws-cdk-lib";
+import * as apigw from "aws-cdk-lib/aws-apigateway";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as rds from "aws-cdk-lib/aws-rds";
+import { Template } from "aws-cdk-lib/assertions";
+import { monitoring } from "./monitoring";
+
+// Pinned so the synthesized template never depends on the environment running the tests.
+const TEST_ENV: cdk.Environment = { account: "123456789012", region: "eu-central-1" };
+
+const POOL_ERROR_NAMESPACE = "ExpenseBudgetTracker/Db";
+const POOL_ERROR_METRIC_NAME = "PoolErrors";
+
+// Rendered CloudWatch filter patterns, written out literally so they can be compared with a
+// real log line: the ECS surfaces log one JSON object per line, while Lambda prefixes every
+// line with a timestamp and request id and can only be matched as text.
+const WEB_POOL_ERROR_PATTERN = '{ ($.domain = "db") && ($.action = "pool_error") }';
+const AUTH_POOL_ERROR_PATTERN = '{ ($.domain = "auth") && ($.action = "db_pool_error") }';
+const SQL_API_POOL_ERROR_PATTERN = '"database_pool_error"';
+const FX_POOL_ERROR_PATTERN = '"Postgres pool error"';
+
+type MetricFilterShape = Readonly<{
+  logGroup: string;
+  pattern: string;
+  defaultValue: unknown;
+}>;
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Expected a template object, got ${JSON.stringify(value)}`);
+  }
+  return value as Record<string, unknown>;
+};
+
+const requireString = (value: unknown, field: string): string => {
+  if (typeof value !== "string") {
+    throw new Error(`Expected ${field} to be a literal string, got ${JSON.stringify(value)}`);
+  }
+  return value;
+};
+
+const stubFunction = (stack: cdk.Stack, id: string): lambda.Function =>
+  new lambda.Function(stack, id, {
+    runtime: lambda.Runtime.NODEJS_24_X,
+    handler: "index.handler",
+    code: lambda.Code.fromInline("exports.handler = async () => ({});"),
+  });
+
+const stubWebService = (stack: cdk.Stack, cluster: ecs.Cluster): ecs.FargateService => {
+  const taskDefinition = new ecs.FargateTaskDefinition(stack, "WebTaskDef", {
+    cpu: 256,
+    memoryLimitMiB: 512,
+  });
+  taskDefinition.addContainer("web", {
+    image: ecs.ContainerImage.fromRegistry("public.ecr.aws/docker/library/nginx:stable"),
+    portMappings: [{ containerPort: 8080 }],
+  });
+  return new ecs.FargateService(stack, "WebService", { cluster, taskDefinition });
+};
+
+// monitoring() is the real production function; everything it observes is stubbed with the
+// same construct types the stack passes in, so a pool that loses its metric filter here
+// loses its alarm in production too.
+const synthesizeMonitoringTemplate = (): Template => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "MonitoringTestStack", { env: TEST_ENV });
+  const vpc = new ec2.Vpc(stack, "Vpc");
+  const cluster = new ecs.Cluster(stack, "Cluster", { vpc });
+  const restApi = new apigw.RestApi(stack, "RestApi");
+  restApi.root.addMethod("GET");
+  const alb = new elbv2.ApplicationLoadBalancer(stack, "Alb", { vpc });
+  const webTargetGroup = new elbv2.ApplicationTargetGroup(stack, "WebTargetGroup", {
+    vpc,
+    port: 8080,
+    targetType: elbv2.TargetType.IP,
+  });
+  // monitoring() reads webTargetGroup.metrics, which resolves the load balancer name from
+  // the first listener and throws while the target group is attached to none. ingress()
+  // always forwards to it from a listener, so the stub has to as well. `open: false`
+  // matches ingress() and keeps the synthesized security group closed.
+  alb.addListener("AlbTestListener", {
+    port: 80,
+    open: false,
+    defaultTargetGroups: [webTargetGroup],
+  });
+  monitoring(stack, {
+    alertEmail: "alerts@example.com",
+    alb,
+    webTargetGroup,
+    webLogGroup: new logs.LogGroup(stack, "WebLogGroup"),
+    authLogGroup: new logs.LogGroup(stack, "AuthLogGroup"),
+    webAclName: "expense-tracker-web-acl",
+    webService: stubWebService(stack, cluster),
+    cluster,
+    db: new rds.DatabaseInstance(stack, "Db", {
+      engine: rds.DatabaseInstanceEngine.postgres({
+        version: rds.PostgresEngineVersion.of("18.6", "18"),
+      }),
+      vpc,
+    }),
+    fxFetcher: stubFunction(stack, "FxFetcher"),
+    restApi,
+    authorizerFn: stubFunction(stack, "AuthorizerFn"),
+    sqlApiFn: stubFunction(stack, "SqlApiFn"),
+    mcpHttpApi: new apigwv2.HttpApi(stack, "McpHttpApi"),
+    mcpFn: stubFunction(stack, "McpFn"),
+    customEmailSenderFn: stubFunction(stack, "CustomEmailSenderFn"),
+  });
+  return Template.fromStack(stack);
+};
+
+const singleTransformation = (properties: Record<string, unknown>): Record<string, unknown> => {
+  const transformations = properties.MetricTransformations;
+  if (!Array.isArray(transformations) || transformations.length !== 1) {
+    throw new Error(`Expected one metric transformation, got ${JSON.stringify(transformations)}`);
+  }
+  return asRecord(transformations[0]);
+};
+
+const poolErrorMetricFilters = (template: Template): ReadonlyArray<MetricFilterShape> =>
+  Object.values(template.findResources("AWS::Logs::MetricFilter"))
+    .map((resource) => asRecord(asRecord(resource).Properties))
+    .map((properties) => ({ properties, transformation: singleTransformation(properties) }))
+    .filter(
+      ({ transformation }) =>
+        transformation.MetricNamespace === POOL_ERROR_NAMESPACE
+        && transformation.MetricName === POOL_ERROR_METRIC_NAME,
+    )
+    .map(({ properties, transformation }) => ({
+      logGroup: JSON.stringify(properties.LogGroupName),
+      pattern: requireString(properties.FilterPattern, "FilterPattern"),
+      defaultValue: transformation.DefaultValue,
+    }));
+
+// The ECS log groups are declared by the stack, so their metric filters reference them by
+// logical id and the pairing of pattern to log group can be pinned.
+const logGroupRef = (template: Template, constructId: string): string => {
+  const matches = Object.keys(template.findResources("AWS::Logs::LogGroup")).filter((logicalId) =>
+    logicalId.startsWith(constructId),
+  );
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one ${constructId} log group, found ${matches.length}`);
+  }
+  return JSON.stringify({ Ref: matches[0] });
+};
+
+const patternsWatching = (
+  filters: ReadonlyArray<MetricFilterShape>,
+  logGroup: string,
+): ReadonlyArray<string> =>
+  filters.filter((filter) => filter.logGroup === logGroup).map((filter) => filter.pattern);
+
+const alertTopicLogicalId = (template: Template): string => {
+  const topics = Object.entries(template.findResources("AWS::SNS::Topic"));
+  if (topics.length !== 1) {
+    throw new Error(`Expected exactly one alert topic, found ${topics.length}`);
+  }
+  return topics[0][0];
+};
+
+test("every Postgres pool reports its errors into one shared metric", (): void => {
+  const template = synthesizeMonitoringTemplate();
+  const filters = poolErrorMetricFilters(template);
+
+  assert.deepEqual(
+    filters.map((filter) => filter.pattern).sort(),
+    [
+      AUTH_POOL_ERROR_PATTERN,
+      FX_POOL_ERROR_PATTERN,
+      SQL_API_POOL_ERROR_PATTERN,
+      SQL_API_POOL_ERROR_PATTERN,
+      SQL_API_POOL_ERROR_PATTERN,
+      WEB_POOL_ERROR_PATTERN,
+    ].sort(),
+  );
+  assert.equal(
+    new Set(filters.map((filter) => filter.logGroup)).size,
+    filters.length,
+    "Expected each pool-error metric filter to watch a different log group",
+  );
+  // The two ECS patterns are near-identical, so a swap between them would keep the checks
+  // above green while blinding both services. The three Lambda surfaces share one pattern.
+  assert.deepEqual(patternsWatching(filters, logGroupRef(template, "WebLogGroup")), [
+    WEB_POOL_ERROR_PATTERN,
+  ]);
+  assert.deepEqual(patternsWatching(filters, logGroupRef(template, "AuthLogGroup")), [
+    AUTH_POOL_ERROR_PATTERN,
+  ]);
+  // A period with no matching line must publish a real 0, so the alarm below decides on
+  // datapoints instead of on how CloudWatch pads a sparse metric.
+  assert.deepEqual(
+    filters.map((filter) => filter.defaultValue),
+    filters.map(() => 0),
+  );
+});
+
+test("the pool error alarm needs errors in 6 consecutive periods, not one burst", (): void => {
+  const template = synthesizeMonitoringTemplate();
+  const alarms = Object.values(template.findResources("AWS::CloudWatch::Alarm"))
+    .map((resource) => asRecord(asRecord(resource).Properties))
+    .filter((properties) => properties.MetricName === POOL_ERROR_METRIC_NAME);
+
+  assert.equal(alarms.length, 1);
+  const alarm = alarms[0];
+  assert.equal(alarm.Namespace, POOL_ERROR_NAMESPACE);
+  assert.equal(alarm.Statistic, "Sum");
+  // Six 5-minute periods, every one of which has to contain a matching line: a one-off
+  // connection loss is self-limiting — each pool logs it once and reconnects, and a stale
+  // Lambda environment logs it once when it is next thawed — so it is very unlikely to
+  // fill all six.
+  assert.equal(alarm.Period, 300);
+  assert.equal(alarm.EvaluationPeriods, 6);
+  assert.equal(alarm.DatapointsToAlarm, 6);
+  assert.equal(alarm.Threshold, 1);
+  assert.equal(alarm.ComparisonOperator, "GreaterThanOrEqualToThreshold");
+  assert.equal(alarm.TreatMissingData, "notBreaching");
+  assert.deepEqual(alarm.AlarmActions, [{ Ref: alertTopicLogicalId(template) }]);
+});

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -16,16 +16,17 @@ export interface MonitoringProps {
   alb: elbv2.ApplicationLoadBalancer;
   webTargetGroup: elbv2.ApplicationTargetGroup;
   webLogGroup: logs.LogGroup;
+  authLogGroup: logs.LogGroup;
   webAclName: string;
   webService: ecs.FargateService;
   cluster: ecs.Cluster;
   db: rds.DatabaseInstance;
-  fxFetcher: lambda.IFunction;
+  fxFetcher: lambda.Function;
   restApi: apigw.RestApi;
-  authorizerFn: lambda.IFunction;
-  sqlApiFn: lambda.IFunction;
+  authorizerFn: lambda.Function;
+  sqlApiFn: lambda.Function;
   mcpHttpApi: apigwv2.HttpApi;
-  mcpFn: lambda.IFunction;
+  mcpFn: lambda.Function;
   customEmailSenderFn: lambda.IFunction;
 }
 
@@ -186,6 +187,96 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     threshold: 1,
     evaluationPeriods: 1,
     alarmDescription: "Web application logged an error event",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
+
+  // --- Postgres pool errors ---
+  // Every pool logs an error instead of crashing when the server closes a pooled
+  // connection, so these log lines are the only signal that a pool is failing.
+  // All surfaces feed one metric: the pools all talk to the same database.
+  const dbPoolErrorNamespace = "ExpenseBudgetTracker/Db";
+  const dbPoolErrorMetricName = "PoolErrors";
+
+  const countDbPoolErrors = (
+    id: string,
+    logGroup: logs.ILogGroup,
+    filterPattern: logs.IFilterPattern,
+  ): void => {
+    new logs.MetricFilter(scope, id, {
+      logGroup,
+      filterPattern,
+      metricNamespace: dbPoolErrorNamespace,
+      metricName: dbPoolErrorMetricName,
+      metricValue: "1",
+      // Publish an explicit 0 for periods with no match, so "errors in every one of the last
+      // N periods" is decided by real datapoints instead of by missing-data padding.
+      defaultValue: 0,
+    });
+  };
+
+  // ECS ships each structured log line to CloudWatch verbatim, so it matches as JSON.
+  countDbPoolErrors(
+    "WebDbPoolErrorMetricFilter",
+    props.webLogGroup,
+    logs.FilterPattern.all(
+      logs.FilterPattern.stringValue("$.domain", "=", "db"),
+      logs.FilterPattern.stringValue("$.action", "=", "pool_error"),
+    ),
+  );
+  countDbPoolErrors(
+    "AuthDbPoolErrorMetricFilter",
+    props.authLogGroup,
+    logs.FilterPattern.all(
+      logs.FilterPattern.stringValue("$.domain", "=", "auth"),
+      logs.FilterPattern.stringValue("$.action", "=", "db_pool_error"),
+    ),
+  );
+
+  // Lambda prefixes every stdout line with a timestamp and request id, so the log event
+  // is not valid JSON and only a substring match on the action name finds it. Reading
+  // `fn.logGroup` also materializes the function log group the filter needs to attach to.
+  // A frozen execution environment cannot process I/O, so a pooled connection dropped while
+  // it sleeps only surfaces when that environment is next thawed.
+  countDbPoolErrors(
+    "AuthorizerDbPoolErrorMetricFilter",
+    props.authorizerFn.logGroup,
+    logs.FilterPattern.allTerms("database_pool_error"),
+  );
+  countDbPoolErrors(
+    "SqlApiDbPoolErrorMetricFilter",
+    props.sqlApiFn.logGroup,
+    logs.FilterPattern.allTerms("database_pool_error"),
+  );
+  countDbPoolErrors(
+    "McpDbPoolErrorMetricFilter",
+    props.mcpFn.logGroup,
+    logs.FilterPattern.allTerms("database_pool_error"),
+  );
+  // The FX fetcher has no structured logger and logs the error as plain text. Its pool is
+  // opened and ended inside a single scheduled invocation, so only a connection dropped
+  // during that run reaches this filter.
+  countDbPoolErrors(
+    "FxDbPoolErrorMetricFilter",
+    props.fxFetcher.logGroup,
+    logs.FilterPattern.allTerms("Postgres pool error"),
+  );
+
+  new cloudwatch.Alarm(scope, "DbPoolErrorsAlarm", {
+    metric: new cloudwatch.Metric({
+      namespace: dbPoolErrorNamespace,
+      metricName: dbPoolErrorMetricName,
+      period: cdk.Duration.minutes(5),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    // Every one of the six periods has to contain a matching line. A one-off drop is
+    // self-limiting — each pool logs it once and reconnects, and each stale Lambda
+    // environment logs it once when it is next thawed — so it is very unlikely to fill
+    // all six.
+    evaluationPeriods: 6,
+    datapointsToAlarm: 6,
+    alarmDescription:
+      "Postgres pool errors in every one of the last 6 five-minute periods — a single connection loss (routine RDS maintenance, restart, failover) is logged once per pool and rarely fills every period, so this means connections keep being dropped",
     treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
   }).addAlarmAction(new cloudwatch_actions.SnsAction(alertTopic));
 

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -120,6 +120,7 @@ export class ExpenseBudgetTrackerStack extends cdk.Stack {
       alb: ing.alb,
       webTargetGroup: ing.webTargetGroup,
       webLogGroup: comp.webLogGroup,
+      authLogGroup: comp.authLogGroup,
       webAclName: ing.webAclName,
       webService: comp.webService,
       cluster: comp.cluster,


### PR DESCRIPTION
## Why

[#271](https://github.com/kirill-markin/expense-budget-tracker/pull/271) stopped a dropped Postgres connection from crashing the process — every pool now logs it instead. That closed the crash, but it also removed the only signal: `McpLambdaErrorAlarm` no longer fires for this class, and `WebErrorMetricFilter` matches `$.action` exactly, so the deliberately-named `pool_error` event is outside it. An RDS failover would now be logged everywhere and alarmed nowhere.

## What

Metric filters on all six pool-owning surfaces (web ECS, auth ECS, authorizer / SQL API / MCP Lambdas, FX Lambda) feed one shared `ExpenseBudgetTracker/Db` / `PoolErrors` metric, with one alarm on the existing alert topic.

The threshold is duration-based, not volume-based: routine RDS maintenance drops every pooled connection at once, so counting would page on exactly the event that should stay silent. The alarm requires a matching line in **each** of six consecutive five-minute periods. A one-off loss is logged once per pool instance, and a frozen Lambda environment only logs it when next thawed, so a single event is unlikely to fill the whole window.

## Notes

- The auth pool lives in the auth ECS service, not the custom-email-sender Lambda, so its log group is threaded through `compute.ts` → `stack.ts`.
- Lambda stdout is prefixed by the runtime and is not valid JSON, so those filters match the action token as text rather than a JSON field.
- Reading `<fn>.logGroup` materializes CDK `LogRetention` custom resources on deploy. Accepted deliberately: those groups are already never-expire, and `fromLogGroupName` would break a fresh-account deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)