### PR TITLE
Reject SET/RESET statements in the SQL policy parser

### DIFF
--- a/packages/agent-shared/src/sql-policy.test.ts
+++ b/packages/agent-shared/src/sql-policy.test.ts
@@ -364,6 +364,47 @@ test("validateExpenseSql still rejects set_config before function allowlist chec
   );
 });
 
+test("validateExpenseSql rejects session and role control statements with a dedicated code", (): void => {
+  const sessionControlStatements: ReadonlyArray<string> = [
+    "SET ROLE app",
+    "set role app",
+    "RESET ROLE",
+    "SET SESSION AUTHORIZATION app",
+    "SET \"app.user_id\" = 'x'",
+    "SET LOCAL \"app.workspace_id\" = 'x'",
+  ];
+
+  for (const sql of sessionControlStatements) {
+    assert.throws(
+      () => validateExpenseSql(sql),
+      (error: unknown) =>
+        error instanceof SqlPolicyError && error.code === "session_control_not_allowed",
+      `Expected session_control_not_allowed for: ${sql}`,
+    );
+  }
+});
+
+test("validateExpenseSql rejects a trailing SET ROLE in a multi-statement script", (): void => {
+  assert.throws(
+    () => validateExpenseSql("SELECT 1; SET ROLE app"),
+    (error: unknown) => error instanceof SqlPolicyError,
+  );
+});
+
+test("validateExpenseSql still accepts ordinary SELECT and WITH statements unchanged", (): void => {
+  const selectValidated = validateExpenseSql(
+    "SELECT account_id FROM ledger_entries ORDER BY account_id LIMIT 1",
+  );
+  assert.equal(selectValidated.statements.length, 1);
+  assert.deepEqual(selectValidated.statements[0]?.referencedRelations, ["ledger_entries"]);
+
+  const withValidated = validateExpenseSql(
+    "WITH totals AS (SELECT account_id, SUM(amount) AS balance FROM ledger_entries GROUP BY account_id) SELECT * FROM totals",
+  );
+  assert.equal(withValidated.statements.length, 1);
+  assert.deepEqual(withValidated.statements[0]?.referencedRelations, ["ledger_entries"]);
+});
+
 test("validateExpenseSql still allows direct relation queries without function calls", (): void => {
   const validated = validateExpenseSql("SELECT account_id FROM ledger_entries ORDER BY account_id LIMIT 1");
   assert.equal(validated.statements.length, 1);

--- a/packages/agent-shared/src/sql-policy.ts
+++ b/packages/agent-shared/src/sql-policy.ts
@@ -134,6 +134,7 @@ type SqlPolicyErrorCode =
   | "read_only_sql_required"
   | "mutation_sql_required"
   | "on_conflict_not_allowed"
+  | "session_control_not_allowed"
   | "set_config_not_allowed"
   | "function_calls_not_allowed"
   | "sql_comments_not_allowed"
@@ -1451,6 +1452,12 @@ export const isExpenseSqlMutation = (sql: string): boolean =>
 
 const validateExpenseSqlStatement = (sql: string): ValidatedExpenseSqlStatement => {
   const firstKeyword = getFirstKeyword(sql);
+  if (firstKeyword === "SET" || firstKeyword === "RESET") {
+    fail(
+      "session_control_not_allowed",
+      "SET, SET ROLE, SET SESSION AUTHORIZATION, and RESET statements are not allowed",
+    );
+  }
   if (firstKeyword === undefined || !ALLOWED_FIRST_KEYWORDS.has(firstKeyword)) {
     fail("unsupported_statement", "Only SELECT, WITH, INSERT, UPDATE, and DELETE statements are allowed");
   }


### PR DESCRIPTION
## What

Add an explicit `session_control_not_allowed` rejection in `validateExpenseSqlStatement` for statements whose first keyword is `SET` or `RESET` — `SET ROLE`, `SET SESSION AUTHORIZATION`, `SET LOCAL`, `RESET ROLE`, and `SET "app.user_id" = ...` — placed ahead of the generic first-keyword allowlist, plus regression tests.

## Why

These statements were already rejected as the generic `unsupported_statement`, so this is **purely additive** — no change to accept/reject behavior for any currently-accepted SQL. The dedicated error code and tests lock the rejection in so a future refactor of the allowlist cannot silently re-open two isolation gaps in the shared SQL policy that guards the machine API, MCP, web chat, and web agent SQL surfaces:

- **`SET ROLE app` privilege re-escalation** (restricted role climbing back to the `app` login role).
- **`SET "app.user_id" = ...` RLS-context override** (setting the placeholder GUC directly).

This is the defense-in-depth "belt" at the parser boundary. The deeper DB-layer redesign (a dedicated restricted login role; moving tenant identity off settable `app.*` GUCs) is intentionally deferred as separate, non-urgent follow-up.

## Scope

Two files only: `packages/agent-shared/src/sql-policy.ts` and its test. No migrations, no DB/role changes, no changes to the function-allowlist / attribute-notation logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)